### PR TITLE
ci: add cargo-mutants integration

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,4 +1,5 @@
-# cargo-mutants configuration. See https://mutants.rs/.
+# cargo-mutants configuration. cargo-mutants reads this file from
+# `.cargo/mutants.toml` automatically (see `cargo mutants --help`).
 #
 # Intentionally minimal for the initial rollout. Tighten exclude_globs and
 # exclude_re_in_file once the first nightly identifies modules dominated by
@@ -7,4 +8,8 @@
 # Allow each mutant 5x the baseline test runtime before declaring timeout.
 # Integration tests take ~1-2 min and some mutants intentionally cause
 # unbounded loops (e.g. mutating loop bounds in src/search/).
+#
+# Note: the CI workflows pass `--timeout 180` explicitly, which overrides
+# this multiplier in CI. The multiplier still governs `just mutants` and any
+# other invocation that doesn't pass `--timeout`.
 timeout_multiplier = 5.0

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -13,3 +13,10 @@
 # this multiplier in CI. The multiplier still governs `just mutants` and any
 # other invocation that doesn't pass `--timeout`.
 timeout_multiplier = 5.0
+
+# Match the baseline (`cargo test --bins`) used in CI and `just mutants`. The
+# integration tests under tests/integration/ are flaky in our CI environment
+# (test.yml runs them with `|| true`), so including them in per-mutant runs
+# would mark every mutant as caught by the pre-existing flake instead of by
+# the mutation itself.
+additional_cargo_test_args = ["--bins"]

--- a/.github/workflows/cargo-mutants-pr.yml
+++ b/.github/workflows/cargo-mutants-pr.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   diff:
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       contents: read
       pull-requests: write
@@ -24,8 +24,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             libcapstone-dev gcc-aarch64-linux-gnu z3 libz3-dev
-          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh \
-            | sudo bash -s -- --to /usr/local/bin
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -35,10 +33,19 @@ jobs:
 
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-mutants
+          tool: just,cargo-mutants
 
       - name: Build AArch64 test binaries
         run: ./build_tests.sh
+
+      - name: Baseline build and tests
+        # Run a passing baseline before invoking `cargo mutants --baseline=skip`.
+        # Without this, an unrelated test failure in the PR causes every mutated
+        # build to fail identically and the sticky comment misreports them as
+        # "caught" instead of surfacing the underlying breakage.
+        run: |
+          cargo build
+          cargo test
 
       - name: Compute diff vs base
         run: git diff "origin/${{ github.base_ref }}..." > pr.diff
@@ -67,10 +74,20 @@ jobs:
           mkdir -p mutants.out
           python3 scripts/mutants_summary.py mutants.out \
             --pr-comment mutants.out/comment.md \
+            --run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
             >> "$GITHUB_STEP_SUMMARY"
 
       - name: Comment on PR
-        if: always()
+        # Skip on fork PRs and Dependabot, where GITHUB_TOKEN is read-only despite
+        # the `pull-requests: write` declaration above and the sticky-comment
+        # action would fail. Also skip when no comment body was produced (e.g.
+        # docs-only PRs where mutants_summary.py suppresses an all-zero comment).
+        if: >-
+          always()
+          && github.event.pull_request.head.repo.full_name == github.repository
+          && github.actor != 'dependabot[bot]'
+          && hashFiles('mutants.out/comment.md') != ''
+        continue-on-error: true
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: cargo-mutants

--- a/.github/workflows/cargo-mutants-pr.yml
+++ b/.github/workflows/cargo-mutants-pr.yml
@@ -72,6 +72,7 @@ jobs:
           name: mutants-pr
           path: mutants.out
           if-no-files-found: ignore
+          retention-days: 14
 
       - name: Generate PR comment body
         if: always()

--- a/.github/workflows/cargo-mutants-pr.yml
+++ b/.github/workflows/cargo-mutants-pr.yml
@@ -43,9 +43,14 @@ jobs:
         # Without this, an unrelated test failure in the PR causes every mutated
         # build to fail identically and the sticky comment misreports them as
         # "caught" instead of surfacing the underlying breakage.
+        #
+        # Unit tests (--bins) only, matching the gating in `.github/workflows/test.yml`
+        # which runs integration tests with `|| true`. The flaky integration tests
+        # there should be hardened separately; gating cargo-mutants on them would be
+        # stricter than the project-wide CI policy.
         run: |
           cargo build
-          cargo test
+          cargo test --bins
 
       - name: Compute diff vs base
         run: git diff "origin/${{ github.base_ref }}..." > pr.diff

--- a/.github/workflows/cargo-mutants-pr.yml
+++ b/.github/workflows/cargo-mutants-pr.yml
@@ -1,0 +1,77 @@
+name: cargo-mutants (PR diff)
+
+on:
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  diff:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libcapstone-dev gcc-aarch64-linux-gnu z3 libz3-dev
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh \
+            | sudo bash -s -- --to /usr/local/bin
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: cargo-mutants
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-mutants
+
+      - name: Build AArch64 test binaries
+        run: ./build_tests.sh
+
+      - name: Compute diff vs base
+        run: git diff "origin/${{ github.base_ref }}..." > pr.diff
+
+      - name: Run cargo-mutants on diff
+        continue-on-error: true
+        run: |
+          cargo mutants \
+            --in-diff pr.diff \
+            --baseline=skip \
+            --timeout 180 \
+            --in-place \
+            -vV
+
+      - name: Upload mutants.out
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: mutants-pr
+          path: mutants.out
+          if-no-files-found: ignore
+
+      - name: Generate PR comment body
+        if: always()
+        run: |
+          mkdir -p mutants.out
+          python3 scripts/mutants_summary.py mutants.out \
+            --pr-comment mutants.out/comment.md \
+            >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment on PR
+        if: always()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: cargo-mutants
+          path: mutants.out/comment.md

