### PR TITLE
Add LLM-assisted superoptimizer (Codex Spark flow)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,48 @@
+# s11 — Domain Context
+
+A glossary of domain terms used in this superoptimizer. Update inline as terms get sharpened.
+
+## Glossary
+
+### Target
+The original instruction sequence we are trying to optimize. Always a `Vec<Instruction>` from the s11 IR, drawn from the 20-opcode AArch64 subset. "The target" is fixed input; "candidates" are what search algorithms produce as potential replacements.
+
+### Candidate
+A `Vec<Instruction>` produced by a search algorithm as a potential replacement for the target. A candidate is not yet accepted as an optimization — it must be (a) cheaper than the target by some metric and (b) semantically equivalent on live-out state.
+
+### Optimization (the noun)
+A candidate that is both **strictly cheaper** than the target and **proven equivalent** on the live-out contract. The metric of "cheaper" is search-config dependent (cost model in `src/semantics/cost.rs`, or byte count for the LLM-assisted flow).
+
+### Live-out
+The set of architectural registers (and, implicitly, flags read by the target's downstream context) whose values must agree between target and candidate after execution. Carried as `LiveOutMask` in `src/semantics/state.rs`. Fed into `EquivalenceConfig` and `SearchAlgorithm::search`.
+
+### Live-in
+The set of architectural registers whose initial values the target reads. Currently *not* surfaced in `SearchAlgorithm::search`. The LLM-assisted flow needs this in the prompt; computed by def-use analysis on the target rather than added to the trait (see ADR-0001).
+
+### Equivalence (fast vs SMT)
+Two notions, layered:
+- **Fast equivalence**: target and candidate produce the same live-out state for a fixed corpus of random + edge-case inputs (`src/validation/random.rs`). Cheap, refutation-only.
+- **SMT equivalence**: Z3 proves the live-out state is bit-identical for *all* inputs (`src/semantics/equivalence.rs`). Expensive, gives a proof.
+A candidate is "an optimization" only after passing both, in that order.
+
+### LLM-assisted search (Codex Spark flow)
+A `SearchAlgorithm` impl that delegates candidate generation to the OpenAI Codex CLI running model `gpt-5.3-codex-spark`. The LLM is the candidate generator; the existing fast-then-SMT equivalence pipeline is the verifier. The metric is **instruction count** (equivalently, byte count, since AArch64 is fixed-width 4-byte) — not the cost model. Chosen for the MVP because "smaller program" is the LLM's most natural objective and the most legible success criterion to a human reader.
+
+**Operational shape (MVP):**
+- One `codex exec` invocation per loop iteration. `-m gpt-5.3-codex-spark`, `--output-schema <single-string-asm.json>`, `-o <answer.json>`, `-s read-only`, `--ephemeral`, `--skip-git-repo-check`. Subscription auth is implicit (already done via `codex login`).
+- Each call is **fresh** — no feedback from prior iterations. Diversity comes from default temperature.
+- Calls are **sequential** within one search.
+- Loop terminates when **either** an optimization is found, **or** `max_codex_calls` is reached, **or** `SearchConfig.timeout` elapses.
+- Per-iteration outcomes: parse-fail → log unsupported mnemonics, continue. Equivalence-fail → log, continue. Not-shorter → log, continue. Equivalent and shorter → **success**, return.
+- Verification reuses `EquivalenceConfig::default().with_live_out(live_out)`: 10 random tests (fast path), then Z3 with 30s timeout.
+
+**Deliverable:** local-only. A bash/`just` target that runs the search across a fixed corpus of 5–10 small asm targets known to be optimizable (drawn from existing equivalence tests). No CI, no mocked Codex backend, no `CandidateGenerator` trait abstraction.
+
+### Flags-live-out (MVP exclusion)
+For the LLM-assisted search MVP only, targets whose final architectural state includes a meaningful NZCV value (i.e., flags are live-out) are **refused** rather than processed. `LiveOutMask` does not currently encode flags, and adding flags to the live-out contract would require co-ordinated changes to `EquivalenceConfig` and all four search algorithms — out of scope for the MVP. The LLM flow detects flags-live-out by static inspection of the target and bails with an explicit message. See ADR-0002.
+
+### Subset hint (intentionally absent)
+The LLM prompt does **not** enumerate the 20-opcode subset s11's parser accepts. The model is invited to use any AArch64 mnemonic it knows. Outputs that use unsupported instructions are recorded as a research signal (which mnemonics the model "wanted" to reach for), not treated as wasted calls. See ADR-0003.
+
+### Unsupported-mnemonic ledger
+A first-class output of an LLM-assisted search run, alongside the (optional) optimization. A multiset of mnemonics the model emitted that `parse_assembly_string` rejected — interpretable as "which instructions should s11 add support for next, sorted by frequency of LLM demand on real targets." Surfaced in the `SearchStatistics` (or a sibling `LlmStatistics`) returned from `SearchAlgorithm::search`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,12 +62,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,17 +187,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chacha20"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "rand_core 0.10.0",
-]
-
-[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,15 +242,6 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "crossbeam-channel"
@@ -354,12 +328,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55dd888a213fc57e957abf2aa305ee3e8a28dbe05687a251f33b637cd46b0070"
 
 [[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,12 +354,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -480,39 +442,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "rand_core 0.10.0",
- "wasip2",
- "wasip3",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -709,12 +642,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,18 +660,6 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
-dependencies = [
- "equivalent",
- "hashbrown 0.16.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -799,12 +714,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1026,16 +935,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,7 +975,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -1120,7 +1019,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1168,18 +1067,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
-dependencies = [
- "chacha20",
- "getrandom 0.4.1",
- "rand_core 0.10.0",
+ "rand_core",
 ]
 
 [[package]]
@@ -1189,7 +1077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -1202,18 +1090,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
-
-[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.9.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -1409,17 +1291,11 @@ dependencies = [
  "elf",
  "num_cpus",
  "proptest",
- "rand 0.10.0",
+ "rand",
  "rand_chacha",
  "rayon",
  "z3",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -1724,12 +1600,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1789,16 +1659,7 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen 0.46.0",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -1858,40 +1719,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -2090,94 +1917,6 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,8 +1076,8 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.3",
- "rand_chacha 0.9.0",
+ "rand 0.9.2",
+ "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -1120,7 +1120,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.3",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1167,7 +1167,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.3",
 ]
 
@@ -1190,16 +1190,6 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -1420,7 +1410,7 @@ dependencies = [
  "num_cpus",
  "proptest",
  "rand 0.10.0",
- "rand_chacha 0.10.0",
+ "rand_chacha",
  "rayon",
  "z3",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
  "chacha20",
  "getrandom 0.4.1",
@@ -1419,7 +1419,7 @@ dependencies = [
  "elf",
  "num_cpus",
  "proptest",
- "rand 0.10.1",
+ "rand 0.10.0",
  "rand_chacha 0.10.0",
  "rayon",
  "z3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,6 +1294,8 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rayon",
+ "serde",
+ "serde_json",
  "z3",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ z3 = { version = "0.19", optional = true }
 dynasmrt = "4.0.1"
 dynasm = "4.0.1"
 rand = "0.10"
-rand_chacha = "0.10"
+rand_chacha = "0.9"
 rayon = "1.10"
 crossbeam-channel = "0.5"
 num_cpus = "1.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ rand_chacha = "0.9"
 rayon = "1.10"
 crossbeam-channel = "0.5"
 num_cpus = "1.16"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [features]
 default = ["z3"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ clap = { version = "4.5", features = ["derive"] }
 z3 = { version = "0.19", optional = true }
 dynasmrt = "4.0.1"
 dynasm = "4.0.1"
-rand = "0.10"
+rand = "0.9"
 rand_chacha = "0.9"
 rayon = "1.10"
 crossbeam-channel = "0.5"

--- a/Justfile
+++ b/Justfile
@@ -72,6 +72,12 @@ test-all: build-tests build
     @echo "Running complete test suite..."
     ./test_all.sh
 
+# Run the LLM-assisted superoptimizer demo against the local corpus.
+# Requires `codex` CLI installed and authenticated (subscription).
+llm-demo: build
+    @echo "Running LLM-assisted superoptimizer demo..."
+    ./tests/data/llm_demo/run_demo.sh
+
 # Help message (can be more detailed than just listing)
 help:
     @echo "Available commands for AArch64 Super-Optimizer MVP (run with 'just <command>'):"

--- a/docs/adr/0001-derive-live-in-from-def-use.md
+++ b/docs/adr/0001-derive-live-in-from-def-use.md
@@ -1,0 +1,32 @@
+# ADR-0001 — Derive live-in from intra-sequence def-use rather than threading through the search trait
+
+Status: Accepted
+Date: 2026-05-07
+
+## Context
+
+The LLM-assisted search algorithm (`LlmSearch`, see `src/search/llm/`) needs to tell the model which registers (and flags) the target reads before writing — i.e., the target's live-in set. The existing `SearchAlgorithm::search` trait at `src/search/mod.rs:39` exposes only `live_out` and the target itself. No live-in is plumbed through.
+
+Three options were considered:
+
+1. **Extend the trait** with a `live_in: &LiveInMask` argument. Forces every existing impl (enumerative, stochastic, symbolic) to accept and ignore a parameter only one consumer uses.
+2. **Derive live-in from the target via def-use analysis** inside `LlmSearch`, reusing the `target` argument the trait already provides. Add a `compute_live_in_registers(&[Instruction])` helper alongside the existing `compute_written_registers` in `src/validation/live_out.rs`.
+3. **Configure live-in on the `LlmSearch` struct** via a builder method, requiring the caller to compute and pass live-in explicitly.
+
+## Decision
+
+Option 2: derive live-in from the target via intra-sequence def-use analysis.
+
+A new helper `compute_live_in_registers(&[Instruction]) -> LiveOutMask` is added in `src/validation/live_out.rs` (the type is reused — it's structurally a set-of-registers, despite the name). Flag-livein is tracked by a separate boolean predicate `reads_flags_before_writing(&[Instruction]) -> bool` because flags don't fit `LiveOutMask`'s bitset.
+
+## Consequences
+
+**Positive:**
+- The `SearchAlgorithm` trait stays unchanged; existing impls untouched.
+- The derived live-in is **the semantically correct one** for an isolated sequence — a register the target reads before defining is, definitionally, live-in. Over-approximation ("all registers are live-in") would tell the LLM nothing; under-approximation (caller-supplied) risks the LLM thinking it can clobber a value the target reads.
+- The helper has wider value: symbolic synthesis can constrain free variables tighter, stochastic search can pick scratch registers from the non-live-in set.
+
+**Negative / scope:**
+- This is **intra-sequence only**. It tells us what the sequence *itself* reads, not what the caller's downstream code expects to be untouched. For the MVP — single `s11 opt` regions of short asm — that's exactly right. For whole-function optimization with values that live across the region, this approach would need to be revisited (and at that point the trait extension becomes the right answer because the information has nowhere to come from but the caller).
+
+**Reversibility:** moderate. If we later need caller-supplied live-in, we'd add an optional builder method on `LlmSearch` and prefer it over the derived value when present. The helper itself stays useful as a default. We are not painting ourselves into a corner.

--- a/docs/adr/0002-mvp-restricts-flags-live-out.md
+++ b/docs/adr/0002-mvp-restricts-flags-live-out.md
@@ -1,0 +1,31 @@
+# ADR-0002 — LLM-assisted search MVP refuses targets with flags live-out
+
+Status: Accepted
+Date: 2026-05-07
+
+## Context
+
+`LiveOutMask` (`src/semantics/state.rs`) is a register-only bitset. It does not encode whether NZCV is part of the live-out contract. The 20-opcode subset includes flag writers (`CMP`, `CMN`, `TST`) and flag readers (`CSEL`, `CSINC`, `CSINV`, `CSNEG`); a target whose final instruction is `CMP` (for example) has flags as a real downstream output even though no register value reflects it.
+
+`EquivalenceConfig` and all four search algorithms thread `LiveOutMask` through; none of them check NZCV equivalence. This is a pre-existing soundness gap with respect to flags-live-out, but only matters for the LLM flow because the LLM is the only generator that might *legitimately* drop a final flag-setting instruction (the others enumerate from a pool that includes it).
+
+Two options:
+
+1. **Restrict the MVP corpus**: refuse LLM-flow execution on targets where flags are live-out (statically detectable: any flag writer with no later flag-using or flag-overwriting instruction before the end). Sound. Narrower applicable input class than other search algorithms.
+2. **Extend live-out contract to include flags**: thread a `flags_live_out: bool` through `LiveOutMask` and `EquivalenceConfig`, update all four algorithms, update the SMT encoding to constrain NZCV. Wider impact, deserves its own ADR, slows down the MVP.
+
+## Decision
+
+Option 1. The LLM flow refuses to run on targets where static analysis says flags are live-out, with a clear diagnostic message.
+
+## Consequences
+
+**Positive:**
+- The MVP's verifier (`check_equivalence_with_config`) is **sound** for the corpus the LLM flow accepts. No risk of declaring a candidate equivalent when it has dropped a needed flag-setter.
+- The change scope is local to `src/search/llm/` plus a static-analysis helper. No edits to existing search algorithms, the SMT module, or `LiveOutMask`.
+
+**Negative:**
+- The LLM flow has a **narrower applicable input class than the rest of the optimizer**. A user who feeds it a region ending in `CMP` for a downstream branch sees a refusal, not an attempt.
+- We are explicitly accepting a known pre-existing soundness gap (flags-live-out is unmodelled by `EquivalenceConfig` for *all* algorithms) rather than fixing it. Fix is deferred.
+
+**Reversibility:** high. When flags-live-out becomes a supported part of the live-out contract (its own ADR), the static refusal in the LLM flow is replaced by passing the flag-live-out bit through to the prompt and the equivalence check.

--- a/docs/adr/0003-llm-prompt-no-subset-hint.md
+++ b/docs/adr/0003-llm-prompt-no-subset-hint.md
@@ -1,0 +1,34 @@
+# ADR-0003 — LLM prompt does not constrain the model to the s11 mnemonic subset; rejected outputs become a research signal
+
+Status: Accepted
+Date: 2026-05-07
+
+## Context
+
+`parse_assembly_string` in `src/parser/mod.rs` accepts only a 20-opcode subset of AArch64 (MOV, ADD, SUB, AND, ORR, EOR, LSL, LSR, ASR, MUL, SDIV, UDIV, CMP, CMN, TST, CSEL, CSINC, CSINV, CSNEG). The LLM-assisted search algorithm could either:
+
+1. **Tell the model about the subset** (a ~40-token instruction in the system prompt), reducing parse-rejection rate but biasing the model toward its training distribution within that subset.
+2. **Say nothing about the subset**, allowing the model to use any AArch64 mnemonic it knows. Many completions will be rejected at the parse stage. The rejected mnemonics are themselves informative: the model is implicitly voting for which instructions s11 should support next.
+3. **Tell the model and also log** when it ignores the constraint (impossible to distinguish from confused output).
+
+## Decision
+
+Option 2: do not constrain the model in the prompt. Treat parse-rejection as a first-class output, not lossage.
+
+Concretely:
+- The prompt contains the live-in registers, live-out registers, and the target asm. No mnemonic list, no flags discussion, no SMT mention.
+- Each Codex call's response is run through `parse_assembly_string`. On parse failure, the offending mnemonics (extracted from the parse error or by simple pre-tokenisation) are recorded in an **unsupported-mnemonic ledger** carried in `SearchStatistics` (or a sibling `LlmStatistics`).
+- The loop continues to the next call (subject to the calls + time budget) — parse-rejection is a non-fatal outcome of an iteration, on equal footing with "rejected by fast equivalence" and "not strictly shorter."
+
+## Consequences
+
+**Positive:**
+- The MVP gets a free side-output: a frequency-ranked list of "instructions s11 doesn't support that the LLM wants to use." That directly informs the next phase of s11's instruction-set growth, with empirical demand data.
+- The prompt stays minimal — no hand-curated subset list to maintain as s11 adds opcodes.
+- The model is not biased into a smaller search space; it can suggest any rewrite it knows, and we filter post-hoc.
+
+**Negative:**
+- A meaningful fraction of Codex calls per run will return parse-rejected output. With the user's subscription, marginal call cost is ~zero, but wall-clock budget and `max_codex_calls` budget are both consumed by these rejections. The MVP defaults (60s timeout, 20 calls) need to be set with this in mind.
+- Two failure modes look superficially similar in logs ("LLM didn't help") — parse-rejection vs equivalence-rejection — and must be reported separately for the ledger to be useful.
+
+**Reversibility:** trivial. If parse-rejection rate proves catastrophic in practice, append the subset list to the system prompt — one-line change, ledger keeps working.

--- a/src/main.rs
+++ b/src/main.rs
@@ -580,6 +580,7 @@ fn run_optimization(
             let result = search.search(target, &live_out, &config);
 
             print_search_statistics(&result.statistics);
+            print_llm_timings(search.timings(), result.statistics.elapsed_time);
             print_unsupported_mnemonic_ledger(search.ledger());
 
             if result.found_optimization {
@@ -629,6 +630,38 @@ fn run_optimization(
                 Ok(None)
             }
         }
+    }
+}
+
+/// Print the per-phase timing breakdown from an LLM-assisted run.
+fn print_llm_timings(timings: &search::llm::LlmTimings, total: Duration) {
+    let codex = timings.codex_time.as_secs_f64();
+    let verify = timings.verify_time.as_secs_f64();
+    let other = (total.as_secs_f64() - codex - verify).max(0.0);
+    println!("\nLLM phase timing:");
+    println!(
+        "  Codex calls:      {:>7.2}s   ({} call{})",
+        codex,
+        timings.codex_calls,
+        if timings.codex_calls == 1 { "" } else { "s" }
+    );
+    println!(
+        "  Verification:     {:>7.2}s   ({} verification{}, parse + fast + SMT)",
+        verify,
+        timings.verifications,
+        if timings.verifications == 1 { "" } else { "s" }
+    );
+    println!("  Other:            {:>7.2}s", other);
+    println!("  Total:            {:>7.2}s", total.as_secs_f64());
+    if total.as_secs_f64() > 0.0 {
+        println!(
+            "  Codex share:      {:>6.1}%",
+            100.0 * codex / total.as_secs_f64()
+        );
+        println!(
+            "  Verify share:     {:>6.1}%",
+            100.0 * verify / total.as_secs_f64()
+        );
     }
 }
 
@@ -947,6 +980,7 @@ fn run_llm_opt(
     let result = searcher.search(&target, &live_out, &config);
 
     print_search_statistics(&result.statistics);
+    print_llm_timings(searcher.timings(), result.statistics.elapsed_time);
     print_unsupported_mnemonic_ledger(searcher.ledger());
 
     println!();

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,9 @@ mod validation;
 use assembler::AArch64Assembler;
 use elf_patcher::{AddressWindow, ElfPatcher, parse_hex_address};
 use ir::{Instruction, Operand, Register};
-use search::config::{Algorithm, SearchConfig, SearchMode, StochasticConfig, SymbolicConfig};
+use search::config::{
+    Algorithm, LlmConfig, SearchConfig, SearchMode, StochasticConfig, SymbolicConfig,
+};
 use search::parallel::{ParallelConfig, run_parallel_search};
 use search::{SearchAlgorithm, StochasticSearch, SymbolicSearch};
 use semantics::cost::CostMetric;
@@ -189,7 +191,7 @@ enum Commands {
         #[arg(long, default_value = "20")]
         llm_max_calls: u32,
         /// Codex model identifier (LLM algorithm)
-        #[arg(long, default_value = "gpt-5.3-codex-spark")]
+        #[arg(long, default_value_t = search::config::DEFAULT_LLM_MODEL.to_string())]
         llm_model: String,
     },
     /// Run LLM-assisted optimization on a single assembly file (demo entry point)
@@ -204,7 +206,7 @@ enum Commands {
         #[arg(long, default_value = "20")]
         max_calls: u32,
         /// Codex model identifier
-        #[arg(long, default_value = "gpt-5.3-codex-spark")]
+        #[arg(long, default_value_t = search::config::DEFAULT_LLM_MODEL.to_string())]
         model: String,
         /// Overall timeout in seconds (across all calls)
         #[arg(long, default_value = "120")]
@@ -567,14 +569,17 @@ fn run_optimization(
             println!("  Model: {}", options.llm_model);
             println!("  Max codex calls: {}", options.llm_max_calls);
 
-            let mut config = SearchConfig::default()
+            let llm = LlmConfig::default()
+                .with_max_codex_calls(options.llm_max_calls)
+                .with_model(options.llm_model.clone());
+
+            let config = SearchConfig::default()
                 .with_cost_metric(options.cost_metric)
                 .with_timeout_option(options.timeout)
                 .with_verbose(options.verbose)
                 .with_registers(available_registers)
-                .with_immediates(available_immediates);
-            config.llm.max_codex_calls = options.llm_max_calls;
-            config.llm.model = options.llm_model.clone();
+                .with_immediates(available_immediates)
+                .with_llm(llm);
 
             let mut search = search::llm::LlmSearch::new();
             let result = search.search(target, &live_out, &config);
@@ -704,12 +709,11 @@ fn print_llm_timings(timings: &search::llm::LlmTimings, total: Duration) {
 
 /// Print the unsupported-mnemonic ledger from an LLM-assisted run.
 fn print_unsupported_mnemonic_ledger(ledger: &search::llm::ledger::UnsupportedMnemonicLedger) {
-    let entries = ledger.clone().into_sorted();
-    if entries.is_empty() {
+    if ledger.is_empty() {
         return;
     }
     println!("\nUnsupported mnemonics emitted by the LLM (frequency-ranked):");
-    for (mnem, count) in entries {
+    for (mnem, count) in ledger.sorted_entries() {
         println!("  {:>5}  {}", count, mnem);
     }
 }
@@ -1006,12 +1010,15 @@ fn run_llm_opt(
         .parse()
         .map_err(|e: validation::live_out::ParseLiveOutError| e.to_string())?;
 
-    let mut config = SearchConfig::default()
+    let llm = LlmConfig::default()
+        .with_max_codex_calls(max_calls)
+        .with_model(model);
+
+    let config = SearchConfig::default()
+        .with_algorithm(Algorithm::Llm)
         .with_timeout(Duration::from_secs(timeout_secs))
-        .with_verbose(verbose);
-    config.algorithm = Algorithm::Llm;
-    config.llm.max_codex_calls = max_calls;
-    config.llm.model = model.to_string();
+        .with_verbose(verbose)
+        .with_llm(llm);
 
     let mut searcher = search::llm::LlmSearch::new();
     let result = searcher.search(&target, &live_out, &config);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1014,6 +1014,12 @@ fn run_llm_opt(
         .with_max_codex_calls(max_calls)
         .with_model(model);
 
+    // Note: `available_registers` and `available_immediates` are intentionally
+    // omitted here. `LlmSearch` does not enumerate over a register/immediate
+    // pool — Codex generates candidates directly. The other algorithms
+    // (enumerative, stochastic, symbolic) need those fields and set them in
+    // `optimize_elf_binary`. If `LlmSearch` ever falls back to one of those
+    // generators, this entry point must populate the pools too.
     let config = SearchConfig::default()
         .with_algorithm(Algorithm::Llm)
         .with_timeout(Duration::from_secs(timeout_secs))

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,8 @@ enum CliAlgorithm {
     Symbolic,
     /// Hybrid parallel search (symbolic + multiple stochastic workers)
     Hybrid,
+    /// LLM-assisted search via Codex CLI
+    Llm,
 }
 
 impl From<CliAlgorithm> for Algorithm {
@@ -57,6 +59,7 @@ impl From<CliAlgorithm> for Algorithm {
             CliAlgorithm::Stochastic => Algorithm::Stochastic,
             CliAlgorithm::Symbolic => Algorithm::Symbolic,
             CliAlgorithm::Hybrid => Algorithm::Hybrid,
+            CliAlgorithm::Llm => Algorithm::Llm,
         }
     }
 }
@@ -180,6 +183,35 @@ enum Commands {
         /// Disable symbolic worker in hybrid mode (all workers run stochastic)
         #[arg(long)]
         no_symbolic: bool,
+
+        // --- LLM-assisted search options ---
+        /// Maximum number of `codex exec` invocations per target (LLM algorithm)
+        #[arg(long, default_value = "20")]
+        llm_max_calls: u32,
+        /// Codex model identifier (LLM algorithm)
+        #[arg(long, default_value = "gpt-5.3-codex-spark")]
+        llm_model: String,
+    },
+    /// Run LLM-assisted optimization on a single assembly file (demo entry point)
+    LlmOpt {
+        /// Path to an .s file containing the target sequence (GAS syntax)
+        #[arg(long)]
+        asm: PathBuf,
+        /// Live-out registers (comma-separated, e.g. "x0,x1")
+        #[arg(long)]
+        live_out: String,
+        /// Maximum number of `codex exec` invocations
+        #[arg(long, default_value = "20")]
+        max_calls: u32,
+        /// Codex model identifier
+        #[arg(long, default_value = "gpt-5.3-codex-spark")]
+        model: String,
+        /// Overall timeout in seconds (across all calls)
+        #[arg(long, default_value = "120")]
+        timeout: u64,
+        /// Enable verbose output
+        #[arg(short, long)]
+        verbose: bool,
     },
     /// Check semantic equivalence of two assembly files
     Equiv {
@@ -329,6 +361,9 @@ struct OptimizationOptions {
     // Parallel/Hybrid options
     cores: Option<usize>,
     no_symbolic: bool,
+    // LLM options
+    llm_max_calls: u32,
+    llm_model: String,
 }
 
 // --- Optimization Function ---
@@ -527,6 +562,32 @@ fn run_optimization(
                 Ok(None)
             }
         }
+        Algorithm::Llm => {
+            println!("\nRunning LLM-assisted (Codex) search...");
+            println!("  Model: {}", options.llm_model);
+            println!("  Max codex calls: {}", options.llm_max_calls);
+
+            let mut config = SearchConfig::default()
+                .with_cost_metric(options.cost_metric)
+                .with_timeout_option(options.timeout)
+                .with_verbose(options.verbose)
+                .with_registers(available_registers)
+                .with_immediates(available_immediates);
+            config.llm.max_codex_calls = options.llm_max_calls;
+            config.llm.model = options.llm_model.clone();
+
+            let mut search = search::llm::LlmSearch::new();
+            let result = search.search(target, &live_out, &config);
+
+            print_search_statistics(&result.statistics);
+            print_unsupported_mnemonic_ledger(search.ledger());
+
+            if result.found_optimization {
+                Ok(result.optimized_sequence)
+            } else {
+                Ok(None)
+            }
+        }
         Algorithm::Hybrid => {
             let num_cores = options.cores.unwrap_or_else(num_cpus::get);
             println!("\nRunning hybrid parallel search...");
@@ -568,6 +629,18 @@ fn run_optimization(
                 Ok(None)
             }
         }
+    }
+}
+
+/// Print the unsupported-mnemonic ledger from an LLM-assisted run.
+fn print_unsupported_mnemonic_ledger(ledger: &search::llm::ledger::UnsupportedMnemonicLedger) {
+    let entries = ledger.clone().into_sorted();
+    if entries.is_empty() {
+        return;
+    }
+    println!("\nUnsupported mnemonics emitted by the LLM (frequency-ranked):");
+    for (mnem, count) in entries {
+        println!("  {:>5}  {}", count, mnem);
     }
 }
 
@@ -843,6 +916,45 @@ fn find_shorter_equivalent(original_seq: &[Instruction]) -> Option<Vec<Instructi
 
 // --- Equivalence Checking Command ---
 
+fn run_llm_opt(
+    asm: &Path,
+    live_out_str: &str,
+    max_calls: u32,
+    model: &str,
+    timeout_secs: u64,
+    verbose: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let target = parser::parse_assembly_file(asm)?;
+    if verbose {
+        println!("Target ({} instructions):", target.len());
+        for instr in &target {
+            println!("  {}", instr);
+        }
+    }
+
+    let live_out: LiveOutMask = live_out_str
+        .parse()
+        .map_err(|e: validation::live_out::ParseLiveOutError| e.to_string())?;
+
+    let mut config = SearchConfig::default()
+        .with_timeout(Duration::from_secs(timeout_secs))
+        .with_verbose(verbose);
+    config.algorithm = Algorithm::Llm;
+    config.llm.max_codex_calls = max_calls;
+    config.llm.model = model.to_string();
+
+    let mut searcher = search::llm::LlmSearch::new();
+    let result = searcher.search(&target, &live_out, &config);
+
+    print_search_statistics(&result.statistics);
+    print_unsupported_mnemonic_ledger(searcher.ledger());
+
+    println!();
+    println!("{}", result);
+
+    Ok(())
+}
+
 fn run_equiv(
     file1: &Path,
     file2: &Path,
@@ -1005,6 +1117,8 @@ fn main() {
             solver_timeout,
             cores,
             no_symbolic,
+            llm_max_calls,
+            llm_model,
         } => {
             // Architecture selection
             if let Some(a) = arch {
@@ -1048,6 +1162,8 @@ fn main() {
                 solver_timeout: Duration::from_secs(solver_timeout),
                 cores,
                 no_symbolic,
+                llm_max_calls,
+                llm_model,
             };
 
             match optimize_elf_binary(&binary, start_addr, end_addr, &options) {
@@ -1058,6 +1174,20 @@ fn main() {
                 }
             }
         }
+        Commands::LlmOpt {
+            asm,
+            live_out,
+            max_calls,
+            model,
+            timeout,
+            verbose,
+        } => match run_llm_opt(&asm, &live_out, max_calls, &model, timeout, verbose) {
+            Ok(()) => {}
+            Err(e) => {
+                eprintln!("llm-opt: {}", e);
+                std::process::exit(1);
+            }
+        },
         Commands::Equiv {
             file1,
             file2,

--- a/src/main.rs
+++ b/src/main.rs
@@ -633,34 +633,46 @@ fn run_optimization(
     }
 }
 
+/// Format a Duration with a unit chosen to keep ~3 significant digits visible.
+fn fmt_dur(d: Duration) -> String {
+    let secs = d.as_secs_f64();
+    if secs >= 1.0 {
+        format!("{:>8.2} s ", secs)
+    } else if secs >= 0.001 {
+        format!("{:>8.2} ms", secs * 1_000.0)
+    } else {
+        format!("{:>8.1} µs", secs * 1_000_000.0)
+    }
+}
+
 /// Print the per-phase timing breakdown from an LLM-assisted run.
 fn print_llm_timings(timings: &search::llm::LlmTimings, total: Duration) {
-    let codex = timings.codex_time.as_secs_f64();
-    let verify = timings.verify_time.as_secs_f64();
-    let other = (total.as_secs_f64() - codex - verify).max(0.0);
+    let codex = timings.codex_time;
+    let verify = timings.verify_time;
+    let other = total.saturating_sub(codex).saturating_sub(verify);
     println!("\nLLM phase timing:");
     println!(
-        "  Codex calls:      {:>7.2}s   ({} call{})",
-        codex,
+        "  Codex calls:      {}   ({} call{})",
+        fmt_dur(codex),
         timings.codex_calls,
         if timings.codex_calls == 1 { "" } else { "s" }
     );
     println!(
-        "  Verification:     {:>7.2}s   ({} verification{}, parse + fast + SMT)",
-        verify,
+        "  Verification:     {}   ({} verification{}, parse + fast + SMT)",
+        fmt_dur(verify),
         timings.verifications,
         if timings.verifications == 1 { "" } else { "s" }
     );
-    println!("  Other:            {:>7.2}s", other);
-    println!("  Total:            {:>7.2}s", total.as_secs_f64());
+    println!("  Other:            {}", fmt_dur(other));
+    println!("  Total:            {}", fmt_dur(total));
     if total.as_secs_f64() > 0.0 {
         println!(
-            "  Codex share:      {:>6.1}%",
-            100.0 * codex / total.as_secs_f64()
+            "  Codex share:      {:>6.2}%",
+            100.0 * codex.as_secs_f64() / total.as_secs_f64()
         );
         println!(
-            "  Verify share:     {:>6.1}%",
-            100.0 * verify / total.as_secs_f64()
+            "  Verify share:     {:>6.2}%",
+            100.0 * verify.as_secs_f64() / total.as_secs_f64()
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -633,6 +633,17 @@ fn run_optimization(
     }
 }
 
+/// Format a byte count with a unit chosen to keep ~3 significant digits visible.
+fn fmt_bytes(n: usize) -> String {
+    if n >= 1_048_576 {
+        format!("{:>7.2} MB", n as f64 / 1_048_576.0)
+    } else if n >= 1_024 {
+        format!("{:>7.2} kB", n as f64 / 1_024.0)
+    } else {
+        format!("{:>7} B ", n)
+    }
+}
+
 /// Format a Duration with a unit chosen to keep ~3 significant digits visible.
 fn fmt_dur(d: Duration) -> String {
     let secs = d.as_secs_f64();
@@ -663,6 +674,20 @@ fn print_llm_timings(timings: &search::llm::LlmTimings, total: Duration) {
         timings.verifications,
         if timings.verifications == 1 { "" } else { "s" }
     );
+    if timings.smt_calls > 0 {
+        let avg_bytes = timings.smt_formula_bytes_total / timings.smt_calls as usize;
+        println!(
+            "    SMT invoked:    {} time{}",
+            timings.smt_calls,
+            if timings.smt_calls == 1 { "" } else { "s" }
+        );
+        println!(
+            "    SMT formula:    {}  total   ({}  avg, {}  max)",
+            fmt_bytes(timings.smt_formula_bytes_total),
+            fmt_bytes(avg_bytes),
+            fmt_bytes(timings.smt_formula_bytes_max),
+        );
+    }
     println!("  Other:            {}", fmt_dur(other));
     println!("  Total:            {}", fmt_dur(total));
     if total.as_secs_f64() > 0.0 {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -92,6 +92,8 @@ impl fmt::Display for ParseLineError {
     }
 }
 
+impl std::error::Error for ParseLineError {}
+
 /// Parse a register name (case-insensitive)
 pub fn parse_register(s: &str) -> Result<Register, String> {
     match s.to_lowercase().as_str() {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -30,6 +30,7 @@ impl ParseError {
         }
     }
 
+    #[allow(dead_code)]
     pub fn with_column(mut self, column: usize) -> Self {
         self.column = Some(column);
         self

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -70,6 +70,28 @@ pub enum LineResult {
     Skip,
 }
 
+/// Structured failure mode for `parse_line`. Distinguishes "the parser doesn't
+/// recognise this opcode" from any other parse failure (operand parsing,
+/// encoding-range violations, etc.) so consumers can act on the unknown
+/// mnemonic without string-matching the human-readable message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseLineError {
+    /// The leading token is not one of the parser's supported mnemonics.
+    /// The string is the offending mnemonic, lowercased.
+    UnknownInstruction(String),
+    /// Any other parse failure (operand error, encoding error, etc.).
+    Other(String),
+}
+
+impl fmt::Display for ParseLineError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ParseLineError::UnknownInstruction(m) => write!(f, "unknown instruction: {}", m),
+            ParseLineError::Other(s) => f.write_str(s),
+        }
+    }
+}
+
 /// Parse a register name (case-insensitive)
 pub fn parse_register(s: &str) -> Result<Register, String> {
     match s.to_lowercase().as_str() {
@@ -464,7 +486,7 @@ fn parse_csneg(operands: &[&str]) -> Result<Instruction, String> {
 }
 
 /// Parse a single line of assembly
-pub fn parse_line(line: &str) -> Result<LineResult, String> {
+pub fn parse_line(line: &str) -> Result<LineResult, ParseLineError> {
     // Strip comments first
     let line = strip_comments(line);
     let trimmed = line.trim();
@@ -500,34 +522,34 @@ pub fn parse_line(line: &str) -> Result<LineResult, String> {
     };
 
     let instruction = match opcode.as_str() {
-        "mov" => parse_mov(&operands)?,
-        "add" => parse_add(&operands)?,
-        "sub" => parse_sub(&operands)?,
-        "and" => parse_and(&operands)?,
-        "orr" => parse_orr(&operands)?,
-        "eor" => parse_eor(&operands)?,
-        "lsl" => parse_lsl(&operands)?,
-        "lsr" => parse_lsr(&operands)?,
-        "asr" => parse_asr(&operands)?,
-        "mul" => parse_mul(&operands)?,
-        "sdiv" => parse_sdiv(&operands)?,
-        "udiv" => parse_udiv(&operands)?,
-        "cmp" => parse_cmp(&operands)?,
-        "cmn" => parse_cmn(&operands)?,
-        "tst" => parse_tst(&operands)?,
-        "csel" => parse_csel(&operands)?,
-        "csinc" => parse_csinc(&operands)?,
-        "csinv" => parse_csinv(&operands)?,
-        "csneg" => parse_csneg(&operands)?,
-        _ => return Err(format!("unknown instruction: {}", opcode)),
+        "mov" => parse_mov(&operands).map_err(ParseLineError::Other)?,
+        "add" => parse_add(&operands).map_err(ParseLineError::Other)?,
+        "sub" => parse_sub(&operands).map_err(ParseLineError::Other)?,
+        "and" => parse_and(&operands).map_err(ParseLineError::Other)?,
+        "orr" => parse_orr(&operands).map_err(ParseLineError::Other)?,
+        "eor" => parse_eor(&operands).map_err(ParseLineError::Other)?,
+        "lsl" => parse_lsl(&operands).map_err(ParseLineError::Other)?,
+        "lsr" => parse_lsr(&operands).map_err(ParseLineError::Other)?,
+        "asr" => parse_asr(&operands).map_err(ParseLineError::Other)?,
+        "mul" => parse_mul(&operands).map_err(ParseLineError::Other)?,
+        "sdiv" => parse_sdiv(&operands).map_err(ParseLineError::Other)?,
+        "udiv" => parse_udiv(&operands).map_err(ParseLineError::Other)?,
+        "cmp" => parse_cmp(&operands).map_err(ParseLineError::Other)?,
+        "cmn" => parse_cmn(&operands).map_err(ParseLineError::Other)?,
+        "tst" => parse_tst(&operands).map_err(ParseLineError::Other)?,
+        "csel" => parse_csel(&operands).map_err(ParseLineError::Other)?,
+        "csinc" => parse_csinc(&operands).map_err(ParseLineError::Other)?,
+        "csinv" => parse_csinv(&operands).map_err(ParseLineError::Other)?,
+        "csneg" => parse_csneg(&operands).map_err(ParseLineError::Other)?,
+        _ => return Err(ParseLineError::UnknownInstruction(opcode)),
     };
 
     // Validate encoding
     if !instruction.is_encodable_aarch64() {
-        return Err(format!(
+        return Err(ParseLineError::Other(format!(
             "instruction cannot be encoded in AArch64: {}",
             instruction
-        ));
+        )));
     }
 
     Ok(LineResult::Instruction(instruction))
@@ -563,8 +585,8 @@ pub fn parse_assembly_string(
             Ok(LineResult::Skip) => {
                 // Nothing to do
             }
-            Err(msg) => {
-                return Err(ParseError::new(line_number, msg, line));
+            Err(err) => {
+                return Err(ParseError::new(line_number, err.to_string(), line));
             }
         }
     }

--- a/src/search/config.rs
+++ b/src/search/config.rs
@@ -258,9 +258,8 @@ impl SymbolicConfig {
 /// Default Codex model identifier used by the LLM-assisted search flow.
 ///
 /// Single source of truth for the model name; CLI defaults reference this
-/// constant rather than embedding the literal in multiple places.
-/// Identifier comes from the OpenAI Codex Spark announcement
-/// (https://openai.com/index/introducing-gpt-5-3-codex-spark/).
+/// constant rather than embedding the literal in multiple places. Identifier
+/// is the OpenAI Codex Spark model exposed via the `codex` CLI.
 pub const DEFAULT_LLM_MODEL: &str = "gpt-5.3-codex-spark";
 
 /// Configuration for the LLM-assisted (Codex) search algorithm.

--- a/src/search/config.rs
+++ b/src/search/config.rs
@@ -269,7 +269,15 @@ pub struct LlmConfig {
     pub max_codex_calls: u32,
     /// Codex model identifier (passed to `codex exec -m`).
     pub model: String,
-    /// Path to the `codex` binary (override for testing or unusual installs).
+    /// Path to the `codex` binary. Override for tests or unusual installs.
+    ///
+    /// **Security note:** treat this field as a Rust-only override. It is
+    /// **not** wired up to any CLI flag, environment variable, or config file
+    /// — only Rust callers within this crate can change it. If a future
+    /// change exposes this to user input, it becomes an arbitrary-command-
+    /// execution surface (we `Command::new(codex_bin)` the value), and that
+    /// route should be locked down (e.g., resolve through `which` and reject
+    /// non-canonical paths) before being shipped.
     pub codex_bin: String,
 }
 

--- a/src/search/config.rs
+++ b/src/search/config.rs
@@ -18,6 +18,8 @@ pub enum Algorithm {
     Symbolic,
     /// Hybrid: parallel execution with symbolic + multiple stochastic workers
     Hybrid,
+    /// LLM-assisted search via Codex CLI
+    Llm,
 }
 
 impl std::fmt::Display for Algorithm {
@@ -27,6 +29,7 @@ impl std::fmt::Display for Algorithm {
             Algorithm::Stochastic => write!(f, "stochastic"),
             Algorithm::Symbolic => write!(f, "symbolic"),
             Algorithm::Hybrid => write!(f, "hybrid"),
+            Algorithm::Llm => write!(f, "llm"),
         }
     }
 }
@@ -40,8 +43,9 @@ impl std::str::FromStr for Algorithm {
             "stochastic" | "stoch" | "mcmc" => Ok(Algorithm::Stochastic),
             "symbolic" | "sym" | "smt" => Ok(Algorithm::Symbolic),
             "hybrid" | "parallel" => Ok(Algorithm::Hybrid),
+            "llm" | "codex" => Ok(Algorithm::Llm),
             _ => Err(format!(
-                "Unknown algorithm: '{}'. Valid options: enumerative, stochastic, symbolic, hybrid",
+                "Unknown algorithm: '{}'. Valid options: enumerative, stochastic, symbolic, hybrid, llm",
                 s
             )),
         }
@@ -251,6 +255,27 @@ impl SymbolicConfig {
     }
 }
 
+/// Configuration for the LLM-assisted (Codex) search algorithm.
+#[derive(Debug, Clone)]
+pub struct LlmConfig {
+    /// Maximum number of `codex exec` invocations per search.
+    pub max_codex_calls: u32,
+    /// Codex model identifier (passed to `codex exec -m`).
+    pub model: String,
+    /// Path to the `codex` binary (override for testing or unusual installs).
+    pub codex_bin: String,
+}
+
+impl Default for LlmConfig {
+    fn default() -> Self {
+        Self {
+            max_codex_calls: 20,
+            model: "gpt-5.3-codex-spark".to_string(),
+            codex_bin: "codex".to_string(),
+        }
+    }
+}
+
 /// Main search configuration
 #[derive(Debug, Clone)]
 pub struct SearchConfig {
@@ -268,6 +293,8 @@ pub struct SearchConfig {
     pub stochastic: StochasticConfig,
     /// Symbolic-specific configuration
     pub symbolic: SymbolicConfig,
+    /// LLM-specific configuration
+    pub llm: LlmConfig,
     /// Verbose output during search
     pub verbose: bool,
 }
@@ -291,6 +318,7 @@ impl Default for SearchConfig {
             ],
             stochastic: StochasticConfig::default(),
             symbolic: SymbolicConfig::default(),
+            llm: LlmConfig::default(),
             verbose: false,
         }
     }

--- a/src/search/config.rs
+++ b/src/search/config.rs
@@ -255,6 +255,14 @@ impl SymbolicConfig {
     }
 }
 
+/// Default Codex model identifier used by the LLM-assisted search flow.
+///
+/// Single source of truth for the model name; CLI defaults reference this
+/// constant rather than embedding the literal in multiple places.
+/// Identifier comes from the OpenAI Codex Spark announcement
+/// (https://openai.com/index/introducing-gpt-5-3-codex-spark/).
+pub const DEFAULT_LLM_MODEL: &str = "gpt-5.3-codex-spark";
+
 /// Configuration for the LLM-assisted (Codex) search algorithm.
 #[derive(Debug, Clone)]
 pub struct LlmConfig {
@@ -270,9 +278,26 @@ impl Default for LlmConfig {
     fn default() -> Self {
         Self {
             max_codex_calls: 20,
-            model: "gpt-5.3-codex-spark".to_string(),
+            model: DEFAULT_LLM_MODEL.to_string(),
             codex_bin: "codex".to_string(),
         }
+    }
+}
+
+impl LlmConfig {
+    pub fn with_max_codex_calls(mut self, n: u32) -> Self {
+        self.max_codex_calls = n;
+        self
+    }
+
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = model.into();
+        self
+    }
+
+    pub fn with_codex_bin(mut self, bin: impl Into<String>) -> Self {
+        self.codex_bin = bin.into();
+        self
     }
 }
 
@@ -352,6 +377,11 @@ impl SearchConfig {
 
     pub fn with_stochastic(mut self, stochastic: StochasticConfig) -> Self {
         self.stochastic = stochastic;
+        self
+    }
+
+    pub fn with_llm(mut self, llm: LlmConfig) -> Self {
+        self.llm = llm;
         self
     }
 

--- a/src/search/llm/codex.rs
+++ b/src/search/llm/codex.rs
@@ -2,8 +2,9 @@
 
 use serde::Deserialize;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::search::config::LlmConfig;
 
@@ -11,6 +12,7 @@ use crate::search::config::LlmConfig;
 pub enum EnvelopeError {
     InvalidJson,
     MissingAssemblyField,
+    EmptyAssembly,
 }
 
 #[derive(Debug)]
@@ -38,23 +40,53 @@ struct Envelope {
 }
 
 /// Parse the Codex `--output-schema` envelope into the assembly string.
+///
+/// Returns `EmptyAssembly` for an envelope whose `assembly` field is the empty
+/// string — the LLM essentially saying "no candidate" — so the caller can
+/// treat it as a non-candidate iteration without burning a verifier slot.
 pub fn parse_codex_envelope(json: &str) -> Result<String, EnvelopeError> {
     let env: Envelope = serde_json::from_str(json).map_err(|_| EnvelopeError::InvalidJson)?;
-    env.assembly.ok_or(EnvelopeError::MissingAssemblyField)
+    let asm = env.assembly.ok_or(EnvelopeError::MissingAssemblyField)?;
+    if asm.trim().is_empty() {
+        return Err(EnvelopeError::EmptyAssembly);
+    }
+    Ok(asm)
+}
+
+/// Per-process monotonic counter ensuring temp-file paths are unique across
+/// concurrent and sequential `invoke_codex` calls within a single process.
+/// Combined with the PID, this avoids cross-process collisions too.
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// RAII guard that removes a path on drop. Survives early returns / panics.
+struct TempPath(PathBuf);
+
+impl Drop for TempPath {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+impl TempPath {
+    fn as_path(&self) -> &Path {
+        &self.0
+    }
 }
 
 /// Invoke `codex exec` with the given prompt and schema, return the asm string.
 ///
 /// Uses an ephemeral, read-only Codex run with subscription auth (no API key needed).
-/// Schema and answer files are written under the system temp dir.
+/// Schema and answer files are written under the system temp dir with PID +
+/// monotonic-counter naming and removed via RAII guards before this function
+/// returns (success, error, or panic).
 pub fn invoke_codex(config: &LlmConfig, prompt: &str, schema: &str) -> Result<String, CodexError> {
+    let id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
     let tmp = std::env::temp_dir();
-    let schema_path = tmp.join(format!("s11-codex-schema-{}.json", std::process::id()));
-    let answer_path = tmp.join(format!("s11-codex-answer-{}.json", std::process::id()));
+    let schema_path = TempPath(tmp.join(format!("s11-codex-schema-{}-{}.json", pid, id)));
+    let answer_path = TempPath(tmp.join(format!("s11-codex-answer-{}-{}.json", pid, id)));
 
-    write_file(&schema_path, schema).map_err(CodexError::Io)?;
-    // Pre-clear any stale answer file.
-    let _ = std::fs::remove_file(&answer_path);
+    write_file(schema_path.as_path(), schema).map_err(CodexError::Io)?;
 
     let output = Command::new(&config.codex_bin)
         .arg("exec")
@@ -65,9 +97,9 @@ pub fn invoke_codex(config: &LlmConfig, prompt: &str, schema: &str) -> Result<St
         .arg("--ephemeral")
         .arg("--skip-git-repo-check")
         .arg("--output-schema")
-        .arg(&schema_path)
+        .arg(schema_path.as_path())
         .arg("-o")
-        .arg(&answer_path)
+        .arg(answer_path.as_path())
         .arg(prompt)
         .output()
         .map_err(|e| CodexError::Io(e.to_string()))?;
@@ -79,7 +111,7 @@ pub fn invoke_codex(config: &LlmConfig, prompt: &str, schema: &str) -> Result<St
         });
     }
 
-    let json = std::fs::read_to_string(&answer_path)
+    let json = std::fs::read_to_string(answer_path.as_path())
         .map_err(|e| CodexError::Io(format!("reading answer file: {}", e)))?;
 
     parse_codex_envelope(&json).map_err(CodexError::Envelope)
@@ -101,9 +133,21 @@ mod tests {
     }
 
     #[test]
-    fn parses_empty_assembly() {
+    fn rejects_empty_assembly() {
         let json = r#"{"assembly":""}"#;
-        assert_eq!(parse_codex_envelope(json), Ok(String::new()));
+        assert_eq!(
+            parse_codex_envelope(json),
+            Err(EnvelopeError::EmptyAssembly)
+        );
+    }
+
+    #[test]
+    fn rejects_whitespace_only_assembly() {
+        let json = r#"{"assembly":"   \n\t  "}"#;
+        assert_eq!(
+            parse_codex_envelope(json),
+            Err(EnvelopeError::EmptyAssembly)
+        );
     }
 
     #[test]

--- a/src/search/llm/codex.rs
+++ b/src/search/llm/codex.rs
@@ -15,6 +15,22 @@ pub enum EnvelopeError {
     EmptyAssembly,
 }
 
+impl std::fmt::Display for EnvelopeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EnvelopeError::InvalidJson => f.write_str("envelope is not valid JSON"),
+            EnvelopeError::MissingAssemblyField => {
+                f.write_str("envelope is missing the `assembly` field")
+            }
+            EnvelopeError::EmptyAssembly => {
+                f.write_str("envelope `assembly` field is empty or whitespace-only")
+            }
+        }
+    }
+}
+
+impl std::error::Error for EnvelopeError {}
+
 #[derive(Debug)]
 pub enum CodexError {
     Io(String),
@@ -29,7 +45,16 @@ impl std::fmt::Display for CodexError {
             CodexError::NonZeroExit { status, stderr } => {
                 write!(f, "codex exited with status {}: {}", status, stderr)
             }
-            CodexError::Envelope(e) => write!(f, "codex envelope parse error: {:?}", e),
+            CodexError::Envelope(e) => write!(f, "codex envelope parse error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for CodexError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            CodexError::Envelope(e) => Some(e),
+            _ => None,
         }
     }
 }

--- a/src/search/llm/codex.rs
+++ b/src/search/llm/codex.rs
@@ -1,0 +1,128 @@
+//! Codex CLI invocation and response parsing.
+
+use serde::Deserialize;
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+
+use crate::search::config::LlmConfig;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EnvelopeError {
+    InvalidJson,
+    MissingAssemblyField,
+}
+
+#[derive(Debug)]
+pub enum CodexError {
+    Io(String),
+    NonZeroExit { status: i32, stderr: String },
+    Envelope(EnvelopeError),
+}
+
+impl std::fmt::Display for CodexError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CodexError::Io(e) => write!(f, "codex io error: {}", e),
+            CodexError::NonZeroExit { status, stderr } => {
+                write!(f, "codex exited with status {}: {}", status, stderr)
+            }
+            CodexError::Envelope(e) => write!(f, "codex envelope parse error: {:?}", e),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct Envelope {
+    assembly: Option<String>,
+}
+
+/// Parse the Codex `--output-schema` envelope into the assembly string.
+pub fn parse_codex_envelope(json: &str) -> Result<String, EnvelopeError> {
+    let env: Envelope = serde_json::from_str(json).map_err(|_| EnvelopeError::InvalidJson)?;
+    env.assembly.ok_or(EnvelopeError::MissingAssemblyField)
+}
+
+/// Invoke `codex exec` with the given prompt and schema, return the asm string.
+///
+/// Uses an ephemeral, read-only Codex run with subscription auth (no API key needed).
+/// Schema and answer files are written under the system temp dir.
+pub fn invoke_codex(config: &LlmConfig, prompt: &str, schema: &str) -> Result<String, CodexError> {
+    let tmp = std::env::temp_dir();
+    let schema_path = tmp.join(format!("s11-codex-schema-{}.json", std::process::id()));
+    let answer_path = tmp.join(format!("s11-codex-answer-{}.json", std::process::id()));
+
+    write_file(&schema_path, schema).map_err(CodexError::Io)?;
+    // Pre-clear any stale answer file.
+    let _ = std::fs::remove_file(&answer_path);
+
+    let output = Command::new(&config.codex_bin)
+        .arg("exec")
+        .arg("-m")
+        .arg(&config.model)
+        .arg("-s")
+        .arg("read-only")
+        .arg("--ephemeral")
+        .arg("--skip-git-repo-check")
+        .arg("--output-schema")
+        .arg(&schema_path)
+        .arg("-o")
+        .arg(&answer_path)
+        .arg(prompt)
+        .output()
+        .map_err(|e| CodexError::Io(e.to_string()))?;
+
+    if !output.status.success() {
+        return Err(CodexError::NonZeroExit {
+            status: output.status.code().unwrap_or(-1),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        });
+    }
+
+    let json = std::fs::read_to_string(&answer_path)
+        .map_err(|e| CodexError::Io(format!("reading answer file: {}", e)))?;
+
+    parse_codex_envelope(&json).map_err(CodexError::Envelope)
+}
+
+fn write_file(path: &Path, content: &str) -> Result<(), String> {
+    let mut f = std::fs::File::create(path).map_err(|e| e.to_string())?;
+    f.write_all(content.as_bytes()).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_basic_envelope() {
+        let json = r#"{"assembly":"mov x0, x1"}"#;
+        assert_eq!(parse_codex_envelope(json), Ok("mov x0, x1".to_string()));
+    }
+
+    #[test]
+    fn parses_empty_assembly() {
+        let json = r#"{"assembly":""}"#;
+        assert_eq!(parse_codex_envelope(json), Ok(String::new()));
+    }
+
+    #[test]
+    fn rejects_invalid_json() {
+        assert_eq!(parse_codex_envelope("{"), Err(EnvelopeError::InvalidJson));
+    }
+
+    #[test]
+    fn rejects_missing_assembly_field() {
+        let json = r#"{"foo":"bar"}"#;
+        assert_eq!(
+            parse_codex_envelope(json),
+            Err(EnvelopeError::MissingAssemblyField)
+        );
+    }
+
+    #[test]
+    fn ignores_extra_fields() {
+        let json = r#"{"assembly":"mov x0, x1", "rationale":"shorter"}"#;
+        assert_eq!(parse_codex_envelope(json), Ok("mov x0, x1".to_string()));
+    }
+}

--- a/src/search/llm/codex.rs
+++ b/src/search/llm/codex.rs
@@ -117,8 +117,25 @@ pub fn invoke_codex(config: &LlmConfig, prompt: &str, schema: &str) -> Result<St
     parse_codex_envelope(&json).map_err(CodexError::Envelope)
 }
 
+/// Create a new file with owner-only (`0o600`) permissions on Unix; falls
+/// back to default permissions on non-Unix platforms (the LLM flow is only
+/// tested on Linux). The schema file is dull but the answer file briefly
+/// contains the model's response — we don't want to leak it to other users
+/// on a multi-user host during the (small) window before the RAII guard
+/// removes the file.
 fn write_file(path: &Path, content: &str) -> Result<(), String> {
-    let mut f = std::fs::File::create(path).map_err(|e| e.to_string())?;
+    use std::fs::OpenOptions;
+
+    let mut opts = OpenOptions::new();
+    opts.write(true).create(true).truncate(true);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+
+    let mut f = opts.open(path).map_err(|e| e.to_string())?;
     f.write_all(content.as_bytes()).map_err(|e| e.to_string())
 }
 

--- a/src/search/llm/ledger.rs
+++ b/src/search/llm/ledger.rs
@@ -20,10 +20,15 @@ impl UnsupportedMnemonicLedger {
         *self.counts.entry(mnemonic.to_string()).or_insert(0) += 1;
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.counts.is_empty()
+    }
+
     /// Return the ledger as `(mnemonic, count)` pairs sorted by count
-    /// descending, breaking ties alphabetically.
-    pub fn into_sorted(self) -> Vec<(String, u32)> {
-        let mut pairs: Vec<(String, u32)> = self.counts.into_iter().collect();
+    /// descending, breaking ties alphabetically. Borrows; does not consume.
+    pub fn sorted_entries(&self) -> Vec<(String, u32)> {
+        let mut pairs: Vec<(String, u32)> =
+            self.counts.iter().map(|(k, v)| (k.clone(), *v)).collect();
         pairs.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
         pairs
     }
@@ -36,14 +41,15 @@ mod tests {
     #[test]
     fn empty_ledger() {
         let l = UnsupportedMnemonicLedger::new();
-        assert!(l.into_sorted().is_empty());
+        assert!(l.is_empty());
+        assert!(l.sorted_entries().is_empty());
     }
 
     #[test]
     fn single_record() {
         let mut l = UnsupportedMnemonicLedger::new();
         l.record("ldr");
-        assert_eq!(l.into_sorted(), vec![("ldr".to_string(), 1)]);
+        assert_eq!(l.sorted_entries(), vec![("ldr".to_string(), 1)]);
     }
 
     #[test]
@@ -52,7 +58,7 @@ mod tests {
         l.record("ldr");
         l.record("ldr");
         l.record("ldr");
-        assert_eq!(l.into_sorted(), vec![("ldr".to_string(), 3)]);
+        assert_eq!(l.sorted_entries(), vec![("ldr".to_string(), 3)]);
     }
 
     #[test]
@@ -64,7 +70,7 @@ mod tests {
         l.record("b"); // 1
         // Expected: ldr (2), b (1), str (1)  — alpha tie-break for the 1s.
         assert_eq!(
-            l.into_sorted(),
+            l.sorted_entries(),
             vec![
                 ("ldr".to_string(), 2),
                 ("b".to_string(), 1),

--- a/src/search/llm/ledger.rs
+++ b/src/search/llm/ledger.rs
@@ -1,0 +1,75 @@
+//! Ledger of unsupported mnemonics emitted by the LLM during a search.
+//!
+//! Per ADR-0003, parse-rejection is a research signal, not lossage. This
+//! accumulator records each rejected mnemonic and emits a frequency-ranked
+//! report at the end of a run.
+
+use std::collections::HashMap;
+
+#[derive(Debug, Default, Clone)]
+pub struct UnsupportedMnemonicLedger {
+    counts: HashMap<String, u32>,
+}
+
+impl UnsupportedMnemonicLedger {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn record(&mut self, mnemonic: &str) {
+        *self.counts.entry(mnemonic.to_string()).or_insert(0) += 1;
+    }
+
+    /// Return the ledger as `(mnemonic, count)` pairs sorted by count
+    /// descending, breaking ties alphabetically.
+    pub fn into_sorted(self) -> Vec<(String, u32)> {
+        let mut pairs: Vec<(String, u32)> = self.counts.into_iter().collect();
+        pairs.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        pairs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_ledger() {
+        let l = UnsupportedMnemonicLedger::new();
+        assert!(l.into_sorted().is_empty());
+    }
+
+    #[test]
+    fn single_record() {
+        let mut l = UnsupportedMnemonicLedger::new();
+        l.record("ldr");
+        assert_eq!(l.into_sorted(), vec![("ldr".to_string(), 1)]);
+    }
+
+    #[test]
+    fn repeated_mnemonic_aggregates() {
+        let mut l = UnsupportedMnemonicLedger::new();
+        l.record("ldr");
+        l.record("ldr");
+        l.record("ldr");
+        assert_eq!(l.into_sorted(), vec![("ldr".to_string(), 3)]);
+    }
+
+    #[test]
+    fn sorted_by_count_desc_then_alpha() {
+        let mut l = UnsupportedMnemonicLedger::new();
+        l.record("str"); // 1
+        l.record("ldr"); // 1
+        l.record("ldr"); // 2
+        l.record("b"); // 1
+        // Expected: ldr (2), b (1), str (1)  — alpha tie-break for the 1s.
+        assert_eq!(
+            l.into_sorted(),
+            vec![
+                ("ldr".to_string(), 2),
+                ("b".to_string(), 1),
+                ("str".to_string(), 1),
+            ]
+        );
+    }
+}

--- a/src/search/llm/mod.rs
+++ b/src/search/llm/mod.rs
@@ -43,9 +43,13 @@ pub struct LlmTimings {
     /// verifications: parse-fail and fast-path-refutations don't reach SMT).
     pub smt_calls: u32,
     /// Sum of SMT formula sizes (bytes of SMT-LIB rendering) across all
-    /// solver invocations in this search.
+    /// solver invocations in this search **whose result was Equivalent**.
+    /// Sat / Unknown SMT outcomes do not contribute (we don't pay
+    /// `solver.to_string()` on those paths). A run that hit SMT many times
+    /// but never proved equivalence will read 0 here even though `smt_calls`
+    /// is positive.
     pub smt_formula_bytes_total: usize,
-    /// Largest SMT formula size (bytes) seen in any single invocation.
+    /// Largest SMT formula size (bytes) seen on an Equivalent SMT outcome.
     pub smt_formula_bytes_max: usize,
 }
 
@@ -79,6 +83,13 @@ impl SearchAlgorithm for LlmSearch {
         live_out: &LiveOutMask,
         config: &SearchConfig,
     ) -> SearchResult {
+        // Reset accumulators at the start of every search so a caller that
+        // checks `ledger()` / `timings()` between two searches without a
+        // manual `reset()` never sees stale data from the previous run.
+        self.last_stats = SearchStatistics::default();
+        self.last_ledger = UnsupportedMnemonicLedger::new();
+        self.last_timings = LlmTimings::default();
+
         let mut stats = SearchStatistics::new(crate::search::config::Algorithm::Llm);
         stats.original_cost = target.len() as u64;
         stats.best_cost_found = target.len() as u64;
@@ -199,16 +210,24 @@ impl SearchAlgorithm for LlmSearch {
                         ledger.record(m);
                     }
                     if config.verbose {
-                        eprintln!(
-                            "llm-search: parse-fail on call {} ({} unsupported mnemonic{})",
-                            call_idx,
-                            unsupported_mnemonics.len(),
-                            if unsupported_mnemonics.len() == 1 {
-                                ""
-                            } else {
-                                "s"
-                            }
-                        );
+                        if unsupported_mnemonics.is_empty() {
+                            eprintln!(
+                                "llm-search: parse-fail on call {} (operand or encoding error; \
+                                 no unknown mnemonics)",
+                                call_idx
+                            );
+                        } else {
+                            eprintln!(
+                                "llm-search: parse-fail on call {} ({} unsupported mnemonic{})",
+                                call_idx,
+                                unsupported_mnemonics.len(),
+                                if unsupported_mnemonics.len() == 1 {
+                                    ""
+                                } else {
+                                    "s"
+                                }
+                            );
+                        }
                     }
                 }
                 IterationOutcome::NotShorter { candidate_len } => {

--- a/src/search/llm/mod.rs
+++ b/src/search/llm/mod.rs
@@ -41,6 +41,14 @@ pub struct LlmTimings {
     /// Wall-clock time spent in the verification pipeline (parse + fast-path
     /// random testing + Z3 SMT). Dominated by SMT for non-parse-fail outcomes.
     pub verify_time: Duration,
+    /// Number of times the SMT solver was actually invoked (subset of
+    /// verifications: parse-fail and fast-path-refutations don't reach SMT).
+    pub smt_calls: u32,
+    /// Sum of SMT formula sizes (bytes of SMT-LIB rendering) across all
+    /// solver invocations in this search.
+    pub smt_formula_bytes_total: usize,
+    /// Largest SMT formula size (bytes) seen in any single invocation.
+    pub smt_formula_bytes_max: usize,
 }
 
 #[derive(Default)]
@@ -149,9 +157,20 @@ impl SearchAlgorithm for LlmSearch {
             };
 
             let verify_start = Instant::now();
-            let outcome = classify(target, &raw, live_out);
+            let (outcome, metrics) = classify(target, &raw, live_out);
             timings.verifications += 1;
             timings.verify_time += verify_start.elapsed();
+            if let Some(m) = metrics
+                && m.smt_called
+            {
+                timings.smt_calls += 1;
+                if let Some(bytes) = m.smt_formula_bytes {
+                    timings.smt_formula_bytes_total += bytes;
+                    if bytes > timings.smt_formula_bytes_max {
+                        timings.smt_formula_bytes_max = bytes;
+                    }
+                }
+            }
             match outcome {
                 IterationOutcome::Success(seq) => {
                     if config.verbose {

--- a/src/search/llm/mod.rs
+++ b/src/search/llm/mod.rs
@@ -29,10 +29,25 @@ use self::prompt::{OUTPUT_SCHEMA, build_prompt};
 /// times, sequentially, with fresh prompts. The first candidate that parses,
 /// is strictly shorter than the target, and is provably equivalent (per the
 /// existing fast + SMT pipeline) is returned.
+/// Per-phase timing breakdown for one `LlmSearch::search` run.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct LlmTimings {
+    /// Number of times `codex exec` was invoked.
+    pub codex_calls: u32,
+    /// Wall-clock time spent inside `codex exec` invocations.
+    pub codex_time: Duration,
+    /// Number of candidate verifications attempted (one per parseable response).
+    pub verifications: u32,
+    /// Wall-clock time spent in the verification pipeline (parse + fast-path
+    /// random testing + Z3 SMT). Dominated by SMT for non-parse-fail outcomes.
+    pub verify_time: Duration,
+}
+
 #[derive(Default)]
 pub struct LlmSearch {
     last_stats: SearchStatistics,
     last_ledger: UnsupportedMnemonicLedger,
+    last_timings: LlmTimings,
 }
 
 impl LlmSearch {
@@ -43,6 +58,11 @@ impl LlmSearch {
     /// The unsupported-mnemonic ledger from the most recent search.
     pub fn ledger(&self) -> &UnsupportedMnemonicLedger {
         &self.last_ledger
+    }
+
+    /// Per-phase timing breakdown for the most recent search.
+    pub fn timings(&self) -> &LlmTimings {
+        &self.last_timings
     }
 }
 
@@ -57,6 +77,7 @@ impl SearchAlgorithm for LlmSearch {
         stats.original_cost = target.len() as u64;
         stats.best_cost_found = target.len() as u64;
         let mut ledger = UnsupportedMnemonicLedger::new();
+        let mut timings = LlmTimings::default();
         let started = Instant::now();
 
         // Per ADR-0002: refuse targets where flags are live-out.
@@ -68,6 +89,7 @@ impl SearchAlgorithm for LlmSearch {
             stats.elapsed_time = started.elapsed();
             self.last_stats = stats.clone();
             self.last_ledger = ledger;
+            self.last_timings = timings;
             return SearchResult::no_optimization(target.to_vec(), stats);
         }
 
@@ -96,14 +118,18 @@ impl SearchAlgorithm for LlmSearch {
                 );
             }
             let call_start = Instant::now();
-            let raw = match invoke_codex(&config.llm, &prompt, OUTPUT_SCHEMA) {
+            let codex_result = invoke_codex(&config.llm, &prompt, OUTPUT_SCHEMA);
+            let codex_elapsed = call_start.elapsed();
+            timings.codex_calls += 1;
+            timings.codex_time += codex_elapsed;
+            let raw = match codex_result {
                 Ok(s) => {
                     if config.verbose {
                         eprintln!(
                             "llm-search: [{:>2}/{}]   ← codex returned in {:.2}s",
                             call_idx + 1,
                             max_calls,
-                            call_start.elapsed().as_secs_f64()
+                            codex_elapsed.as_secs_f64()
                         );
                     }
                     s
@@ -114,7 +140,7 @@ impl SearchAlgorithm for LlmSearch {
                             "llm-search: [{:>2}/{}]   ✗ codex error after {:.2}s: {}",
                             call_idx + 1,
                             max_calls,
-                            call_start.elapsed().as_secs_f64(),
+                            codex_elapsed.as_secs_f64(),
                             e
                         );
                     }
@@ -122,7 +148,11 @@ impl SearchAlgorithm for LlmSearch {
                 }
             };
 
-            match classify(target, &raw, live_out) {
+            let verify_start = Instant::now();
+            let outcome = classify(target, &raw, live_out);
+            timings.verifications += 1;
+            timings.verify_time += verify_start.elapsed();
+            match outcome {
                 IterationOutcome::Success(seq) => {
                     if config.verbose {
                         eprintln!(
@@ -176,6 +206,7 @@ impl SearchAlgorithm for LlmSearch {
         stats.elapsed_time = started.elapsed();
         self.last_stats = stats.clone();
         self.last_ledger = ledger;
+        self.last_timings = timings;
 
         match found {
             Some(seq) => SearchResult::with_optimization(target.to_vec(), seq, stats),
@@ -190,5 +221,6 @@ impl SearchAlgorithm for LlmSearch {
     fn reset(&mut self) {
         self.last_stats = SearchStatistics::default();
         self.last_ledger = UnsupportedMnemonicLedger::new();
+        self.last_timings = LlmTimings::default();
     }
 }

--- a/src/search/llm/mod.rs
+++ b/src/search/llm/mod.rs
@@ -1,0 +1,194 @@
+//! LLM-assisted superoptimization (Codex Spark flow).
+//!
+//! See CONTEXT.md and docs/adr/0001-0003 for the design.
+
+#![allow(dead_code)]
+
+pub mod codex;
+pub mod ledger;
+pub mod outcome;
+pub mod prompt;
+
+use std::time::{Duration, Instant};
+
+use crate::ir::Instruction;
+use crate::search::SearchAlgorithm;
+use crate::search::config::SearchConfig;
+use crate::search::result::{SearchResult, SearchStatistics};
+use crate::semantics::state::LiveOutMask;
+use crate::validation::live_out::{compute_live_in_registers, flags_live_out};
+
+use self::codex::invoke_codex;
+use self::ledger::UnsupportedMnemonicLedger;
+use self::outcome::{IterationOutcome, classify};
+use self::prompt::{OUTPUT_SCHEMA, build_prompt};
+
+/// LLM-assisted search using the Codex CLI.
+///
+/// Each call to `search` invokes `codex exec` up to `LlmConfig.max_codex_calls`
+/// times, sequentially, with fresh prompts. The first candidate that parses,
+/// is strictly shorter than the target, and is provably equivalent (per the
+/// existing fast + SMT pipeline) is returned.
+#[derive(Default)]
+pub struct LlmSearch {
+    last_stats: SearchStatistics,
+    last_ledger: UnsupportedMnemonicLedger,
+}
+
+impl LlmSearch {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The unsupported-mnemonic ledger from the most recent search.
+    pub fn ledger(&self) -> &UnsupportedMnemonicLedger {
+        &self.last_ledger
+    }
+}
+
+impl SearchAlgorithm for LlmSearch {
+    fn search(
+        &mut self,
+        target: &[Instruction],
+        live_out: &LiveOutMask,
+        config: &SearchConfig,
+    ) -> SearchResult {
+        let mut stats = SearchStatistics::new(crate::search::config::Algorithm::Llm);
+        stats.original_cost = target.len() as u64;
+        stats.best_cost_found = target.len() as u64;
+        let mut ledger = UnsupportedMnemonicLedger::new();
+        let started = Instant::now();
+
+        // Per ADR-0002: refuse targets where flags are live-out.
+        if flags_live_out(target) {
+            eprintln!(
+                "llm-search: target has flags live-out (per ADR-0002 the LLM \
+                 flow is not sound on this input). Refusing."
+            );
+            stats.elapsed_time = started.elapsed();
+            self.last_stats = stats.clone();
+            self.last_ledger = ledger;
+            return SearchResult::no_optimization(target.to_vec(), stats);
+        }
+
+        let live_in = compute_live_in_registers(target);
+        let prompt = build_prompt(target, &live_in, live_out);
+        let timeout = config.timeout.unwrap_or(Duration::from_secs(60));
+        let max_calls = config.llm.max_codex_calls;
+
+        let mut found: Option<Vec<Instruction>> = None;
+
+        for call_idx in 0..max_calls {
+            if started.elapsed() >= timeout {
+                if config.verbose {
+                    eprintln!("llm-search: timeout after {} calls", call_idx);
+                }
+                break;
+            }
+            stats.candidates_evaluated += 1;
+
+            if config.verbose {
+                eprintln!(
+                    "llm-search: [{:>2}/{}] calling codex (elapsed {:.2}s)",
+                    call_idx + 1,
+                    max_calls,
+                    started.elapsed().as_secs_f64()
+                );
+            }
+            let call_start = Instant::now();
+            let raw = match invoke_codex(&config.llm, &prompt, OUTPUT_SCHEMA) {
+                Ok(s) => {
+                    if config.verbose {
+                        eprintln!(
+                            "llm-search: [{:>2}/{}]   ← codex returned in {:.2}s",
+                            call_idx + 1,
+                            max_calls,
+                            call_start.elapsed().as_secs_f64()
+                        );
+                    }
+                    s
+                }
+                Err(e) => {
+                    if config.verbose {
+                        eprintln!(
+                            "llm-search: [{:>2}/{}]   ✗ codex error after {:.2}s: {}",
+                            call_idx + 1,
+                            max_calls,
+                            call_start.elapsed().as_secs_f64(),
+                            e
+                        );
+                    }
+                    continue;
+                }
+            };
+
+            match classify(target, &raw, live_out) {
+                IterationOutcome::Success(seq) => {
+                    if config.verbose {
+                        eprintln!(
+                            "llm-search: success on call {} ({} -> {} instructions)",
+                            call_idx,
+                            target.len(),
+                            seq.len()
+                        );
+                    }
+                    stats.smt_queries += 1;
+                    stats.smt_equivalent += 1;
+                    stats.candidates_passed_fast += 1;
+                    stats.improvements_found += 1;
+                    stats.best_cost_found = seq.len() as u64;
+                    found = Some(seq);
+                    break;
+                }
+                IterationOutcome::ParseFail {
+                    unsupported_mnemonic,
+                } => {
+                    if let Some(m) = unsupported_mnemonic {
+                        ledger.record(&m);
+                    }
+                    if config.verbose {
+                        eprintln!("llm-search: parse-fail on call {}", call_idx);
+                    }
+                }
+                IterationOutcome::NotShorter { candidate_len } => {
+                    if config.verbose {
+                        eprintln!(
+                            "llm-search: not-shorter on call {} (got {} instructions)",
+                            call_idx, candidate_len
+                        );
+                    }
+                }
+                IterationOutcome::EquivFail => {
+                    stats.smt_queries += 1;
+                    if config.verbose {
+                        eprintln!("llm-search: equiv-fail on call {}", call_idx);
+                    }
+                }
+                IterationOutcome::EquivUnknown => {
+                    stats.smt_queries += 1;
+                    if config.verbose {
+                        eprintln!("llm-search: equiv-unknown on call {}", call_idx);
+                    }
+                }
+            }
+        }
+
+        stats.elapsed_time = started.elapsed();
+        self.last_stats = stats.clone();
+        self.last_ledger = ledger;
+
+        match found {
+            Some(seq) => SearchResult::with_optimization(target.to_vec(), seq, stats),
+            None => SearchResult::no_optimization(target.to_vec(), stats),
+        }
+    }
+
+    fn statistics(&self) -> SearchStatistics {
+        self.last_stats.clone()
+    }
+
+    fn reset(&mut self) {
+        self.last_stats = SearchStatistics::default();
+        self.last_ledger = UnsupportedMnemonicLedger::new();
+    }
+}

--- a/src/search/llm/mod.rs
+++ b/src/search/llm/mod.rs
@@ -2,8 +2,6 @@
 //!
 //! See CONTEXT.md and docs/adr/0001-0003 for the design.
 
-#![allow(dead_code)]
-
 pub mod codex;
 pub mod ledger;
 pub mod outcome;
@@ -115,7 +113,6 @@ impl SearchAlgorithm for LlmSearch {
                 }
                 break;
             }
-            stats.candidates_evaluated += 1;
 
             if config.verbose {
                 eprintln!(
@@ -140,6 +137,9 @@ impl SearchAlgorithm for LlmSearch {
                             codex_elapsed.as_secs_f64()
                         );
                     }
+                    // Codex produced a candidate; this is the moment we count
+                    // it as "evaluated" — Codex IO errors above don't.
+                    stats.candidates_evaluated += 1;
                     s
                 }
                 Err(e) => {
@@ -158,16 +158,19 @@ impl SearchAlgorithm for LlmSearch {
 
             let verify_start = Instant::now();
             let (outcome, metrics) = classify(target, &raw, live_out);
-            timings.verifications += 1;
-            timings.verify_time += verify_start.elapsed();
-            if let Some(m) = metrics
-                && m.smt_called
-            {
-                timings.smt_calls += 1;
-                if let Some(bytes) = m.smt_formula_bytes {
-                    timings.smt_formula_bytes_total += bytes;
-                    if bytes > timings.smt_formula_bytes_max {
-                        timings.smt_formula_bytes_max = bytes;
+            let verify_elapsed = verify_start.elapsed();
+            // Only count as a "verification" when the verifier actually ran.
+            // Parse-fail and not-shorter short-circuit before the verifier.
+            if let Some(m) = metrics {
+                timings.verifications += 1;
+                timings.verify_time += verify_elapsed;
+                if m.smt_called {
+                    timings.smt_calls += 1;
+                    if let Some(bytes) = m.smt_formula_bytes {
+                        timings.smt_formula_bytes_total += bytes;
+                        if bytes > timings.smt_formula_bytes_max {
+                            timings.smt_formula_bytes_max = bytes;
+                        }
                     }
                 }
             }
@@ -190,13 +193,22 @@ impl SearchAlgorithm for LlmSearch {
                     break;
                 }
                 IterationOutcome::ParseFail {
-                    unsupported_mnemonic,
+                    unsupported_mnemonics,
                 } => {
-                    if let Some(m) = unsupported_mnemonic {
-                        ledger.record(&m);
+                    for m in &unsupported_mnemonics {
+                        ledger.record(m);
                     }
                     if config.verbose {
-                        eprintln!("llm-search: parse-fail on call {}", call_idx);
+                        eprintln!(
+                            "llm-search: parse-fail on call {} ({} unsupported mnemonic{})",
+                            call_idx,
+                            unsupported_mnemonics.len(),
+                            if unsupported_mnemonics.len() == 1 {
+                                ""
+                            } else {
+                                "s"
+                            }
+                        );
                     }
                 }
                 IterationOutcome::NotShorter { candidate_len } => {
@@ -241,5 +253,95 @@ impl SearchAlgorithm for LlmSearch {
         self.last_stats = SearchStatistics::default();
         self.last_ledger = UnsupportedMnemonicLedger::new();
         self.last_timings = LlmTimings::default();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! No-Codex unit tests of `LlmSearch::search` flow gates.
+    //!
+    //! These tests do NOT invoke Codex — they exercise paths that short-circuit
+    //! before any candidate generation (the ADR-0002 flags-live-out refusal,
+    //! and the `max_codex_calls = 0` budget exhaustion). For end-to-end LLM
+    //! coverage see `tests/data/llm_demo/` and `just llm-demo`.
+    use super::*;
+    use crate::ir::{Operand, Register};
+    use crate::search::config::LlmConfig;
+
+    fn live_out_x0() -> LiveOutMask {
+        let mut m = LiveOutMask::empty();
+        m.add(Register::X0);
+        m
+    }
+
+    fn cfg_no_calls() -> SearchConfig {
+        SearchConfig::default().with_llm(LlmConfig::default().with_max_codex_calls(0))
+    }
+
+    #[test]
+    fn flags_live_out_target_is_refused_without_calling_codex() {
+        // Target ends in a flag-writer; per ADR-0002 the LLM flow refuses.
+        let target = vec![
+            Instruction::Add {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Register(Register::X2),
+            },
+            Instruction::Cmp {
+                rn: Register::X0,
+                rm: Operand::Immediate(0),
+            },
+        ];
+
+        let mut search = LlmSearch::new();
+        let result = search.search(&target, &live_out_x0(), &cfg_no_calls());
+
+        assert!(
+            !result.found_optimization,
+            "flags-live-out target must be refused, not optimized"
+        );
+        assert!(
+            result.optimized_sequence.is_none(),
+            "no optimized sequence expected on refusal"
+        );
+
+        let timings = search.timings();
+        assert_eq!(
+            timings.codex_calls, 0,
+            "refusal must short-circuit before any codex invocation"
+        );
+        assert_eq!(timings.smt_calls, 0);
+        assert_eq!(timings.verifications, 0);
+        assert!(search.ledger().is_empty());
+    }
+
+    #[test]
+    fn non_flags_live_out_target_proceeds_until_budget_exhausted() {
+        // Same shape but ending on a register-writing instruction (no flag
+        // writer at all). Should NOT be refused. With max_codex_calls=0 the
+        // loop budget exhausts before any call, but the function still
+        // returns a no-optimization result rather than the refusal path.
+        let target = vec![
+            Instruction::Add {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Register(Register::X2),
+            },
+            Instruction::Sub {
+                rd: Register::X0,
+                rn: Register::X0,
+                rm: Operand::Immediate(1),
+            },
+        ];
+
+        let mut search = LlmSearch::new();
+        let result = search.search(&target, &live_out_x0(), &cfg_no_calls());
+
+        assert!(!result.found_optimization);
+        let timings = search.timings();
+        assert_eq!(
+            timings.codex_calls, 0,
+            "max_codex_calls = 0 means zero codex invocations"
+        );
     }
 }

--- a/src/search/llm/outcome.rs
+++ b/src/search/llm/outcome.rs
@@ -4,7 +4,7 @@
 //! Success, ParseFail, NotShorter, EquivFail, EquivUnknown.
 
 use crate::ir::Instruction;
-use crate::parser::parse_assembly_string;
+use crate::parser::{LineResult, parse_assembly_string, parse_line};
 use crate::semantics::equivalence::{
     EquivalenceConfig, EquivalenceMetrics, EquivalenceResult, check_equivalence_with_config_metrics,
 };
@@ -14,7 +14,11 @@ use crate::semantics::state::LiveOutMask;
 pub enum IterationOutcome {
     Success(Vec<Instruction>),
     ParseFail {
-        unsupported_mnemonic: Option<String>,
+        /// All unsupported mnemonics observed in the raw response, lowercased,
+        /// in order of appearance. May contain duplicates (one entry per
+        /// occurrence). Empty if the parse failure was not due to an unknown
+        /// instruction (e.g., immediate-out-of-range, malformed operands).
+        unsupported_mnemonics: Vec<String>,
     },
     NotShorter {
         candidate_len: usize,
@@ -35,10 +39,10 @@ pub fn classify(
 ) -> (IterationOutcome, Option<EquivalenceMetrics>) {
     let candidate = match parse_assembly_string(raw_asm, "<llm-output>".to_string()) {
         Ok(v) => v,
-        Err(err) => {
+        Err(_) => {
             return (
                 IterationOutcome::ParseFail {
-                    unsupported_mnemonic: extract_mnemonic(&err.line_content),
+                    unsupported_mnemonics: extract_unsupported_mnemonics(raw_asm),
                 },
                 None,
             );
@@ -66,11 +70,27 @@ pub fn classify(
     (outcome, Some(metrics))
 }
 
-/// Extract the offending mnemonic from a parser error's line_content.
-/// Returns the first whitespace-separated token, lowercased, or None if the
-/// line is empty/whitespace.
-fn extract_mnemonic(line: &str) -> Option<String> {
-    line.split_whitespace().next().map(|s| s.to_lowercase())
+/// Walk every line of the raw response and collect mnemonics the parser
+/// rejected as unknown. Independent of the single-error-stop behavior of
+/// `parse_assembly_string` so a response with several unsupported lines
+/// contributes every mnemonic to the ledger (per ADR-0003 — full multiset).
+fn extract_unsupported_mnemonics(raw: &str) -> Vec<String> {
+    const PREFIX: &str = "unknown instruction: ";
+    let mut found = Vec::new();
+    for line in raw.lines() {
+        match parse_line(line) {
+            Ok(LineResult::Instruction(_)) | Ok(LineResult::Skip) => {}
+            Err(msg) => {
+                if let Some(rest) = msg.strip_prefix(PREFIX) {
+                    let mnem = rest.trim().to_lowercase();
+                    if !mnem.is_empty() {
+                        found.push(mnem);
+                    }
+                }
+            }
+        }
+    }
+    found
 }
 
 #[cfg(test)]
@@ -94,10 +114,44 @@ mod tests {
         assert_eq!(
             outcome,
             IterationOutcome::ParseFail {
-                unsupported_mnemonic: Some("ldr".to_string())
+                unsupported_mnemonics: vec!["ldr".to_string()]
             }
         );
         assert!(metrics.is_none(), "parse-fail must not invoke verifier");
+    }
+
+    #[test]
+    fn parse_fail_collects_all_unsupported_mnemonics_in_response() {
+        // Response with three different unsupported instructions interleaved
+        // with one supported `mov`. All three unsupported should be captured.
+        let target = vec![Instruction::MovImm {
+            rd: Register::X0,
+            imm: 1,
+        }];
+        let raw = "ldr x0, [x1]\nmov x0, x1\nstr x2, [x3]\nb .Lend\n";
+        let (outcome, metrics) = classify(&target, raw, &live_out_x0());
+        let mnemonics = match outcome {
+            IterationOutcome::ParseFail {
+                unsupported_mnemonics,
+            } => unsupported_mnemonics,
+            other => panic!("expected ParseFail, got {:?}", other),
+        };
+        assert!(
+            mnemonics.contains(&"ldr".to_string()),
+            "ldr missing from {:?}",
+            mnemonics
+        );
+        assert!(
+            mnemonics.contains(&"str".to_string()),
+            "str missing from {:?}",
+            mnemonics
+        );
+        assert!(
+            mnemonics.contains(&"b".to_string()),
+            "b missing from {:?}",
+            mnemonics
+        );
+        assert!(metrics.is_none());
     }
 
     #[test]

--- a/src/search/llm/outcome.rs
+++ b/src/search/llm/outcome.rs
@@ -4,7 +4,7 @@
 //! Success, ParseFail, NotShorter, EquivFail, EquivUnknown.
 
 use crate::ir::Instruction;
-use crate::parser::{LineResult, parse_assembly_string, parse_line};
+use crate::parser::{ParseLineError, parse_assembly_string, parse_line};
 use crate::semantics::equivalence::{
     EquivalenceConfig, EquivalenceMetrics, EquivalenceResult, check_equivalence_with_config_metrics,
 };
@@ -74,19 +74,17 @@ pub fn classify(
 /// rejected as unknown. Independent of the single-error-stop behavior of
 /// `parse_assembly_string` so a response with several unsupported lines
 /// contributes every mnemonic to the ledger (per ADR-0003 — full multiset).
+///
+/// Type-driven (matches `ParseLineError::UnknownInstruction`) rather than
+/// string-matched: a parser-error wording change can't silently empty the
+/// ledger.
 fn extract_unsupported_mnemonics(raw: &str) -> Vec<String> {
-    const PREFIX: &str = "unknown instruction: ";
     let mut found = Vec::new();
     for line in raw.lines() {
-        match parse_line(line) {
-            Ok(LineResult::Instruction(_)) | Ok(LineResult::Skip) => {}
-            Err(msg) => {
-                if let Some(rest) = msg.strip_prefix(PREFIX) {
-                    let mnem = rest.trim().to_lowercase();
-                    if !mnem.is_empty() {
-                        found.push(mnem);
-                    }
-                }
+        if let Err(ParseLineError::UnknownInstruction(mnem)) = parse_line(line) {
+            // `parse_line` already lowercases the opcode before this branch.
+            if !mnem.is_empty() {
+                found.push(mnem);
             }
         }
     }

--- a/src/search/llm/outcome.rs
+++ b/src/search/llm/outcome.rs
@@ -6,7 +6,7 @@
 use crate::ir::Instruction;
 use crate::parser::parse_assembly_string;
 use crate::semantics::equivalence::{
-    EquivalenceConfig, EquivalenceResult, check_equivalence_with_config,
+    EquivalenceConfig, EquivalenceMetrics, EquivalenceResult, check_equivalence_with_config_metrics,
 };
 use crate::semantics::state::LiveOutMask;
 
@@ -24,30 +24,46 @@ pub enum IterationOutcome {
 }
 
 /// Classify an LLM-returned candidate against the target.
-pub fn classify(target: &[Instruction], raw_asm: &str, live_out: &LiveOutMask) -> IterationOutcome {
+///
+/// Also returns optional `EquivalenceMetrics` from the verification attempt
+/// (None when the candidate did not reach the verifier — i.e. parse-fail or
+/// not-shorter).
+pub fn classify(
+    target: &[Instruction],
+    raw_asm: &str,
+    live_out: &LiveOutMask,
+) -> (IterationOutcome, Option<EquivalenceMetrics>) {
     let candidate = match parse_assembly_string(raw_asm, "<llm-output>".to_string()) {
         Ok(v) => v,
         Err(err) => {
-            return IterationOutcome::ParseFail {
-                unsupported_mnemonic: extract_mnemonic(&err.line_content),
-            };
+            return (
+                IterationOutcome::ParseFail {
+                    unsupported_mnemonic: extract_mnemonic(&err.line_content),
+                },
+                None,
+            );
         }
     };
 
     if candidate.len() >= target.len() {
-        return IterationOutcome::NotShorter {
-            candidate_len: candidate.len(),
-        };
+        return (
+            IterationOutcome::NotShorter {
+                candidate_len: candidate.len(),
+            },
+            None,
+        );
     }
 
     let cfg = EquivalenceConfig::default().live_out(live_out.clone());
-    match check_equivalence_with_config(target, &candidate, &cfg) {
+    let (result, metrics) = check_equivalence_with_config_metrics(target, &candidate, &cfg);
+    let outcome = match result {
         EquivalenceResult::Equivalent => IterationOutcome::Success(candidate),
         EquivalenceResult::NotEquivalent | EquivalenceResult::NotEquivalentFast(_) => {
             IterationOutcome::EquivFail
         }
         EquivalenceResult::Unknown(_) => IterationOutcome::EquivUnknown,
-    }
+    };
+    (outcome, Some(metrics))
 }
 
 /// Extract the offending mnemonic from a parser error's line_content.
@@ -74,13 +90,14 @@ mod tests {
             rd: Register::X0,
             imm: 1,
         }];
-        let outcome = classify(&target, "ldr x0, [x1]", &live_out_x0());
+        let (outcome, metrics) = classify(&target, "ldr x0, [x1]", &live_out_x0());
         assert_eq!(
             outcome,
             IterationOutcome::ParseFail {
                 unsupported_mnemonic: Some("ldr".to_string())
             }
         );
+        assert!(metrics.is_none(), "parse-fail must not invoke verifier");
     }
 
     #[test]
@@ -97,7 +114,7 @@ mod tests {
                 rm: Operand::Immediate(1),
             },
         ];
-        let outcome = classify(&target, "add x0, x1, #1", &live_out_x0());
+        let (outcome, metrics) = classify(&target, "add x0, x1, #1", &live_out_x0());
         match outcome {
             IterationOutcome::Success(seq) => {
                 assert_eq!(seq.len(), 1);
@@ -112,6 +129,12 @@ mod tests {
             }
             other => panic!("expected Success, got {:?}", other),
         }
+        let metrics = metrics.expect("success path must have metrics");
+        assert!(metrics.smt_called, "success path must call SMT");
+        assert!(
+            metrics.smt_formula_bytes.map(|n| n > 0).unwrap_or(false),
+            "smt_formula_bytes should be populated and non-zero"
+        );
     }
 
     #[test]
@@ -121,8 +144,9 @@ mod tests {
             rd: Register::X0,
             imm: 0,
         }];
-        let outcome = classify(&target, "mov x0, #0", &live_out_x0());
+        let (outcome, metrics) = classify(&target, "mov x0, #0", &live_out_x0());
         assert_eq!(outcome, IterationOutcome::NotShorter { candidate_len: 1 });
+        assert!(metrics.is_none(), "not-shorter must short-circuit verifier");
     }
 
     #[test]
@@ -139,7 +163,10 @@ mod tests {
                 rm: Operand::Immediate(1),
             },
         ];
-        let outcome = classify(&target, "mov x0, #5", &live_out_x0());
+        let (outcome, metrics) = classify(&target, "mov x0, #5", &live_out_x0());
         assert_eq!(outcome, IterationOutcome::EquivFail);
+        let metrics = metrics.expect("equiv-fail still passes through verifier");
+        // Fast-path random testing should have refuted this without reaching SMT.
+        assert!(!metrics.smt_called, "fast-path refutation should skip SMT");
     }
 }

--- a/src/search/llm/outcome.rs
+++ b/src/search/llm/outcome.rs
@@ -1,0 +1,145 @@
+//! Per-iteration outcome classification for the LLM loop.
+//!
+//! Given the raw assembly text returned by Codex, classify it as one of:
+//! Success, ParseFail, NotShorter, EquivFail, EquivUnknown.
+
+use crate::ir::Instruction;
+use crate::parser::parse_assembly_string;
+use crate::semantics::equivalence::{
+    EquivalenceConfig, EquivalenceResult, check_equivalence_with_config,
+};
+use crate::semantics::state::LiveOutMask;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IterationOutcome {
+    Success(Vec<Instruction>),
+    ParseFail {
+        unsupported_mnemonic: Option<String>,
+    },
+    NotShorter {
+        candidate_len: usize,
+    },
+    EquivFail,
+    EquivUnknown,
+}
+
+/// Classify an LLM-returned candidate against the target.
+pub fn classify(target: &[Instruction], raw_asm: &str, live_out: &LiveOutMask) -> IterationOutcome {
+    let candidate = match parse_assembly_string(raw_asm, "<llm-output>".to_string()) {
+        Ok(v) => v,
+        Err(err) => {
+            return IterationOutcome::ParseFail {
+                unsupported_mnemonic: extract_mnemonic(&err.line_content),
+            };
+        }
+    };
+
+    if candidate.len() >= target.len() {
+        return IterationOutcome::NotShorter {
+            candidate_len: candidate.len(),
+        };
+    }
+
+    let cfg = EquivalenceConfig::default().live_out(live_out.clone());
+    match check_equivalence_with_config(target, &candidate, &cfg) {
+        EquivalenceResult::Equivalent => IterationOutcome::Success(candidate),
+        EquivalenceResult::NotEquivalent | EquivalenceResult::NotEquivalentFast(_) => {
+            IterationOutcome::EquivFail
+        }
+        EquivalenceResult::Unknown(_) => IterationOutcome::EquivUnknown,
+    }
+}
+
+/// Extract the offending mnemonic from a parser error's line_content.
+/// Returns the first whitespace-separated token, lowercased, or None if the
+/// line is empty/whitespace.
+fn extract_mnemonic(line: &str) -> Option<String> {
+    line.split_whitespace().next().map(|s| s.to_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::{Operand, Register};
+
+    fn live_out_x0() -> LiveOutMask {
+        let mut m = LiveOutMask::empty();
+        m.add(Register::X0);
+        m
+    }
+
+    #[test]
+    fn parse_fail_extracts_unsupported_mnemonic() {
+        let target = vec![Instruction::MovImm {
+            rd: Register::X0,
+            imm: 1,
+        }];
+        let outcome = classify(&target, "ldr x0, [x1]", &live_out_x0());
+        assert_eq!(
+            outcome,
+            IterationOutcome::ParseFail {
+                unsupported_mnemonic: Some("ldr".to_string())
+            }
+        );
+    }
+
+    #[test]
+    fn success_when_shorter_and_equivalent() {
+        // mov x0, x1 ; add x0, x0, #1   ≡  add x0, x1, #1   (1 fewer instruction)
+        let target = vec![
+            Instruction::MovReg {
+                rd: Register::X0,
+                rn: Register::X1,
+            },
+            Instruction::Add {
+                rd: Register::X0,
+                rn: Register::X0,
+                rm: Operand::Immediate(1),
+            },
+        ];
+        let outcome = classify(&target, "add x0, x1, #1", &live_out_x0());
+        match outcome {
+            IterationOutcome::Success(seq) => {
+                assert_eq!(seq.len(), 1);
+                assert_eq!(
+                    seq[0],
+                    Instruction::Add {
+                        rd: Register::X0,
+                        rn: Register::X1,
+                        rm: Operand::Immediate(1)
+                    }
+                );
+            }
+            other => panic!("expected Success, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn not_shorter_when_same_length() {
+        // 1-instruction target; candidate also 1 instruction (and equivalent).
+        let target = vec![Instruction::MovImm {
+            rd: Register::X0,
+            imm: 0,
+        }];
+        let outcome = classify(&target, "mov x0, #0", &live_out_x0());
+        assert_eq!(outcome, IterationOutcome::NotShorter { candidate_len: 1 });
+    }
+
+    #[test]
+    fn equiv_fail_when_candidate_is_wrong() {
+        // 2-instruction target writes x0=2; 1-instruction candidate writes x0=5.
+        let target = vec![
+            Instruction::MovImm {
+                rd: Register::X0,
+                imm: 1,
+            },
+            Instruction::Add {
+                rd: Register::X0,
+                rn: Register::X0,
+                rm: Operand::Immediate(1),
+            },
+        ];
+        let outcome = classify(&target, "mov x0, #5", &live_out_x0());
+        assert_eq!(outcome, IterationOutcome::EquivFail);
+    }
+}

--- a/src/search/llm/outcome.rs
+++ b/src/search/llm/outcome.rs
@@ -78,6 +78,12 @@ pub fn classify(
 /// Type-driven (matches `ParseLineError::UnknownInstruction`) rather than
 /// string-matched: a parser-error wording change can't silently empty the
 /// ledger.
+///
+/// Note: the loop above (`parse_assembly_string`) and this function each
+/// re-parse the response. The two-pass shape is intentional — we only walk
+/// every line a second time on the cold path (parse failure), and only when
+/// we want every offending mnemonic rather than just the first error site.
+/// Per-call cost is negligible at the MVP target sizes (3–20 instructions).
 fn extract_unsupported_mnemonics(raw: &str) -> Vec<String> {
     let mut found = Vec::new();
     for line in raw.lines() {

--- a/src/search/llm/prompt.rs
+++ b/src/search/llm/prompt.rs
@@ -28,7 +28,7 @@ pub fn build_prompt(
 SHORTER (fewer instructions) sequence that produces the same values for the listed \
 live-out registers, given the listed live-in registers as inputs. Registers not in \
 the live-out set may be clobbered freely. If you cannot find a strictly shorter \
-equivalent, return the input sequence verbatim.\n\n",
+equivalent, return an empty `assembly` field — do NOT return the input verbatim.\n\n",
     );
     s.push_str(&format!(
         "Live-in registers: {}\n",

--- a/src/search/llm/prompt.rs
+++ b/src/search/llm/prompt.rs
@@ -1,0 +1,96 @@
+//! Prompt construction for the Codex-assisted search loop.
+
+use crate::ir::{Instruction, Register};
+use crate::semantics::state::LiveOutMask;
+
+/// Render a register set as a comma-separated list (e.g. "x0, x1, x2").
+fn render_register_set(mask: &LiveOutMask) -> String {
+    let mut names: Vec<String> = (0..=30u8)
+        .filter_map(Register::from_index)
+        .filter(|r| mask.contains(*r))
+        .map(|r| format!("{}", r).to_lowercase())
+        .collect();
+    if mask.contains(Register::SP) {
+        names.push("sp".to_string());
+    }
+    names.join(", ")
+}
+
+/// Build the full prompt sent to `codex exec`.
+pub fn build_prompt(
+    target: &[Instruction],
+    live_in: &LiveOutMask,
+    live_out: &LiveOutMask,
+) -> String {
+    let mut s = String::new();
+    s.push_str(
+        "You are an AArch64 superoptimizer. Given a short instruction sequence, return a \
+SHORTER (fewer instructions) sequence that produces the same values for the listed \
+live-out registers, given the listed live-in registers as inputs. Registers not in \
+the live-out set may be clobbered freely. If you cannot find a strictly shorter \
+equivalent, return the input sequence verbatim.\n\n",
+    );
+    s.push_str(&format!(
+        "Live-in registers: {}\n",
+        render_register_set(live_in)
+    ));
+    s.push_str(&format!(
+        "Live-out registers: {}\n",
+        render_register_set(live_out)
+    ));
+    s.push_str("\nTarget:\n");
+    for instr in target {
+        s.push_str(&format!("{}\n", instr));
+    }
+    s
+}
+
+/// JSON schema enforced via `codex exec --output-schema`.
+pub const OUTPUT_SCHEMA: &str = r#"{
+  "type": "object",
+  "properties": {
+    "assembly": {
+      "type": "string",
+      "description": "AArch64 assembly, GNU syntax, one instruction per line."
+    }
+  },
+  "required": ["assembly"],
+  "additionalProperties": false
+}
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::{Operand, Register};
+
+    fn mask(regs: &[Register]) -> LiveOutMask {
+        let mut m = LiveOutMask::empty();
+        for r in regs {
+            m.add(*r);
+        }
+        m
+    }
+
+    #[test]
+    fn prompt_includes_live_in_live_out_and_target() {
+        let target = vec![
+            Instruction::MovReg {
+                rd: Register::X0,
+                rn: Register::X1,
+            },
+            Instruction::Add {
+                rd: Register::X0,
+                rn: Register::X0,
+                rm: Operand::Immediate(1),
+            },
+        ];
+        let live_in = mask(&[Register::X1]);
+        let live_out = mask(&[Register::X0]);
+        let prompt = build_prompt(&target, &live_in, &live_out);
+        assert!(prompt.contains("Live-in registers: x1"));
+        assert!(prompt.contains("Live-out registers: x0"));
+        assert!(prompt.contains("mov x0, x1"));
+        assert!(prompt.contains("add x0, x0, #1"));
+    }
+}

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -8,6 +8,7 @@
 
 pub mod candidate;
 pub mod config;
+pub mod llm;
 pub mod parallel;
 pub mod result;
 pub mod stochastic;

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -137,13 +137,14 @@ pub struct EquivalenceMetrics {
     pub smt_formula_bytes: Option<usize>,
 }
 
-/// Like `check_equivalence_with_config`, but also reports per-call metrics.
-pub fn check_equivalence_with_config_metrics(
+/// Run the fast-path random + edge-case checks. Returns either a
+/// `NotEquivalentFast` refutation, `None` if the fast path passed, or
+/// `Some(Equivalent)` if `fast_only` short-circuits.
+fn run_fast_path(
     seq1: &[Instruction],
     seq2: &[Instruction],
     config: &EquivalenceConfig,
-) -> (EquivalenceResult, EquivalenceMetrics) {
-    let mut metrics = EquivalenceMetrics::default();
+) -> Option<EquivalenceResult> {
     let input_regs: Vec<_> = config.live_out.iter().cloned().collect();
 
     let random_config = RandomInputConfig {
@@ -157,7 +158,7 @@ pub fn check_equivalence_with_config_metrics(
         let state2 = apply_sequence_concrete(input.clone(), seq2);
 
         if !states_equal_for_live_out(&state1, &state2, &config.live_out) {
-            return (EquivalenceResult::NotEquivalentFast(input.clone()), metrics);
+            return Some(EquivalenceResult::NotEquivalentFast(input.clone()));
         }
     }
 
@@ -167,87 +168,71 @@ pub fn check_equivalence_with_config_metrics(
         let state2 = apply_sequence_concrete(input.clone(), seq2);
 
         if !states_equal_for_live_out(&state1, &state2, &config.live_out) {
-            return (EquivalenceResult::NotEquivalentFast(input.clone()), metrics);
+            return Some(EquivalenceResult::NotEquivalentFast(input.clone()));
         }
     }
 
     if config.fast_only {
-        return (EquivalenceResult::Equivalent, metrics);
+        return Some(EquivalenceResult::Equivalent);
     }
 
-    let solver_config = SolverConfig {
-        timeout: config.smt_timeout,
-    };
-    let solver = create_solver_with_config(&solver_config);
-
-    let initial_state = MachineState::new_symbolic("init");
-
-    let final_state1 = apply_sequence(initial_state.clone(), seq1);
-    let final_state2 = apply_sequence(initial_state, seq2);
-
-    solver.assert(states_not_equal_for_live_out(
-        &final_state1,
-        &final_state2,
-        &config.live_out,
-    ));
-
-    metrics.smt_called = true;
-    metrics.smt_formula_bytes = Some(solver.to_string().len());
-
-    let result = match solver.check() {
-        SatResult::Unsat => EquivalenceResult::Equivalent,
-        SatResult::Sat => EquivalenceResult::NotEquivalent,
-        SatResult::Unknown => {
-            EquivalenceResult::Unknown("SMT solver returned unknown (possibly timeout)".to_string())
-        }
-    };
-    (result, metrics)
+    None
 }
 
-/// Check equivalence with configuration (fast path + optional SMT)
+/// Check equivalence with configuration (fast path + optional SMT). No metrics.
 pub fn check_equivalence_with_config(
     seq1: &[Instruction],
     seq2: &[Instruction],
     config: &EquivalenceConfig,
 ) -> EquivalenceResult {
-    let input_regs: Vec<_> = config.live_out.iter().cloned().collect();
-
-    let random_config = RandomInputConfig {
-        count: config.random_test_count,
-        registers: input_regs.clone(),
-    };
-    let random_inputs = generate_random_inputs(&random_config);
-
-    for input in &random_inputs {
-        let state1 = apply_sequence_concrete(input.clone(), seq1);
-        let state2 = apply_sequence_concrete(input.clone(), seq2);
-
-        if !states_equal_for_live_out(&state1, &state2, &config.live_out) {
-            return EquivalenceResult::NotEquivalentFast(input.clone());
-        }
+    if let Some(fast) = run_fast_path(seq1, seq2, config) {
+        return fast;
     }
 
-    let edge_inputs = generate_edge_case_inputs(&input_regs);
-    for input in &edge_inputs {
-        let state1 = apply_sequence_concrete(input.clone(), seq1);
-        let state2 = apply_sequence_concrete(input.clone(), seq2);
+    let solver = build_smt_solver(seq1, seq2, config);
+    interpret_smt_result(solver.check())
+}
 
-        if !states_equal_for_live_out(&state1, &state2, &config.live_out) {
-            return EquivalenceResult::NotEquivalentFast(input.clone());
-        }
+/// Like `check_equivalence_with_config`, but also reports per-call metrics
+/// including the SMT formula size in bytes. Use this only when the metrics
+/// are actually consumed — `solver.to_string()` is non-trivial work compared
+/// to `solver.check()` on small problems.
+pub fn check_equivalence_with_config_metrics(
+    seq1: &[Instruction],
+    seq2: &[Instruction],
+    config: &EquivalenceConfig,
+) -> (EquivalenceResult, EquivalenceMetrics) {
+    let metrics = EquivalenceMetrics::default();
+
+    if let Some(fast) = run_fast_path(seq1, seq2, config) {
+        return (fast, metrics);
     }
 
-    if config.fast_only {
-        return EquivalenceResult::Equivalent;
-    }
+    let solver = build_smt_solver(seq1, seq2, config);
+    let smt_formula_bytes = solver.to_string().len();
+    let result = interpret_smt_result(solver.check());
+    (
+        result,
+        EquivalenceMetrics {
+            smt_called: true,
+            smt_formula_bytes: Some(smt_formula_bytes),
+        },
+    )
+}
 
+/// Build a Z3 solver populated with the assertion that the two sequences
+/// disagree on the live-out state. Caller invokes `check()` next.
+fn build_smt_solver(
+    seq1: &[Instruction],
+    seq2: &[Instruction],
+    config: &EquivalenceConfig,
+) -> z3::Solver {
     let solver_config = SolverConfig {
         timeout: config.smt_timeout,
     };
     let solver = create_solver_with_config(&solver_config);
 
     let initial_state = MachineState::new_symbolic("init");
-
     let final_state1 = apply_sequence(initial_state.clone(), seq1);
     let final_state2 = apply_sequence(initial_state, seq2);
 
@@ -256,8 +241,11 @@ pub fn check_equivalence_with_config(
         &final_state2,
         &config.live_out,
     ));
+    solver
+}
 
-    match solver.check() {
+fn interpret_smt_result(result: SatResult) -> EquivalenceResult {
+    match result {
         SatResult::Unsat => EquivalenceResult::Equivalent,
         SatResult::Sat => EquivalenceResult::NotEquivalent,
         SatResult::Unknown => {

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -124,6 +124,86 @@ pub fn check_equivalence(seq1: &[Instruction], seq2: &[Instruction]) -> Equivale
     }
 }
 
+/// Optional per-call metrics from the equivalence pipeline.
+#[derive(Debug, Default, Clone)]
+pub struct EquivalenceMetrics {
+    /// Whether the SMT solver was actually invoked. False when fast-path
+    /// refuted the candidate, when fast_only is set, or when the candidate
+    /// was rejected before reaching SMT for any other reason.
+    pub smt_called: bool,
+    /// Size of the SMT-LIB rendering of the loaded solver (assertions +
+    /// declarations) at the moment `check()` was called. None if SMT was
+    /// not called.
+    pub smt_formula_bytes: Option<usize>,
+}
+
+/// Like `check_equivalence_with_config`, but also reports per-call metrics.
+pub fn check_equivalence_with_config_metrics(
+    seq1: &[Instruction],
+    seq2: &[Instruction],
+    config: &EquivalenceConfig,
+) -> (EquivalenceResult, EquivalenceMetrics) {
+    let mut metrics = EquivalenceMetrics::default();
+    let input_regs: Vec<_> = config.live_out.iter().cloned().collect();
+
+    let random_config = RandomInputConfig {
+        count: config.random_test_count,
+        registers: input_regs.clone(),
+    };
+    let random_inputs = generate_random_inputs(&random_config);
+
+    for input in &random_inputs {
+        let state1 = apply_sequence_concrete(input.clone(), seq1);
+        let state2 = apply_sequence_concrete(input.clone(), seq2);
+
+        if !states_equal_for_live_out(&state1, &state2, &config.live_out) {
+            return (EquivalenceResult::NotEquivalentFast(input.clone()), metrics);
+        }
+    }
+
+    let edge_inputs = generate_edge_case_inputs(&input_regs);
+    for input in &edge_inputs {
+        let state1 = apply_sequence_concrete(input.clone(), seq1);
+        let state2 = apply_sequence_concrete(input.clone(), seq2);
+
+        if !states_equal_for_live_out(&state1, &state2, &config.live_out) {
+            return (EquivalenceResult::NotEquivalentFast(input.clone()), metrics);
+        }
+    }
+
+    if config.fast_only {
+        return (EquivalenceResult::Equivalent, metrics);
+    }
+
+    let solver_config = SolverConfig {
+        timeout: config.smt_timeout,
+    };
+    let solver = create_solver_with_config(&solver_config);
+
+    let initial_state = MachineState::new_symbolic("init");
+
+    let final_state1 = apply_sequence(initial_state.clone(), seq1);
+    let final_state2 = apply_sequence(initial_state, seq2);
+
+    solver.assert(states_not_equal_for_live_out(
+        &final_state1,
+        &final_state2,
+        &config.live_out,
+    ));
+
+    metrics.smt_called = true;
+    metrics.smt_formula_bytes = Some(solver.to_string().len());
+
+    let result = match solver.check() {
+        SatResult::Unsat => EquivalenceResult::Equivalent,
+        SatResult::Sat => EquivalenceResult::NotEquivalent,
+        SatResult::Unknown => {
+            EquivalenceResult::Unknown("SMT solver returned unknown (possibly timeout)".to_string())
+        }
+    };
+    (result, metrics)
+}
+
 /// Check equivalence with configuration (fast path + optional SMT)
 pub fn check_equivalence_with_config(
     seq1: &[Instruction],

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -197,6 +197,11 @@ pub fn check_equivalence_with_config(
 /// including the SMT formula size in bytes. Use this only when the metrics
 /// are actually consumed — `solver.to_string()` is non-trivial work compared
 /// to `solver.check()` on small problems.
+///
+/// Formula-size is captured **only when the solver returns `unsat`**
+/// (i.e., the candidate was proven equivalent). For `sat` (counter-example)
+/// or `unknown` (timeout) we skip the serialization — the size is
+/// uninteresting in those cases and the cost would be paid on the slow paths.
 pub fn check_equivalence_with_config_metrics(
     seq1: &[Instruction],
     seq2: &[Instruction],
@@ -209,13 +214,18 @@ pub fn check_equivalence_with_config_metrics(
     }
 
     let solver = build_smt_solver(seq1, seq2, config);
-    let smt_formula_bytes = solver.to_string().len();
-    let result = interpret_smt_result(solver.check());
+    let sat_result = solver.check();
+    let smt_formula_bytes = if sat_result == SatResult::Unsat {
+        Some(solver.to_string().len())
+    } else {
+        None
+    };
+    let result = interpret_smt_result(sat_result);
     (
         result,
         EquivalenceMetrics {
             smt_called: true,
-            smt_formula_bytes: Some(smt_formula_bytes),
+            smt_formula_bytes,
         },
     )
 }

--- a/src/semantics/mod.rs
+++ b/src/semantics/mod.rs
@@ -6,11 +6,14 @@ pub mod equivalence;
 pub mod smt;
 pub mod state;
 
-// Re-export main functionality
+// Re-export main functionality. Some items are surfaced for external
+// consumers (or to be discoverable from the public surface of the crate)
+// and aren't called from within this binary, hence the targeted allow.
 pub use concrete::apply_sequence_concrete;
 pub use equivalence::{
     EquivalenceConfig, EquivalenceResult, check_equivalence, check_equivalence_with_config,
 };
+
 #[allow(unused_imports)]
 pub use equivalence::{EquivalenceMetrics, check_equivalence_with_config_metrics};
 #[allow(unused_imports)]

--- a/src/semantics/mod.rs
+++ b/src/semantics/mod.rs
@@ -12,4 +12,6 @@ pub use equivalence::{
     EquivalenceConfig, EquivalenceResult, check_equivalence, check_equivalence_with_config,
 };
 #[allow(unused_imports)]
+pub use equivalence::{EquivalenceMetrics, check_equivalence_with_config_metrics};
+#[allow(unused_imports)]
 pub use state::{ConcreteMachineState, ConcreteValue, ConditionFlags, LiveOutMask};

--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -83,15 +83,15 @@ pub fn compute_written_registers(instructions: &[Instruction]) -> LiveOutMask {
 
 /// Returns true if NZCV may be observable after the sequence executes.
 ///
-/// Conservative static check: refuse if **any** flag-writing instruction is
-/// present, regardless of whether a later instruction overwrites it.
+/// Static check: returns true iff **any** flag-writing instruction is
+/// present in the sequence.
 ///
-/// Sound for the current 20-opcode subset because no instruction in it kills
-/// NZCV without also setting it — if any flag-writer is present, the last
-/// flag-writer's NZCV is observable downstream. If a flag-clobbering or
-/// flag-clearing instruction (e.g. an explicit `MSR NZCV, ...`) is added to
-/// the subset later, this predicate must be revisited: the "any" form would
-/// then be conservative (over-refuse), not exact.
+/// **Exact (not over-approximate) for the current 20-opcode subset.** No
+/// instruction in the subset clears NZCV without also setting it, so any
+/// sequence containing a flag-writer always has live-out flags at the end.
+/// If a flag-clobbering or flag-clearing instruction (e.g. an explicit
+/// `MSR NZCV, ...`) is added later, this predicate becomes a conservative
+/// over-approximation and may need revisiting.
 pub fn flags_live_out(instructions: &[Instruction]) -> bool {
     instructions.iter().any(|i| i.modifies_flags())
 }

--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -83,9 +83,12 @@ pub fn compute_written_registers(instructions: &[Instruction]) -> LiveOutMask {
 
 /// Returns true if NZCV may be observable after the sequence executes.
 ///
-/// Conservative static check: any flag-writing instruction in the sequence makes
-/// NZCV live-out, since the latest flag-write is by definition not overwritten
-/// later in this sequence and downstream code may observe it.
+/// Conservative static check: refuse if **any** flag-writing instruction is
+/// present, regardless of whether a later instruction overwrites it. This is
+/// correct (not just conservative) for the s11 20-opcode subset, which has no
+/// instruction that "kills" NZCV without also setting it: if any flag-writer
+/// exists, the *last* one's NZCV is by definition not overwritten later in
+/// the sequence and downstream code may observe it.
 pub fn flags_live_out(instructions: &[Instruction]) -> bool {
     instructions.iter().any(|i| i.modifies_flags())
 }
@@ -93,6 +96,9 @@ pub fn flags_live_out(instructions: &[Instruction]) -> bool {
 /// Returns true if any instruction reads NZCV flags before any instruction writes them.
 ///
 /// In live-in terms: NZCV is part of the live-in set iff this returns true.
+/// Intended consumer is the LLM prompt builder (per ADR-0001); not currently
+/// wired up because ADR-0003 omits flags from the prompt for the MVP.
+#[allow(dead_code)]
 pub fn reads_flags_before_writing(instructions: &[Instruction]) -> bool {
     for instr in instructions {
         if instr.reads_flags() {

--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -81,10 +81,56 @@ pub fn compute_written_registers(instructions: &[Instruction]) -> LiveOutMask {
     mask
 }
 
+/// Returns true if NZCV may be observable after the sequence executes.
+///
+/// Conservative static check: any flag-writing instruction in the sequence makes
+/// NZCV live-out, since the latest flag-write is by definition not overwritten
+/// later in this sequence and downstream code may observe it.
+pub fn flags_live_out(instructions: &[Instruction]) -> bool {
+    instructions.iter().any(|i| i.modifies_flags())
+}
+
+/// Returns true if any instruction reads NZCV flags before any instruction writes them.
+///
+/// In live-in terms: NZCV is part of the live-in set iff this returns true.
+pub fn reads_flags_before_writing(instructions: &[Instruction]) -> bool {
+    for instr in instructions {
+        if instr.reads_flags() {
+            return true;
+        }
+        if instr.modifies_flags() {
+            return false;
+        }
+    }
+    false
+}
+
+/// Compute the set of registers read before written by a sequence of instructions.
+///
+/// This is the intra-sequence live-in set: any register the sequence reads
+/// before defining (writing) is in the result. XZR is never included.
+pub fn compute_live_in_registers(instructions: &[Instruction]) -> LiveOutMask {
+    let mut live_in = LiveOutMask::empty();
+    let mut written = LiveOutMask::empty();
+
+    for instr in instructions {
+        for src in instr.source_registers() {
+            if !written.contains(src) {
+                live_in.add(src);
+            }
+        }
+        if let Some(dest) = instr.destination() {
+            written.add(dest);
+        }
+    }
+
+    live_in
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ir::Operand;
+    use crate::ir::{Condition, Operand};
 
     #[test]
     fn test_parse_register_x0() {
@@ -218,6 +264,175 @@ mod tests {
         let mask = compute_written_registers(&instructions);
         assert!(mask.contains(Register::X0));
         assert_eq!(mask.len(), 1);
+    }
+
+    #[test]
+    fn test_compute_live_in_registers_empty() {
+        let mask = compute_live_in_registers(&[]);
+        assert!(mask.is_empty());
+    }
+
+    #[test]
+    fn test_compute_live_in_registers_mov_imm_no_sources() {
+        let instructions = vec![Instruction::MovImm {
+            rd: Register::X0,
+            imm: 42,
+        }];
+        let mask = compute_live_in_registers(&instructions);
+        assert!(mask.is_empty());
+    }
+
+    #[test]
+    fn test_flags_live_out_empty() {
+        assert!(!flags_live_out(&[]));
+    }
+
+    #[test]
+    fn test_flags_live_out_cmp() {
+        let instructions = vec![Instruction::Cmp {
+            rn: Register::X0,
+            rm: Operand::Register(Register::X1),
+        }];
+        assert!(flags_live_out(&instructions));
+    }
+
+    #[test]
+    fn test_flags_live_out_add_only() {
+        let instructions = vec![Instruction::Add {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        }];
+        assert!(!flags_live_out(&instructions));
+    }
+
+    #[test]
+    fn test_flags_live_out_cmp_then_add() {
+        // CMP's flags are still live at end (ADD doesn't overwrite them).
+        let instructions = vec![
+            Instruction::Cmp {
+                rn: Register::X0,
+                rm: Operand::Register(Register::X1),
+            },
+            Instruction::Add {
+                rd: Register::X2,
+                rn: Register::X0,
+                rm: Operand::Register(Register::X1),
+            },
+        ];
+        assert!(flags_live_out(&instructions));
+    }
+
+    #[test]
+    fn test_reads_flags_before_writing_empty() {
+        assert!(!reads_flags_before_writing(&[]));
+    }
+
+    #[test]
+    fn test_reads_flags_before_writing_csel_alone() {
+        let instructions = vec![Instruction::Csel {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+            cond: Condition::EQ,
+        }];
+        assert!(reads_flags_before_writing(&instructions));
+    }
+
+    #[test]
+    fn test_reads_flags_before_writing_cmp_then_csel() {
+        let instructions = vec![
+            Instruction::Cmp {
+                rn: Register::X0,
+                rm: Operand::Register(Register::X1),
+            },
+            Instruction::Csel {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Register::X2,
+                cond: Condition::EQ,
+            },
+        ];
+        assert!(!reads_flags_before_writing(&instructions));
+    }
+
+    #[test]
+    fn test_reads_flags_before_writing_csel_then_cmp() {
+        let instructions = vec![
+            Instruction::Csel {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Register::X2,
+                cond: Condition::EQ,
+            },
+            Instruction::Cmp {
+                rn: Register::X0,
+                rm: Operand::Register(Register::X1),
+            },
+        ];
+        assert!(reads_flags_before_writing(&instructions));
+    }
+
+    #[test]
+    fn test_compute_live_in_registers_xzr_excluded() {
+        // MOV x0, xzr — xzr is read but must not appear in live-in (mirrors
+        // compute_written_registers' exclusion of xzr writes).
+        let instructions = vec![Instruction::MovReg {
+            rd: Register::X0,
+            rn: Register::XZR,
+        }];
+        let mask = compute_live_in_registers(&instructions);
+        assert!(!mask.contains(Register::XZR));
+        assert!(mask.is_empty());
+    }
+
+    #[test]
+    fn test_compute_live_in_registers_cmp_reads_both() {
+        // CMP has no destination but reads both operands — both are live-in.
+        let instructions = vec![Instruction::Cmp {
+            rn: Register::X0,
+            rm: Operand::Register(Register::X1),
+        }];
+        let mask = compute_live_in_registers(&instructions);
+        assert!(mask.contains(Register::X0));
+        assert!(mask.contains(Register::X1));
+        assert_eq!(mask.len(), 2);
+    }
+
+    #[test]
+    fn test_compute_live_in_registers_def_kills_use() {
+        // ADD x0, x1, #5 ; ADD x2, x0, #1 — x0 is written before second use
+        let instructions = vec![
+            Instruction::Add {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Immediate(5),
+            },
+            Instruction::Add {
+                rd: Register::X2,
+                rn: Register::X0,
+                rm: Operand::Immediate(1),
+            },
+        ];
+        let mask = compute_live_in_registers(&instructions);
+        assert!(mask.contains(Register::X1));
+        assert!(!mask.contains(Register::X0));
+        assert!(!mask.contains(Register::X2));
+        assert_eq!(mask.len(), 1);
+    }
+
+    #[test]
+    fn test_compute_live_in_registers_add_two_sources() {
+        let instructions = vec![Instruction::Add {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        }];
+        let mask = compute_live_in_registers(&instructions);
+        assert!(mask.contains(Register::X1));
+        assert!(mask.contains(Register::X2));
+        assert!(!mask.contains(Register::X0));
+        assert_eq!(mask.len(), 2);
     }
 
     #[test]

--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -84,11 +84,14 @@ pub fn compute_written_registers(instructions: &[Instruction]) -> LiveOutMask {
 /// Returns true if NZCV may be observable after the sequence executes.
 ///
 /// Conservative static check: refuse if **any** flag-writing instruction is
-/// present, regardless of whether a later instruction overwrites it. This is
-/// correct (not just conservative) for the s11 20-opcode subset, which has no
-/// instruction that "kills" NZCV without also setting it: if any flag-writer
-/// exists, the *last* one's NZCV is by definition not overwritten later in
-/// the sequence and downstream code may observe it.
+/// present, regardless of whether a later instruction overwrites it.
+///
+/// Sound for the current 20-opcode subset because no instruction in it kills
+/// NZCV without also setting it — if any flag-writer is present, the last
+/// flag-writer's NZCV is observable downstream. If a flag-clobbering or
+/// flag-clearing instruction (e.g. an explicit `MSR NZCV, ...`) is added to
+/// the subset later, this predicate must be revisited: the "any" form would
+/// then be conservative (over-refuse), not exact.
 pub fn flags_live_out(instructions: &[Instruction]) -> bool {
     instructions.iter().any(|i| i.modifies_flags())
 }
@@ -96,8 +99,9 @@ pub fn flags_live_out(instructions: &[Instruction]) -> bool {
 /// Returns true if any instruction reads NZCV flags before any instruction writes them.
 ///
 /// In live-in terms: NZCV is part of the live-in set iff this returns true.
-/// Intended consumer is the LLM prompt builder (per ADR-0001); not currently
-/// wired up because ADR-0003 omits flags from the prompt for the MVP.
+/// Used by the prompt builder when flags-live-in support is added (ADR-0001
+/// defines the helper; ADR-0003 omits flags from the prompt for the MVP, so
+/// the function has no consumer yet).
 #[allow(dead_code)]
 pub fn reads_flags_before_writing(instructions: &[Instruction]) -> bool {
     for instr in instructions {

--- a/tests/data/llm_demo/01_mov_add.s
+++ b/tests/data/llm_demo/01_mov_add.s
@@ -1,0 +1,5 @@
+// Live-in: x1
+// Live-out: x0
+// Expected reduction: mov + add (2) -> add (1)
+mov x0, x1
+add x0, x0, #1

--- a/tests/data/llm_demo/02_xor_zero.s
+++ b/tests/data/llm_demo/02_xor_zero.s
@@ -1,5 +1,6 @@
 // Live-in: (none)
 // Live-out: x0
-// Expected reduction: eor x0, x0, x0 (1) — already minimal; mov x0, #0 (1) is alt
+// Expected reduction: 2 -> 1 (drop the redundant `mov x0, x0`).
+//   `eor x0, x0, x0` and `mov x0, #0` are also valid 1-instruction equivalents.
 mov x0, #0
 mov x0, x0

--- a/tests/data/llm_demo/02_xor_zero.s
+++ b/tests/data/llm_demo/02_xor_zero.s
@@ -1,0 +1,5 @@
+// Live-in: (none)
+// Live-out: x0
+// Expected reduction: eor x0, x0, x0 (1) — already minimal; mov x0, #0 (1) is alt
+mov x0, #0
+mov x0, x0

--- a/tests/data/llm_demo/03_redundant_mov.s
+++ b/tests/data/llm_demo/03_redundant_mov.s
@@ -1,0 +1,5 @@
+// Live-in: x1
+// Live-out: x0
+// Expected reduction: mov chain -> single mov
+mov x2, x1
+mov x0, x2

--- a/tests/data/llm_demo/04_add_chain.s
+++ b/tests/data/llm_demo/04_add_chain.s
@@ -1,0 +1,6 @@
+// Live-in: x1
+// Live-out: x0
+// Expected reduction: x0 = x1 + 1 + 2 -> x0 = x1 + 3 (3 -> 1)
+mov x0, x1
+add x0, x0, #1
+add x0, x0, #2

--- a/tests/data/llm_demo/05_sub_via_add.s
+++ b/tests/data/llm_demo/05_sub_via_add.s
@@ -1,0 +1,5 @@
+// Live-in: x1
+// Live-out: x0
+// Expected reduction: x0 = x1 - 1 directly (2 -> 1)
+mov x0, x1
+sub x0, x0, #1

--- a/tests/data/llm_demo/06_double_via_shift.s
+++ b/tests/data/llm_demo/06_double_via_shift.s
@@ -1,0 +1,5 @@
+// Live-in: x1
+// Live-out: x0
+// Expected reduction: x0 = x1 + x1 -> lsl x0, x1, #1 (or single add) (2 -> 1)
+mov x0, x1
+add x0, x0, x1

--- a/tests/data/llm_demo/07_dead_compute.s
+++ b/tests/data/llm_demo/07_dead_compute.s
@@ -1,0 +1,6 @@
+// Live-in: x1
+// Live-out: x0
+// Expected reduction: dead computation in x2 can be removed (3 -> 2 or fewer)
+mov x0, x1
+add x2, x1, #100
+add x0, x0, #5

--- a/tests/data/llm_demo/08_chain05.s
+++ b/tests/data/llm_demo/08_chain05.s
@@ -1,0 +1,9 @@
+// Live-in:  x1
+// Live-out: x0
+// Length:   5 instructions
+// Computes: x0 = x1 + 4   (chain of +1 increments — collapses to a single add)
+mov x0, x1
+add x0, x0, #1
+add x0, x0, #1
+add x0, x0, #1
+add x0, x0, #1

--- a/tests/data/llm_demo/09_chain10.s
+++ b/tests/data/llm_demo/09_chain10.s
@@ -1,0 +1,15 @@
+// Live-in:  x1, x3
+// Live-out: x0
+// Length:   10 instructions
+// Computes: x0 = 2 * (x1 + x3)
+//   with redundant moves and identity adds that should be eliminable.
+mov x0, x1
+mov x2, x3
+add x4, x0, x2
+mov x5, x4
+add x6, x4, x4
+sub x7, x6, x0
+mov x0, x6
+add x0, x0, #2
+sub x0, x0, #2
+add x0, x0, #0

--- a/tests/data/llm_demo/10_chain15.s
+++ b/tests/data/llm_demo/10_chain15.s
@@ -1,0 +1,21 @@
+// Live-in:  x1, x3
+// Live-out: x0
+// Length:   15 instructions
+// Computes: x0 = (x1 + 5) * (x3 - 1)
+//   with dead intermediates (x5, x6, x7, x8, x9) and self-cancelling
+//   add/sub pairs around x0.
+mov x0, x1
+add x0, x0, #5
+mov x2, x3
+sub x2, x2, #1
+mul x4, x0, x2
+mov x5, x4
+mov x6, x5
+add x7, x6, x5
+mov x0, x4
+add x0, x0, x0
+sub x0, x0, x4
+add x0, x0, #0
+sub x0, x0, #0
+add x8, x0, #1
+mov x9, x8

--- a/tests/data/llm_demo/11_chain20.s
+++ b/tests/data/llm_demo/11_chain20.s
@@ -1,0 +1,25 @@
+// Live-in:  x1, x3
+// Live-out: x0
+// Length:   20 instructions
+// Computes: x0 = (x1 + 5) * (x3 - 1)   (same expression as 10_chain15.s,
+//   padded with more dead writes and zero-net-effect arithmetic on x0).
+mov x0, x1
+add x0, x0, #5
+mov x2, x3
+sub x2, x2, #1
+mul x4, x0, x2
+mov x5, x4
+mov x6, x5
+add x7, x6, x5
+mov x0, x4
+add x0, x0, x0
+sub x0, x0, x4
+add x0, x0, #0
+sub x0, x0, #0
+add x8, x0, #1
+mov x9, x8
+mov x10, x4
+add x10, x10, x10
+sub x11, x0, x4
+add x0, x0, x11
+mov x12, x0

--- a/tests/data/llm_demo/run_demo.sh
+++ b/tests/data/llm_demo/run_demo.sh
@@ -17,6 +17,10 @@ TARGETS=(
   "05_sub_via_add.s|x0"
   "06_double_via_shift.s|x0"
   "07_dead_compute.s|x0"
+  "08_chain05.s|x0"
+  "09_chain10.s|x0"
+  "10_chain15.s|x0"
+  "11_chain20.s|x0"
 )
 
 cd "$ROOT"

--- a/tests/data/llm_demo/run_demo.sh
+++ b/tests/data/llm_demo/run_demo.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Local LLM-superoptimizer demo. Iterates the corpus and runs `s11 llm-opt`
+# against each. Requires the codex CLI to be installed and authenticated
+# (subscription).
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+# Each row: filename, live-out spec.
+TARGETS=(
+  "01_mov_add.s|x0"
+  "02_xor_zero.s|x0"
+  "03_redundant_mov.s|x0"
+  "04_add_chain.s|x0"
+  "05_sub_via_add.s|x0"
+  "06_double_via_shift.s|x0"
+  "07_dead_compute.s|x0"
+)
+
+cd "$ROOT"
+
+if [ ! -x "$ROOT/target/release/s11" ] && [ ! -x "$ROOT/target/debug/s11" ]; then
+  echo "building s11 (debug) ..."
+  cargo build
+fi
+
+S11="$ROOT/target/release/s11"
+[ -x "$S11" ] || S11="$ROOT/target/debug/s11"
+
+successes=0
+total=${#TARGETS[@]}
+
+for entry in "${TARGETS[@]}"; do
+  file="${entry%%|*}"
+  liveout="${entry##*|}"
+  asm="$SCRIPT_DIR/$file"
+  echo
+  echo "=================================================================="
+  echo "[$file] live-out=$liveout"
+  echo "=================================================================="
+  if "$S11" llm-opt --asm "$asm" --live-out "$liveout" --max-calls 5 --timeout 60 -v; then
+    successes=$((successes + 1))
+  fi
+done
+
+echo
+echo "=================================================================="
+echo "Demo complete: $successes / $total targets ran without runtime error."
+echo "(Run with --verbose to see per-iteration outcomes.)"
+echo "=================================================================="

--- a/tests/data/llm_demo/run_demo.sh
+++ b/tests/data/llm_demo/run_demo.sh
@@ -3,7 +3,9 @@
 # against each. Requires the codex CLI to be installed and authenticated
 # (subscription).
 
-set -u
+# Per-target failures are expected and handled via `if "$S11" ...`; we only
+# want to abort on infrastructure errors (missing binary, build failure).
+set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"


### PR DESCRIPTION
## Summary

- Adds an LLM-assisted `SearchAlgorithm` impl (`LlmSearch`) that delegates candidate generation to the local Codex CLI (`codex exec -m gpt-5.3-codex-spark`) and reuses the existing fast-random + Z3 SMT equivalence pipeline as the verifier.
- New CLI entry points: `s11 llm-opt --asm <file> --live-out <regs>` (demo) and `s11 opt --algorithm llm` (symmetry with other algorithms). `just llm-demo` walks a 7-target corpus.
- **Includes 3 reverts** of the rand 0.10 / rand_chacha 0.10 dependabot bumps that left main uncompilable. CI did not catch this because dependabot PRs were merged without a local `./ci_check.sh` run.

## Design

Decisions are captured in `CONTEXT.md` and three ADRs:

- **ADR-0001** — derive live-in via intra-sequence def-use rather than threading through the `SearchAlgorithm` trait.
- **ADR-0002** — MVP refuses targets where flags are live-out (the existing `LiveOutMask` doesn't model NZCV; out-of-scope for the MVP).
- **ADR-0003** — prompt does *not* enumerate the s11 opcode subset; rejected mnemonics become a frequency-ranked **research signal** ("which opcodes should s11 add next"), surfaced after each run.

## Loop economics

- One `codex exec` per iteration, fresh prompt, sequential, default temperature.
- Bounded by `max_codex_calls` (default 20) and `SearchConfig.timeout` (default 60s); whichever fires first.
- First strictly shorter, provably equivalent candidate wins.

## Test plan

- [x] `cargo test` — 280 tests (267 unit + 13 integration), all pass
- [x] `cargo fmt -- --check` clean
- [x] `cargo build` clean (zero warnings)
- [x] `./ci_check.sh` clean
- [x] CLI smoke-test: `s11 llm-opt --help` renders
- [x] Flags-live-out gate verified manually (refuses on `cmp x0, x1`)
- [ ] Live demo: `just llm-demo` against real Codex (requires interactive subscription auth — run locally)

## What's tested by units vs the demo

Units cover deterministic pieces: live-in def-use, flags-live-in/out predicates, JSON envelope parsing, outcome classification, ledger aggregation. The Codex shell-out and end-to-end loop wiring are exercised by the bash demo against real Codex; intentionally not mocked.

## Files

| Area | New | Modified |
|---|---|---|
| Design docs | `CONTEXT.md`, `docs/adr/0001-0003.md` | — |
| Library | `src/search/llm/{mod,codex,ledger,outcome,prompt}.rs` | `src/search/{mod,config}.rs`, `src/validation/live_out.rs` |
| CLI | — | `src/main.rs` (new `LlmOpt` subcommand + `Algorithm::Llm` arm) |
| Demo | `tests/data/llm_demo/*.s`, `run_demo.sh` | `Justfile` (`llm-demo` recipe) |
| Deps | — | `Cargo.toml` (+`serde`, +`serde_json`; rand reverted to 0.9.x) |