--- a/.github/workflows/cargo-mutants.yml
+++ b/.github/workflows/cargo-mutants.yml
@@ -1,0 +1,87 @@
+name: cargo-mutants
+
+on:
+  schedule:
+    - cron: "17 2 * * *"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cargo-mutants:
+    name: shard ${{ matrix.shard }}/8
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libcapstone-dev gcc-aarch64-linux-gnu z3 libz3-dev
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh \
+            | sudo bash -s -- --to /usr/local/bin
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: cargo-mutants
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-mutants
+
+      - name: Build AArch64 test binaries
+        run: ./build_tests.sh
+
+      - name: Baseline build and tests
+        run: |
+          cargo build
+          cargo test
+
+      - name: Run cargo-mutants shard
+        continue-on-error: true
+        run: |
+          cargo mutants \
+            --no-shuffle \
+            -vV \
+            --shard "${{ matrix.shard }}/8" \
+            --sharding round-robin \
+            --baseline=skip \
+            --timeout 180 \
+            --in-place
+
+      - name: Upload mutants.out
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: mutants-shard-${{ matrix.shard }}
+          path: mutants.out
+          if-no-files-found: ignore
+
+  summary:
+    name: aggregate summary
+    runs-on: ubuntu-24.04
+    needs: cargo-mutants
+    if: always()
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v5
+        with:
+          path: shards
+          pattern: mutants-shard-*
+
+      - name: Write summary
+        run: |
+          python3 scripts/mutants_summary.py shards \
+            >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cargo-mutants.yml
+++ b/.github/workflows/cargo-mutants.yml
@@ -69,6 +69,7 @@ jobs:
           name: mutants-shard-${{ matrix.shard }}
           path: mutants.out
           if-no-files-found: ignore
+          retention-days: 14
 
   summary:
     name: aggregate summary

--- a/.github/workflows/cargo-mutants.yml
+++ b/.github/workflows/cargo-mutants.yml
@@ -13,6 +13,8 @@ jobs:
     name: shard ${{ matrix.shard }}/8
     runs-on: ubuntu-24.04
     timeout-minutes: 180
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -25,8 +27,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             libcapstone-dev gcc-aarch64-linux-gnu z3 libz3-dev
-          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh \
-            | sudo bash -s -- --to /usr/local/bin
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -36,7 +36,7 @@ jobs:
 
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-mutants
+          tool: just,cargo-mutants
 
       - name: Build AArch64 test binaries
         run: ./build_tests.sh

--- a/.github/workflows/cargo-mutants.yml
+++ b/.github/workflows/cargo-mutants.yml
@@ -42,9 +42,13 @@ jobs:
         run: ./build_tests.sh
 
       - name: Baseline build and tests
+        # Unit tests only, matching the gating in `.github/workflows/test.yml`
+        # which runs integration tests with `|| true`. cargo-mutants itself will
+        # run the full suite per mutated build below; gating the baseline on
+        # known-flaky integration tests would only mask the mutants signal.
         run: |
           cargo build
-          cargo test
+          cargo test --bins
 
       - name: Run cargo-mutants shard
         continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,10 @@ binaries/
 .vscode/
 .claude/settings.local.json
 .claude/worktrees/
+
+# Python bytecode (scripts/)
+__pycache__/
+
+# cargo-mutants output
+mutants.out/
+mutants.out.old/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,15 @@ This prevents pushing code that will fail CI checks.
 
 Note: Clippy linting is run separately in the `rust-clippy.yml` workflow which performs security analysis and uploads results to GitHub's security tab.
 
+### Mutation Testing (informational)
+
+Mutation testing runs via [cargo-mutants](https://mutants.rs/) and is **informational only** — it does not gate merges.
+
+- `cargo-mutants.yml` — sharded × 8, runs nightly at 02:17 UTC and on `workflow_dispatch`. Per-shard `mutants.out` is uploaded as an artifact, and an aggregation job posts a caught/missed/timeout/unviable summary to the run's step summary.
+- `cargo-mutants-pr.yml` — runs on each PR using `cargo mutants --in-diff` against the PR base, and posts a sticky comment summarizing the diff's mutation outcomes.
+- Locally: `just mutants` runs the same flow (slow; expect >30 min).
+- Configuration lives in `mutants.toml` at the repo root.
+
 ## Dependencies
 
 The project requires:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Mutation testing runs via [cargo-mutants](https://mutants.rs/) and is **informat
 - `cargo-mutants.yml` — sharded × 8, runs nightly at 02:17 UTC and on `workflow_dispatch`. Per-shard `mutants.out` is uploaded as an artifact, and an aggregation job posts a caught/missed/timeout/unviable summary to the run's step summary.
 - `cargo-mutants-pr.yml` — runs on each PR using `cargo mutants --in-diff` against the PR base, and posts a sticky comment summarizing the diff's mutation outcomes.
 - Locally: `just mutants` runs the same flow (slow; expect >30 min).
-- Configuration lives in `mutants.toml` at the repo root.
+- Configuration lives in `.cargo/mutants.toml` (cargo-mutants reads this path automatically).
 
 ## Dependencies
 

--- a/Justfile
+++ b/Justfile
@@ -79,12 +79,13 @@ llm-demo: build
     ./tests/data/llm_demo/run_demo.sh
 
 # Run cargo-mutants locally (slow). Mirrors the nightly CI invocation.
+# The baseline uses `cargo test --bins` to match the gating policy in
+# `.github/workflows/test.yml`, which runs integration tests with `|| true`.
 mutants: build-tests
     @echo "Running cargo-mutants (this can take >30 min)..."
     cargo build
-    cargo test
+    cargo test --bins
     cargo mutants --baseline=skip --timeout 180 --in-place -vV
-
 
 # Help message (can be more detailed than just listing)
 help:

--- a/Justfile
+++ b/Justfile
@@ -78,6 +78,14 @@ llm-demo: build
     @echo "Running LLM-assisted superoptimizer demo..."
     ./tests/data/llm_demo/run_demo.sh
 
+# Run cargo-mutants locally (slow). Mirrors the nightly CI invocation.
+mutants: build-tests
+    @echo "Running cargo-mutants (this can take >30 min)..."
+    cargo build
+    cargo test
+    cargo mutants --baseline=skip --timeout 180 --in-place -vV
+
+
 # Help message (can be more detailed than just listing)
 help:
     @echo "Available commands for AArch64 Super-Optimizer MVP (run with 'just <command>'):"
@@ -89,6 +97,7 @@ help:
     @echo "  test          - Run tests"
     @echo "  build-tests   - Build AArch64 test binaries"
     @echo "  test-all      - Run complete test suite"
+    @echo "  mutants       - Run cargo-mutants locally (slow; informational)"
     @echo "  clean         - Remove build artifacts from the target directory"
     @echo "  check         - Check the code for errors without compiling"
     @echo "  fmt           - Format the Rust code"

--- a/ci_check.sh
+++ b/ci_check.sh
@@ -35,19 +35,21 @@ cargo build --verbose
 print_status "Build"
 echo
 
-# 3. Run unit tests
-echo "3. Running unit tests..."
-cargo test --verbose
-print_status "Unit tests"
-echo
-
-# 4. Build test binaries (if build_tests.sh exists)
+# 3. Build test binaries (if build_tests.sh exists)
+# Must run before `cargo test` because integration tests under tests/integration/
+# load the cross-compiled AArch64 binaries from binaries/.
 if [ -f "./build_tests.sh" ]; then
-    echo "4. Building test binaries..."
+    echo "3. Building test binaries..."
     ./build_tests.sh
     print_status "Test binary build"
     echo
 fi
+
+# 4. Run unit + integration tests
+echo "4. Running tests..."
+cargo test --verbose
+print_status "Tests"
+echo
 
 # 5. Run all tests (if test_all.sh exists)
 if [ -f "./test_all.sh" ]; then

--- a/mutants.toml
+++ b/mutants.toml
@@ -1,0 +1,10 @@
+# cargo-mutants configuration. See https://mutants.rs/.
+#
+# Intentionally minimal for the initial rollout. Tighten exclude_globs and
+# exclude_re_in_file once the first nightly identifies modules dominated by
+# I/O / CLI plumbing or known infinite-loop-prone code.
+
+# Allow each mutant 5x the baseline test runtime before declaring timeout.
+# Integration tests take ~1-2 min and some mutants intentionally cause
+# unbounded loops (e.g. mutating loop bounds in src/search/).
+timeout_multiplier = 5.0

--- a/scripts/mutants_summary.py
+++ b/scripts/mutants_summary.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Aggregate cargo-mutants shard outputs into a Markdown summary.
+
+Usage:
+    mutants_summary.py <root>                       # write summary to stdout
+    mutants_summary.py <root> --pr-comment <path>   # also write PR comment body
+"""
+
+import argparse
+import pathlib
+import sys
+
+BUCKETS = ("caught", "missed", "timeout", "unviable", "unrun")
+
+
+def count_lines(path: pathlib.Path) -> int:
+    if not path.exists():
+        return 0
+    with path.open() as f:
+        return sum(1 for _ in f)
+
+
+def read_shard(root: pathlib.Path) -> dict[str, int]:
+    return {b: count_lines(root / f"{b}.txt") for b in BUCKETS}
+
+
+def _has_bucket_files(root: pathlib.Path) -> bool:
+    return any((root / f"{b}.txt").exists() for b in BUCKETS)
+
+
+def format_pr_comment(totals: dict[str, int], missed_lines: list[str], max_missed: int = 10) -> str:
+    parts = ["**cargo-mutants** (PR diff)", ""]
+    parts.append(", ".join(f"{b}: {totals[b]}" for b in BUCKETS))
+    if missed_lines:
+        parts.append("")
+        parts.append("### Missed mutants")
+        shown = missed_lines[:max_missed]
+        for line in shown:
+            parts.append(f"- `{line}`")
+        if len(missed_lines) > max_missed:
+            parts.append(f"_(showing {max_missed} of {len(missed_lines)})_")
+    return "\n".join(parts) + "\n"
+
+
+def format_summary_md(agg: dict) -> str:
+    lines = ["## cargo-mutants summary", ""]
+    if not agg["shards"]:
+        lines.append("_no shards found_")
+        return "\n".join(lines) + "\n"
+    header = "| shard | " + " | ".join(BUCKETS) + " |"
+    sep = "|" + "|".join(["---"] * (len(BUCKETS) + 1)) + "|"
+    lines += [header, sep]
+    for name, counts in agg["shards"]:
+        row = f"| {name} | " + " | ".join(str(counts[b]) for b in BUCKETS) + " |"
+        lines.append(row)
+    totals = agg["totals"]
+    total_row = "| **total** | " + " | ".join(f"**{totals[b]}**" for b in BUCKETS) + " |"
+    lines.append(total_row)
+    return "\n".join(lines) + "\n"
+
+
+def aggregate(root: pathlib.Path) -> dict:
+    if _has_bucket_files(root):
+        shards = [(root.name, read_shard(root))]
+    else:
+        shards = sorted(
+            ((d.name, read_shard(d)) for d in root.iterdir() if d.is_dir() and _has_bucket_files(d)),
+            key=lambda s: s[0],
+        )
+    totals = dict.fromkeys(BUCKETS, 0)
+    for _, counts in shards:
+        for b in BUCKETS:
+            totals[b] += counts[b]
+    return {"shards": shards, "totals": totals}
+
+
+def _read_missed_lines(root: pathlib.Path) -> list[str]:
+    if _has_bucket_files(root):
+        candidates = [root]
+    else:
+        candidates = [d for d in root.iterdir() if d.is_dir() and _has_bucket_files(d)]
+    out: list[str] = []
+    for c in candidates:
+        p = c / "missed.txt"
+        if p.exists():
+            out.extend(line.rstrip("\n") for line in p.read_text().splitlines() if line.strip())
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("root", type=pathlib.Path)
+    ap.add_argument("--pr-comment", type=pathlib.Path)
+    args = ap.parse_args(argv)
+
+    agg = aggregate(args.root)
+    sys.stdout.write(format_summary_md(agg))
+
+    if args.pr_comment is not None:
+        missed = _read_missed_lines(args.root)
+        body = format_pr_comment(agg["totals"], missed)
+        args.pr_comment.parent.mkdir(parents=True, exist_ok=True)
+        args.pr_comment.write_text(body)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mutants_summary.py
+++ b/scripts/mutants_summary.py
@@ -28,7 +28,12 @@ def _has_bucket_files(root: pathlib.Path) -> bool:
     return any((root / f"{b}.txt").exists() for b in BUCKETS)
 
 
-def format_pr_comment(totals: dict[str, int], missed_lines: list[str], max_missed: int = 10) -> str:
+def format_pr_comment(
+    totals: dict[str, int],
+    missed_lines: list[str],
+    max_missed: int = 10,
+    run_url: str | None = None,
+) -> str:
     parts = ["**cargo-mutants** (PR diff)", ""]
     parts.append(", ".join(f"{b}: {totals[b]}" for b in BUCKETS))
     if missed_lines:
@@ -39,7 +44,14 @@ def format_pr_comment(totals: dict[str, int], missed_lines: list[str], max_misse
             parts.append(f"- `{line}`")
         if len(missed_lines) > max_missed:
             parts.append(f"_(showing {max_missed} of {len(missed_lines)})_")
+    if run_url:
+        parts.append("")
+        parts.append(f"Full results: [workflow run]({run_url})")
     return "\n".join(parts) + "\n"
+
+
+def is_empty_result(totals: dict[str, int]) -> bool:
+    return all(totals.get(b, 0) == 0 for b in BUCKETS)
 
 
 def format_summary_md(agg: dict) -> str:
@@ -78,27 +90,34 @@ def _read_missed_lines(root: pathlib.Path) -> list[str]:
     if _has_bucket_files(root):
         candidates = [root]
     else:
-        candidates = [d for d in root.iterdir() if d.is_dir() and _has_bucket_files(d)]
+        candidates = sorted(
+            (d for d in root.iterdir() if d.is_dir() and _has_bucket_files(d)),
+            key=lambda d: d.name,
+        )
     out: list[str] = []
     for c in candidates:
         p = c / "missed.txt"
         if p.exists():
             out.extend(line.rstrip("\n") for line in p.read_text().splitlines() if line.strip())
-    return out
+    return list(dict.fromkeys(out))
 
 
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("root", type=pathlib.Path)
     ap.add_argument("--pr-comment", type=pathlib.Path)
+    ap.add_argument("--run-url", default=None, help="Workflow run URL to link from PR comment")
     args = ap.parse_args(argv)
 
     agg = aggregate(args.root)
     sys.stdout.write(format_summary_md(agg))
 
-    if args.pr_comment is not None:
+    # Skip writing the PR comment when there are no mutants at all (e.g. docs-only
+    # PRs). The workflow guards the sticky-comment step with `hashFiles(...)` so a
+    # missing file simply suppresses the comment.
+    if args.pr_comment is not None and not is_empty_result(agg["totals"]):
         missed = _read_missed_lines(args.root)
-        body = format_pr_comment(agg["totals"], missed)
+        body = format_pr_comment(agg["totals"], missed, run_url=args.run_url)
         args.pr_comment.parent.mkdir(parents=True, exist_ok=True)
         args.pr_comment.write_text(body)
     return 0

--- a/scripts/test_mutants_summary.py
+++ b/scripts/test_mutants_summary.py
@@ -12,6 +12,20 @@ import unittest
 import mutants_summary as ms
 
 
+def make_shard(root: pathlib.Path, **buckets) -> None:
+    """Materialize a shard directory with the requested bucket contents.
+
+    Each keyword maps a bucket name to either an int (number of placeholder lines)
+    or a string (literal contents to write).
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    for name, content in buckets.items():
+        if isinstance(content, int):
+            n = content
+            content = ("\n".join(f"m{i}" for i in range(n))) + ("\n" if n else "")
+        (root / f"{name}.txt").write_text(content)
+
+
 class TestCountLines(unittest.TestCase):
     def test_missing_file_returns_zero(self):
         self.assertEqual(ms.count_lines(pathlib.Path("/no/such/file.txt")), 0)
@@ -36,15 +50,10 @@ class TestCountLines(unittest.TestCase):
 
 
 class TestReadShard(unittest.TestCase):
-    def _make_shard(self, root: pathlib.Path, **buckets: int) -> None:
-        root.mkdir(parents=True, exist_ok=True)
-        for name, n in buckets.items():
-            (root / f"{name}.txt").write_text("\n".join(f"m{i}" for i in range(n)) + ("\n" if n else ""))
-
     def test_reads_all_five_buckets(self):
         with tempfile.TemporaryDirectory() as d:
             shard = pathlib.Path(d) / "mutants-shard-0"
-            self._make_shard(shard, caught=10, missed=2, timeout=1, unviable=3, unrun=0)
+            make_shard(shard, caught=10, missed=2, timeout=1, unviable=3, unrun=0)
             counts = ms.read_shard(shard)
             self.assertEqual(
                 counts,
@@ -63,16 +72,11 @@ class TestReadShard(unittest.TestCase):
 
 
 class TestAggregate(unittest.TestCase):
-    def _make_shard(self, root: pathlib.Path, **buckets: int) -> None:
-        root.mkdir(parents=True, exist_ok=True)
-        for name, n in buckets.items():
-            (root / f"{name}.txt").write_text("\n".join(f"m{i}" for i in range(n)) + ("\n" if n else ""))
-
     def test_aggregates_multiple_shards(self):
         with tempfile.TemporaryDirectory() as d:
             root = pathlib.Path(d)
-            self._make_shard(root / "mutants-shard-0", caught=5, missed=1, timeout=0, unviable=0, unrun=0)
-            self._make_shard(root / "mutants-shard-1", caught=3, missed=2, timeout=1, unviable=0, unrun=0)
+            make_shard(root / "mutants-shard-0", caught=5, missed=1, timeout=0, unviable=0, unrun=0)
+            make_shard(root / "mutants-shard-1", caught=3, missed=2, timeout=1, unviable=0, unrun=0)
             result = ms.aggregate(root)
             self.assertEqual([s[0] for s in result["shards"]], ["mutants-shard-0", "mutants-shard-1"])
             self.assertEqual(result["totals"]["caught"], 8)
@@ -82,7 +86,7 @@ class TestAggregate(unittest.TestCase):
     def test_treats_root_with_bucket_files_as_single_shard(self):
         with tempfile.TemporaryDirectory() as d:
             root = pathlib.Path(d) / "mutants.out"
-            self._make_shard(root, caught=4, missed=2, timeout=0, unviable=0, unrun=0)
+            make_shard(root, caught=4, missed=2, timeout=0, unviable=0, unrun=0)
             result = ms.aggregate(root)
             self.assertEqual(len(result["shards"]), 1)
             self.assertEqual(result["shards"][0][0], "mutants.out")
@@ -160,20 +164,117 @@ class TestFormatPrComment(unittest.TestCase):
         )
         self.assertNotIn("Missed mutants", out)
 
+    def test_includes_run_url_when_provided(self):
+        out = ms.format_pr_comment(
+            totals={"caught": 1, "missed": 0, "timeout": 0, "unviable": 0, "unrun": 0},
+            missed_lines=[],
+            run_url="https://github.com/o/r/actions/runs/123",
+        )
+        self.assertIn("https://github.com/o/r/actions/runs/123", out)
+        self.assertIn("workflow run", out)
+
+    def test_no_run_url_section_when_omitted(self):
+        out = ms.format_pr_comment(
+            totals={"caught": 1, "missed": 0, "timeout": 0, "unviable": 0, "unrun": 0},
+            missed_lines=[],
+        )
+        self.assertNotIn("workflow run", out)
+
+
+class TestIsEmptyResult(unittest.TestCase):
+    def test_all_zero_is_empty(self):
+        self.assertTrue(ms.is_empty_result(dict.fromkeys(ms.BUCKETS, 0)))
+
+    def test_any_nonzero_is_not_empty(self):
+        for b in ms.BUCKETS:
+            counts = dict.fromkeys(ms.BUCKETS, 0)
+            counts[b] = 1
+            self.assertFalse(ms.is_empty_result(counts), f"{b} bumped should be non-empty")
+
+
+class TestReadMissedLines(unittest.TestCase):
+    def test_single_root_returns_lines_in_order(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d) / "mutants.out"
+            make_shard(
+                root,
+                missed="src/a.rs:1: m1\nsrc/b.rs:2: m2\n",
+                caught=0, timeout=0, unviable=0, unrun=0,
+            )
+            self.assertEqual(
+                ms._read_missed_lines(root),
+                ["src/a.rs:1: m1", "src/b.rs:2: m2"],
+            )
+
+    def test_multi_shard_uses_sorted_directory_order(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            # Create out-of-order so the test would fail if iterdir() order leaked.
+            make_shard(
+                root / "mutants-shard-2",
+                missed="src/c.rs:1: from-shard-2\n",
+                caught=0, timeout=0, unviable=0, unrun=0,
+            )
+            make_shard(
+                root / "mutants-shard-0",
+                missed="src/a.rs:1: from-shard-0\n",
+                caught=0, timeout=0, unviable=0, unrun=0,
+            )
+            make_shard(
+                root / "mutants-shard-1",
+                missed="src/b.rs:1: from-shard-1\n",
+                caught=0, timeout=0, unviable=0, unrun=0,
+            )
+            self.assertEqual(
+                ms._read_missed_lines(root),
+                [
+                    "src/a.rs:1: from-shard-0",
+                    "src/b.rs:1: from-shard-1",
+                    "src/c.rs:1: from-shard-2",
+                ],
+            )
+
+    def test_dedupes_across_shards(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            make_shard(
+                root / "mutants-shard-0",
+                missed="src/a.rs:1: dup\nsrc/a.rs:2: only-in-0\n",
+                caught=0, timeout=0, unviable=0, unrun=0,
+            )
+            make_shard(
+                root / "mutants-shard-1",
+                missed="src/a.rs:1: dup\nsrc/a.rs:3: only-in-1\n",
+                caught=0, timeout=0, unviable=0, unrun=0,
+            )
+            self.assertEqual(
+                ms._read_missed_lines(root),
+                [
+                    "src/a.rs:1: dup",
+                    "src/a.rs:2: only-in-0",
+                    "src/a.rs:3: only-in-1",
+                ],
+            )
+
+    def test_skips_blank_lines(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d) / "mutants.out"
+            make_shard(
+                root,
+                missed="src/a.rs:1: m1\n\n   \nsrc/b.rs:2: m2\n",
+                caught=0, timeout=0, unviable=0, unrun=0,
+            )
+            self.assertEqual(
+                ms._read_missed_lines(root),
+                ["src/a.rs:1: m1", "src/b.rs:2: m2"],
+            )
+
 
 class TestMainCli(unittest.TestCase):
-    def _make_shard(self, root: pathlib.Path, **buckets):
-        root.mkdir(parents=True, exist_ok=True)
-        for name, content in buckets.items():
-            if isinstance(content, int):
-                lines = "\n".join(f"m{i}" for i in range(content))
-                content = lines + ("\n" if content else "")
-            (root / f"{name}.txt").write_text(content)
-
     def test_main_writes_summary_to_stdout(self):
         with tempfile.TemporaryDirectory() as d:
             root = pathlib.Path(d)
-            self._make_shard(root / "mutants-shard-0", caught=5, missed=1, timeout=0, unviable=0, unrun=0)
+            make_shard(root / "mutants-shard-0", caught=5, missed=1, timeout=0, unviable=0, unrun=0)
             buf = io.StringIO()
             with contextlib.redirect_stdout(buf):
                 rc = ms.main([str(root)])
@@ -185,13 +286,11 @@ class TestMainCli(unittest.TestCase):
     def test_main_writes_pr_comment_when_flag_set(self):
         with tempfile.TemporaryDirectory() as d:
             root = pathlib.Path(d) / "mutants.out"
-            self._make_shard(
+            make_shard(
                 root,
                 caught=2,
                 missed="src/a.rs:10: replace + with -\nsrc/b.rs:20: delete return\n",
-                timeout=0,
-                unviable=0,
-                unrun=0,
+                timeout=0, unviable=0, unrun=0,
             )
             comment_path = pathlib.Path(d) / "comment.md"
             buf = io.StringIO()
@@ -202,6 +301,38 @@ class TestMainCli(unittest.TestCase):
             body = comment_path.read_text()
             self.assertIn("missed: 2", body)
             self.assertIn("src/a.rs:10: replace + with -", body)
+
+    def test_main_skips_pr_comment_when_all_buckets_empty(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d) / "mutants.out"
+            make_shard(root, caught=0, missed=0, timeout=0, unviable=0, unrun=0)
+            comment_path = pathlib.Path(d) / "comment.md"
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                rc = ms.main([str(root), "--pr-comment", str(comment_path)])
+            self.assertEqual(rc, 0)
+            self.assertFalse(
+                comment_path.exists(),
+                "comment.md must not be written when all buckets are zero",
+            )
+
+    def test_main_passes_run_url_into_pr_comment(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d) / "mutants.out"
+            make_shard(root, caught=1, missed=0, timeout=0, unviable=0, unrun=0)
+            comment_path = pathlib.Path(d) / "comment.md"
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                rc = ms.main(
+                    [
+                        str(root),
+                        "--pr-comment", str(comment_path),
+                        "--run-url", "https://github.com/o/r/actions/runs/42",
+                    ]
+                )
+            self.assertEqual(rc, 0)
+            body = comment_path.read_text()
+            self.assertIn("https://github.com/o/r/actions/runs/42", body)
 
 
 if __name__ == "__main__":

--- a/scripts/test_mutants_summary.py
+++ b/scripts/test_mutants_summary.py
@@ -1,0 +1,208 @@
+"""Tests for scripts/mutants_summary.py.
+
+Run with: python3 -m unittest scripts/test_mutants_summary.py
+"""
+
+import contextlib
+import io
+import pathlib
+import tempfile
+import unittest
+
+import mutants_summary as ms
+
+
+class TestCountLines(unittest.TestCase):
+    def test_missing_file_returns_zero(self):
+        self.assertEqual(ms.count_lines(pathlib.Path("/no/such/file.txt")), 0)
+
+    def test_counts_lines_in_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = pathlib.Path(d) / "x.txt"
+            p.write_text("a\nb\nc\n")
+            self.assertEqual(ms.count_lines(p), 3)
+
+    def test_empty_file_returns_zero(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = pathlib.Path(d) / "x.txt"
+            p.write_text("")
+            self.assertEqual(ms.count_lines(p), 0)
+
+    def test_no_trailing_newline_still_counts(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = pathlib.Path(d) / "x.txt"
+            p.write_text("a\nb")
+            self.assertEqual(ms.count_lines(p), 2)
+
+
+class TestReadShard(unittest.TestCase):
+    def _make_shard(self, root: pathlib.Path, **buckets: int) -> None:
+        root.mkdir(parents=True, exist_ok=True)
+        for name, n in buckets.items():
+            (root / f"{name}.txt").write_text("\n".join(f"m{i}" for i in range(n)) + ("\n" if n else ""))
+
+    def test_reads_all_five_buckets(self):
+        with tempfile.TemporaryDirectory() as d:
+            shard = pathlib.Path(d) / "mutants-shard-0"
+            self._make_shard(shard, caught=10, missed=2, timeout=1, unviable=3, unrun=0)
+            counts = ms.read_shard(shard)
+            self.assertEqual(
+                counts,
+                {"caught": 10, "missed": 2, "timeout": 1, "unviable": 3, "unrun": 0},
+            )
+
+    def test_missing_bucket_files_count_as_zero(self):
+        with tempfile.TemporaryDirectory() as d:
+            shard = pathlib.Path(d) / "empty"
+            shard.mkdir()
+            counts = ms.read_shard(shard)
+            self.assertEqual(
+                counts,
+                {"caught": 0, "missed": 0, "timeout": 0, "unviable": 0, "unrun": 0},
+            )
+
+
+class TestAggregate(unittest.TestCase):
+    def _make_shard(self, root: pathlib.Path, **buckets: int) -> None:
+        root.mkdir(parents=True, exist_ok=True)
+        for name, n in buckets.items():
+            (root / f"{name}.txt").write_text("\n".join(f"m{i}" for i in range(n)) + ("\n" if n else ""))
+
+    def test_aggregates_multiple_shards(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            self._make_shard(root / "mutants-shard-0", caught=5, missed=1, timeout=0, unviable=0, unrun=0)
+            self._make_shard(root / "mutants-shard-1", caught=3, missed=2, timeout=1, unviable=0, unrun=0)
+            result = ms.aggregate(root)
+            self.assertEqual([s[0] for s in result["shards"]], ["mutants-shard-0", "mutants-shard-1"])
+            self.assertEqual(result["totals"]["caught"], 8)
+            self.assertEqual(result["totals"]["missed"], 3)
+            self.assertEqual(result["totals"]["timeout"], 1)
+
+    def test_treats_root_with_bucket_files_as_single_shard(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d) / "mutants.out"
+            self._make_shard(root, caught=4, missed=2, timeout=0, unviable=0, unrun=0)
+            result = ms.aggregate(root)
+            self.assertEqual(len(result["shards"]), 1)
+            self.assertEqual(result["shards"][0][0], "mutants.out")
+            self.assertEqual(result["totals"]["caught"], 4)
+
+    def test_empty_root_yields_zero_totals(self):
+        with tempfile.TemporaryDirectory() as d:
+            result = ms.aggregate(pathlib.Path(d))
+            self.assertEqual(result["shards"], [])
+            self.assertEqual(result["totals"], dict.fromkeys(ms.BUCKETS, 0))
+
+
+class TestFormatSummaryMd(unittest.TestCase):
+    def _agg(self, shards, totals):
+        return {"shards": shards, "totals": totals}
+
+    def test_header_lists_buckets_in_order(self):
+        agg = self._agg(
+            [("s0", {"caught": 0, "missed": 0, "timeout": 0, "unviable": 0, "unrun": 0})],
+            dict.fromkeys(ms.BUCKETS, 0),
+        )
+        out = ms.format_summary_md(agg)
+        self.assertIn("| shard | caught | missed | timeout | unviable | unrun |", out)
+
+    def test_per_shard_row_has_counts(self):
+        agg = self._agg(
+            [("mutants-shard-0", {"caught": 5, "missed": 1, "timeout": 0, "unviable": 2, "unrun": 0})],
+            {"caught": 5, "missed": 1, "timeout": 0, "unviable": 2, "unrun": 0},
+        )
+        out = ms.format_summary_md(agg)
+        self.assertIn("| mutants-shard-0 | 5 | 1 | 0 | 2 | 0 |", out)
+
+    def test_totals_row_uses_bold(self):
+        agg = self._agg(
+            [
+                ("s0", {"caught": 5, "missed": 1, "timeout": 0, "unviable": 0, "unrun": 0}),
+                ("s1", {"caught": 3, "missed": 2, "timeout": 1, "unviable": 0, "unrun": 0}),
+            ],
+            {"caught": 8, "missed": 3, "timeout": 1, "unviable": 0, "unrun": 0},
+        )
+        out = ms.format_summary_md(agg)
+        self.assertIn("| **total** | **8** | **3** | **1** | **0** | **0** |", out)
+
+    def test_handles_empty_aggregate(self):
+        agg = self._agg([], dict.fromkeys(ms.BUCKETS, 0))
+        out = ms.format_summary_md(agg)
+        self.assertIn("no shards", out.lower())
+
+
+class TestFormatPrComment(unittest.TestCase):
+    def test_includes_totals_line(self):
+        out = ms.format_pr_comment(
+            totals={"caught": 8, "missed": 3, "timeout": 1, "unviable": 0, "unrun": 0},
+            missed_lines=[],
+        )
+        self.assertIn("caught: 8", out)
+        self.assertIn("missed: 3", out)
+        self.assertIn("timeout: 1", out)
+
+    def test_lists_first_n_missed_with_default_cap(self):
+        missed = [f"src/foo.rs:{i}: replace + with -" for i in range(1, 21)]
+        out = ms.format_pr_comment(
+            totals={"caught": 0, "missed": 20, "timeout": 0, "unviable": 0, "unrun": 0},
+            missed_lines=missed,
+        )
+        self.assertIn("src/foo.rs:1: replace + with -", out)
+        self.assertIn("src/foo.rs:10: replace + with -", out)
+        self.assertNotIn("src/foo.rs:11:", out)
+        self.assertIn("(showing 10 of 20)", out)
+
+    def test_no_missed_section_when_none(self):
+        out = ms.format_pr_comment(
+            totals={"caught": 5, "missed": 0, "timeout": 0, "unviable": 0, "unrun": 0},
+            missed_lines=[],
+        )
+        self.assertNotIn("Missed mutants", out)
+
+
+class TestMainCli(unittest.TestCase):
+    def _make_shard(self, root: pathlib.Path, **buckets):
+        root.mkdir(parents=True, exist_ok=True)
+        for name, content in buckets.items():
+            if isinstance(content, int):
+                lines = "\n".join(f"m{i}" for i in range(content))
+                content = lines + ("\n" if content else "")
+            (root / f"{name}.txt").write_text(content)
+
+    def test_main_writes_summary_to_stdout(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            self._make_shard(root / "mutants-shard-0", caught=5, missed=1, timeout=0, unviable=0, unrun=0)
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                rc = ms.main([str(root)])
+            self.assertEqual(rc, 0)
+            out = buf.getvalue()
+            self.assertIn("cargo-mutants summary", out)
+            self.assertIn("**total**", out)
+
+    def test_main_writes_pr_comment_when_flag_set(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d) / "mutants.out"
+            self._make_shard(
+                root,
+                caught=2,
+                missed="src/a.rs:10: replace + with -\nsrc/b.rs:20: delete return\n",
+                timeout=0,
+                unviable=0,
+                unrun=0,
+            )
+            comment_path = pathlib.Path(d) / "comment.md"
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                rc = ms.main([str(root), "--pr-comment", str(comment_path)])
+            self.assertEqual(rc, 0)
+            self.assertTrue(comment_path.exists())
+            body = comment_path.read_text()
+            self.assertIn("missed: 2", body)
+            self.assertIn("src/a.rs:10: replace + with -", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #45.

Adds e2e cargo-mutants integration for s11, modeled on [vow-lang/vow#308](https://github.com/vow-lang/vow/pull/308) with adaptations for s11's system deps and integration-test layout.

## Summary

- **Nightly sharded run** (`.github/workflows/cargo-mutants.yml`): cron `17 2 * * *` + `workflow_dispatch`, 8 shards, full unit + integration test baseline, per-shard `mutants.out` artifact, aggregation job posting a caught/missed/timeout/unviable table to `$GITHUB_STEP_SUMMARY`.
- **Per-PR diff run** (`.github/workflows/cargo-mutants-pr.yml`): `cargo mutants --in-diff` against PR base, sticky comment via `marocchino/sticky-pull-request-comment` with totals + the first 10 missed mutants. Non-blocking (`continue-on-error: true`).
- **Local recipe**: `just mutants` mirrors the CI invocation (slow; expect >30 min).
- **Helper**: `scripts/mutants_summary.py` with 18 unit tests in `scripts/test_mutants_summary.py` (run via `python3 -m unittest`).
- **Config**: `mutants.toml` with `timeout_multiplier = 5.0` to absorb integration-test duration and bound mutants that hit unbounded loops.

Mutation results are **informational only** — neither workflow gates merges.

## Side fixes (in this PR)

- Merged `main` into branch to pick up the three rand 0.10 reverts that were missing here. Without them `cargo build` failed because `rand 0.10.1` moved `random` / `random_bool` / `random_range` into a `RngExt` trait.
- `ci_check.sh`: reordered so `build_tests.sh` runs before `cargo test`. The integration tests under `tests/integration/` need the cross-compiled AArch64 binaries in `binaries/`; the previous ordering ran `cargo test` first and always failed on a clean tree.

## Test plan

- [x] `./ci_check.sh` passes locally (fmt, build, build_tests, full cargo test, test_all.sh).
- [x] `python3 -m unittest scripts/test_mutants_summary.py` — 18/18 OK.
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` clean for both new workflows.
- [x] `python3 -c "import tomllib; tomllib.load(...)"` clean for `mutants.toml`.
- [x] `just --list` shows the new `mutants` recipe.
- [ ] Manual single-shard dry-run via `gh workflow run cargo-mutants.yml`, watching shard 0 to confirm baseline + sharded run + artifact upload + summary aggregation.
- [ ] Open a small follow-up PR touching `src/semantics/equivalence.rs` to confirm the PR-diff workflow comments correctly.