### PR TITLE
Add x86-64 + x86-32 backend with minimal core ISA (MOV/ADD/SUB/AND/OR/XOR/CMP)

### DIFF
--- a/.ultraplan/x86-backend.md
+++ b/.ultraplan/x86-backend.md
@@ -1,0 +1,420 @@
+# Plan: x86 Backend (x86-64 primary + x86-32 secondary), Minimal Core ISA
+
+## Goal
+Land an x86 backend in s11 with a full vertical slice (IR → concrete + SMT semantics → cost → enumerative search → dynasm assembler → ELF patcher → CLI) for the minimal core opcodes **MOV / ADD / SUB / AND / OR / XOR / CMP**. Both **x86-64 (primary)** and **x86-32 (secondary)** as two ISA marker structs sharing one register/operand/instruction enum family — mirroring the existing `RiscV64`/`RiscV32` pattern in `src/isa/riscv.rs`.
+
+## Critical context from exploration
+
+1. **RISC-V is scaffold-only, not wired through.** The CLI rejects it at `src/main.rs:1172-1178` and `src/main.rs:1212-1217`. Mirroring `src/isa/riscv.rs` gives the trait scaffolding *but does nothing end-to-end*. To make x86 actually optimize binaries, the semantics/search/assembler/elf_patcher/CLI layers — currently AArch64-only — must each gain an x86 dispatch.
+2. **The `ISA` / `ConcreteExecutor` / `SymbolicExecutor` / `CostModel` / `Assembler` traits in `src/isa/traits.rs` are aspirational** — implementations exist for no backend. AArch64 bypasses them and works against concrete `crate::ir::Instruction` directly. **This plan does NOT attempt to retrofit the codebase onto the traits.** It introduces x86 via **parallel ISA-tagged code paths** (the same shape RISC-V was meant to follow but didn't reach).
+3. **Z3 BV width is hardcoded to 64** at `src/semantics/smt.rs:69-86`. x86-32 needs a parameterised width path.
+4. **Two-operand destructive x86 form (`add rax, rbx` clobbers rax)** fits the existing `destination() -> Option<Register>` model — `rd` is both source and dest. The IR variant must list it once in `source_registers()`.
+5. **EFLAGS ≠ NZCV.** `ConditionFlags` (`src/semantics/state.rs:11-100`) is AArch64-specific. For the **CMP-only** initial scope, we only need ZF/SF/CF/OF/PF/AF set by CMP and *unused thereafter* (no CMOVcc, no Jcc). Plan therefore models EFLAGS as a separate struct on the x86 machine state but **does not yet feed it into search**.
+6. **dynasmrt 4.0.1 (`Cargo.toml:18-19`) supports both `dynasmrt::x64` and `dynasmrt::x86`** modules; both ship in the default feature set — verified in Phase 0.
+7. **capstone 0.14 (`Cargo.toml:15`)** ships x86 disassembly by default.
+
+## Architectural decision (baked into this plan)
+
+> **Decision:** Add x86 as a **parallel pipeline** dispatched on `CliArch` in `main.rs`. Do NOT generalise the existing AArch64 pipeline to be ISA-generic. The AArch64 path stays exactly as-is; an x86 sibling path is added next to it. This keeps the PR reviewable and avoids touching working AArch64 code.
+>
+> **Tradeoff:** Some code is duplicated (semantics matchers, cost match arms, candidate enumeration). Future work can collapse them onto the existing trait surface. Mitigation: x86-side helpers live behind a single `x86` module so cross-cutting refactors later are local.
+
+## Key files
+
+| File | Role | Status |
+|---|---|---|
+| `src/isa/x86.rs` | x86 register/operand/instruction enums + `ISA` trait impls + generator + tests | **NEW** |
+| `src/isa/mod.rs:6-21` | Add `pub mod x86;` + re-exports | MOD |
+| `src/semantics/state.rs:11-100` | Add x86 `Eflags` struct alongside `ConditionFlags` | MOD |
+| `src/semantics/state.rs:131-196` | Add `X86ConcreteMachineState` (separate from AArch64 state) | MOD (additive) |
+| `src/semantics/concrete_x86.rs` | x86 concrete interpreter (mirrors `concrete.rs:15-174` shape) | **NEW** |
+| `src/semantics/smt_x86.rs` | x86 SMT lowering with parameterised BV width (32 or 64) | **NEW** |
+| `src/semantics/cost_x86.rs` | x86 cost model (CodeSize uses variable lengths) | **NEW** |
+| `src/semantics/equivalence.rs:109-255` | Add `check_equivalence_x86` sibling | MOD |
+| `src/semantics/mod.rs` | Re-export new x86 sub-modules | MOD |
+| `src/assembler/x86.rs` | `X86Assembler` using `dynasmrt::x64::Assembler` and `dynasmrt::x86::Assembler` | **NEW** |
+| `src/assembler/mod.rs` | `pub mod x86;` declaration | MOD |
+| `src/elf_patcher/mod.rs:5-7,29-35,84-89,155-165` | Tag `ElfPatcher` with `DetectedArch`; ISA-conditional alignment + NOP | MOD |
+| `src/search/candidate_x86.rs` | x86 enumerative candidate generation | **NEW** |
+| `src/search/mod.rs` | Wire `candidate_x86` module | MOD |
+| `src/main.rs:108-118` | Add `X86_64` and `X86_32` to `CliArch` | MOD |
+| `src/main.rs:1168-1260` | `Disasm` and `Opt` match arms — add x86 branches | MOD |
+| `src/main.rs:241-274` | Make `analyze_elf_binary` arch-aware (Capstone init + `e_machine` whitelist) | MOD |
+| `src/main.rs:373-467` | New `optimize_elf_binary_x86` sibling function | MOD (additive) |
+| `Cargo.toml:13-26` | Verify (and pin if needed) `dynasmrt` features and capstone features | MOD-maybe |
+| `tests/integration/disasm_test.rs` + `tests/integration/opt_test.rs` | Add x86 integration cases | MOD |
+| `build_tests.sh` | Add host-`gcc` (x86_64) and `gcc -m32` (i386) cross paths | MOD |
+| `test_all.sh:30-56,59` | Add x86 binary loop | MOD |
+| `CLAUDE.md:7,10,15,33-98` | Broaden ISA & opcode-count language | MOD |
+
+---
+
+## Phase 0 — Validate external dependencies (no source changes outside `.ultraplan/`)
+
+### Step 0.1. Confirm `dynasmrt 4.0.1` exposes `x64` and `x86` modules and ships in default features
+- **Action**: `cargo doc --no-deps -p dynasmrt 2>&1 | head -50` or `cargo tree -e features -p dynasmrt`. Inspect `~/.cargo/registry/src/.../dynasmrt-4.0.1/Cargo.toml` for default features.
+- **Acceptance**: both `dynasmrt::x64::Assembler` and `dynasmrt::x86::Assembler` resolve in a scratch `cargo check` (write a one-line scratch test, do NOT commit).
+- **Fallback**: if x86 backends are gated behind a Cargo feature, update `Cargo.toml:18-19` to `dynasmrt = { version = "4.0.1", features = ["x64", "x86"] }` and `dynasm = { version = "4.0.1", features = ["x64", "x86"] }`.
+
+### Step 0.2. Confirm `capstone 0.14` ships x86 by default
+- **Action**: `grep -n 'x86' ~/.cargo/registry/src/.../capstone-0.14*/Cargo.toml` or trial-build `Capstone::new().x86().mode(arch::x86::ArchMode::Mode64).build()` in a scratch.
+- **Acceptance**: builds without changing `Cargo.toml`.
+
+---
+
+## Phase 1 — x86 ISA layer (`src/isa/x86.rs`)
+
+This phase produces a self-contained module that compiles + tests pass, but does not affect any other code paths.
+
+### Step 1.1. Create `src/isa/x86.rs` [new] mirroring `src/isa/riscv.rs:1-1006`
+- **Module preamble** (mirrors `riscv.rs:1-11`): `use crate::isa::traits::{ISA, InstructionGenerator, InstructionType, OperandType, RegisterType};` plus `rand::Rng` for the generator.
+- **`enum X86Register`**: 16 general-purpose 64-bit GPRs `RAX, RBX, RCX, RDX, RSI, RDI, RBP, RSP, R8..R15` with `#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]`. Mirrors `riscv.rs:14-48`.
+  - Note: x86-32 callers will use only `RAX..RDI` (the low 8); we expose all 16 from the enum and let the `ISA::register_count` / `general_registers` methods filter per variant.
+- **`impl X86Register`** (mirrors `riscv.rs:50-163`): `index() -> Option<u8>` (RAX=0, RCX=1, RDX=2, RBX=3, RSP=4, RBP=5, RSI=6, RDI=7, R8..R15=8..15 — Intel encoding order), `from_index`, optional `abi_name` helper.
+- **`impl fmt::Display for X86Register`** (mirrors `riscv.rs:165-169`): lowercase Intel-syntax mnemonics (`rax`, `rbx`, ...).
+- **`impl RegisterType for X86Register`** (mirrors `riscv.rs:171-187`):
+  - `is_zero_register() = false` (x86 has none).
+  - `is_special()`: `true` for `RSP` only (see policy note below the ISA struct impls).
+- **`enum X86Operand { Register(X86Register), Immediate(i64) }`** mirrors `riscv.rs:191-194`.
+- **`impl fmt::Display for X86Operand`** (mirrors `riscv.rs:196-203`): `imm` prefix per Intel syntax (raw integer, no `#`).
+- **`impl OperandType for X86Operand`** (mirrors `riscv.rs:205-229`).
+- **`enum X86Instruction`** (seven variants, all in **two-operand destructive form** — `rd` is both first source and destination):
+  ```
+  MovReg { rd: X86Register, rs: X86Register }
+  MovImm { rd: X86Register, imm: i64 }
+  AddReg { rd: X86Register, rs: X86Register }       // rd = rd + rs ; sets EFLAGS
+  AddImm { rd: X86Register, imm: i64 }              // rd = rd + imm ; sets EFLAGS
+  SubReg { rd: X86Register, rs: X86Register }       // rd = rd - rs ; sets EFLAGS
+  SubImm { rd: X86Register, imm: i64 }
+  AndReg / AndImm / OrReg / OrImm / XorReg / XorImm // each clobbers CF/OF, sets SF/ZF/PF, AF undefined
+  CmpReg { rn: X86Register, rs: X86Register }       // rn - rs ; sets EFLAGS, no register write
+  CmpImm { rn: X86Register, imm: i64 }
+  ```
+  Total: 13 variants (each opcode except CMP has reg and imm forms; CMP has reg and imm; MOV has reg and imm). Pattern mirrors `riscv.rs:232-318` (where Add/Addi etc. are split per-operand-shape).
+- **`impl X86Instruction`** inherent helpers (`destination`, `source_registers`) mirror `riscv.rs:320-364`:
+  - `destination()`: `Some(rd)` for MOV/ADD/SUB/AND/OR/XOR variants; `None` for `CmpReg`/`CmpImm`.
+  - `source_registers()`: **intentional divergence from AArch64/RISC-V documented convention** — both existing ISAs treat the destination as *not* a source (`src/ir/instructions.rs:230-273`, `src/isa/riscv.rs:343-363`). x86's two-operand destructive form requires `rd` to *also* appear in sources for liveness analysis to work correctly (`src/validation/live_out.rs:122-138` reads `source_registers()` to compute live-in). Therefore:
+    - `MovReg { rd, rs }` → `[rs]` (MOV is non-destructive: rd is fully overwritten).
+    - `MovImm { rd, imm }` → `[]`.
+    - `AddReg / SubReg / AndReg / OrReg / XorReg { rd, rs }` → `[rd, rs]` (rd is read AND written).
+    - `AddImm / SubImm / AndImm / OrImm / XorImm { rd, imm }` → `[rd]`.
+    - `CmpReg { rn, rs }` → `[rn, rs]`; `CmpImm { rn, imm }` → `[rn]`.
+  - **Doc-comment at top of `enum X86Instruction`** must explicitly state this divergence and the reason, otherwise a future refactor that "normalises" with AArch64 will silently regress liveness.
+- **`impl fmt::Display for X86Instruction`** (mirrors `riscv.rs:366-393`): Intel syntax (`add rax, rbx`).
+- **`impl InstructionType for X86Instruction`** (mirrors `riscv.rs:395-452`):
+  - `opcode_id` numbers the 13 variants 0..12. **Must equal `opcode_count`** (cross-reference the `aarch64.rs:268`/`aarch64.rs:525` mismatch flagged in exploration; do not repeat the bug).
+  - `has_side_effects()`: `true` for every variant except `MovReg`/`MovImm` (EFLAGS changes are observable side-effects). **This diverges from AArch64/RV behaviour and is the only place `has_side_effects` is currently `true` in the codebase** — flag for reviewer.
+- **`struct X86_64;` + `impl ISA for X86_64`** (mirrors `riscv.rs:454-486`):
+  - `name() = "x86-64"`, `register_count() = 16`, `register_width() = 64`, `instruction_size() = None` (variable-length).
+  - `general_registers()`: return all 16 GPRs via `(0..16).filter_map(X86Register::from_index).collect()` — mirror the RISC-V convention (`riscv.rs:479-481`) which returns *all* registers including the special ones. Callers (CLI `optimize_elf_binary_x86`) are responsible for filtering RSP out of the search-available pool, the same way `main.rs:479-488` builds the AArch64 available-register list (it excludes XZR/SP by listing only X0..X7).
+  - `zero_register() = None`.
+- **`struct X86_32;` + `impl ISA for X86_32`** (mirrors `riscv.rs:488-520`):
+  - `name() = "x86-32"`, `register_count() = 8`, `register_width() = 32`, `instruction_size() = None`.
+  - `general_registers()`: return the low 8 GPRs via `(0..8).filter_map(X86Register::from_index).collect()`. CLI filters ESP at call sites.
+- **`is_special()` policy**: only `RSP` is special. **RBP is *not* special** — modern x86-64 SysV ABI does not require a frame pointer (`-fomit-frame-pointer` is GCC's default since 4.6) and excluding RBP would bias the search against valid optimisations that use RBP as a scratch register.
+- **`struct X86InstructionGenerator;` + `impl InstructionGenerator<X86Instruction>`** (mirrors `riscv.rs:522-809`): three strategies in `mutate` (full re-gen / change-dest / change-source). `opcode_count() = 13`.
+- **`#[cfg(test)] mod tests`** (mirrors `riscv.rs:811-1006`):
+  - Trait conformance: every `RegisterType`/`OperandType`/`InstructionType` method invariant.
+  - Display round-trip.
+  - Generator: `generate_all` returns expected count given N registers and M immediates.
+  - Generator: `generate_random` only produces opcode IDs in `0..opcode_count`.
+  - Generator: `mutate` invariants (mutated instruction is reachable from neighbourhood).
+  - `X86_32` vs `X86_64` metadata correctness.
+
+### Step 1.2. Wire `src/isa/x86.rs` into the ISA namespace
+- **File**: `src/isa/mod.rs:6-21`
+- **Change**:
+  - After `pub mod riscv;` add `pub mod x86;`.
+  - Extend the `pub use aarch64::AArch64;` / `pub use riscv::{...};` block at lines 17-21 with `pub use x86::{X86_32, X86_64, X86Instruction, X86InstructionGenerator, X86Operand, X86Register};`.
+  - Update the doc comment at line 4: append "x86" to the example list.
+
+### Step 1.3. Verify Phase 1 compiles in isolation
+- `cargo check` and `cargo test --lib isa::x86 -- --nocapture`. No other code paths touched yet.
+
+---
+
+## Phase 2 — x86 machine state and concrete interpreter
+
+### Step 2.1. Add `Eflags` struct in `src/semantics/state.rs`
+- **File**: `src/semantics/state.rs` (after the `ConditionFlags` block at lines 11-100, additive)
+- **Change**: Add `pub struct Eflags { cf: bool, pf: bool, af: bool, zf: bool, sf: bool, of: bool }` with `from_sub`/`from_logical`/`from_add` constructors mirroring the existing `ConditionFlags::from_*` patterns. AF can be left as `false` (undefined per x86 ABI) — comment it.
+- **Reuses**: `from_sub` / `from_logical` / `from_add` shape from `state.rs:25-64`.
+- **Why kept separate from `ConditionFlags`**: AArch64 NZCV semantics for `from_add`/`from_sub` differ slightly (e.g. C-flag polarity on SUB). Reusing would be wrong.
+
+### Step 2.2. Add `X86ConcreteMachineState` in `src/semantics/state.rs`
+- **File**: `src/semantics/state.rs` (after `ConcreteMachineState` at lines 131-196, additive)
+- **Change**: Mirror `ConcreteMachineState` but:
+  - `HashMap<X86Register, ConcreteValue>` keyed by `X86Register`.
+  - Carries `Eflags` instead of `ConditionFlags`.
+  - `new_zeroed()` enumerates the 16 GPRs (use `X86Register::from_index` for 0..16).
+  - Width-aware: `X86_64` writes 64-bit values; `X86_32` writes 32-bit values zero-extended to 64. Carry a `width: u32` field on the state to control mask-on-write.
+- **Reuses**: `ConcreteValue` from `state.rs`.
+
+### Step 2.3. Create `src/semantics/concrete_x86.rs` [new]
+- **Path**: `src/semantics/concrete_x86.rs` (parent dir `src/semantics/` exists).
+- **Content**: `apply_instruction_concrete_x86(state, instr) -> X86ConcreteMachineState` — a `match instr` over the 13 x86 variants. For each arithmetic/logic variant, also compute `Eflags::from_*` and stash it in `state.flags`. Width-mask results to 32 or 64 bits per `state.width`.
+- **Reuses**:
+  - Shape and signature pattern from `src/semantics/concrete.rs:15-174`.
+  - `wrapping_add` / `wrapping_sub` / bitwise ops (Rust stdlib).
+- **Tests** at end of file: per-opcode functional check for each of the 13 variants in both x86-64 (64-bit width) and x86-32 (32-bit width) modes.
+
+### Step 2.4. Wire module
+- **File**: `src/semantics/mod.rs:1-20`
+- **Change**: Add `pub mod concrete_x86;` and re-export `apply_instruction_concrete_x86`. Update the doc comment at `:1` to drop "for AArch64 instructions" or broaden.
+
+---
+
+## Phase 3 — x86 SMT lowering
+
+### Step 3.1. Create `src/semantics/smt_x86.rs` [new]
+- **Path**: `src/semantics/smt_x86.rs`.
+- **Content**: Parameterise the Z3 BV width. Mirror `src/semantics/smt.rs:60-220` shape but:
+  - `MachineStateX86 { regs: HashMap<X86Register, BV>, width: u32 }`.
+  - `new_symbolic(ctx, prefix, width)`: create 16 fresh `BV::new_const(name, width)`.
+  - `apply_instruction(state, instr) -> MachineStateX86`: bitvector ops per opcode, both register and immediate forms. **CMP is a no-op for now (no symbolic flag plumbing)** — exactly like AArch64 at `smt.rs:201-204`.
+- **Reuses**: `BV` import + Z3 context plumbing from `src/semantics/smt.rs:1-30`.
+- **Tests**: bitvector identity invariants (e.g. `xor rax, rax` produces a BV equal to `BV::from_i64(0, width)`); width round-trip.
+
+### Step 3.2. Add `check_equivalence_x86` in `src/semantics/equivalence.rs`
+- **File**: `src/semantics/equivalence.rs:109-255`
+- **Change**: Add sibling `check_equivalence_x86(seq1: &[X86Instruction], seq2: &[X86Instruction], config: &X86EquivConfig)` that orchestrates the x86 concrete fast path (Step 2.3) and x86 SMT verification (Step 3.1).
+- **`X86EquivConfig` must carry `width: u32`** — `optimize_elf_binary_x86` (Step 7.4) sets it to 64 for `CliArch::X86_64` and 32 for `CliArch::X86_32`. Z3 will panic on mixed-width BV ops, so `MachineStateX86::new_symbolic` and every `BV::from_i64(*imm, width)` in `apply_instruction` must read from `config.width`. Both `seq1` and `seq2` must be validated as belonging to the same width before lowering.
+- **Reuses**: orchestration shape from `equivalence.rs:143-255`. Live-out logic must be x86-register-keyed — define `X86LiveOutMask` alongside the existing `LiveOutMask` (`state.rs:218-282`).
+- **EFLAGS soundness — critical, see also Risks section**: x86's CMP / AddReg / etc. mutate EFLAGS. The concrete interpreter (Step 2.3) computes EFLAGS; the SMT path leaves CMP as a no-op (mirroring AArch64). Without further care, the optimiser could drop a target's trailing CMP and incorrectly call the shorter sequence equivalent. **Mitigation (in this step)**: extend the fast-path equivalence comparator `states_equal_for_live_out` (currently at `concrete.rs:211-222`) with an x86 sibling `states_equal_for_live_out_x86` that **also compares `Eflags`** when CMP is present anywhere in either sequence. Concretely: if `seq1.iter().any(|i| matches!(i, X86Instruction::CmpReg{..} | X86Instruction::CmpImm{..}))` OR same for `seq2`, require `state1.flags == state2.flags` after applying each random-input test. The SMT path stays a no-op for CMP, but the fast path's coverage of EFLAGS catches the regression empirically. Document this as an MVP soundness compromise.
+
+### Step 3.3. Wire module
+- **File**: `src/semantics/mod.rs` — add `pub mod smt_x86;` (gated under `#[cfg(feature = "z3")]` to match the existing `smt` module gating convention if any; check `mod.rs` to confirm).
+
+---
+
+## Phase 4 — x86 cost model
+
+### Step 4.1. Create `src/semantics/cost_x86.rs` [new]
+- **Path**: `src/semantics/cost_x86.rs`.
+- **Content**: Mirror `src/semantics/cost.rs:5-47`:
+  - `InstructionCount`: 1 per instruction.
+  - `Latency`: 1 for ALU (every opcode in the initial set).
+  - `CodeSize`: variable per x86 — implement a per-variant byte-length lookup table for the minimal set. Initial-set sizes:
+    - `MovImm` reg=RAX/imm fits 32 bits → 5 bytes (opcode + 4); imm doesn't fit → 10 bytes (REX.W + opcode + 8). Use a conservative upper bound of 10 to start; refine later.
+    - `MovReg` → 3 bytes (REX + opcode + ModRM).
+    - `AddReg`/`SubReg`/`AndReg`/`OrReg`/`XorReg`/`CmpReg` → 3 bytes.
+    - `AddImm`/`SubImm`/... → 6 bytes (REX + opcode + ModRM + imm8) if imm fits int8 ; 7 bytes otherwise. Approximate as 7.
+  - For x86-32: subtract REX prefix (one byte less than the x86-64 sizes above).
+- **Tests**: cost ordering invariant (e.g. `MovImm` of small constant ≤ `MovImm` of large constant).
+
+### Step 4.2. Wire module
+- **File**: `src/semantics/mod.rs` — add `pub mod cost_x86;`.
+
+---
+
+## Phase 5 — `X86Assembler` (dynasm-based)
+
+### Step 5.1. Create `src/assembler/x86.rs` [new]
+- **Path**: `src/assembler/x86.rs` (parent dir `src/assembler/` exists).
+- **Content**:
+  - `pub struct X86Assembler { mode: X86Mode }` where `X86Mode = { Mode64, Mode32 }`.
+  - `pub fn new_64() -> Self` / `pub fn new_32() -> Self`.
+  - `pub fn assemble_instructions(&mut self, instructions: &[X86Instruction]) -> Result<Vec<u8>, String>`.
+  - Two encoder bodies: `encode_64(ops: &mut dynasmrt::x64::Assembler, instr) -> Result<(), String>` and `encode_32(ops: &mut dynasmrt::x86::Assembler, instr) -> Result<(), String>`.
+  - Each encoder body is a match over the 13 variants using `dynasm!(ops; .arch x64; mov Rq(rd), Rq(rs))` and `; .arch x86; mov Rd(rd), Rd(rs)` respectively.
+- **Reuses**: encoding pattern, error shape, and the Capstone round-trip test idiom from `src/assembler/mod.rs:30-364, 400-731`.
+- **dynasm Intel-syntax operand sizes**: `Rq(...)` for 64-bit, `Rd(...)` for 32-bit register operands per dynasm-rs docs.
+- **Tests** at end of file: round-trip each opcode through Capstone in both modes — copy the `disassemble_and_verify` helper pattern from `src/assembler/mod.rs:502-537`, adapted for x86 mnemonics.
+
+### Step 5.2. Wire module
+- **File**: `src/assembler/mod.rs:1-3`
+- **Change**: Add `pub mod x86;` before the existing `use` statements. Keep `AArch64Assembler` exactly as-is.
+
+---
+
+## Phase 6 — ELF patcher ISA-awareness
+
+The patcher needs to accept three architectures with different alignment and NOP semantics.
+
+### Step 6.1. Introduce a `DetectedArch` tag and store it on `ElfPatcher`
+- **File**: `src/elf_patcher/mod.rs:5-7`
+- **Change**: Add `pub enum DetectedArch { Aarch64, X86_64, X86_32 }`. Extend `ElfPatcher` to carry `arch: DetectedArch` alongside `file_data`.
+
+### Step 6.2. Detect arch from `e_machine`
+- **File**: `src/elf_patcher/mod.rs:28-35`
+- **Change**: Replace the `EM_AARCH64`-only guard with a match:
+  ```
+  let arch = match elf.ehdr.e_machine {
+      elf::abi::EM_AARCH64 => DetectedArch::Aarch64,
+      elf::abi::EM_X86_64  => DetectedArch::X86_64,
+      elf::abi::EM_386     => DetectedArch::X86_32,
+      m => return Err(format!("Unsupported architecture (e_machine={})", m).into()),
+  };
+  ```
+  Pass `arch` into the new constructor field.
+- **Acceptance**: existing AArch64 tests still pass; new test asserts an x86-64 ELF parses without error.
+
+### Step 6.3. Alignment check is per-arch
+- **File**: `src/elf_patcher/mod.rs:84-89`
+- **Change**: Only enforce 4-byte alignment when `self.arch == Aarch64`. For x86, accept byte-aligned windows. Update the error string.
+
+### Step 6.4. NOP padding is per-arch
+- **File**: `src/elf_patcher/mod.rs:155-165`
+- **Change**: Three things change inside this block (not just the loop bound):
+  1. The `nop_bytes` slice (`:157`): per-arch — `vec![0x1f, 0x20, 0x03, 0xd5]` for `Aarch64`; `vec![0x90]` for `X86_64`/`X86_32`.
+  2. The for-loop iteration count (`:158`): `remaining / nop_bytes.len()`.
+  3. The buffer-write step inside the loop (`:160`): `nop_start + nop_bytes.len()` instead of `nop_start + 4`; `copy_from_slice(&nop_bytes)` works with any slice length.
+  4. The bounds check (`:161`): same — `nop_start + nop_bytes.len() <= file_offset + window_size`.
+- After the loop, any sub-`nop_bytes.len()` remainder (for x86 it's always 0 because the slice is 1 byte; for AArch64 it's always 0 because the window is 4-aligned per Step 6.3) — so no remainder handling needed.
+- **Note for reviewer**: multi-byte NOP (`0x66 0x90`, ... `0x0f 0x1f 0x84 0x00 0x00 0x00 0x00 0x00`) is a perf optimisation; deferred.
+
+### Step 6.5. Extend `src/elf_patcher/mod.rs:184-213` tests
+- Add tests for the three branches: AArch64 4-byte alignment failure stays; x86_64 byte-aligned window accepted; x86 NOP padding produces `0x90` bytes.
+- **Test data approach**: build a minimal in-memory ELF byte buffer (mirroring the `proptest` dev-dep at `Cargo.toml:32-33` if needed) rather than requiring real on-disk fixtures from Phase 9.2. Reuse the existing unit-test pattern at `elf_patcher/mod.rs:184-213` which currently tests pure helpers — extend with `ElfPatcher::from_bytes(&[u8])` if it exists (check `:5-23`), otherwise add a `#[cfg(test)] fn new_for_test(bytes: Vec<u8>, arch: DetectedArch)` constructor that bypasses ELF parsing.
+
+### Step 6.6. Reflect arch detection in `src/main.rs:241-274` (`analyze_elf_binary`)
+- **File**: `src/main.rs:253-263`
+- **Change**: Replace the `EM_AARCH64` check with the same `e_machine` match; print the detected arch name in the human output.
+
+---
+
+## Phase 7 — CLI dispatch
+
+### Step 7.1. Extend `CliArch`
+- **File**: `src/main.rs:108-118`
+- **Change**: Add `X86_64` and `X86_32` variants to the enum with doc comments mirroring the existing entries.
+
+### Step 7.2. `Disasm` arm — wire x86 Capstone init
+- **File**: `src/main.rs:1168-1186`
+- **Change**: Replace the AArch64-only acceptance with a per-arch dispatch. For x86 branches, call a new `analyze_elf_binary_with_arch(path, true, arch)` that selects `Capstone::new().x86().mode(arch::x86::ArchMode::Mode64).build()` for x86-64 and `.Mode32` for x86-32, mirroring the existing `arm64().mode(arch::arm64::ArchMode::Arm)` at `:277-281, :399-403`.
+
+### Step 7.3. `Opt` arm — wire x86 optimization pipeline
+- **File**: `src/main.rs:1188-1260`
+- **Change**: For `CliArch::X86_64` and `CliArch::X86_32`, dispatch to a **new** `optimize_elf_binary_x86(path, window, options, mode)`. Leave the AArch64 path through `optimize_elf_binary` untouched.
+
+### Step 7.4. Create `optimize_elf_binary_x86`
+- **File**: `src/main.rs` (additive — same file, append after the existing `optimize_elf_binary` at `:373-467`)
+- **Change**: Mirror the existing pipeline:
+  1. `ElfPatcher::new(path)` (already arch-aware after Phase 6).
+  2. `ElfPatcher::validate_address_window` — alignment now correct per arch.
+  3. Read bytes via `ElfPatcher::get_instructions_in_window`.
+  4. Disassemble with Capstone `.x86()` (mode per `CliArch`).
+  5. **Convert to x86 IR**: new helper `convert_to_x86_ir(&capstone_instructions, mode) -> Vec<X86Instruction>`. Mirrors `main.rs:742-774` but recognises the 7 mnemonics (mov, add, sub, and, or, xor, cmp) with Intel-syntax operands. Unrecognised mnemonics print a warning and are dropped (same policy as the AArch64 path).
+  6. Run the **enumerative** search (see Phase 8). Skip stochastic / symbolic / hybrid / LLM for the initial PR; emit a friendly error if the user passes `--algorithm` with anything else.
+  7. Verify equivalence with `check_equivalence_x86` (Phase 3.2).
+  8. Assemble with `X86Assembler::new_64()` or `new_32()` (Phase 5).
+  9. Write the patched ELF.
+- **Reuses**: orchestration shape from `main.rs:373-467` (esp. window handling, equiv-fail messaging).
+
+### Step 7.5. Help text
+- **File**: `src/main.rs:33`
+- **Change**: Broaden `#[command(about = "s11 - AArch64 Optimizer")]` to "s11 - Superoptimizer (AArch64, x86)".
+- **Note on live-out**: `optimize_elf_binary` infers live-out from `instr.destination()` (`main.rs:493-499`), not from CLI. The new `optimize_elf_binary_x86` (Step 7.4) will mirror that pattern using `X86Instruction::destination()` to build an `X86LiveOutMask`. No CLI default change needed for the `opt` subcommand. The `equiv` subcommand (`main.rs:226`) keeps its AArch64 default; running `equiv` on x86 assembly is out of scope for v1.
+
+---
+
+## Phase 8 — x86 enumerative search (the only search backend for v1)
+
+### Step 8.1. Create `src/search/candidate_x86.rs` [new]
+- **Path**: `src/search/candidate_x86.rs`.
+- **Content**: Mirror the shape of `src/search/candidate.rs:14-22, 25-100`:
+  - `generate_all_x86_instructions(registers: &[X86Register], immediates: &[i64]) -> Vec<X86Instruction>`: nested loops over (rd, rs) producing the 13 variants.
+  - No encoding-gate equivalent of `is_encodable_aarch64` — x86 immediate ranges are wide and our cost model already prices large immediates; defer encodability filtering to the assembler (which returns `Err` for unsupported encodings).
+- **Tests**: count invariant — for N registers and M immediates, the generator returns exactly `2*N + 6*(N*N + N*M) + 2*(N + N*M) = ...` (work out exact formula in implementation and assert).
+
+### Step 8.2. Wire module
+- **File**: `src/search/mod.rs:1-30`
+- **Change**: Add `pub mod candidate_x86;`. Do NOT add x86 to the `SearchAlgorithm` trait — the v1 x86 path bypasses the trait and calls the enumerator + equivalence checker directly inside `optimize_elf_binary_x86`.
+
+### Step 8.3. Enumerative loop in `optimize_elf_binary_x86`
+- **File**: `src/main.rs` (in the new function from Step 7.4)
+- **Change**: Replicate the length-1 enumerative shape from `main.rs:948-989` (`find_shorter_equivalent`) and the AArch64 candidate generator at `main.rs:891-946` (`generate_all_instructions`) over `X86Instruction`. Call `candidate_x86::generate_all_x86_instructions` for candidate generation. **Use `cost_x86::sequence_cost` with `CodeSize` as a tie-breaker** among candidates of the same length: this gives `cost_x86` (Phase 4) a real consumer in v1 and matches a user-visible expectation that "shorter" should mean *bytes*, not just instruction count. Length still dominates (a 2-instruction sequence wins over a 1-instruction sequence only if cost says so, which on x86 can happen — but for v1 we keep the "must be strictly shorter in instruction count" rule and tie-break by bytes).
+
+### Step 8.4. Explicit error for unsupported algorithms
+- In `optimize_elf_binary_x86`, when the user passes `--algorithm` ≠ `enumerative`, print `"x86 only supports --algorithm enumerative in this release; stochastic/symbolic/hybrid/llm are AArch64-only"` and exit 1. This is intentional MVP scope — flag in the PR description.
+
+---
+
+## Phase 9 — Tests
+
+### Step 9.1. Unit-test parity
+- `cargo test --lib isa::x86` — Phase 1 tests.
+- `cargo test --lib semantics::concrete_x86` — Phase 2.3 tests.
+- `cargo test --lib semantics::smt_x86` — Phase 3.1 tests (gated on `--features z3`).
+- `cargo test --lib semantics::cost_x86` — Phase 4.1 tests.
+- `cargo test --lib assembler::x86` — Phase 5.1 Capstone round-trip tests.
+- `cargo test --lib elf_patcher` — extended Phase 6.5 tests.
+
+### Step 9.2. Build test ELFs for x86
+- **File**: `build_tests.sh`
+- **Change**: Add a second pass that compiles each `tests/*.c` with host `gcc` for x86-64 into `binaries/x86_64/` and with `gcc -m32` for i386 into `binaries/x86_32/`. Keep the existing `aarch64-linux-gnu-gcc` path intact.
+- **Acceptance**: `./build_tests.sh` produces both AArch64 and x86 binaries on a host with `gcc-multilib` installed. Document the dep in `BUILD.md`.
+
+### Step 9.3. Integration tests
+- **File**: `tests/integration/disasm_test.rs`
+- **Change**: Add a new test `test_disasm_x86_64` that invokes the compiled `s11` with `disasm --binary binaries/x86_64/simple --arch x86-64` and asserts non-zero output.
+- **File**: `tests/integration/opt_test.rs`
+- **Change**: Add `test_opt_x86_64_minimal` exercising `opt --binary binaries/x86_64/optimizable --arch x86-64 --start-addr ... --end-addr ...` with a known-shortening fixture. Pick an addr range that contains only the 7 supported mnemonics — generate from a hand-written tiny .c snippet specifically for this.
+
+### Step 9.4. `test_all.sh` smoke-loop
+- **File**: `test_all.sh:30-56,59`
+- **Change**: Add a parallel loop over `binaries/x86_64/*` (and `binaries/x86_32/*` if cross-compilation is reliable on the CI host) that invokes `s11 disasm --arch x86-64 <bin>` and asserts exit 0.
+
+### Step 9.5. `ci_check.sh`
+- **File**: `ci_check.sh:1-65`
+- **Change**: No source change required — the script invokes `cargo test` and `test_all.sh`, both of which gain the x86 cases above.
+
+---
+
+## Phase 10 — Documentation
+
+### Step 10.1. CLAUDE.md
+- **File**: `CLAUDE.md`
+- **Lines & changes**:
+  - `:7` "s11 is an AArch64 superoptimizer" → "s11 is a superoptimizer (AArch64 primary, x86 and RISC-V backends)".
+  - `:10` "20 AArch64 instructions" → "20 AArch64 / 13 x86 instructions" (or restructure).
+  - `:15` "ISA abstraction supporting AArch64 (primary) and RISC-V (secondary)" → "AArch64 (primary), x86-64/x86-32 (initial vertical slice), RISC-V (trait scaffolding)".
+  - `:74-98` add `src/isa/x86.rs`, `src/semantics/{concrete,smt,cost}_x86.rs`, `src/assembler/x86.rs`, `src/search/candidate_x86.rs` to the module map.
+
+### Step 10.2. README.md (if it mentions ISAs)
+- Grep first; broaden as needed. Out of scope if unchanged.
+
+### Step 10.3. BUILD.md
+- Document the `gcc -m32` / `gcc-multilib` requirement added by Step 9.2.
+
+---
+
+## Testing checklist (verification commands)
+
+In order:
+
+1. `cargo fmt -- --check`
+2. `cargo build --verbose`
+3. `cargo test --lib` — all unit tests including new x86 modules.
+4. `./build_tests.sh` (after Phase 9.2 changes) — produces all three arch binaries.
+5. `./test_all.sh` — smoke tests pass for all three arches.
+6. `./ci_check.sh` — full pre-push gate.
+7. Manual: `./target/debug/s11 disasm --binary binaries/x86_64/simple --arch x86-64`.
+8. Manual: `./target/debug/s11 opt --binary binaries/x86_64/optimizable --arch x86-64 --start-addr <X> --end-addr <Y> --algorithm enumerative`.
+
+*Removed `--no-default-features`*: the existing AArch64 `smt.rs` is NOT feature-gated despite `z3` being marked `optional = true` in `Cargo.toml`. Adding `--no-default-features` to the verification gate would fail on `main` today, before any x86 code lands. Fixing that gating is a separate ADR-level cleanup.
+
+## Risks (carried over from exploration; mitigations in-plan)
+
+| Risk | Mitigation |
+|---|---|
+| dynasm `x64`/`x86` modules not in default features | Phase 0.1 fallback: explicit `features = ["x64","x86"]` in `Cargo.toml`. |
+| capstone x86 mode requires explicit feature | Phase 0.2 trial-build. |
+| Z3 BV width hardcoded to 64 in `smt.rs` | Phase 3.1 isolates x86 SMT into a new file with a `width: u32` parameter; AArch64 path stays at 64. Step 3.2's `X86EquivConfig` threads width from `CliArch`. |
+| `has_side_effects()` is `false` everywhere today; x86 EFLAGS forces it to `true` | Step 1.1 flags this for reviewer. No downstream caller of `has_side_effects()` exists in search code today (verified by grep), so it's a passive marker for now. |
+| `LiveOutMask` is AArch64-keyed (`state.rs:218-282`) | Add `X86LiveOutMask` sibling (Step 3.2). No retrofit. |
+| Two enumeration paths (`candidate.rs` vs `aarch64.rs`) disagree on opcode subset — risk of repeating for x86 | Single x86 generator lives in `candidate_x86.rs`. The trait generator in `isa/x86.rs` is for trait-conformance tests only; not wired into search. Document in `src/isa/x86.rs` module doc. |
+| **EFLAGS soundness gap for CMP-shortening (x86-specific)** | Step 3.2 extends the *fast path* equivalence to compare `Eflags` when any CMP appears in either sequence. SMT path stays a no-op (mirrors AArch64). MVP compromise; documented inline. |
+| `source_registers()` convention divergence | Step 1.1 documents the intentional divergence at the top of `enum X86Instruction`. Liveness analysis at `src/validation/live_out.rs:122-138` remains correct. |
+| `--algorithm` other than enumerative will fail confusingly for x86 | Step 8.4: explicit early error. PR description calls out the v1 scope. |
+| Integration tests require `gcc-multilib` | Step 9.2 documents the dep; CI gate documents the optional skip if the toolchain is absent. |
+| `cargo-mutants` config (`.cargo/mutants.toml`) gains a large new surface, lengthening local mutation runs | Out of scope for this PR. Note in PR description that `just mutants -- --diff` is the recommended invocation while iterating. |
+
+## Out of scope for v1 (called out explicitly)
+
+- Stochastic / Symbolic / Hybrid / LLM search for x86. Explicit error in Step 8.4.
+- CMOVcc / Jcc and the symbolic EFLAGS plumbing they would need.
+- Sub-register aliasing (AL/AH/AX/EAX/RAX).
+- Multi-byte NOPs in ELF patcher.
+- RISC-V activation (still scaffolded only — explicitly out of scope; reuse the CliArch rejection branches as-is).
+- Generalising AArch64/RISC-V/x86 onto the trait surface in `src/isa/traits.rs`. A follow-up issue should propose this refactor independently.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,16 +4,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-s11 is an AArch64 superoptimizer written in Rust. It finds shorter or faster equivalent instruction sequences using multiple search strategies and SMT-based equivalence checking.
+s11 is a superoptimizer written in Rust. It finds shorter or faster equivalent instruction sequences using multiple search strategies and SMT-based equivalence checking. Primary target is AArch64; x86-64 and x86-32 are supported through a parallel pipeline; RISC-V is scaffold-only.
 
 **Key Features:**
-- ELF binary reading and disassembly using Capstone engine
-- 20 AArch64 instructions: MOV, ADD, SUB, AND, ORR, EOR, LSL, LSR, ASR, MUL, SDIV, UDIV, CMP, CMN, TST, CSEL, CSINC, CSINV, CSNEG
-- Four search algorithms: enumerative, stochastic (MCMC), symbolic (SMT synthesis), and hybrid
-- SMT-based equivalence checking using Z3
+- ELF binary reading and disassembly using Capstone engine (auto-detects e_machine)
+- **AArch64** (20 instructions): MOV, ADD, SUB, AND, ORR, EOR, LSL, LSR, ASR, MUL, SDIV, UDIV, CMP, CMN, TST, CSEL, CSINC, CSINV, CSNEG — full pipeline including stochastic/symbolic/hybrid/LLM search
+- **x86-64 + x86-32** (14 variants, 7 mnemonics): MOV, ADD, SUB, AND, OR, XOR, CMP (each with reg/imm forms) — enumerative search only in v1
+- SMT-based equivalence checking using Z3 (width-parameterised for x86-32 vs x86-64)
 - Multi-threaded parallel search with worker coordination
-- ISA abstraction supporting AArch64 (primary) and RISC-V (secondary)
-- Binary patching for applying optimizations
+- ISA abstraction supporting AArch64 (primary), x86-64/x86-32, RISC-V (scaffolded)
+- Binary patching for applying optimizations (per-arch alignment + NOP padding)
 
 ## Development Commands
 
@@ -61,10 +61,13 @@ Mutation testing runs via [cargo-mutants](https://mutants.rs/) and is **informat
 
 The project requires:
 - Rust toolchain with 2024 edition support
-- External crates: `elf`, `capstone`, `clap`, `z3`, `rayon`, `crossbeam-channel`
-- Capstone engine (usually installed via system package manager)
+- External crates: `elf`, `capstone`, `clap`, `z3`, `rayon`, `crossbeam-channel`, `dynasmrt`/`dynasm` (both ship aarch64 + x64 + x86 backends in default features)
+- Capstone engine (usually installed via system package manager) — auto-detects x86 and arm64 modes
 - Z3 SMT solver and development libraries (for semantic equivalence checking)
 - `just` command runner for running build tasks (required by test_all.sh)
+- For building x86 test binaries via `build_tests.sh`:
+  - Host `gcc` for x86-64 (produced into `binaries/x86_64/`)
+  - `gcc -m32` for x86-32 (requires `gcc-multilib`; gracefully skipped if absent)
 
 ## Architecture
 
@@ -72,29 +75,38 @@ The project requires:
 
 ```
 src/
-├── main.rs              # CLI and ELF binary analysis
-├── ir/                  # Intermediate Representation
-│   ├── types.rs         # Register, Operand, Condition enums
-│   └── instructions.rs  # Instruction enum (20 opcodes)
+├── main.rs              # CLI; AArch64 + x86 optimization pipelines
+├── ir/                  # AArch64 IR (Register, Operand, Condition, Instruction)
+│   ├── types.rs
+│   └── instructions.rs
 ├── isa/                 # ISA Abstraction Layer
-│   ├── traits.rs        # ISA trait definitions
+│   ├── traits.rs        # ISA trait definitions (aspirational; not all backends use)
 │   ├── aarch64.rs       # AArch64 backend
-│   └── riscv.rs         # RISC-V backend
+│   ├── riscv.rs         # RISC-V backend (trait scaffolding only, not wired through)
+│   └── x86.rs           # x86 backend (X86_64 + X86_32; full vertical slice)
 ├── semantics/           # Execution semantics
-│   ├── concrete.rs      # Concrete interpreter
-│   ├── smt.rs           # Symbolic interpreter (Z3)
-│   ├── equivalence.rs   # SMT equivalence checking
-│   ├── cost.rs          # Instruction cost model
-│   └── state.rs         # Machine state (registers, flags)
-├── search/              # Search algorithms
-│   ├── enumerative/     # Exhaustive search
-│   ├── stochastic/      # MCMC with Metropolis-Hastings
-│   ├── symbolic/        # SMT-based synthesis
-│   └── parallel/        # Multi-threaded coordination
+│   ├── concrete.rs      # AArch64 concrete interpreter
+│   ├── concrete_x86.rs  # x86 concrete interpreter (width-aware)
+│   ├── smt.rs           # AArch64 SMT lowering (64-bit BVs)
+│   ├── smt_x86.rs       # x86 SMT lowering (width-parameterised BVs)
+│   ├── cost.rs          # AArch64 cost model
+│   ├── cost_x86.rs      # x86 cost model (variable-length CodeSize)
+│   ├── equivalence.rs   # check_equivalence (AArch64) + check_equivalence_x86 (EFLAGS fast-path)
+│   └── state.rs         # Machine state: ConditionFlags (NZCV), Eflags, *MachineState, LiveOutMask
+├── search/              # Search algorithms (AArch64-typed in v1)
+│   ├── candidate.rs     # AArch64 candidate generation
+│   ├── candidate_x86.rs # x86 candidate generation
+│   ├── stochastic/      # MCMC with Metropolis-Hastings (AArch64)
+│   ├── symbolic/        # SMT-based synthesis (AArch64)
+│   ├── parallel/        # Multi-threaded coordination (AArch64)
+│   └── llm/             # LLM-assisted search via Codex CLI (AArch64)
 ├── validation/          # Input validation
-│   ├── live_out.rs      # Live-out register tracking
-│   └── random.rs        # Random input generation
-└── assembler/           # Machine code generation (dynasm)
+│   ├── live_out.rs      # Live-out register tracking (AArch64)
+│   └── random.rs        # Random input generation (AArch64)
+├── assembler/           # Machine code generation (dynasm)
+│   ├── mod.rs           # AArch64Assembler
+│   └── x86.rs           # X86Assembler (Mode64 / Mode32)
+└── elf_patcher/         # ELF read/patch with DetectedArch (AArch64/X86_64/X86_32)
 ```
 
 ### Search Algorithms
@@ -107,14 +119,20 @@ src/
 ### Key CLI Options
 
 ```bash
-# Disassemble a binary
-s11 disasm --binary <file>
+# Disassemble a binary (auto-detects arch from ELF; --arch is optional)
+s11 disasm <file>
+s11 disasm --arch x86-64 <file>
 
 # Optimize a code region
-s11 opt --binary <file> --start-addr <hex> --end-addr <hex>
+s11 opt <file> --start-addr <hex> --end-addr <hex>
 
-# Algorithm selection
-s11 opt ... --algorithm [enumerative|stochastic|symbolic|hybrid]
+# Architecture selection
+s11 opt ... --arch [aarch64|x86-64|x86-32]    # riscv32/64 still rejected
+
+# Algorithm selection (AArch64 only)
+s11 opt ... --algorithm [enumerative|stochastic|symbolic|hybrid|llm]
+
+# x86 currently supports --algorithm enumerative only.
 
 # Parallel execution
 s11 opt ... --cores <n> --timeout <seconds>

--- a/build_tests.sh
+++ b/build_tests.sh
@@ -1,35 +1,55 @@
 #!/bin/bash
 
-# Build script for AArch64 test binaries
+# Build script for AArch64 + x86 test binaries.
 set -e
 
 echo "Building AArch64 test binaries..."
 echo "Current directory: $(pwd)"
-echo "Checking for cross-compiler..."
+echo "Checking for AArch64 cross-compiler..."
 which aarch64-linux-gnu-gcc || (echo "ERROR: aarch64-linux-gnu-gcc not found!" && exit 1)
 
-# Create binaries directory
-mkdir -p binaries
+mkdir -p binaries binaries/x86_64 binaries/x86_32
 
-# Compile each test with different optimization levels
+# --- AArch64 (cross-compiled) ---
 for test_file in tests/*.c; do
     base_name=$(basename "$test_file" .c)
-    echo "Compiling $base_name..."
-    
-    # Debug version (no optimization)
+    echo "Compiling AArch64 $base_name..."
     aarch64-linux-gnu-gcc -g -O0 -o "binaries/${base_name}_debug" "$test_file"
-    
-    # Optimized version
-    aarch64-linux-gnu-gcc -O2 -o "binaries/${base_name}_opt" "$test_file"
-    
-    # Highly optimized version
-    aarch64-linux-gnu-gcc -O3 -o "binaries/${base_name}_opt3" "$test_file"
+    aarch64-linux-gnu-gcc -O2     -o "binaries/${base_name}_opt"   "$test_file"
+    aarch64-linux-gnu-gcc -O3     -o "binaries/${base_name}_opt3"  "$test_file"
 done
 
+# --- x86-64 (host gcc) ---
+if command -v gcc >/dev/null && [ "$(gcc -dumpmachine | head -c 6)" = "x86_64" ]; then
+    echo "Building x86-64 test binaries with host gcc..."
+    for test_file in tests/*.c; do
+        base_name=$(basename "$test_file" .c)
+        echo "Compiling x86-64 $base_name..."
+        gcc -g -O0 -o "binaries/x86_64/${base_name}_debug" "$test_file"
+        gcc -O2     -o "binaries/x86_64/${base_name}_opt"   "$test_file"
+    done
+else
+    echo "Skipping x86-64 (no x86_64 host gcc)."
+fi
+
+# --- x86-32 (gcc -m32, requires multilib) ---
+if gcc -m32 -E -x c - </dev/null >/dev/null 2>&1; then
+    echo "Building x86-32 test binaries with gcc -m32..."
+    for test_file in tests/*.c; do
+        base_name=$(basename "$test_file" .c)
+        echo "Compiling x86-32 $base_name..."
+        gcc -m32 -g -O0 -o "binaries/x86_32/${base_name}_debug" "$test_file" \
+            || echo "  ... skipped (link or compile failure)"
+    done
+else
+    echo "Skipping x86-32 (gcc -m32 not usable; install gcc-multilib to enable)."
+fi
+
 echo "Built binaries:"
-ls -la binaries/
+ls -la binaries/ binaries/x86_64/ binaries/x86_32/ 2>/dev/null || true
 
 echo "Verifying binary types:"
-for binary in binaries/*; do
+for binary in binaries/* binaries/x86_64/* binaries/x86_32/*; do
+    [ -f "$binary" ] || continue
     echo "$(basename "$binary"): $(file "$binary" | cut -d: -f2-)"
 done

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -1,3 +1,5 @@
+pub mod x86;
+
 use crate::ir::types::Condition;
 use crate::ir::{Instruction, Operand, Register};
 use dynasmrt::{DynasmApi, dynasm};

--- a/src/assembler/x86.rs
+++ b/src/assembler/x86.rs
@@ -1,0 +1,575 @@
+//! Dynasm-based assembler for the x86 backend.
+//!
+//! Two modes:
+//! - `X86Assembler::new_64()` → uses `dynasmrt::x64::Assembler` and
+//!   emits 64-bit instruction encodings.
+//! - `X86Assembler::new_32()` → uses `dynasmrt::x86::Assembler` and
+//!   emits 32-bit encodings (no REX prefix; R8..R15 not accessible).
+//!
+//! Capstone round-trip tests at the bottom verify byte-level correctness
+//! for every variant: encode → disassemble → assert mnemonic + operand
+//! strings match.
+
+#![allow(dead_code)]
+// The dynasm! macro auto-inserts `.into()` calls when accepting register
+// indices, which clippy flags as `useless_conversion` whenever the supplied
+// value is already the target type (here, `u8`). The conversion is dynasm's
+// design, not ours, and there's no way to suppress it per-call without
+// disfiguring the macro invocations. Allow at module scope.
+#![allow(clippy::useless_conversion)]
+
+use crate::isa::x86::{X86Instruction, X86Register};
+use dynasm::dynasm;
+use dynasmrt::DynasmApi;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum X86Mode {
+    Mode64,
+    Mode32,
+}
+
+pub struct X86Assembler {
+    mode: X86Mode,
+}
+
+impl X86Assembler {
+    pub fn new_64() -> Self {
+        Self {
+            mode: X86Mode::Mode64,
+        }
+    }
+
+    pub fn new_32() -> Self {
+        Self {
+            mode: X86Mode::Mode32,
+        }
+    }
+
+    pub fn mode(&self) -> X86Mode {
+        self.mode
+    }
+
+    pub fn assemble_instructions(
+        &mut self,
+        instructions: &[X86Instruction],
+    ) -> Result<Vec<u8>, String> {
+        match self.mode {
+            X86Mode::Mode64 => assemble_64(instructions),
+            X86Mode::Mode32 => assemble_32(instructions),
+        }
+    }
+}
+
+fn reg_index(reg: X86Register) -> Result<u8, String> {
+    reg.index()
+        .ok_or_else(|| format!("register {:?} has no index", reg))
+}
+
+fn reg_index_32(reg: X86Register) -> Result<u8, String> {
+    let i = reg_index(reg)?;
+    if i >= 8 {
+        return Err(format!("register {:?} not available in x86-32 mode", reg));
+    }
+    Ok(i)
+}
+
+fn assemble_64(instructions: &[X86Instruction]) -> Result<Vec<u8>, String> {
+    let mut ops =
+        dynasmrt::x64::Assembler::new().map_err(|e| format!("dynasm x64 init failed: {:?}", e))?;
+    for instr in instructions {
+        encode_64(&mut ops, instr)?;
+    }
+    let buf = ops
+        .finalize()
+        .map_err(|e| format!("dynasm finalize failed: {:?}", e))?;
+    Ok(buf.to_vec())
+}
+
+fn assemble_32(instructions: &[X86Instruction]) -> Result<Vec<u8>, String> {
+    let mut ops =
+        dynasmrt::x86::Assembler::new().map_err(|e| format!("dynasm x86 init failed: {:?}", e))?;
+    for instr in instructions {
+        encode_32(&mut ops, instr)?;
+    }
+    let buf = ops
+        .finalize()
+        .map_err(|e| format!("dynasm finalize failed: {:?}", e))?;
+    Ok(buf.to_vec())
+}
+
+fn encode_64(ops: &mut dynasmrt::x64::Assembler, instr: &X86Instruction) -> Result<(), String> {
+    match instr {
+        X86Instruction::MovReg { rd, rs } => {
+            let rd = reg_index(*rd)?;
+            let rs = reg_index(*rs)?;
+            dynasm!(ops ; .arch x64 ; mov Rq(rd), Rq(rs));
+            Ok(())
+        }
+        X86Instruction::MovImm { rd, imm } => {
+            let rd = reg_index(*rd)?;
+            // Prefer the imm32 sign-extended encoding (5 bytes including
+            // REX) when the immediate fits — Capstone shows this as
+            // canonical "mov rax, 0x...". Fall back to MOVABS (10 bytes)
+            // for the rare full 64-bit immediate case.
+            if let Ok(i32_imm) = i32::try_from(*imm) {
+                dynasm!(ops ; .arch x64 ; mov Rq(rd), i32_imm);
+            } else {
+                let imm = *imm;
+                dynasm!(ops ; .arch x64 ; mov Rq(rd), QWORD imm);
+            }
+            Ok(())
+        }
+        X86Instruction::AddReg { rd, rs } => {
+            let rd = reg_index(*rd)?;
+            let rs = reg_index(*rs)?;
+            dynasm!(ops ; .arch x64 ; add Rq(rd), Rq(rs));
+            Ok(())
+        }
+        X86Instruction::AddImm { rd, imm } => {
+            let rd = reg_index(*rd)?;
+            let imm = imm_i32(*imm)?;
+            dynasm!(ops ; .arch x64 ; add Rq(rd), imm);
+            Ok(())
+        }
+        X86Instruction::SubReg { rd, rs } => {
+            let rd = reg_index(*rd)?;
+            let rs = reg_index(*rs)?;
+            dynasm!(ops ; .arch x64 ; sub Rq(rd), Rq(rs));
+            Ok(())
+        }
+        X86Instruction::SubImm { rd, imm } => {
+            let rd = reg_index(*rd)?;
+            let imm = imm_i32(*imm)?;
+            dynasm!(ops ; .arch x64 ; sub Rq(rd), imm);
+            Ok(())
+        }
+        X86Instruction::AndReg { rd, rs } => {
+            let rd = reg_index(*rd)?;
+            let rs = reg_index(*rs)?;
+            dynasm!(ops ; .arch x64 ; and Rq(rd), Rq(rs));
+            Ok(())
+        }
+        X86Instruction::AndImm { rd, imm } => {
+            let rd = reg_index(*rd)?;
+            let imm = imm_i32(*imm)?;
+            dynasm!(ops ; .arch x64 ; and Rq(rd), imm);
+            Ok(())
+        }
+        X86Instruction::OrReg { rd, rs } => {
+            let rd = reg_index(*rd)?;
+            let rs = reg_index(*rs)?;
+            dynasm!(ops ; .arch x64 ; or Rq(rd), Rq(rs));
+            Ok(())
+        }
+        X86Instruction::OrImm { rd, imm } => {
+            let rd = reg_index(*rd)?;
+            let imm = imm_i32(*imm)?;
+            dynasm!(ops ; .arch x64 ; or Rq(rd), imm);
+            Ok(())
+        }
+        X86Instruction::XorReg { rd, rs } => {
+            let rd = reg_index(*rd)?;
+            let rs = reg_index(*rs)?;
+            dynasm!(ops ; .arch x64 ; xor Rq(rd), Rq(rs));
+            Ok(())
+        }
+        X86Instruction::XorImm { rd, imm } => {
+            let rd = reg_index(*rd)?;
+            let imm = imm_i32(*imm)?;
+            dynasm!(ops ; .arch x64 ; xor Rq(rd), imm);
+            Ok(())
+        }
+        X86Instruction::CmpReg { rn, rs } => {
+            let rn = reg_index(*rn)?;
+            let rs = reg_index(*rs)?;
+            dynasm!(ops ; .arch x64 ; cmp Rq(rn), Rq(rs));
+            Ok(())
+        }
+        X86Instruction::CmpImm { rn, imm } => {
+            let rn = reg_index(*rn)?;
+            let imm = imm_i32(*imm)?;
+            dynasm!(ops ; .arch x64 ; cmp Rq(rn), imm);
+            Ok(())
+        }
+    }
+}
+
+/// Truncate an `i64` immediate down to `i32` for the imm32-form opcodes.
+/// Returns an error if the value would not be representable as a
+/// sign-extended 32-bit immediate.
+fn imm_i32(imm: i64) -> Result<i32, String> {
+    i32::try_from(imm).map_err(|_| format!("immediate {} does not fit in 32 bits", imm))
+}
+
+fn encode_32(ops: &mut dynasmrt::x86::Assembler, instr: &X86Instruction) -> Result<(), String> {
+    match instr {
+        X86Instruction::MovReg { rd, rs } => {
+            let rd = reg_index_32(*rd)?;
+            let rs = reg_index_32(*rs)?;
+            dynasm!(ops ; .arch x86 ; mov Rd(rd), Rd(rs));
+            Ok(())
+        }
+        X86Instruction::MovImm { rd, imm } => {
+            let rd = reg_index_32(*rd)?;
+            let imm = imm_i32(*imm)?;
+            dynasm!(ops ; .arch x86 ; mov Rd(rd), imm);
+            Ok(())
+        }
+        X86Instruction::AddReg { rd, rs } => {
+            let rd = reg_index_32(*rd)?;
+            let rs = reg_index_32(*rs)?;
+            dynasm!(ops ; .arch x86 ; add Rd(rd), Rd(rs));
+            Ok(())
+        }
+        X86Instruction::AddImm { rd, imm } => {
+            let rd = reg_index_32(*rd)?;
+            let imm = imm_i32(*imm)?;
+            dynasm!(ops ; .arch x86 ; add Rd(rd), imm);
+            Ok(())
+        }
+        X86Instruction::SubReg { rd, rs } => {
+            let rd = reg_index_32(*rd)?;
+            let rs = reg_index_32(*rs)?;
+            dynasm!(ops ; .arch x86 ; sub Rd(rd), Rd(rs));
+            Ok(())
+        }
+        X86Instruction::SubImm { rd, imm } => {
+            let rd = reg_index_32(*rd)?;
+            let imm = imm_i32(*imm)?;
+            dynasm!(ops ; .arch x86 ; sub Rd(rd), imm);
+            Ok(())
+        }
+        X86Instruction::AndReg { rd, rs } => {
+            let rd = reg_index_32(*rd)?;
+            let rs = reg_index_32(*rs)?;
+            dynasm!(ops ; .arch x86 ; and Rd(rd), Rd(rs));
+            Ok(())
+        }
+        X86Instruction::AndImm { rd, imm } => {
+            let rd = reg_index_32(*rd)?;
+            let imm = imm_i32(*imm)?;
+            dynasm!(ops ; .arch x86 ; and Rd(rd), imm);
+            Ok(())
+        }
+        X86Instruction::OrReg { rd, rs } => {
+            let rd = reg_index_32(*rd)?;
+            let rs = reg_index_32(*rs)?;
+            dynasm!(ops ; .arch x86 ; or Rd(rd), Rd(rs));
+            Ok(())
+        }
+        X86Instruction::OrImm { rd, imm } => {
+            let rd = reg_index_32(*rd)?;
+            let imm = imm_i32(*imm)?;
+            dynasm!(ops ; .arch x86 ; or Rd(rd), imm);
+            Ok(())
+        }
+        X86Instruction::XorReg { rd, rs } => {
+            let rd = reg_index_32(*rd)?;
+            let rs = reg_index_32(*rs)?;
+            dynasm!(ops ; .arch x86 ; xor Rd(rd), Rd(rs));
+            Ok(())
+        }
+        X86Instruction::XorImm { rd, imm } => {
+            let rd = reg_index_32(*rd)?;
+            let imm = imm_i32(*imm)?;
+            dynasm!(ops ; .arch x86 ; xor Rd(rd), imm);
+            Ok(())
+        }
+        X86Instruction::CmpReg { rn, rs } => {
+            let rn = reg_index_32(*rn)?;
+            let rs = reg_index_32(*rs)?;
+            dynasm!(ops ; .arch x86 ; cmp Rd(rn), Rd(rs));
+            Ok(())
+        }
+        X86Instruction::CmpImm { rn, imm } => {
+            let rn = reg_index_32(*rn)?;
+            let imm = imm_i32(*imm)?;
+            dynasm!(ops ; .arch x86 ; cmp Rd(rn), imm);
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use capstone::prelude::*;
+
+    fn disasm_x86_64(bytes: &[u8]) -> Vec<(String, String)> {
+        let cs = Capstone::new()
+            .x86()
+            .mode(arch::x86::ArchMode::Mode64)
+            .syntax(arch::x86::ArchSyntax::Intel)
+            .build()
+            .expect("capstone init");
+        let insns = cs.disasm_all(bytes, 0x0).expect("disassemble");
+        insns
+            .iter()
+            .map(|i| {
+                (
+                    i.mnemonic().unwrap_or("").to_string(),
+                    i.op_str().unwrap_or("").to_string(),
+                )
+            })
+            .collect()
+    }
+
+    fn disasm_x86_32(bytes: &[u8]) -> Vec<(String, String)> {
+        let cs = Capstone::new()
+            .x86()
+            .mode(arch::x86::ArchMode::Mode32)
+            .syntax(arch::x86::ArchSyntax::Intel)
+            .build()
+            .expect("capstone init");
+        let insns = cs.disasm_all(bytes, 0x0).expect("disassemble");
+        insns
+            .iter()
+            .map(|i| {
+                (
+                    i.mnemonic().unwrap_or("").to_string(),
+                    i.op_str().unwrap_or("").to_string(),
+                )
+            })
+            .collect()
+    }
+
+    fn check_x86_32(instr: X86Instruction, expected_mnemonic: &str, expect_operands: &[&str]) {
+        let mut asm = X86Assembler::new_32();
+        let bytes = asm
+            .assemble_instructions(&[instr])
+            .expect("32-bit encoding succeeds");
+        let disasm = disasm_x86_32(&bytes);
+        assert_eq!(disasm.len(), 1);
+        assert_eq!(
+            disasm[0].0, expected_mnemonic,
+            "mnemonic mismatch (operands: {})",
+            disasm[0].1
+        );
+        for op in expect_operands {
+            assert!(
+                disasm[0].1.contains(op),
+                "missing operand {} (got: {})",
+                op,
+                disasm[0].1
+            );
+        }
+    }
+
+    #[test]
+    fn movreg_x86_32_uses_eax_form() {
+        check_x86_32(
+            X86Instruction::MovReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            "mov",
+            &["eax", "ebx"],
+        );
+    }
+
+    #[test]
+    fn add_imm_x86_32() {
+        check_x86_32(
+            X86Instruction::AddImm {
+                rd: X86Register::RCX,
+                imm: 9,
+            },
+            "add",
+            &["ecx", "9"],
+        );
+    }
+
+    #[test]
+    fn x86_32_rejects_extended_register() {
+        let mut asm = X86Assembler::new_32();
+        let err = asm
+            .assemble_instructions(&[X86Instruction::MovReg {
+                rd: X86Register::R8,
+                rs: X86Register::RAX,
+            }])
+            .expect_err("R8 not addressable in 32-bit mode");
+        assert!(
+            err.contains("not available in x86-32"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    fn check_x86_64(instr: X86Instruction, expected_mnemonic: &str, expect_operands: &[&str]) {
+        let mut asm = X86Assembler::new_64();
+        let bytes = asm
+            .assemble_instructions(&[instr])
+            .expect("encoding succeeds");
+        let disasm = disasm_x86_64(&bytes);
+        assert_eq!(disasm.len(), 1, "expected one instruction");
+        assert_eq!(
+            disasm[0].0, expected_mnemonic,
+            "mnemonic mismatch (operands: {})",
+            disasm[0].1
+        );
+        for op in expect_operands {
+            assert!(
+                disasm[0].1.contains(op),
+                "missing operand {} (got: {})",
+                op,
+                disasm[0].1
+            );
+        }
+    }
+
+    #[test]
+    fn movimm_x86_64() {
+        check_x86_64(
+            X86Instruction::MovImm {
+                rd: X86Register::RAX,
+                imm: 42,
+            },
+            "mov",
+            &["rax", "0x2a"],
+        );
+    }
+
+    #[test]
+    fn add_variants_x86_64() {
+        check_x86_64(
+            X86Instruction::AddReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            "add",
+            &["rax", "rbx"],
+        );
+        check_x86_64(
+            X86Instruction::AddImm {
+                rd: X86Register::RAX,
+                imm: 5,
+            },
+            "add",
+            &["rax", "5"],
+        );
+    }
+
+    #[test]
+    fn sub_variants_x86_64() {
+        check_x86_64(
+            X86Instruction::SubReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            "sub",
+            &["rax", "rbx"],
+        );
+        check_x86_64(
+            X86Instruction::SubImm {
+                rd: X86Register::RAX,
+                imm: 5,
+            },
+            "sub",
+            &["rax", "5"],
+        );
+    }
+
+    #[test]
+    fn and_or_xor_variants_x86_64() {
+        check_x86_64(
+            X86Instruction::AndReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            "and",
+            &["rax", "rbx"],
+        );
+        check_x86_64(
+            X86Instruction::OrReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            "or",
+            &["rax", "rbx"],
+        );
+        check_x86_64(
+            X86Instruction::XorReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            "xor",
+            &["rax", "rbx"],
+        );
+        check_x86_64(
+            X86Instruction::AndImm {
+                rd: X86Register::RAX,
+                imm: 0xff,
+            },
+            "and",
+            &["rax", "0xff"],
+        );
+        check_x86_64(
+            X86Instruction::OrImm {
+                rd: X86Register::RAX,
+                imm: 1,
+            },
+            "or",
+            &["rax", "1"],
+        );
+        check_x86_64(
+            X86Instruction::XorImm {
+                rd: X86Register::RAX,
+                imm: 1,
+            },
+            "xor",
+            &["rax", "1"],
+        );
+    }
+
+    #[test]
+    fn cmp_variants_x86_64() {
+        check_x86_64(
+            X86Instruction::CmpReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            "cmp",
+            &["rax", "rbx"],
+        );
+        check_x86_64(
+            X86Instruction::CmpImm {
+                rn: X86Register::RAX,
+                imm: 7,
+            },
+            "cmp",
+            &["rax", "7"],
+        );
+    }
+
+    #[test]
+    fn movreg_with_extended_register_r9() {
+        check_x86_64(
+            X86Instruction::MovReg {
+                rd: X86Register::R9,
+                rs: X86Register::RAX,
+            },
+            "mov",
+            &["r9", "rax"],
+        );
+    }
+
+    #[test]
+    fn movreg_x86_64_round_trips_through_capstone() {
+        let mut asm = X86Assembler::new_64();
+        let bytes = asm
+            .assemble_instructions(&[X86Instruction::MovReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            }])
+            .expect("encode mov rax, rbx");
+        let disasm = disasm_x86_64(&bytes);
+        assert_eq!(disasm.len(), 1);
+        assert_eq!(disasm[0].0, "mov");
+        // Capstone produces "rax, rbx" (Intel syntax).
+        assert!(
+            disasm[0].1.contains("rax") && disasm[0].1.contains("rbx"),
+            "operands: {}",
+            disasm[0].1
+        );
+    }
+}

--- a/src/elf_patcher/mod.rs
+++ b/src/elf_patcher/mod.rs
@@ -2,8 +2,48 @@ use elf::{ElfBytes, endian::AnyEndian};
 use std::fs;
 use std::path::Path;
 
+/// Architecture detected from the ELF `e_machine` field. Drives
+/// per-arch behaviours: instruction alignment for window validation
+/// and NOP byte choice for padding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DetectedArch {
+    Aarch64,
+    X86_64,
+    X86_32,
+}
+
+impl DetectedArch {
+    /// Required byte alignment for an instruction-window start/end.
+    pub fn instruction_alignment(&self) -> u64 {
+        match self {
+            DetectedArch::Aarch64 => 4,
+            DetectedArch::X86_64 | DetectedArch::X86_32 => 1,
+        }
+    }
+
+    /// Per-instruction NOP bytes used to pad a shorter patch back up to
+    /// the original window size. AArch64 NOP is 0xd5_03_20_1f (LE); x86
+    /// NOP is the single-byte 0x90.
+    pub fn nop_bytes(&self) -> &'static [u8] {
+        match self {
+            DetectedArch::Aarch64 => &[0x1f, 0x20, 0x03, 0xd5],
+            DetectedArch::X86_64 | DetectedArch::X86_32 => &[0x90],
+        }
+    }
+
+    fn from_e_machine(machine: u16) -> Option<Self> {
+        match machine {
+            elf::abi::EM_AARCH64 => Some(DetectedArch::Aarch64),
+            elf::abi::EM_X86_64 => Some(DetectedArch::X86_64),
+            elf::abi::EM_386 => Some(DetectedArch::X86_32),
+            _ => None,
+        }
+    }
+}
+
 pub struct ElfPatcher {
     file_data: Vec<u8>,
+    arch: DetectedArch,
 }
 
 #[derive(Debug, Clone)]
@@ -24,17 +64,17 @@ impl ElfPatcher {
     pub fn new(path: &Path) -> Result<Self, Box<dyn std::error::Error>> {
         let file_data = fs::read(path)?;
         let elf = ElfBytes::<AnyEndian>::minimal_parse(&file_data)?;
-
-        // Verify it's AArch64
-        if elf.ehdr.e_machine != elf::abi::EM_AARCH64 {
-            return Err(format!(
-                "Not an AArch64 binary (machine type: {})",
+        let arch = DetectedArch::from_e_machine(elf.ehdr.e_machine).ok_or_else(|| {
+            format!(
+                "Unsupported architecture (e_machine: {})",
                 elf.ehdr.e_machine
             )
-            .into());
-        }
+        })?;
+        Ok(Self { file_data, arch })
+    }
 
-        Ok(Self { file_data })
+    pub fn arch(&self) -> DetectedArch {
+        self.arch
     }
 
     pub fn get_text_sections(&self) -> Result<Vec<TextSection>, Box<dyn std::error::Error>> {
@@ -81,11 +121,14 @@ impl ElfPatcher {
                     return Err("Start address must be less than end address".to_string());
                 }
 
-                // Ensure addresses are 4-byte aligned (AArch64 instruction alignment)
-                if !window.start.is_multiple_of(4) || !window.end.is_multiple_of(4) {
-                    return Err(
-                        "Addresses must be 4-byte aligned for AArch64 instructions".to_string()
-                    );
+                let align = self.arch.instruction_alignment();
+                if align > 1
+                    && (!window.start.is_multiple_of(align) || !window.end.is_multiple_of(align))
+                {
+                    return Err(format!(
+                        "Addresses must be {}-byte aligned for {:?} instructions",
+                        align, self.arch
+                    ));
                 }
 
                 return Ok(section);
@@ -151,15 +194,15 @@ impl ElfPatcher {
         let patch_end = file_offset + new_code.len();
         patched_data[file_offset..patch_end].copy_from_slice(new_code);
 
-        // If new code is smaller than window, pad with NOPs
+        // If new code is smaller than window, pad with arch-appropriate NOPs.
         if new_code.len() < window_size {
             let remaining = window_size - new_code.len();
-            let nop_bytes = vec![0x1f, 0x20, 0x03, 0xd5]; // AArch64 NOP instruction
-
-            for i in 0..remaining / 4 {
-                let nop_start = patch_end + i * 4;
-                if nop_start + 4 <= file_offset + window_size {
-                    patched_data[nop_start..nop_start + 4].copy_from_slice(&nop_bytes);
+            let nop = self.arch.nop_bytes();
+            let n = nop.len();
+            for i in 0..remaining / n {
+                let nop_start = patch_end + i * n;
+                if nop_start + n <= file_offset + window_size {
+                    patched_data[nop_start..nop_start + n].copy_from_slice(nop);
                 }
             }
         }
@@ -184,6 +227,40 @@ pub fn parse_hex_address(addr_str: &str) -> Result<u64, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn detected_arch_alignment() {
+        assert_eq!(DetectedArch::Aarch64.instruction_alignment(), 4);
+        assert_eq!(DetectedArch::X86_64.instruction_alignment(), 1);
+        assert_eq!(DetectedArch::X86_32.instruction_alignment(), 1);
+    }
+
+    #[test]
+    fn detected_arch_nop_bytes() {
+        assert_eq!(
+            DetectedArch::Aarch64.nop_bytes(),
+            &[0x1f, 0x20, 0x03, 0xd5][..]
+        );
+        assert_eq!(DetectedArch::X86_64.nop_bytes(), &[0x90][..]);
+        assert_eq!(DetectedArch::X86_32.nop_bytes(), &[0x90][..]);
+    }
+
+    #[test]
+    fn detected_arch_from_e_machine() {
+        assert_eq!(
+            DetectedArch::from_e_machine(elf::abi::EM_AARCH64),
+            Some(DetectedArch::Aarch64)
+        );
+        assert_eq!(
+            DetectedArch::from_e_machine(elf::abi::EM_X86_64),
+            Some(DetectedArch::X86_64)
+        );
+        assert_eq!(
+            DetectedArch::from_e_machine(elf::abi::EM_386),
+            Some(DetectedArch::X86_32)
+        );
+        assert_eq!(DetectedArch::from_e_machine(0xffff), None);
+    }
 
     #[test]
     fn test_parse_hex_address() {

--- a/src/isa/mod.rs
+++ b/src/isa/mod.rs
@@ -1,11 +1,12 @@
 //! ISA (Instruction Set Architecture) abstraction layer
 //!
 //! This module provides traits for abstracting over different instruction set architectures,
-//! enabling the optimizer to work with multiple ISAs (AArch64, RISC-V, etc.)
+//! enabling the optimizer to work with multiple ISAs (AArch64, RISC-V, x86, etc.)
 
 pub mod aarch64;
 pub mod riscv;
 mod traits;
+pub mod x86;
 
 #[allow(unused_imports)]
 pub use traits::{
@@ -19,3 +20,5 @@ pub use aarch64::AArch64;
 pub use riscv::{
     RiscV32, RiscV64, RiscVInstruction, RiscVInstructionGenerator, RiscVOperand, RiscVRegister,
 };
+#[allow(unused_imports)]
+pub use x86::{X86_32, X86_64, X86Instruction, X86InstructionGenerator, X86Operand, X86Register};

--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -1,0 +1,977 @@
+//! x86 ISA backend (x86-64 primary, x86-32 secondary).
+//!
+//! Mirrors the dual-variant pattern of `src/isa/riscv.rs`: a single set of
+//! `X86Register` / `X86Operand` / `X86Instruction` enums shared by the
+//! `X86_64` and `X86_32` ISA marker structs.
+//!
+//! **Initial instruction set**: MOV, ADD, SUB, AND, OR, XOR, CMP — each with
+//! register and immediate forms (14 variants total: 7 mnemonics × 2 forms).
+
+#![allow(dead_code)]
+// x86 register names are conventionally uppercase (RAX, RBX, ...) in every
+// Intel/AMD manual, Capstone disassembly output, GAS/Intel syntax, and gdb
+// `info registers`. Lowercasing to `Rax`/`Rbx` per Rust's default
+// upper_case_acronyms lint would make the IR diverge from every external
+// reference. Keep the uppercase names and silence the lint module-wide.
+#![allow(clippy::upper_case_acronyms)]
+
+use crate::isa::traits::{ISA, InstructionGenerator, InstructionType, OperandType, RegisterType};
+use rand::{Rng, RngExt};
+use std::fmt;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum X86Register {
+    RAX,
+    RCX,
+    RDX,
+    RBX,
+    RSP,
+    RBP,
+    RSI,
+    RDI,
+    R8,
+    R9,
+    R10,
+    R11,
+    R12,
+    R13,
+    R14,
+    R15,
+}
+
+impl X86Register {
+    pub fn index(&self) -> Option<u8> {
+        Some(match self {
+            X86Register::RAX => 0,
+            X86Register::RCX => 1,
+            X86Register::RDX => 2,
+            X86Register::RBX => 3,
+            X86Register::RSP => 4,
+            X86Register::RBP => 5,
+            X86Register::RSI => 6,
+            X86Register::RDI => 7,
+            X86Register::R8 => 8,
+            X86Register::R9 => 9,
+            X86Register::R10 => 10,
+            X86Register::R11 => 11,
+            X86Register::R12 => 12,
+            X86Register::R13 => 13,
+            X86Register::R14 => 14,
+            X86Register::R15 => 15,
+        })
+    }
+
+    pub fn mnemonic(&self) -> &'static str {
+        match self {
+            X86Register::RAX => "rax",
+            X86Register::RCX => "rcx",
+            X86Register::RDX => "rdx",
+            X86Register::RBX => "rbx",
+            X86Register::RSP => "rsp",
+            X86Register::RBP => "rbp",
+            X86Register::RSI => "rsi",
+            X86Register::RDI => "rdi",
+            X86Register::R8 => "r8",
+            X86Register::R9 => "r9",
+            X86Register::R10 => "r10",
+            X86Register::R11 => "r11",
+            X86Register::R12 => "r12",
+            X86Register::R13 => "r13",
+            X86Register::R14 => "r14",
+            X86Register::R15 => "r15",
+        }
+    }
+
+    pub fn from_index(i: u8) -> Option<Self> {
+        Some(match i {
+            0 => X86Register::RAX,
+            1 => X86Register::RCX,
+            2 => X86Register::RDX,
+            3 => X86Register::RBX,
+            4 => X86Register::RSP,
+            5 => X86Register::RBP,
+            6 => X86Register::RSI,
+            7 => X86Register::RDI,
+            8 => X86Register::R8,
+            9 => X86Register::R9,
+            10 => X86Register::R10,
+            11 => X86Register::R11,
+            12 => X86Register::R12,
+            13 => X86Register::R13,
+            14 => X86Register::R14,
+            15 => X86Register::R15,
+            _ => return None,
+        })
+    }
+}
+
+impl fmt::Display for X86Register {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.mnemonic())
+    }
+}
+
+impl RegisterType for X86Register {
+    fn index(&self) -> Option<u8> {
+        X86Register::index(self)
+    }
+
+    fn from_index(idx: u8) -> Option<Self> {
+        X86Register::from_index(idx)
+    }
+
+    fn is_zero_register(&self) -> bool {
+        false
+    }
+
+    fn is_special(&self) -> bool {
+        // Only RSP. RBP is not special — modern x86-64 ABIs do not require
+        // a frame pointer, so excluding it would bias the search away from
+        // valid scratch-register uses.
+        matches!(self, X86Register::RSP)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum X86Operand {
+    Register(X86Register),
+    Immediate(i64),
+}
+
+impl fmt::Display for X86Operand {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            X86Operand::Register(r) => write!(f, "{}", r),
+            X86Operand::Immediate(imm) => write!(f, "{}", imm),
+        }
+    }
+}
+
+/// x86 instruction variants for the initial minimal core set.
+///
+/// **Intentional divergence from AArch64/RISC-V**: x86 arithmetic and
+/// logic ops use the two-operand destructive form (`add rd, rs` reads
+/// AND writes `rd`). `source_registers()` therefore includes `rd` for
+/// these variants — see `validation::live_out::compute_live_in_registers`
+/// for why this matters for liveness analysis. A future refactor that
+/// "normalises" with the other ISAs (where `source_registers()` excludes
+/// the destination) would silently regress liveness for x86.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum X86Instruction {
+    /// `mov rd, rs` — non-destructive register copy; no EFLAGS effect.
+    MovReg { rd: X86Register, rs: X86Register },
+    /// `mov rd, imm` — load immediate; no EFLAGS effect.
+    MovImm { rd: X86Register, imm: i64 },
+    /// `add rd, rs` — `rd = rd + rs`; sets EFLAGS.
+    AddReg { rd: X86Register, rs: X86Register },
+    /// `add rd, imm` — `rd = rd + imm`; sets EFLAGS.
+    AddImm { rd: X86Register, imm: i64 },
+    /// `sub rd, rs` — `rd = rd - rs`; sets EFLAGS.
+    SubReg { rd: X86Register, rs: X86Register },
+    /// `sub rd, imm` — `rd = rd - imm`; sets EFLAGS.
+    SubImm { rd: X86Register, imm: i64 },
+    /// `and rd, rs` — `rd = rd & rs`; clears CF/OF, sets SF/ZF/PF.
+    AndReg { rd: X86Register, rs: X86Register },
+    /// `and rd, imm` — `rd = rd & imm`; clears CF/OF, sets SF/ZF/PF.
+    AndImm { rd: X86Register, imm: i64 },
+    /// `or rd, rs` — `rd = rd | rs`; clears CF/OF, sets SF/ZF/PF.
+    OrReg { rd: X86Register, rs: X86Register },
+    /// `or rd, imm` — `rd = rd | imm`; clears CF/OF, sets SF/ZF/PF.
+    OrImm { rd: X86Register, imm: i64 },
+    /// `xor rd, rs` — `rd = rd ^ rs`; clears CF/OF, sets SF/ZF/PF.
+    XorReg { rd: X86Register, rs: X86Register },
+    /// `xor rd, imm` — `rd = rd ^ imm`; clears CF/OF, sets SF/ZF/PF.
+    XorImm { rd: X86Register, imm: i64 },
+    /// `cmp rn, rs` — `rn - rs` discarding the result; sets EFLAGS.
+    CmpReg { rn: X86Register, rs: X86Register },
+    /// `cmp rn, imm` — `rn - imm` discarding the result; sets EFLAGS.
+    CmpImm { rn: X86Register, imm: i64 },
+}
+
+impl X86Instruction {
+    pub fn destination(&self) -> Option<X86Register> {
+        match self {
+            X86Instruction::MovReg { rd, .. }
+            | X86Instruction::MovImm { rd, .. }
+            | X86Instruction::AddReg { rd, .. }
+            | X86Instruction::AddImm { rd, .. }
+            | X86Instruction::SubReg { rd, .. }
+            | X86Instruction::SubImm { rd, .. }
+            | X86Instruction::AndReg { rd, .. }
+            | X86Instruction::AndImm { rd, .. }
+            | X86Instruction::OrReg { rd, .. }
+            | X86Instruction::OrImm { rd, .. }
+            | X86Instruction::XorReg { rd, .. }
+            | X86Instruction::XorImm { rd, .. } => Some(*rd),
+            X86Instruction::CmpReg { .. } | X86Instruction::CmpImm { .. } => None,
+        }
+    }
+
+    pub fn mnemonic(&self) -> &'static str {
+        match self {
+            X86Instruction::MovReg { .. } | X86Instruction::MovImm { .. } => "mov",
+            X86Instruction::AddReg { .. } | X86Instruction::AddImm { .. } => "add",
+            X86Instruction::SubReg { .. } | X86Instruction::SubImm { .. } => "sub",
+            X86Instruction::AndReg { .. } | X86Instruction::AndImm { .. } => "and",
+            X86Instruction::OrReg { .. } | X86Instruction::OrImm { .. } => "or",
+            X86Instruction::XorReg { .. } | X86Instruction::XorImm { .. } => "xor",
+            X86Instruction::CmpReg { .. } | X86Instruction::CmpImm { .. } => "cmp",
+        }
+    }
+
+    /// Registers this instruction reads.
+    ///
+    /// **x86 destructive-form divergence**: for `AddReg/SubReg/AndReg/OrReg/XorReg`
+    /// and their immediate forms, `rd` is BOTH source and destination, so it
+    /// appears here. `MovReg`/`MovImm` are non-destructive (rd is purely
+    /// written), so rd is NOT in the source list. See the enum doc-comment.
+    pub fn source_registers(&self) -> Vec<X86Register> {
+        match self {
+            X86Instruction::MovReg { rs, .. } => vec![*rs],
+            X86Instruction::MovImm { .. } => vec![],
+            X86Instruction::AddReg { rd, rs }
+            | X86Instruction::SubReg { rd, rs }
+            | X86Instruction::AndReg { rd, rs }
+            | X86Instruction::OrReg { rd, rs }
+            | X86Instruction::XorReg { rd, rs } => vec![*rd, *rs],
+            X86Instruction::AddImm { rd, .. }
+            | X86Instruction::SubImm { rd, .. }
+            | X86Instruction::AndImm { rd, .. }
+            | X86Instruction::OrImm { rd, .. }
+            | X86Instruction::XorImm { rd, .. } => vec![*rd],
+            X86Instruction::CmpReg { rn, rs } => vec![*rn, *rs],
+            X86Instruction::CmpImm { rn, .. } => vec![*rn],
+        }
+    }
+}
+
+impl InstructionType for X86Instruction {
+    type Register = X86Register;
+    type Operand = X86Operand;
+
+    fn destination(&self) -> Option<X86Register> {
+        X86Instruction::destination(self)
+    }
+
+    fn source_registers(&self) -> Vec<X86Register> {
+        X86Instruction::source_registers(self)
+    }
+
+    fn opcode_id(&self) -> u8 {
+        match self {
+            X86Instruction::MovReg { .. } => 0,
+            X86Instruction::MovImm { .. } => 1,
+            X86Instruction::AddReg { .. } => 2,
+            X86Instruction::AddImm { .. } => 3,
+            X86Instruction::SubReg { .. } => 4,
+            X86Instruction::SubImm { .. } => 5,
+            X86Instruction::AndReg { .. } => 6,
+            X86Instruction::AndImm { .. } => 7,
+            X86Instruction::OrReg { .. } => 8,
+            X86Instruction::OrImm { .. } => 9,
+            X86Instruction::XorReg { .. } => 10,
+            X86Instruction::XorImm { .. } => 11,
+            X86Instruction::CmpReg { .. } => 12,
+            X86Instruction::CmpImm { .. } => 13,
+        }
+    }
+
+    fn mnemonic(&self) -> &'static str {
+        X86Instruction::mnemonic(self)
+    }
+
+    fn has_side_effects(&self) -> bool {
+        // x86 MOV does not touch EFLAGS. Every other variant in the minimal
+        // core set sets or clobbers flag bits, which is observable state
+        // beyond the destination register.
+        !matches!(
+            self,
+            X86Instruction::MovReg { .. } | X86Instruction::MovImm { .. }
+        )
+    }
+}
+
+impl fmt::Display for X86Instruction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mn = self.mnemonic();
+        match self {
+            X86Instruction::MovReg { rd, rs }
+            | X86Instruction::AddReg { rd, rs }
+            | X86Instruction::SubReg { rd, rs }
+            | X86Instruction::AndReg { rd, rs }
+            | X86Instruction::OrReg { rd, rs }
+            | X86Instruction::XorReg { rd, rs } => write!(f, "{} {}, {}", mn, rd, rs),
+            X86Instruction::MovImm { rd, imm }
+            | X86Instruction::AddImm { rd, imm }
+            | X86Instruction::SubImm { rd, imm }
+            | X86Instruction::AndImm { rd, imm }
+            | X86Instruction::OrImm { rd, imm }
+            | X86Instruction::XorImm { rd, imm } => write!(f, "{} {}, {}", mn, rd, imm),
+            X86Instruction::CmpReg { rn, rs } => write!(f, "{} {}, {}", mn, rn, rs),
+            X86Instruction::CmpImm { rn, imm } => write!(f, "{} {}, {}", mn, rn, imm),
+        }
+    }
+}
+
+/// Marker type for the x86-64 ISA. Shares the `X86Register` / `X86Operand`
+/// / `X86Instruction` enums with `X86_32`; differs only in metadata.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct X86_64;
+
+impl ISA for X86_64 {
+    type Register = X86Register;
+    type Operand = X86Operand;
+    type Instruction = X86Instruction;
+
+    fn name(&self) -> &'static str {
+        "x86-64"
+    }
+
+    fn register_count(&self) -> usize {
+        16
+    }
+
+    fn register_width(&self) -> u32 {
+        64
+    }
+
+    fn instruction_size(&self) -> Option<usize> {
+        // x86 is variable-length.
+        None
+    }
+
+    fn general_registers(&self) -> Vec<X86Register> {
+        // Return all 16 GPRs including RSP — matches the RISC-V pattern
+        // where general_registers() does not pre-filter is_special. CLI
+        // is responsible for excluding RSP from the search-available pool.
+        (0..16u8).filter_map(X86Register::from_index).collect()
+    }
+
+    fn zero_register(&self) -> Option<X86Register> {
+        None
+    }
+}
+
+/// Marker type for the x86-32 (i386) ISA. Shares enums with `X86_64`,
+/// differs in register width (32) and the GPR set (low 8 only).
+#[derive(Clone, Copy, Debug, Default)]
+pub struct X86_32;
+
+impl ISA for X86_32 {
+    type Register = X86Register;
+    type Operand = X86Operand;
+    type Instruction = X86Instruction;
+
+    fn name(&self) -> &'static str {
+        "x86-32"
+    }
+
+    fn register_count(&self) -> usize {
+        8
+    }
+
+    fn register_width(&self) -> u32 {
+        32
+    }
+
+    fn instruction_size(&self) -> Option<usize> {
+        None
+    }
+
+    fn general_registers(&self) -> Vec<X86Register> {
+        (0..8u8).filter_map(X86Register::from_index).collect()
+    }
+
+    fn zero_register(&self) -> Option<X86Register> {
+        None
+    }
+}
+
+/// Stateless generator producing every reg/imm combination of the 14 x86
+/// variants for a given register and immediate pool. Mirrors
+/// `RiscVInstructionGenerator` in shape and complexity.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct X86InstructionGenerator;
+
+const X86_OPCODE_COUNT: u8 = 14;
+
+impl InstructionGenerator<X86Instruction> for X86InstructionGenerator {
+    fn generate_all(&self, registers: &[X86Register], immediates: &[i64]) -> Vec<X86Instruction> {
+        let mut out = Vec::new();
+        // Register-register variants (7 mnemonics).
+        for &rd in registers {
+            for &rs in registers {
+                out.push(X86Instruction::MovReg { rd, rs });
+                out.push(X86Instruction::AddReg { rd, rs });
+                out.push(X86Instruction::SubReg { rd, rs });
+                out.push(X86Instruction::AndReg { rd, rs });
+                out.push(X86Instruction::OrReg { rd, rs });
+                out.push(X86Instruction::XorReg { rd, rs });
+                out.push(X86Instruction::CmpReg { rn: rd, rs });
+            }
+        }
+        // Register-immediate variants (7 mnemonics).
+        for &rd in registers {
+            for &imm in immediates {
+                out.push(X86Instruction::MovImm { rd, imm });
+                out.push(X86Instruction::AddImm { rd, imm });
+                out.push(X86Instruction::SubImm { rd, imm });
+                out.push(X86Instruction::AndImm { rd, imm });
+                out.push(X86Instruction::OrImm { rd, imm });
+                out.push(X86Instruction::XorImm { rd, imm });
+                out.push(X86Instruction::CmpImm { rn: rd, imm });
+            }
+        }
+        out
+    }
+
+    fn generate_random<R: Rng>(
+        &self,
+        rng: &mut R,
+        registers: &[X86Register],
+        immediates: &[i64],
+    ) -> X86Instruction {
+        let opcode = rng.random_range(0..X86_OPCODE_COUNT);
+        let rd = registers[rng.random_range(0..registers.len())];
+        let rs = registers[rng.random_range(0..registers.len())];
+        let imm = immediates[rng.random_range(0..immediates.len())];
+        match opcode {
+            0 => X86Instruction::MovReg { rd, rs },
+            1 => X86Instruction::MovImm { rd, imm },
+            2 => X86Instruction::AddReg { rd, rs },
+            3 => X86Instruction::AddImm { rd, imm },
+            4 => X86Instruction::SubReg { rd, rs },
+            5 => X86Instruction::SubImm { rd, imm },
+            6 => X86Instruction::AndReg { rd, rs },
+            7 => X86Instruction::AndImm { rd, imm },
+            8 => X86Instruction::OrReg { rd, rs },
+            9 => X86Instruction::OrImm { rd, imm },
+            10 => X86Instruction::XorReg { rd, rs },
+            11 => X86Instruction::XorImm { rd, imm },
+            12 => X86Instruction::CmpReg { rn: rd, rs },
+            13 => X86Instruction::CmpImm { rn: rd, imm },
+            _ => unreachable!("opcode out of range"),
+        }
+    }
+
+    fn mutate<R: Rng>(
+        &self,
+        rng: &mut R,
+        instruction: &X86Instruction,
+        registers: &[X86Register],
+        immediates: &[i64],
+    ) -> X86Instruction {
+        // Three strategies, matching the RISC-V mutator:
+        //   0: completely fresh instruction (opcode change)
+        //   1: keep opcode + sources, change destination
+        //   2: keep opcode + destination, change sources/immediate
+        match rng.random_range(0..3) {
+            0 => self.generate_random(rng, registers, immediates),
+            1 => {
+                let new_rd = registers[rng.random_range(0..registers.len())];
+                with_destination(*instruction, new_rd)
+            }
+            2 => {
+                let new_rs = registers[rng.random_range(0..registers.len())];
+                let new_imm = immediates[rng.random_range(0..immediates.len())];
+                with_sources(*instruction, new_rs, new_imm)
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn opcode_count(&self) -> u8 {
+        X86_OPCODE_COUNT
+    }
+}
+
+fn with_destination(instr: X86Instruction, new_rd: X86Register) -> X86Instruction {
+    match instr {
+        X86Instruction::MovReg { rs, .. } => X86Instruction::MovReg { rd: new_rd, rs },
+        X86Instruction::MovImm { imm, .. } => X86Instruction::MovImm { rd: new_rd, imm },
+        X86Instruction::AddReg { rs, .. } => X86Instruction::AddReg { rd: new_rd, rs },
+        X86Instruction::AddImm { imm, .. } => X86Instruction::AddImm { rd: new_rd, imm },
+        X86Instruction::SubReg { rs, .. } => X86Instruction::SubReg { rd: new_rd, rs },
+        X86Instruction::SubImm { imm, .. } => X86Instruction::SubImm { rd: new_rd, imm },
+        X86Instruction::AndReg { rs, .. } => X86Instruction::AndReg { rd: new_rd, rs },
+        X86Instruction::AndImm { imm, .. } => X86Instruction::AndImm { rd: new_rd, imm },
+        X86Instruction::OrReg { rs, .. } => X86Instruction::OrReg { rd: new_rd, rs },
+        X86Instruction::OrImm { imm, .. } => X86Instruction::OrImm { rd: new_rd, imm },
+        X86Instruction::XorReg { rs, .. } => X86Instruction::XorReg { rd: new_rd, rs },
+        X86Instruction::XorImm { imm, .. } => X86Instruction::XorImm { rd: new_rd, imm },
+        // CMP variants have rn instead of rd; mutate rn for symmetry.
+        X86Instruction::CmpReg { rs, .. } => X86Instruction::CmpReg { rn: new_rd, rs },
+        X86Instruction::CmpImm { imm, .. } => X86Instruction::CmpImm { rn: new_rd, imm },
+    }
+}
+
+fn with_sources(instr: X86Instruction, new_rs: X86Register, new_imm: i64) -> X86Instruction {
+    match instr {
+        X86Instruction::MovReg { rd, .. } => X86Instruction::MovReg { rd, rs: new_rs },
+        X86Instruction::MovImm { rd, .. } => X86Instruction::MovImm { rd, imm: new_imm },
+        X86Instruction::AddReg { rd, .. } => X86Instruction::AddReg { rd, rs: new_rs },
+        X86Instruction::AddImm { rd, .. } => X86Instruction::AddImm { rd, imm: new_imm },
+        X86Instruction::SubReg { rd, .. } => X86Instruction::SubReg { rd, rs: new_rs },
+        X86Instruction::SubImm { rd, .. } => X86Instruction::SubImm { rd, imm: new_imm },
+        X86Instruction::AndReg { rd, .. } => X86Instruction::AndReg { rd, rs: new_rs },
+        X86Instruction::AndImm { rd, .. } => X86Instruction::AndImm { rd, imm: new_imm },
+        X86Instruction::OrReg { rd, .. } => X86Instruction::OrReg { rd, rs: new_rs },
+        X86Instruction::OrImm { rd, .. } => X86Instruction::OrImm { rd, imm: new_imm },
+        X86Instruction::XorReg { rd, .. } => X86Instruction::XorReg { rd, rs: new_rs },
+        X86Instruction::XorImm { rd, .. } => X86Instruction::XorImm { rd, imm: new_imm },
+        X86Instruction::CmpReg { rn, .. } => X86Instruction::CmpReg { rn, rs: new_rs },
+        X86Instruction::CmpImm { rn, .. } => X86Instruction::CmpImm { rn, imm: new_imm },
+    }
+}
+
+impl OperandType for X86Operand {
+    type Register = X86Register;
+
+    fn as_register(&self) -> Option<X86Register> {
+        match self {
+            X86Operand::Register(r) => Some(*r),
+            _ => None,
+        }
+    }
+
+    fn as_immediate(&self) -> Option<i64> {
+        match self {
+            X86Operand::Immediate(imm) => Some(*imm),
+            _ => None,
+        }
+    }
+
+    fn from_register(reg: X86Register) -> Self {
+        X86Operand::Register(reg)
+    }
+
+    fn from_immediate(imm: i64) -> Self {
+        X86Operand::Immediate(imm)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn x86_generator_generate_all_covers_every_opcode() {
+        use crate::isa::traits::{InstructionGenerator, InstructionType};
+        let regs = [X86Register::RAX, X86Register::RBX];
+        let imms = [0i64, 1, -1];
+        let all = X86InstructionGenerator.generate_all(&regs, &imms);
+
+        // For each opcode_id, at least one variant must appear.
+        let opcode_count = X86InstructionGenerator.opcode_count();
+        let mut seen = vec![false; opcode_count as usize];
+        for instr in &all {
+            seen[instr.opcode_id() as usize] = true;
+        }
+        for (id, present) in seen.iter().enumerate() {
+            assert!(*present, "opcode_id {} never generated", id);
+        }
+
+        // Sanity: every generated instruction's destination (if any) is
+        // drawn from the supplied register pool, and source registers too.
+        for instr in &all {
+            if let Some(dst) = instr.destination() {
+                assert!(regs.contains(&dst));
+            }
+            for src in instr.source_registers() {
+                assert!(regs.contains(&src));
+            }
+        }
+    }
+
+    #[test]
+    fn x86_generator_random_within_opcode_range() {
+        use crate::isa::traits::{InstructionGenerator, InstructionType};
+        use rand::SeedableRng;
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42);
+        let regs = [X86Register::RAX, X86Register::RBX, X86Register::RCX];
+        let imms = [0i64, 1];
+        let count = X86InstructionGenerator.opcode_count();
+        for _ in 0..200 {
+            let instr = X86InstructionGenerator.generate_random(&mut rng, &regs, &imms);
+            assert!(
+                instr.opcode_id() < count,
+                "{} out of range",
+                instr.opcode_id()
+            );
+        }
+    }
+
+    #[test]
+    fn x86_generator_mutate_changes_instruction() {
+        use crate::isa::traits::{InstructionGenerator, InstructionType};
+        use rand::SeedableRng;
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(7);
+        let regs = [X86Register::RAX, X86Register::RBX];
+        let imms = [0i64, 1, 2, 3];
+        // Mutator can mutate any starting variant without panicking,
+        // and the result is always a valid opcode.
+        let start = X86Instruction::AddReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+        };
+        let count = X86InstructionGenerator.opcode_count();
+        for _ in 0..50 {
+            let mutated = X86InstructionGenerator.mutate(&mut rng, &start, &regs, &imms);
+            assert!(mutated.opcode_id() < count);
+        }
+    }
+
+    #[test]
+    fn x86_32_isa_metadata() {
+        use crate::isa::traits::ISA;
+        let isa = X86_32;
+        assert_eq!(isa.name(), "x86-32");
+        // i386 ABI exposes the low 8 GPRs.
+        assert_eq!(isa.register_count(), 8);
+        assert_eq!(isa.register_width(), 32);
+        assert_eq!(isa.instruction_size(), None);
+        assert_eq!(isa.zero_register(), None);
+        let regs = isa.general_registers();
+        assert_eq!(regs.len(), 8);
+        for i in 0..8u8 {
+            assert!(regs.contains(&X86Register::from_index(i).unwrap()));
+        }
+        // R8..R15 are absent from x86-32.
+        for i in 8..16u8 {
+            assert!(!regs.contains(&X86Register::from_index(i).unwrap()));
+        }
+    }
+
+    #[test]
+    fn x86_64_isa_metadata() {
+        use crate::isa::traits::ISA;
+        let isa = X86_64;
+        assert_eq!(isa.name(), "x86-64");
+        assert_eq!(isa.register_count(), 16);
+        assert_eq!(isa.register_width(), 64);
+        // Variable-length encoding.
+        assert_eq!(isa.instruction_size(), None);
+        assert_eq!(isa.zero_register(), None);
+        let regs = isa.general_registers();
+        // All 16 GPRs surface; CLI is responsible for filtering RSP from the
+        // search-available pool (mirroring main.rs:479-488 for AArch64).
+        assert_eq!(regs.len(), 16);
+        for i in 0..16u8 {
+            assert!(regs.contains(&X86Register::from_index(i).unwrap()));
+        }
+    }
+
+    #[test]
+    fn x86_instruction_type_trait_conformance() {
+        use crate::isa::traits::InstructionType;
+        let rd = X86Register::RAX;
+        let rs = X86Register::RBX;
+        let variants = [
+            X86Instruction::MovReg { rd, rs },
+            X86Instruction::MovImm { rd, imm: 0 },
+            X86Instruction::AddReg { rd, rs },
+            X86Instruction::AddImm { rd, imm: 0 },
+            X86Instruction::SubReg { rd, rs },
+            X86Instruction::SubImm { rd, imm: 0 },
+            X86Instruction::AndReg { rd, rs },
+            X86Instruction::AndImm { rd, imm: 0 },
+            X86Instruction::OrReg { rd, rs },
+            X86Instruction::OrImm { rd, imm: 0 },
+            X86Instruction::XorReg { rd, rs },
+            X86Instruction::XorImm { rd, imm: 0 },
+            X86Instruction::CmpReg { rn: rd, rs },
+            X86Instruction::CmpImm { rn: rd, imm: 0 },
+        ];
+
+        // 7 mnemonics × {reg, imm} forms = 14 variants.
+        assert_eq!(variants.len(), 14);
+        let ids: Vec<u8> = variants
+            .iter()
+            .map(<X86Instruction as InstructionType>::opcode_id)
+            .collect();
+        let mut sorted = ids.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(
+            sorted.len(),
+            ids.len(),
+            "opcode_id values must be unique: {:?}",
+            ids
+        );
+
+        // mnemonic via trait equals inherent.
+        for v in variants.iter() {
+            assert_eq!(
+                <X86Instruction as InstructionType>::mnemonic(v),
+                v.mnemonic()
+            );
+        }
+
+        // EFLAGS side-effects: every variant except MOV mutates EFLAGS.
+        for v in variants.iter() {
+            let is_mov = matches!(
+                v,
+                X86Instruction::MovReg { .. } | X86Instruction::MovImm { .. }
+            );
+            assert_eq!(
+                <X86Instruction as InstructionType>::has_side_effects(v),
+                !is_mov,
+                "has_side_effects wrong for {:?}",
+                v
+            );
+        }
+    }
+
+    #[test]
+    fn x86_instruction_display_intel_syntax() {
+        let rd = X86Register::RAX;
+        let rs = X86Register::RBX;
+        let cases: &[(X86Instruction, &str)] = &[
+            (X86Instruction::MovReg { rd, rs }, "mov rax, rbx"),
+            (X86Instruction::MovImm { rd, imm: 42 }, "mov rax, 42"),
+            (X86Instruction::AddReg { rd, rs }, "add rax, rbx"),
+            (X86Instruction::AddImm { rd, imm: -1 }, "add rax, -1"),
+            (X86Instruction::SubReg { rd, rs }, "sub rax, rbx"),
+            (X86Instruction::SubImm { rd, imm: 1 }, "sub rax, 1"),
+            (X86Instruction::AndReg { rd, rs }, "and rax, rbx"),
+            (X86Instruction::AndImm { rd, imm: 0xff }, "and rax, 255"),
+            (X86Instruction::OrReg { rd, rs }, "or rax, rbx"),
+            (X86Instruction::OrImm { rd, imm: 0 }, "or rax, 0"),
+            (X86Instruction::XorReg { rd, rs }, "xor rax, rbx"),
+            (X86Instruction::XorImm { rd, imm: 1 }, "xor rax, 1"),
+            (X86Instruction::CmpReg { rn: rd, rs }, "cmp rax, rbx"),
+            (X86Instruction::CmpImm { rn: rd, imm: 7 }, "cmp rax, 7"),
+        ];
+        for (instr, expected) in cases {
+            assert_eq!(format!("{}", instr), *expected);
+        }
+    }
+
+    #[test]
+    fn x86_instruction_mnemonic_matches_display_prefix() {
+        let rd = X86Register::RAX;
+        let rs = X86Register::RBX;
+        let cases: &[(X86Instruction, &str)] = &[
+            (X86Instruction::MovReg { rd, rs }, "mov"),
+            (X86Instruction::MovImm { rd, imm: 0 }, "mov"),
+            (X86Instruction::AddReg { rd, rs }, "add"),
+            (X86Instruction::AddImm { rd, imm: 0 }, "add"),
+            (X86Instruction::SubReg { rd, rs }, "sub"),
+            (X86Instruction::SubImm { rd, imm: 0 }, "sub"),
+            (X86Instruction::AndReg { rd, rs }, "and"),
+            (X86Instruction::AndImm { rd, imm: 0 }, "and"),
+            (X86Instruction::OrReg { rd, rs }, "or"),
+            (X86Instruction::OrImm { rd, imm: 0 }, "or"),
+            (X86Instruction::XorReg { rd, rs }, "xor"),
+            (X86Instruction::XorImm { rd, imm: 0 }, "xor"),
+            (X86Instruction::CmpReg { rn: rd, rs }, "cmp"),
+            (X86Instruction::CmpImm { rn: rd, imm: 0 }, "cmp"),
+        ];
+        for (instr, expected) in cases {
+            assert_eq!(instr.mnemonic(), *expected);
+        }
+    }
+
+    #[test]
+    fn x86_instruction_source_registers_destructive_form() {
+        let rd = X86Register::RAX;
+        let rs = X86Register::RBX;
+        // MOV is non-destructive: rd not in sources.
+        assert_eq!(
+            X86Instruction::MovReg { rd, rs }.source_registers(),
+            vec![rs]
+        );
+        assert_eq!(
+            X86Instruction::MovImm { rd, imm: 7 }.source_registers(),
+            Vec::<X86Register>::new()
+        );
+        // Two-operand destructive arithmetic/logic: rd is BOTH source and dest.
+        let reg_destructive = [
+            X86Instruction::AddReg { rd, rs },
+            X86Instruction::SubReg { rd, rs },
+            X86Instruction::AndReg { rd, rs },
+            X86Instruction::OrReg { rd, rs },
+            X86Instruction::XorReg { rd, rs },
+        ];
+        for instr in reg_destructive {
+            assert_eq!(
+                instr.source_registers(),
+                vec![rd, rs],
+                "expected [rd, rs] for {:?}",
+                instr
+            );
+        }
+        // Immediate forms still read rd (destructive).
+        let imm_destructive = [
+            X86Instruction::AddImm { rd, imm: 1 },
+            X86Instruction::SubImm { rd, imm: 1 },
+            X86Instruction::AndImm { rd, imm: 1 },
+            X86Instruction::OrImm { rd, imm: 1 },
+            X86Instruction::XorImm { rd, imm: 1 },
+        ];
+        for instr in imm_destructive {
+            assert_eq!(
+                instr.source_registers(),
+                vec![rd],
+                "expected [rd] for {:?}",
+                instr
+            );
+        }
+        // CMP reads both registers (or just rn for immediate form), writes none.
+        assert_eq!(
+            X86Instruction::CmpReg { rn: rd, rs }.source_registers(),
+            vec![rd, rs]
+        );
+        assert_eq!(
+            X86Instruction::CmpImm { rn: rd, imm: 0 }.source_registers(),
+            vec![rd]
+        );
+    }
+
+    #[test]
+    fn x86_instruction_destination_writes_rd() {
+        // MOV / ADD / SUB / AND / OR / XOR variants write rd.
+        let rd = X86Register::RAX;
+        let rs = X86Register::RBX;
+        let cases: &[(X86Instruction, Option<X86Register>)] = &[
+            (X86Instruction::MovReg { rd, rs }, Some(rd)),
+            (X86Instruction::MovImm { rd, imm: 0 }, Some(rd)),
+            (X86Instruction::AddReg { rd, rs }, Some(rd)),
+            (X86Instruction::AddImm { rd, imm: 0 }, Some(rd)),
+            (X86Instruction::SubReg { rd, rs }, Some(rd)),
+            (X86Instruction::SubImm { rd, imm: 0 }, Some(rd)),
+            (X86Instruction::AndReg { rd, rs }, Some(rd)),
+            (X86Instruction::AndImm { rd, imm: 0 }, Some(rd)),
+            (X86Instruction::OrReg { rd, rs }, Some(rd)),
+            (X86Instruction::OrImm { rd, imm: 0 }, Some(rd)),
+            (X86Instruction::XorReg { rd, rs }, Some(rd)),
+            (X86Instruction::XorImm { rd, imm: 0 }, Some(rd)),
+            // CMP variants never write a register.
+            (X86Instruction::CmpReg { rn: rd, rs }, None),
+            (X86Instruction::CmpImm { rn: rd, imm: 0 }, None),
+        ];
+        for (instr, want) in cases {
+            assert_eq!(
+                instr.destination(),
+                *want,
+                "destination wrong for {:?}",
+                instr
+            );
+        }
+    }
+
+    #[test]
+    fn x86_operand_display_intel_syntax() {
+        assert_eq!(format!("{}", X86Operand::Register(X86Register::RAX)), "rax");
+        // Intel syntax: bare integer for immediates (no '#' or '$').
+        assert_eq!(format!("{}", X86Operand::Immediate(42)), "42");
+        assert_eq!(format!("{}", X86Operand::Immediate(-1)), "-1");
+    }
+
+    #[test]
+    fn x86_operand_type_trait_conformance() {
+        use crate::isa::traits::OperandType;
+        let r = X86Operand::Register(X86Register::RDI);
+        let imm = X86Operand::Immediate(7);
+        assert_eq!(r.as_register(), Some(X86Register::RDI));
+        assert_eq!(r.as_immediate(), None);
+        assert!(r.is_register());
+        assert!(!r.is_immediate());
+        assert_eq!(imm.as_register(), None);
+        assert_eq!(imm.as_immediate(), Some(7));
+        assert!(!imm.is_register());
+        assert!(imm.is_immediate());
+        // Constructors.
+        assert_eq!(
+            X86Operand::from_register(X86Register::RAX),
+            X86Operand::Register(X86Register::RAX)
+        );
+        assert_eq!(X86Operand::from_immediate(-9), X86Operand::Immediate(-9));
+    }
+
+    #[test]
+    fn x86_register_type_trait_conformance() {
+        use crate::isa::traits::RegisterType;
+        // No x86 GPR is a zero register (no hard-coded zero like XZR / x0).
+        for i in 0..16u8 {
+            let r = X86Register::from_index(i).unwrap();
+            assert!(!r.is_zero_register(), "{:?} should not be zero reg", r);
+        }
+        // Only RSP is special; RBP is NOT special (no frame-pointer assumption).
+        for i in 0..16u8 {
+            let r = X86Register::from_index(i).unwrap();
+            let expected_special = r == X86Register::RSP;
+            assert_eq!(
+                r.is_special(),
+                expected_special,
+                "is_special wrong for {:?}",
+                r
+            );
+        }
+        // Trait index() matches inherent index().
+        assert_eq!(
+            <X86Register as RegisterType>::index(&X86Register::R8),
+            Some(8)
+        );
+        // Trait from_index matches inherent.
+        assert_eq!(
+            <X86Register as RegisterType>::from_index(15),
+            Some(X86Register::R15)
+        );
+    }
+
+    #[test]
+    fn x86_register_display_lowercase_intel() {
+        let cases = [
+            (X86Register::RAX, "rax"),
+            (X86Register::RCX, "rcx"),
+            (X86Register::RDX, "rdx"),
+            (X86Register::RBX, "rbx"),
+            (X86Register::RSP, "rsp"),
+            (X86Register::RBP, "rbp"),
+            (X86Register::RSI, "rsi"),
+            (X86Register::RDI, "rdi"),
+            (X86Register::R8, "r8"),
+            (X86Register::R9, "r9"),
+            (X86Register::R10, "r10"),
+            (X86Register::R11, "r11"),
+            (X86Register::R12, "r12"),
+            (X86Register::R13, "r13"),
+            (X86Register::R14, "r14"),
+            (X86Register::R15, "r15"),
+        ];
+        for (r, expected) in cases {
+            assert_eq!(format!("{}", r), expected);
+        }
+    }
+
+    #[test]
+    fn x86_register_index_intel_order() {
+        assert_eq!(X86Register::RAX.index(), Some(0));
+        assert_eq!(X86Register::RCX.index(), Some(1));
+        assert_eq!(X86Register::RDX.index(), Some(2));
+        assert_eq!(X86Register::RBX.index(), Some(3));
+        assert_eq!(X86Register::RSP.index(), Some(4));
+        assert_eq!(X86Register::RBP.index(), Some(5));
+        assert_eq!(X86Register::RSI.index(), Some(6));
+        assert_eq!(X86Register::RDI.index(), Some(7));
+        assert_eq!(X86Register::R8.index(), Some(8));
+        assert_eq!(X86Register::R9.index(), Some(9));
+        assert_eq!(X86Register::R10.index(), Some(10));
+        assert_eq!(X86Register::R11.index(), Some(11));
+        assert_eq!(X86Register::R12.index(), Some(12));
+        assert_eq!(X86Register::R13.index(), Some(13));
+        assert_eq!(X86Register::R14.index(), Some(14));
+        assert_eq!(X86Register::R15.index(), Some(15));
+    }
+
+    #[test]
+    fn x86_register_from_index_round_trip() {
+        for i in 0..16u8 {
+            let r = X86Register::from_index(i).expect("valid index");
+            assert_eq!(r.index(), Some(i));
+        }
+        assert!(X86Register::from_index(16).is_none());
+        assert!(X86Register::from_index(255).is_none());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ use semantics::{EquivalenceResult, LiveOut, LiveOutRegisters, check_equivalence}
 
 #[derive(Parser)]
 #[command(name = "s11")]
-#[command(about = "s11 - AArch64 Optimizer")]
+#[command(about = "s11 - Superoptimizer (AArch64, x86)")]
 #[command(version)]
 #[command(subcommand_required = true)]
 #[command(arg_required_else_help = true)]
@@ -105,7 +105,7 @@ impl From<CliSearchMode> for SearchMode {
 }
 
 /// CLI target architecture selection
-#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+#[derive(Clone, Copy, Debug, Default, ValueEnum, PartialEq, Eq)]
 pub enum CliArch {
     /// AArch64 (ARM64) architecture
     #[default]
@@ -114,6 +114,10 @@ pub enum CliArch {
     Riscv32,
     /// RISC-V 64-bit architecture
     Riscv64,
+    /// x86-64 (AMD64) architecture
+    X86_64,
+    /// x86-32 (i386) architecture
+    X86_32,
 }
 
 #[derive(Subcommand)]
@@ -237,6 +241,20 @@ enum Commands {
 
 // --- ELF Binary Analysis ---
 
+/// Read an ELF's `e_machine` and map it to the matching `CliArch` variant.
+/// Returns an error if the binary can't be read or the architecture isn't
+/// one we support.
+fn detect_cli_arch_from_elf(path: &Path) -> Result<CliArch, Box<dyn std::error::Error>> {
+    let data = fs::read(path)?;
+    let elf = ElfBytes::<AnyEndian>::minimal_parse(&data)?;
+    match elf.ehdr.e_machine {
+        elf::abi::EM_AARCH64 => Ok(CliArch::Aarch64),
+        elf::abi::EM_X86_64 => Ok(CliArch::X86_64),
+        elf::abi::EM_386 => Ok(CliArch::X86_32),
+        m => Err(format!("Unsupported architecture (e_machine: {})", m).into()),
+    }
+}
+
 fn analyze_elf_binary(path: &PathBuf, disasm_mode: bool) -> Result<(), Box<dyn std::error::Error>> {
     if !disasm_mode {
         println!("Analyzing ELF binary: {}", path.display());
@@ -248,18 +266,17 @@ fn analyze_elf_binary(path: &PathBuf, disasm_mode: bool) -> Result<(), Box<dyn s
     // Parse ELF
     let elf = ElfBytes::<AnyEndian>::minimal_parse(&file_data)?;
 
-    // Check if it's AArch64
-    if elf.ehdr.e_machine != elf::abi::EM_AARCH64 {
-        return Err(format!(
-            "Not an AArch64 binary (machine type: {})",
-            elf.ehdr.e_machine
-        )
-        .into());
-    }
+    // Detect architecture; reject anything outside the supported set.
+    let arch = match elf.ehdr.e_machine {
+        elf::abi::EM_AARCH64 => "AArch64",
+        elf::abi::EM_X86_64 => "x86-64",
+        elf::abi::EM_386 => "x86-32",
+        m => return Err(format!("Unsupported architecture (e_machine: {})", m).into()),
+    };
 
     if !disasm_mode {
         println!("ELF Header:");
-        println!("  Architecture: AArch64");
+        println!("  Architecture: {}", arch);
         println!("  Entry point: 0x{:x}", elf.ehdr.e_entry);
         println!(
             "  Type: {}",
@@ -272,12 +289,27 @@ fn analyze_elf_binary(path: &PathBuf, disasm_mode: bool) -> Result<(), Box<dyn s
         );
     }
 
-    // Initialize Capstone disassembler for AArch64
-    let cs = Capstone::new()
-        .arm64()
-        .mode(capstone::arch::arm64::ArchMode::Arm)
-        .detail(true)
-        .build()?;
+    // Initialize Capstone disassembler per architecture.
+    let cs = match elf.ehdr.e_machine {
+        elf::abi::EM_AARCH64 => Capstone::new()
+            .arm64()
+            .mode(capstone::arch::arm64::ArchMode::Arm)
+            .detail(true)
+            .build()?,
+        elf::abi::EM_X86_64 => Capstone::new()
+            .x86()
+            .mode(capstone::arch::x86::ArchMode::Mode64)
+            .syntax(capstone::arch::x86::ArchSyntax::Intel)
+            .detail(true)
+            .build()?,
+        elf::abi::EM_386 => Capstone::new()
+            .x86()
+            .mode(capstone::arch::x86::ArchMode::Mode32)
+            .syntax(capstone::arch::x86::ArchSyntax::Intel)
+            .detail(true)
+            .build()?,
+        _ => unreachable!("e_machine already validated above"),
+    };
 
     // Find and disassemble .text sections
     let section_headers = elf
@@ -872,6 +904,368 @@ fn parse_register(reg_str: &str) -> Result<Register, String> {
     }
 }
 
+// ============================================================================
+// x86 parser + enumerative pipeline
+// ============================================================================
+
+fn parse_x86_register(reg_str: &str) -> Result<isa::x86::X86Register, String> {
+    use isa::x86::X86Register;
+    match reg_str.trim().to_lowercase().as_str() {
+        // 64-bit names map to the canonical X86Register variants.
+        "rax" | "eax" | "ax" | "al" => Ok(X86Register::RAX),
+        "rcx" | "ecx" | "cx" | "cl" => Ok(X86Register::RCX),
+        "rdx" | "edx" | "dx" | "dl" => Ok(X86Register::RDX),
+        "rbx" | "ebx" | "bx" | "bl" => Ok(X86Register::RBX),
+        "rsp" | "esp" | "sp" => Ok(X86Register::RSP),
+        "rbp" | "ebp" | "bp" => Ok(X86Register::RBP),
+        "rsi" | "esi" | "si" => Ok(X86Register::RSI),
+        "rdi" | "edi" | "di" => Ok(X86Register::RDI),
+        "r8" | "r8d" | "r8w" | "r8b" => Ok(X86Register::R8),
+        "r9" | "r9d" | "r9w" | "r9b" => Ok(X86Register::R9),
+        "r10" | "r10d" | "r10w" | "r10b" => Ok(X86Register::R10),
+        "r11" | "r11d" | "r11w" | "r11b" => Ok(X86Register::R11),
+        "r12" | "r12d" | "r12w" | "r12b" => Ok(X86Register::R12),
+        "r13" | "r13d" | "r13w" | "r13b" => Ok(X86Register::R13),
+        "r14" | "r14d" | "r14w" | "r14b" => Ok(X86Register::R14),
+        "r15" | "r15d" | "r15w" | "r15b" => Ok(X86Register::R15),
+        _ => Err(format!("Unknown x86 register: {}", reg_str)),
+    }
+}
+
+/// Parse an Intel-syntax operand string ("rax" or "42" or "0x2a").
+fn parse_x86_operand(op_str: &str) -> Result<isa::x86::X86Operand, String> {
+    use isa::x86::X86Operand;
+    let s = op_str.trim();
+    if let Ok(reg) = parse_x86_register(s) {
+        return Ok(X86Operand::Register(reg));
+    }
+    let imm = parse_x86_immediate(s)?;
+    Ok(X86Operand::Immediate(imm))
+}
+
+fn parse_x86_immediate(s: &str) -> Result<i64, String> {
+    let s = s.trim();
+    if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        // Positive hex: parse via u64 then reinterpret as i64 with
+        // two's-complement wrapping. Capstone's Intel-syntax
+        // disassembler renders a sign-extended `imm = -1` operand as
+        // the full-width `0xffffffffffffffff` (and `-2` as
+        // `0xfffffffffffffffe`, etc.), so any value with the top bit
+        // set must be re-mapped to the corresponding negative i64.
+        // Treating "high bit set" as out-of-range here would reject
+        // legitimate `cmp/and/add rax, -1` lines coming straight from
+        // Capstone — exactly the false rejection raised on this PR.
+        let u =
+            u64::from_str_radix(hex, 16).map_err(|_| format!("Invalid hex immediate: {}", s))?;
+        Ok(u as i64)
+    } else if let Some(hex) = s.strip_prefix("-0x").or_else(|| s.strip_prefix("-0X")) {
+        // Negative hex: the magnitude can be as large as 1<<63 (giving
+        // i64::MIN). `i64::from_str_radix` rejects 0x8000_0000_0000_0000
+        // because that doesn't fit i64 positively. Parse via u64 and
+        // negate carefully with wrapping_neg so INT64_MIN survives.
+        let abs =
+            u64::from_str_radix(hex, 16).map_err(|_| format!("Invalid hex immediate: {}", s))?;
+        if abs > (1u64 << 63) {
+            return Err(format!("Hex immediate {} out of i64 range", s));
+        }
+        Ok((abs as i64).wrapping_neg())
+    } else {
+        s.parse::<i64>()
+            .map_err(|_| format!("Invalid immediate: {}", s))
+    }
+}
+
+/// Convert a `(mnemonic, op_str)` pair (as produced by Capstone Intel
+/// syntax) into an `X86Instruction`. Returns `Ok(None)` for mnemonics
+/// outside the minimal core set, mirroring the AArch64 path.
+fn x86_ir_from_mnemonic(
+    mnemonic: &str,
+    op_str: &str,
+) -> Result<Option<isa::x86::X86Instruction>, String> {
+    use isa::x86::X86Instruction;
+    let mnemonic = mnemonic.trim().to_lowercase();
+    let parts: Vec<&str> = op_str.split(',').map(|s| s.trim()).collect();
+    if parts.len() != 2 {
+        return Ok(None);
+    }
+    let rd = parse_x86_register(parts[0])?;
+    let src_op = parse_x86_operand(parts[1])?;
+    let make = |reg_form: fn(isa::x86::X86Register, isa::x86::X86Register) -> X86Instruction,
+                imm_form: fn(isa::x86::X86Register, i64) -> X86Instruction|
+     -> Result<Option<X86Instruction>, String> {
+        Ok(Some(match src_op {
+            isa::x86::X86Operand::Register(rs) => reg_form(rd, rs),
+            isa::x86::X86Operand::Immediate(imm) => imm_form(rd, imm),
+        }))
+    };
+    let make_cmp =
+        |reg_form: fn(isa::x86::X86Register, isa::x86::X86Register) -> X86Instruction,
+         imm_form: fn(isa::x86::X86Register, i64) -> X86Instruction|
+         -> Result<Option<X86Instruction>, String> {
+            Ok(Some(match src_op {
+                isa::x86::X86Operand::Register(rs) => reg_form(rd, rs),
+                isa::x86::X86Operand::Immediate(imm) => imm_form(rd, imm),
+            }))
+        };
+    match mnemonic.as_str() {
+        "mov" | "movabs" => make(
+            |rd, rs| X86Instruction::MovReg { rd, rs },
+            |rd, imm| X86Instruction::MovImm { rd, imm },
+        ),
+        "add" => make(
+            |rd, rs| X86Instruction::AddReg { rd, rs },
+            |rd, imm| X86Instruction::AddImm { rd, imm },
+        ),
+        "sub" => make(
+            |rd, rs| X86Instruction::SubReg { rd, rs },
+            |rd, imm| X86Instruction::SubImm { rd, imm },
+        ),
+        "and" => make(
+            |rd, rs| X86Instruction::AndReg { rd, rs },
+            |rd, imm| X86Instruction::AndImm { rd, imm },
+        ),
+        "or" => make(
+            |rd, rs| X86Instruction::OrReg { rd, rs },
+            |rd, imm| X86Instruction::OrImm { rd, imm },
+        ),
+        "xor" => make(
+            |rd, rs| X86Instruction::XorReg { rd, rs },
+            |rd, imm| X86Instruction::XorImm { rd, imm },
+        ),
+        "cmp" => make_cmp(
+            |rn, rs| X86Instruction::CmpReg { rn, rs },
+            |rn, imm| X86Instruction::CmpImm { rn, imm },
+        ),
+        _ => Ok(None),
+    }
+}
+
+fn convert_to_x86_ir(
+    instructions: &capstone::Instructions,
+) -> Result<Vec<isa::x86::X86Instruction>, String> {
+    let mut out = Vec::new();
+    for instruction in instructions.iter() {
+        let mn = instruction.mnemonic().unwrap_or("");
+        let ops = instruction.op_str().unwrap_or("");
+        match x86_ir_from_mnemonic(mn, ops) {
+            Ok(Some(ir)) => out.push(ir),
+            Ok(None) => {
+                // Refusing the window is safer than silently dropping the
+                // unsupported instruction: the patcher overwrites the entire
+                // byte window with the reassembled IR, so a dropped `lea`,
+                // `call`, etc. would lose its side effect from the binary.
+                return Err(format!(
+                    "x86 window contains unsupported mnemonic '{} {}' at 0x{:x}; \
+                     cannot optimize. Narrow the --start-addr/--end-addr range \
+                     to exclude it, or add the mnemonic to the supported set.",
+                    mn,
+                    ops,
+                    instruction.address()
+                ));
+            }
+            Err(e) => {
+                return Err(format!(
+                    "failed to parse x86 instruction '{} {}' at 0x{:x}: {}",
+                    mn,
+                    ops,
+                    instruction.address(),
+                    e
+                ));
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Length-1 enumerator for x86: try every candidate of length 1 against
+/// the target sequence, return the first equivalent shorter sequence.
+fn find_shorter_equivalent_x86(
+    target: &[isa::x86::X86Instruction],
+    width: u32,
+) -> Option<Vec<isa::x86::X86Instruction>> {
+    use isa::InstructionType;
+    use isa::x86::X86Register;
+    use search::candidate_x86::generate_all_x86_instructions;
+    use semantics::cost_x86;
+    use semantics::equivalence::{X86EquivalenceConfig, check_equivalence_x86};
+    use semantics::state::X86LiveOutMask;
+
+    if target.is_empty() || target.len() < 2 {
+        // Already length 1; nothing strictly shorter exists.
+        return None;
+    }
+    let target_cost =
+        cost_x86::sequence_cost(target, &semantics::cost::CostMetric::CodeSize, width);
+
+    // Live-out registers = everything the target writes.
+    let live_regs: Vec<X86Register> = target.iter().filter_map(|i| i.destination()).collect();
+    // Flags are live whenever the target contains any instruction with
+    // observable side-effects beyond the register write — every variant
+    // except MOV reports `has_side_effects() == true` because it touches
+    // EFLAGS. Without this, a rewrite like `add rax, 0; mov rax, rbx`
+    // → `mov rax, rbx` could be silently accepted, dropping the EFLAGS
+    // write the surrounding code may consume via Jcc.
+    let flags_live = target.iter().any(InstructionType::has_side_effects);
+    let live_out = X86LiveOutMask::from_registers(live_regs.clone()).with_flags(flags_live);
+
+    // Build a register pool from the registers actually used in the
+    // target, plus a couple of scratch regs.
+    let mut pool: Vec<X86Register> = live_regs.clone();
+    for reg in target.iter().flat_map(|i| i.source_registers()) {
+        if !pool.contains(&reg) {
+            pool.push(reg);
+        }
+    }
+    for extra in [X86Register::RAX, X86Register::RDI] {
+        if !pool.contains(&extra) {
+            pool.push(extra);
+        }
+    }
+    let imms = vec![0i64, 1, -1];
+
+    let candidates = generate_all_x86_instructions(&pool, &imms);
+    let cfg = X86EquivalenceConfig::new_for_64()
+        .live_out(live_out.clone())
+        .fast_only();
+    let cfg = X86EquivalenceConfig { width, ..cfg };
+    for cand in candidates {
+        let seq = vec![cand];
+        let cand_cost =
+            cost_x86::sequence_cost(&seq, &semantics::cost::CostMetric::CodeSize, width);
+        if cand_cost >= target_cost {
+            continue;
+        }
+        match check_equivalence_x86(target, &seq, &cfg) {
+            semantics::equivalence::EquivalenceResult::Equivalent => return Some(seq),
+            _ => continue,
+        }
+    }
+    None
+}
+
+fn optimize_elf_binary_x86(
+    path: &Path,
+    start_addr: u64,
+    end_addr: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use elf_patcher::{AddressWindow, DetectedArch};
+
+    println!("Optimizing x86 ELF binary: {}", path.display());
+    println!("Address window: 0x{:x} - 0x{:x}", start_addr, end_addr);
+
+    let window = AddressWindow {
+        start: start_addr,
+        end: end_addr,
+    };
+    let patcher = elf_patcher::ElfPatcher::new(path)?;
+    let arch = patcher.arch();
+    let width = match arch {
+        DetectedArch::X86_64 => 64u32,
+        DetectedArch::X86_32 => 32u32,
+        DetectedArch::Aarch64 => {
+            return Err("expected x86 binary; got AArch64".into());
+        }
+    };
+    println!("Detected: {:?} (width {})", arch, width);
+
+    let section = patcher.validate_address_window(&window)?;
+    println!("Window is within section: {}", section.name);
+
+    let bytes = patcher.get_instructions_in_window(&window)?;
+    println!("Original code: {} bytes", bytes.len());
+
+    let cs = match arch {
+        DetectedArch::X86_64 => Capstone::new()
+            .x86()
+            .mode(capstone::arch::x86::ArchMode::Mode64)
+            .syntax(capstone::arch::x86::ArchSyntax::Intel)
+            .build()?,
+        DetectedArch::X86_32 => Capstone::new()
+            .x86()
+            .mode(capstone::arch::x86::ArchMode::Mode32)
+            .syntax(capstone::arch::x86::ArchSyntax::Intel)
+            .build()?,
+        DetectedArch::Aarch64 => unreachable!(),
+    };
+    let cs_instrs = cs.disasm_all(&bytes, start_addr)?;
+    println!("Disassembled {} instructions:", cs_instrs.len());
+    for i in cs_instrs.iter() {
+        println!(
+            "  0x{:x}: {} {}",
+            i.address(),
+            i.mnemonic().unwrap_or("???"),
+            i.op_str().unwrap_or("")
+        );
+    }
+
+    // Validate that the disassembled instructions cover the entire byte
+    // window. x86 is variable-length, so an `--end-addr` that lands
+    // mid-instruction (or leaves any undecodable tail bytes) makes
+    // disasm_all return only the complete decoded prefix; the patcher
+    // then overwrites the entire requested byte range with the
+    // reassembled IR, which can replace or NOP part of the next
+    // instruction in the binary. Refuse the window in that case.
+    let decoded_bytes: usize = cs_instrs.iter().map(|i| i.bytes().len()).sum();
+    if decoded_bytes != bytes.len() {
+        return Err(format!(
+            "x86 window 0x{:x}-0x{:x} ({} bytes) does not end on an \
+             instruction boundary: Capstone decoded only {} bytes. Adjust \
+             --end-addr to align with the next instruction's start address.",
+            start_addr,
+            end_addr,
+            bytes.len(),
+            decoded_bytes
+        )
+        .into());
+    }
+
+    let ir = convert_to_x86_ir(&cs_instrs)?;
+    println!("Converted {} instructions to x86 IR:", ir.len());
+    for instr in &ir {
+        println!("  {}", instr);
+    }
+
+    let optimized = find_shorter_equivalent_x86(&ir, width);
+    let Some(final_ir) = optimized else {
+        // Without a shorter sequence to substitute there is nothing to
+        // patch. Round-tripping the original IR through dynasm could
+        // emit different bytes than the source compiler (e.g. a
+        // different MOV imm32 form, or different NOP padding) and
+        // silently produce a non-byte-identical "no-op" output binary.
+        // Leave the input untouched and exit.
+        println!("No optimization found; not patching (input binary left untouched).");
+        return Ok(());
+    };
+    println!("Optimized to {} instructions:", final_ir.len());
+    for i in &final_ir {
+        println!("  {}", i);
+    }
+
+    let mut asm = match arch {
+        DetectedArch::X86_64 => assembler::x86::X86Assembler::new_64(),
+        DetectedArch::X86_32 => assembler::x86::X86Assembler::new_32(),
+        DetectedArch::Aarch64 => unreachable!(),
+    };
+    let new_bytes = asm.assemble_instructions(&final_ir)?;
+    println!("Reassembled to {} bytes", new_bytes.len());
+
+    let output_path = {
+        let mut new_path = path.to_path_buf();
+        let stem = new_path.file_stem().unwrap().to_str().unwrap();
+        let extension = new_path.extension().map(|e| e.to_str().unwrap());
+        let new_name = if let Some(ext) = extension {
+            format!("{}_optimized.{}", stem, ext)
+        } else {
+            format!("{}_optimized", stem)
+        };
+        new_path.set_file_name(new_name);
+        new_path
+    };
+    patcher.create_patched_copy(&output_path, &window, &new_bytes)?;
+    println!("Created optimized binary: {}", output_path.display());
+    Ok(())
+}
+
 // For simplicity in MVP, immediate is fixed for generation, but can be varied in input.
 const IMM_VALUE_FOR_GENERATION: i64 = 1;
 
@@ -1166,14 +1560,33 @@ fn main() {
 
     match args.command {
         Commands::Disasm { binary, arch } => {
-            // Disassemble mode
+            // Disassemble mode. `analyze_elf_binary` auto-detects the
+            // architecture from e_machine and picks the right Capstone
+            // backend. The optional `--arch` is used to (a) early-reject
+            // RISC-V (still unsupported) and (b) cross-check against the
+            // ELF so a stale or wrong `--arch` value fails fast instead of
+            // silently producing disassembly for a different architecture.
             if let Some(a) = arch {
-                // For now, only AArch64 is fully supported for disassembly
                 match a {
-                    CliArch::Aarch64 => {}
                     CliArch::Riscv32 | CliArch::Riscv64 => {
                         eprintln!("RISC-V disassembly is not yet supported");
                         std::process::exit(1);
+                    }
+                    CliArch::Aarch64 | CliArch::X86_64 | CliArch::X86_32 => {
+                        match detect_cli_arch_from_elf(&binary) {
+                            Ok(detected) if detected == a => {}
+                            Ok(detected) => {
+                                eprintln!(
+                                    "Architecture mismatch: --arch {:?} but ELF reports {:?}",
+                                    a, detected
+                                );
+                                std::process::exit(1);
+                            }
+                            Err(e) => {
+                                eprintln!("Error reading ELF: {}", e);
+                                std::process::exit(1);
+                            }
+                        }
                     }
                 }
             }
@@ -1204,17 +1617,57 @@ fn main() {
             llm_max_calls,
             llm_model,
         } => {
-            // Architecture selection
-            if let Some(a) = arch {
-                // For now, only AArch64 is fully supported for optimization
-                match a {
-                    CliArch::Aarch64 => {}
-                    CliArch::Riscv32 | CliArch::Riscv64 => {
-                        eprintln!(
-                            "RISC-V optimization is not yet supported (ISA traits available but not integrated)"
-                        );
-                        std::process::exit(1);
-                    }
+            // Architecture selection — when --arch is omitted, auto-detect
+            // from the ELF e_machine so x86 binaries route through the
+            // x86 pipeline instead of falling into the AArch64 default.
+            let cli_arch = match arch {
+                Some(a) => a,
+                None => detect_cli_arch_from_elf(&binary).unwrap_or_else(|e| {
+                    eprintln!("Error auto-detecting architecture: {}", e);
+                    std::process::exit(1);
+                }),
+            };
+            match cli_arch {
+                CliArch::Aarch64 | CliArch::X86_64 | CliArch::X86_32 => {}
+                CliArch::Riscv32 | CliArch::Riscv64 => {
+                    eprintln!(
+                        "RISC-V optimization is not yet supported (ISA traits available but not integrated)"
+                    );
+                    std::process::exit(1);
+                }
+            }
+            let is_x86 = matches!(cli_arch, CliArch::X86_64 | CliArch::X86_32);
+            if is_x86 && !matches!(algorithm, CliAlgorithm::Enumerative) {
+                eprintln!(
+                    "x86 only supports --algorithm enumerative in this release; \
+                     stochastic/symbolic/hybrid/llm are AArch64-only."
+                );
+                std::process::exit(1);
+            }
+            // The x86 path uses a fixed enumerative + fast-path-only
+            // pipeline in v1, so most search-tuning options are
+            // silently dropped. Warn the user so an unexpected --beta
+            // / --iterations / --timeout / --cores / --cost-metric on
+            // an x86 invocation isn't mistaken for being honored.
+            if is_x86 {
+                let mut ignored: Vec<&str> = Vec::new();
+                if timeout.is_some() {
+                    ignored.push("--timeout");
+                }
+                if !matches!(cost_metric, CliCostMetric::CodeSize) {
+                    ignored.push("--cost-metric (x86 v1 always uses CodeSize)");
+                }
+                if cores.is_some() {
+                    ignored.push("--cores (x86 v1 is single-threaded)");
+                }
+                if !ignored.is_empty() {
+                    eprintln!(
+                        "warning: x86 v1 ignores the following option(s): {}. \
+                         Stochastic/symbolic-specific flags (--beta, --iterations, \
+                         --seed, --search-mode, --solver-timeout, --no-symbolic, \
+                         --llm-*) are also ignored even when not listed.",
+                        ignored.join(", ")
+                    );
                 }
             }
             // Optimization mode
@@ -1250,7 +1703,12 @@ fn main() {
                 llm_model,
             };
 
-            match optimize_elf_binary(&binary, start_addr, end_addr, &options) {
+            let opt_result = if is_x86 {
+                optimize_elf_binary_x86(&binary, start_addr, end_addr)
+            } else {
+                optimize_elf_binary(&binary, start_addr, end_addr, &options)
+            };
+            match opt_result {
                 Ok(()) => println!("\nOptimization completed successfully."),
                 Err(e) => {
                     eprintln!("Error during optimization: {}", e);
@@ -1286,5 +1744,143 @@ fn main() {
                 std::process::exit(1);
             }
         },
+    }
+}
+
+#[cfg(test)]
+mod x86_parser_tests {
+    use super::*;
+    use isa::x86::{X86Instruction, X86Operand, X86Register};
+
+    #[test]
+    fn parse_register_handles_aliased_names() {
+        assert_eq!(parse_x86_register("rax").unwrap(), X86Register::RAX);
+        assert_eq!(parse_x86_register("eax").unwrap(), X86Register::RAX);
+        assert_eq!(parse_x86_register("RAX").unwrap(), X86Register::RAX);
+        assert_eq!(parse_x86_register("r10").unwrap(), X86Register::R10);
+        assert_eq!(parse_x86_register("r10d").unwrap(), X86Register::R10);
+        assert!(parse_x86_register("zmm0").is_err());
+    }
+
+    #[test]
+    fn parse_immediate_int64_boundaries() {
+        // Smallest signed value: -0x8000_0000_0000_0000 = i64::MIN.
+        // The naive `i64::from_str_radix(abs_hex).map(-)` rejects this
+        // because the absolute magnitude doesn't fit i64 positively.
+        assert_eq!(
+            parse_x86_immediate("-0x8000000000000000").unwrap(),
+            i64::MIN
+        );
+        assert_eq!(parse_x86_immediate("0x7FFFFFFFFFFFFFFF").unwrap(), i64::MAX);
+        // Capstone Intel-syntax renders a sign-extended -1 as the
+        // full-width 0xffffffffffffffff. We must accept it as the
+        // wrapping signed value (i64 -1), not reject it as
+        // out-of-range.
+        assert_eq!(parse_x86_immediate("0xffffffffffffffff").unwrap(), -1i64);
+        assert_eq!(parse_x86_immediate("0xfffffffffffffffe").unwrap(), -2i64);
+        assert_eq!(parse_x86_immediate("0x8000000000000000").unwrap(), i64::MIN);
+        // Magnitudes that exceed even u64 width must still fail.
+        assert!(parse_x86_immediate("0x10000000000000000").is_err());
+        assert!(parse_x86_immediate("-0x8000000000000001").is_err());
+    }
+
+    #[test]
+    fn parse_immediate_supports_hex_decimal_signed() {
+        assert_eq!(parse_x86_immediate("42").unwrap(), 42);
+        assert_eq!(parse_x86_immediate("-1").unwrap(), -1);
+        assert_eq!(parse_x86_immediate("0x2a").unwrap(), 42);
+        assert_eq!(parse_x86_immediate("0XFF").unwrap(), 255);
+        assert_eq!(parse_x86_immediate("-0x10").unwrap(), -16);
+    }
+
+    #[test]
+    fn parse_operand_routes_to_register_or_immediate() {
+        assert_eq!(
+            parse_x86_operand("rdi").unwrap(),
+            X86Operand::Register(X86Register::RDI)
+        );
+        assert_eq!(parse_x86_operand("7").unwrap(), X86Operand::Immediate(7));
+    }
+
+    #[test]
+    fn x86_ir_recognises_seven_mnemonics() {
+        let cases = [
+            (
+                "mov",
+                "rax, rbx",
+                X86Instruction::MovReg {
+                    rd: X86Register::RAX,
+                    rs: X86Register::RBX,
+                },
+            ),
+            (
+                "mov",
+                "rax, 42",
+                X86Instruction::MovImm {
+                    rd: X86Register::RAX,
+                    imm: 42,
+                },
+            ),
+            (
+                "add",
+                "rax, rbx",
+                X86Instruction::AddReg {
+                    rd: X86Register::RAX,
+                    rs: X86Register::RBX,
+                },
+            ),
+            (
+                "sub",
+                "rax, 1",
+                X86Instruction::SubImm {
+                    rd: X86Register::RAX,
+                    imm: 1,
+                },
+            ),
+            (
+                "and",
+                "rax, rbx",
+                X86Instruction::AndReg {
+                    rd: X86Register::RAX,
+                    rs: X86Register::RBX,
+                },
+            ),
+            (
+                "or",
+                "rax, 0",
+                X86Instruction::OrImm {
+                    rd: X86Register::RAX,
+                    imm: 0,
+                },
+            ),
+            (
+                "xor",
+                "rax, rax",
+                X86Instruction::XorReg {
+                    rd: X86Register::RAX,
+                    rs: X86Register::RAX,
+                },
+            ),
+            (
+                "cmp",
+                "rax, 5",
+                X86Instruction::CmpImm {
+                    rn: X86Register::RAX,
+                    imm: 5,
+                },
+            ),
+        ];
+        for (mn, ops, expected) in cases {
+            let got = x86_ir_from_mnemonic(mn, ops).unwrap().unwrap();
+            assert_eq!(got, expected, "{} {}", mn, ops);
+        }
+    }
+
+    #[test]
+    fn x86_ir_unsupported_mnemonic_returns_none() {
+        assert!(x86_ir_from_mnemonic("ret", "").unwrap().is_none());
+        assert!(x86_ir_from_mnemonic("jmp", "0x1234").unwrap().is_none());
+        // Two-operand "shl" not in the minimal set.
+        assert!(x86_ir_from_mnemonic("shl", "rax, 1").unwrap().is_none());
     }
 }

--- a/src/search/candidate_x86.rs
+++ b/src/search/candidate_x86.rs
@@ -1,0 +1,93 @@
+//! Candidate generation for the x86 enumerative search.
+//!
+//! Mirrors `search::candidate::generate_all_instructions` but produces
+//! `X86Instruction` values from a register and immediate pool. No
+//! encodability filter is applied here — the assembler is the authority
+//! on what bytes a given variant emits; out-of-range immediates surface
+//! as encoder errors at use-site.
+
+#![allow(dead_code)]
+
+use crate::isa::x86::{X86Instruction, X86Register};
+
+/// Enumerate every reg/reg and reg/imm form of the 14 minimal-core
+/// variants for the given register and immediate pools.
+pub fn generate_all_x86_instructions(
+    registers: &[X86Register],
+    immediates: &[i64],
+) -> Vec<X86Instruction> {
+    let mut out = Vec::with_capacity(
+        registers.len() * registers.len() * 7 + registers.len() * immediates.len() * 7,
+    );
+
+    for &rd in registers {
+        for &rs in registers {
+            out.push(X86Instruction::MovReg { rd, rs });
+            out.push(X86Instruction::AddReg { rd, rs });
+            out.push(X86Instruction::SubReg { rd, rs });
+            out.push(X86Instruction::AndReg { rd, rs });
+            out.push(X86Instruction::OrReg { rd, rs });
+            out.push(X86Instruction::XorReg { rd, rs });
+            out.push(X86Instruction::CmpReg { rn: rd, rs });
+        }
+    }
+
+    for &rd in registers {
+        for &imm in immediates {
+            out.push(X86Instruction::MovImm { rd, imm });
+            out.push(X86Instruction::AddImm { rd, imm });
+            out.push(X86Instruction::SubImm { rd, imm });
+            out.push(X86Instruction::AndImm { rd, imm });
+            out.push(X86Instruction::OrImm { rd, imm });
+            out.push(X86Instruction::XorImm { rd, imm });
+            out.push(X86Instruction::CmpImm { rn: rd, imm });
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn count_matches_formula() {
+        let regs = [X86Register::RAX, X86Register::RBX, X86Register::RCX];
+        let imms = [0i64, 1, -1, 0xff];
+        let all = generate_all_x86_instructions(&regs, &imms);
+        // 7 reg-reg variants × N×N register pairs
+        // + 7 reg-imm variants × N × M
+        let expected = 7 * regs.len() * regs.len() + 7 * regs.len() * imms.len();
+        assert_eq!(all.len(), expected);
+    }
+
+    #[test]
+    fn covers_all_seven_mnemonics() {
+        let regs = [X86Register::RAX];
+        let imms = [0i64];
+        let all = generate_all_x86_instructions(&regs, &imms);
+
+        let mnemonics: std::collections::HashSet<&str> = all.iter().map(|i| i.mnemonic()).collect();
+        assert!(mnemonics.contains("mov"));
+        assert!(mnemonics.contains("add"));
+        assert!(mnemonics.contains("sub"));
+        assert!(mnemonics.contains("and"));
+        assert!(mnemonics.contains("or"));
+        assert!(mnemonics.contains("xor"));
+        assert!(mnemonics.contains("cmp"));
+        assert_eq!(mnemonics.len(), 7);
+    }
+
+    #[test]
+    fn destinations_drawn_from_register_pool() {
+        let regs = [X86Register::RAX, X86Register::RDI];
+        let imms = [0i64];
+        let all = generate_all_x86_instructions(&regs, &imms);
+        for instr in &all {
+            if let Some(dst) = instr.destination() {
+                assert!(regs.contains(&dst), "{:?} dest not in pool", instr);
+            }
+        }
+    }
+}

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -7,6 +7,7 @@
 //! - Hybrid: parallel execution combining symbolic + multiple stochastic workers
 
 pub mod candidate;
+pub mod candidate_x86;
 pub mod config;
 pub mod llm;
 pub mod parallel;

--- a/src/semantics/concrete_x86.rs
+++ b/src/semantics/concrete_x86.rs
@@ -1,0 +1,339 @@
+//! Concrete (non-symbolic) interpreter for the x86 backend.
+//!
+//! Mirrors `semantics::concrete::apply_instruction_concrete` but over
+//! `X86Instruction` and `X86ConcreteMachineState`. Operand widths follow
+//! `state.width()` — writes to registers are already masked by the
+//! state, and flag computation receives the correct width.
+
+#![allow(dead_code)]
+
+use crate::isa::x86::{X86Instruction, X86Operand};
+use crate::semantics::state::{ConcreteValue, Eflags, X86ConcreteMachineState};
+
+/// Apply a single x86 instruction to a concrete machine state.
+pub fn apply_instruction_concrete_x86(
+    mut state: X86ConcreteMachineState,
+    instruction: &X86Instruction,
+) -> X86ConcreteMachineState {
+    match instruction {
+        X86Instruction::MovReg { rd, rs } => {
+            let value = state.get_register(*rs);
+            state.set_register(*rd, value);
+        }
+        X86Instruction::MovImm { rd, imm } => {
+            state.set_register(*rd, ConcreteValue::from_i64(*imm));
+        }
+        X86Instruction::AddReg { rd, rs } => apply_binop_reg(&mut state, *rd, *rs, Binop::Add),
+        X86Instruction::AddImm { rd, imm } => apply_binop_imm(&mut state, *rd, *imm, Binop::Add),
+        X86Instruction::SubReg { rd, rs } => apply_binop_reg(&mut state, *rd, *rs, Binop::Sub),
+        X86Instruction::SubImm { rd, imm } => apply_binop_imm(&mut state, *rd, *imm, Binop::Sub),
+        X86Instruction::AndReg { rd, rs } => apply_binop_reg(&mut state, *rd, *rs, Binop::And),
+        X86Instruction::AndImm { rd, imm } => apply_binop_imm(&mut state, *rd, *imm, Binop::And),
+        X86Instruction::OrReg { rd, rs } => apply_binop_reg(&mut state, *rd, *rs, Binop::Or),
+        X86Instruction::OrImm { rd, imm } => apply_binop_imm(&mut state, *rd, *imm, Binop::Or),
+        X86Instruction::XorReg { rd, rs } => apply_binop_reg(&mut state, *rd, *rs, Binop::Xor),
+        X86Instruction::XorImm { rd, imm } => apply_binop_imm(&mut state, *rd, *imm, Binop::Xor),
+        X86Instruction::CmpReg { rn, rs } => apply_cmp_reg(&mut state, *rn, *rs),
+        X86Instruction::CmpImm { rn, imm } => apply_cmp_imm(&mut state, *rn, *imm),
+    }
+    state
+}
+
+fn apply_cmp_reg(
+    state: &mut X86ConcreteMachineState,
+    rn: crate::isa::x86::X86Register,
+    rs: crate::isa::x86::X86Register,
+) {
+    let lhs = state.get_register(rn).as_u64();
+    let rhs = state.get_register(rs).as_u64();
+    let result = lhs.wrapping_sub(rhs);
+    state.set_flags(Eflags::from_sub(lhs, rhs, result, state.width()));
+}
+
+fn apply_cmp_imm(state: &mut X86ConcreteMachineState, rn: crate::isa::x86::X86Register, imm: i64) {
+    let lhs = state.get_register(rn).as_u64();
+    let rhs = imm as u64;
+    let result = lhs.wrapping_sub(rhs);
+    state.set_flags(Eflags::from_sub(lhs, rhs, result, state.width()));
+}
+
+#[derive(Clone, Copy)]
+enum Binop {
+    Add,
+    Sub,
+    And,
+    Or,
+    Xor,
+}
+
+fn apply_binop_reg(
+    state: &mut X86ConcreteMachineState,
+    rd: crate::isa::x86::X86Register,
+    rs: crate::isa::x86::X86Register,
+    op: Binop,
+) {
+    let lhs = state.get_register(rd).as_u64();
+    let rhs = state.get_register(rs).as_u64();
+    apply_binop(state, rd, lhs, rhs, op);
+}
+
+fn apply_binop_imm(
+    state: &mut X86ConcreteMachineState,
+    rd: crate::isa::x86::X86Register,
+    imm: i64,
+    op: Binop,
+) {
+    let lhs = state.get_register(rd).as_u64();
+    let rhs = imm as u64;
+    apply_binop(state, rd, lhs, rhs, op);
+}
+
+fn apply_binop(
+    state: &mut X86ConcreteMachineState,
+    rd: crate::isa::x86::X86Register,
+    lhs: u64,
+    rhs: u64,
+    op: Binop,
+) {
+    let width = state.width();
+    let (result, flags) = match op {
+        Binop::Add => {
+            let r = lhs.wrapping_add(rhs);
+            (r, Eflags::from_add(lhs, rhs, r, width))
+        }
+        Binop::Sub => {
+            let r = lhs.wrapping_sub(rhs);
+            (r, Eflags::from_sub(lhs, rhs, r, width))
+        }
+        Binop::And => {
+            let r = lhs & rhs;
+            (r, Eflags::from_logical(r, width))
+        }
+        Binop::Or => {
+            let r = lhs | rhs;
+            (r, Eflags::from_logical(r, width))
+        }
+        Binop::Xor => {
+            let r = lhs ^ rhs;
+            (r, Eflags::from_logical(r, width))
+        }
+    };
+    state.set_register(rd, ConcreteValue::new(result));
+    state.set_flags(flags);
+}
+
+/// Convenience for tests / callers that don't have an operand wrapper.
+fn _operand_unused(_op: X86Operand) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::isa::x86::X86Register;
+
+    #[test]
+    fn cmpreg_sets_eflags_without_writing_register() {
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(5));
+        state.set_register(X86Register::RBX, ConcreteValue::new(5));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::CmpReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+        );
+        // Equal operands -> ZF set, no borrow.
+        let flags = after.get_flags();
+        assert!(flags.zf);
+        assert!(!flags.cf);
+        // Operand registers must be unchanged.
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 5);
+        assert_eq!(after.get_register(X86Register::RBX).as_u64(), 5);
+    }
+
+    #[test]
+    fn cmpimm_less_than_sets_cf_and_sf() {
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(3));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::CmpImm {
+                rn: X86Register::RAX,
+                imm: 5,
+            },
+        );
+        assert!(after.get_flags().cf, "3 < 5 -> borrow");
+        assert!(after.get_flags().sf);
+        // rn must be untouched.
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 3);
+    }
+
+    #[test]
+    fn xorreg_self_clears_register_and_sets_zf() {
+        // The canonical x86 zeroing idiom: `xor rax, rax`.
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(0x42));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::XorReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RAX,
+            },
+        );
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 0);
+        let flags = after.get_flags();
+        assert!(flags.zf, "zero flag set");
+        assert!(!flags.cf, "CF cleared by logical");
+        assert!(!flags.of, "OF cleared by logical");
+        assert!(!flags.sf);
+        assert!(flags.pf, "zero has even parity");
+    }
+
+    #[test]
+    fn andimm_masks_register() {
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(0xff_ff));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::AndImm {
+                rd: X86Register::RAX,
+                imm: 0xff,
+            },
+        );
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 0xff);
+        assert!(!after.get_flags().cf);
+        assert!(!after.get_flags().of);
+    }
+
+    #[test]
+    fn orreg_combines_bits() {
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(0xf0));
+        state.set_register(X86Register::RBX, ConcreteValue::new(0x0f));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::OrReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+        );
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 0xff);
+        assert!(!after.get_flags().zf);
+    }
+
+    #[test]
+    fn addreg_writes_sum_and_sets_eflags() {
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(3));
+        state.set_register(X86Register::RBX, ConcreteValue::new(4));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::AddReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+        );
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 7);
+        let flags = after.get_flags();
+        assert!(!flags.cf);
+        assert!(!flags.zf);
+        assert!(!flags.sf);
+        assert!(!flags.of);
+    }
+
+    #[test]
+    fn addimm_carries_set_cf() {
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(u64::MAX));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::AddImm {
+                rd: X86Register::RAX,
+                imm: 1,
+            },
+        );
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 0);
+        assert!(after.get_flags().cf, "carry expected");
+        assert!(after.get_flags().zf, "result is zero");
+    }
+
+    #[test]
+    fn subreg_writes_difference_and_sets_eflags() {
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(10));
+        state.set_register(X86Register::RBX, ConcreteValue::new(3));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::SubReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+        );
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 7);
+        assert!(!after.get_flags().cf, "no borrow");
+        assert!(!after.get_flags().zf);
+    }
+
+    #[test]
+    fn subimm_borrow_sets_cf_and_sf() {
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(3));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::SubImm {
+                rd: X86Register::RAX,
+                imm: 5,
+            },
+        );
+        // 3 - 5 = -2 → 0xff..fe.
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), u64::MAX - 1);
+        assert!(after.get_flags().cf, "borrow");
+        assert!(after.get_flags().sf, "negative");
+    }
+
+    #[test]
+    fn movreg_copies_source_to_destination() {
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RBX, ConcreteValue::new(0xcafebabe));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::MovReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+        );
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 0xcafebabe);
+        // Source unchanged.
+        assert_eq!(after.get_register(X86Register::RBX).as_u64(), 0xcafebabe);
+        // MOV does not change EFLAGS.
+        assert_eq!(after.get_flags(), Eflags::default());
+    }
+
+    #[test]
+    fn movimm_loads_immediate() {
+        let state = X86ConcreteMachineState::new_zeroed(64);
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::MovImm {
+                rd: X86Register::RAX,
+                imm: 42,
+            },
+        );
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 42);
+        assert_eq!(after.get_flags(), Eflags::default());
+    }
+
+    #[test]
+    fn movimm_in_32bit_state_truncates_to_low_32() {
+        let state = X86ConcreteMachineState::new_zeroed(32);
+        // i64 with high bits set; the 32-bit state must truncate.
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::MovImm {
+                rd: X86Register::RAX,
+                imm: 0x1_0000_0042i64,
+            },
+        );
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 0x0000_0042);
+    }
+}

--- a/src/semantics/cost_x86.rs
+++ b/src/semantics/cost_x86.rs
@@ -1,0 +1,145 @@
+//! Cost model for the x86 backend.
+//!
+//! x86 is variable-length, so `CodeSize` is an approximation per variant.
+//! `InstructionCount` and `Latency` mirror the AArch64 module's shape.
+//! Width-aware: x86-32 encodings save one byte per REX prefix.
+
+#![allow(dead_code)]
+
+use crate::isa::x86::X86Instruction;
+use crate::semantics::cost::CostMetric;
+
+/// Cost of a single x86 instruction at the given operand width.
+pub fn instruction_cost(instr: &X86Instruction, metric: &CostMetric, width: u32) -> u64 {
+    match metric {
+        CostMetric::InstructionCount => 1,
+        CostMetric::Latency => instruction_latency(instr),
+        CostMetric::CodeSize => instruction_code_size(instr, width),
+    }
+}
+
+fn instruction_latency(_instr: &X86Instruction) -> u64 {
+    // Every variant in the minimal core set is a single-cycle ALU op on
+    // modern x86 cores. Refine when MUL / IDIV / shifts arrive.
+    1
+}
+
+/// Approximate encoded length in bytes. Conservative upper bounds.
+///
+/// - REX prefix adds 1 byte to x86-64 ops touching r0..r15 with REX.W.
+/// - Register-register: opcode + ModR/M = 2 bytes, plus REX for x86-64
+///   = 3 bytes.
+/// - Register-immediate (32-bit imm): opcode + ModR/M + 4-byte imm
+///   = 6 bytes plus REX for x86-64 = 7 bytes.
+/// - MOV reg, imm32: opcode + ModR/M + 4-byte imm = 6 bytes (x86-32)
+///   or 7 bytes (x86-64 with REX.W); for full 64-bit immediates the
+///   MOV reg, imm64 encoding takes 10 bytes — we use 7 as an upper
+///   bound for small/sign-extendable immediates and document the
+///   approximation.
+fn instruction_code_size(instr: &X86Instruction, width: u32) -> u64 {
+    let rex = if width == 64 { 1 } else { 0 };
+    match instr {
+        X86Instruction::MovReg { .. } => 2 + rex,
+        X86Instruction::MovImm { .. } => 5 + rex,
+        X86Instruction::AddReg { .. }
+        | X86Instruction::SubReg { .. }
+        | X86Instruction::AndReg { .. }
+        | X86Instruction::OrReg { .. }
+        | X86Instruction::XorReg { .. }
+        | X86Instruction::CmpReg { .. } => 2 + rex,
+        X86Instruction::AddImm { .. }
+        | X86Instruction::SubImm { .. }
+        | X86Instruction::AndImm { .. }
+        | X86Instruction::OrImm { .. }
+        | X86Instruction::XorImm { .. }
+        | X86Instruction::CmpImm { .. } => 6 + rex,
+    }
+}
+
+/// Total cost of a sequence at the given width.
+pub fn sequence_cost(seq: &[X86Instruction], metric: &CostMetric, width: u32) -> u64 {
+    seq.iter().map(|i| instruction_cost(i, metric, width)).sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::isa::x86::X86Register;
+
+    #[test]
+    fn instruction_count_is_always_one() {
+        let i = X86Instruction::MovReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+        };
+        assert_eq!(instruction_cost(&i, &CostMetric::InstructionCount, 64), 1);
+        assert_eq!(instruction_cost(&i, &CostMetric::InstructionCount, 32), 1);
+    }
+
+    #[test]
+    fn latency_is_one_for_minimal_set() {
+        let cases = [
+            X86Instruction::MovReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            X86Instruction::AddReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            X86Instruction::CmpImm {
+                rn: X86Register::RAX,
+                imm: 0,
+            },
+        ];
+        for i in cases {
+            assert_eq!(instruction_cost(&i, &CostMetric::Latency, 64), 1);
+        }
+    }
+
+    #[test]
+    fn code_size_x86_64_includes_rex_prefix() {
+        let rr = X86Instruction::AddReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+        };
+        let ri = X86Instruction::AddImm {
+            rd: X86Register::RAX,
+            imm: 5,
+        };
+        assert_eq!(instruction_cost(&rr, &CostMetric::CodeSize, 64), 3);
+        assert_eq!(instruction_cost(&ri, &CostMetric::CodeSize, 64), 7);
+    }
+
+    #[test]
+    fn code_size_x86_32_drops_rex_prefix() {
+        let rr = X86Instruction::AddReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+        };
+        let ri = X86Instruction::AddImm {
+            rd: X86Register::RAX,
+            imm: 5,
+        };
+        assert_eq!(instruction_cost(&rr, &CostMetric::CodeSize, 32), 2);
+        assert_eq!(instruction_cost(&ri, &CostMetric::CodeSize, 32), 6);
+    }
+
+    #[test]
+    fn sequence_cost_sums_individual_costs() {
+        let seq = [
+            X86Instruction::MovReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            X86Instruction::AddReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RCX,
+            },
+        ];
+        // 3 + 3 = 6 bytes on x86-64.
+        assert_eq!(sequence_cost(&seq, &CostMetric::CodeSize, 64), 6);
+        // 2 + 2 = 4 bytes on x86-32.
+        assert_eq!(sequence_cost(&seq, &CostMetric::CodeSize, 32), 4);
+    }
+}

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -351,10 +351,244 @@ pub fn find_counterexample_concrete(
     None
 }
 
+// ============================================================================
+// x86 equivalence checking
+// ============================================================================
+
+/// Equivalence-check configuration for the x86 backend. Carries the
+/// bitvector width (64 for x86-64, 32 for x86-32) which threads through
+/// to `MachineStateX86::new_symbolic` and the immediate lowering.
+#[derive(Debug, Clone)]
+pub struct X86EquivalenceConfig {
+    pub live_out: crate::semantics::state::X86LiveOutMask,
+    pub width: u32,
+    pub random_test_count: usize,
+    pub smt_timeout: Option<Duration>,
+    pub fast_only: bool,
+}
+
+impl X86EquivalenceConfig {
+    pub fn new_for_64() -> Self {
+        Self {
+            live_out: crate::semantics::state::X86LiveOutMask::empty(),
+            width: 64,
+            random_test_count: 10,
+            smt_timeout: Some(Duration::from_secs(30)),
+            fast_only: false,
+        }
+    }
+
+    pub fn new_for_32() -> Self {
+        Self {
+            width: 32,
+            ..Self::new_for_64()
+        }
+    }
+
+    pub fn live_out(mut self, mask: crate::semantics::state::X86LiveOutMask) -> Self {
+        self.live_out = mask;
+        self
+    }
+
+    pub fn fast_only(mut self) -> Self {
+        self.fast_only = true;
+        self
+    }
+}
+
+/// Check whether two x86 instruction sequences are equivalent under the
+/// given live-out mask and operand width. Mirrors `check_equivalence_with_config`
+/// for the AArch64 backend: fast path uses the concrete interpreter over
+/// random inputs (and EFLAGS comparison when CMP is present or the mask
+/// declares flags live); slow path lowers to Z3 BVs and checks UNSAT of the
+/// not-equal assertion over live-out registers.
+pub fn check_equivalence_x86(
+    seq1: &[crate::isa::x86::X86Instruction],
+    seq2: &[crate::isa::x86::X86Instruction],
+    config: &X86EquivalenceConfig,
+) -> EquivalenceResult {
+    // Fast path: 10 random inputs.
+    if let Some(refutation) = run_fast_path_x86(seq1, seq2, config) {
+        return refutation;
+    }
+    if config.fast_only {
+        return EquivalenceResult::Equivalent;
+    }
+
+    // SMT path.
+    let solver_config = SolverConfig {
+        timeout: config.smt_timeout,
+    };
+    let solver = create_solver_with_config(&solver_config);
+    let initial = crate::semantics::smt_x86::MachineStateX86::new_symbolic("init", config.width);
+    let final1 = crate::semantics::smt_x86::apply_sequence(initial.clone(), seq1);
+    let final2 = crate::semantics::smt_x86::apply_sequence(initial, seq2);
+
+    let mut disjuncts: Vec<z3::ast::Bool> = Vec::new();
+    for reg in config.live_out.iter() {
+        let v1 = final1.get_register(*reg);
+        let v2 = final2.get_register(*reg);
+        disjuncts.push(v1.eq(v2).not());
+    }
+    let any_diff = if disjuncts.is_empty() {
+        z3::ast::Bool::from_bool(false)
+    } else {
+        z3::ast::Bool::or(&disjuncts.iter().collect::<Vec<_>>())
+    };
+    solver.assert(&any_diff);
+    interpret_smt_result(solver.check())
+}
+
+fn run_fast_path_x86(
+    seq1: &[crate::isa::x86::X86Instruction],
+    seq2: &[crate::isa::x86::X86Instruction],
+    config: &X86EquivalenceConfig,
+) -> Option<EquivalenceResult> {
+    use crate::isa::x86::X86Register;
+    use crate::semantics::concrete_x86::apply_instruction_concrete_x86;
+    use crate::semantics::state::X86ConcreteMachineState;
+
+    // Detect any CMP in either sequence — that's the trigger to also
+    // compare EFLAGS even if the caller didn't declare flags live.
+    let cmp_present = seq1.iter().chain(seq2.iter()).any(|i| {
+        matches!(
+            i,
+            crate::isa::x86::X86Instruction::CmpReg { .. }
+                | crate::isa::x86::X86Instruction::CmpImm { .. }
+        )
+    });
+    let flags_must_match = cmp_present || config.live_out.flags_live();
+
+    // Deterministic seed sequence: the first four are hand-picked
+    // boundary cases (zero, one, an asymmetric bit pattern, all-ones);
+    // beyond that we mix the iteration index with a golden-ratio
+    // multiplier to scatter through the u64 space without pulling in a
+    // PRNG. The total number of seeds is `config.random_test_count`
+    // (matching the AArch64 path's contract that the field actually
+    // drives the fast-path coverage).
+    let base_seeds: &[u64] = &[0, 1, 0xdead_beef, u64::MAX];
+    for n in 0..config.random_test_count {
+        let seed = if n < base_seeds.len() {
+            base_seeds[n]
+        } else {
+            (n as u64).wrapping_mul(0x9e37_79b9_7f4a_7c15)
+        };
+        let mut state = X86ConcreteMachineState::new_zeroed(config.width);
+        for i in 0..16u8 {
+            if let Some(reg) = X86Register::from_index(i) {
+                state.set_register(
+                    reg,
+                    crate::semantics::state::ConcreteValue::new(seed.wrapping_add(i as u64)),
+                );
+            }
+        }
+        let mut s1 = state.clone();
+        for instr in seq1 {
+            s1 = apply_instruction_concrete_x86(s1, instr);
+        }
+        let mut s2 = state.clone();
+        for instr in seq2 {
+            s2 = apply_instruction_concrete_x86(s2, instr);
+        }
+        for reg in config.live_out.iter() {
+            if s1.get_register(*reg) != s2.get_register(*reg) {
+                // We don't have an X86-typed counterexample state in the
+                // EquivalenceResult yet; report a generic NotEquivalent.
+                return Some(EquivalenceResult::NotEquivalent);
+            }
+        }
+        if flags_must_match && s1.get_flags() != s2.get_flags() {
+            return Some(EquivalenceResult::NotEquivalent);
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::ir::{Operand, Register};
+    use crate::isa::x86::{X86Instruction, X86Register};
+    use crate::semantics::state::X86LiveOutMask;
+
+    #[test]
+    fn x86_mov_zero_equivalent_to_xor_self_when_flags_dead() {
+        let seq_mov = vec![X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: 0,
+        }];
+        let seq_xor = vec![X86Instruction::XorReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RAX,
+        }];
+        let cfg = X86EquivalenceConfig::new_for_64()
+            .live_out(X86LiveOutMask::from_registers(vec![X86Register::RAX]));
+        assert_eq!(
+            check_equivalence_x86(&seq_mov, &seq_xor, &cfg),
+            EquivalenceResult::Equivalent
+        );
+    }
+
+    #[test]
+    fn x86_mov_zero_not_equivalent_to_xor_self_when_flags_live() {
+        // XOR sets EFLAGS; MOV does not. So with flags_live=true, the two
+        // sequences must NOT be considered equivalent.
+        let seq_mov = vec![X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: 0,
+        }];
+        let seq_xor = vec![X86Instruction::XorReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RAX,
+        }];
+        let cfg = X86EquivalenceConfig::new_for_64()
+            .live_out(X86LiveOutMask::from_registers(vec![X86Register::RAX]).with_flags(true))
+            .fast_only();
+        assert!(matches!(
+            check_equivalence_x86(&seq_mov, &seq_xor, &cfg),
+            EquivalenceResult::NotEquivalent
+        ));
+    }
+
+    #[test]
+    fn x86_cmp_difference_caught_by_fast_path_eflags_auto_compare() {
+        // Two CMPs that differ in operands -> different EFLAGS even when
+        // no register is in live-out.
+        let seq1 = vec![X86Instruction::CmpReg {
+            rn: X86Register::RAX,
+            rs: X86Register::RBX,
+        }];
+        let seq2 = vec![X86Instruction::CmpReg {
+            rn: X86Register::RAX,
+            rs: X86Register::RCX,
+        }];
+        let cfg = X86EquivalenceConfig::new_for_64()
+            .live_out(X86LiveOutMask::empty())
+            .fast_only();
+        // CMP is present, so EFLAGS comparison auto-engages.
+        assert!(matches!(
+            check_equivalence_x86(&seq1, &seq2, &cfg),
+            EquivalenceResult::NotEquivalent
+        ));
+    }
+
+    #[test]
+    fn x86_two_movs_with_same_immediate_are_equivalent() {
+        let seq1 = vec![X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: 42,
+        }];
+        let seq2 = vec![X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: 42,
+        }];
+        let cfg = X86EquivalenceConfig::new_for_64()
+            .live_out(X86LiveOutMask::from_registers(vec![X86Register::RAX]));
+        assert_eq!(
+            check_equivalence_x86(&seq1, &seq2, &cfg),
+            EquivalenceResult::Equivalent
+        );
+    }
 
     #[test]
     fn test_mov_zero_eor_equivalence() {

--- a/src/semantics/mod.rs
+++ b/src/semantics/mod.rs
@@ -1,10 +1,13 @@
-//! Semantic analysis and equivalence checking for AArch64 instructions
+//! Semantic analysis and equivalence checking (AArch64 + x86 backends).
 
 pub mod concrete;
+pub mod concrete_x86;
 pub mod cost;
+pub mod cost_x86;
 pub mod equivalence;
 pub mod live_out;
 pub mod smt;
+pub mod smt_x86;
 pub mod state;
 
 // Re-export main functionality. Some items are surfaced for external

--- a/src/semantics/smt_x86.rs
+++ b/src/semantics/smt_x86.rs
@@ -1,0 +1,222 @@
+//! SMT (Z3) constraint generation for the x86 backend.
+//!
+//! Width-parameterised: `MachineStateX86` carries the bitvector width so
+//! the same module handles both x86-64 (width=64) and x86-32 (width=32).
+//! Flags are NOT modelled symbolically yet — CMP variants are encoded as
+//! no-ops, mirroring the AArch64 SMT path's treatment of CMP/CMN/TST.
+
+#![allow(dead_code)]
+
+use crate::isa::x86::{X86Instruction, X86Register};
+use std::collections::HashMap;
+use z3::ast::BV;
+
+#[derive(Clone)]
+pub struct MachineStateX86 {
+    pub registers: HashMap<X86Register, BV>,
+    width: u32,
+}
+
+impl MachineStateX86 {
+    pub fn new_symbolic(prefix: &str, width: u32) -> Self {
+        let mut registers = HashMap::new();
+        for i in 0..16u8 {
+            if let Some(reg) = X86Register::from_index(i) {
+                let name = format!("{}_r{}", prefix, i);
+                registers.insert(reg, BV::new_const(name, width));
+            }
+        }
+        MachineStateX86 { registers, width }
+    }
+
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    pub fn get_register(&self, reg: X86Register) -> &BV {
+        self.registers
+            .get(&reg)
+            .expect("register absent from x86 state")
+    }
+
+    pub fn set_register(&mut self, reg: X86Register, value: BV) {
+        self.registers.insert(reg, value);
+    }
+
+    fn imm_bv(&self, imm: i64) -> BV {
+        BV::from_i64(imm, self.width)
+    }
+}
+
+/// Apply a single x86 instruction symbolically. CMP variants are no-ops
+/// because we do not (yet) model EFLAGS in Z3.
+pub fn apply_instruction(
+    mut state: MachineStateX86,
+    instruction: &X86Instruction,
+) -> MachineStateX86 {
+    match instruction {
+        X86Instruction::MovReg { rd, rs } => {
+            let value = state.get_register(*rs).clone();
+            state.set_register(*rd, value);
+        }
+        X86Instruction::MovImm { rd, imm } => {
+            let value = state.imm_bv(*imm);
+            state.set_register(*rd, value);
+        }
+        X86Instruction::AddReg { rd, rs } => {
+            let lhs = state.get_register(*rd).clone();
+            let rhs = state.get_register(*rs).clone();
+            state.set_register(*rd, lhs.bvadd(&rhs));
+        }
+        X86Instruction::AddImm { rd, imm } => {
+            let lhs = state.get_register(*rd).clone();
+            let rhs = state.imm_bv(*imm);
+            state.set_register(*rd, lhs.bvadd(&rhs));
+        }
+        X86Instruction::SubReg { rd, rs } => {
+            let lhs = state.get_register(*rd).clone();
+            let rhs = state.get_register(*rs).clone();
+            state.set_register(*rd, lhs.bvsub(&rhs));
+        }
+        X86Instruction::SubImm { rd, imm } => {
+            let lhs = state.get_register(*rd).clone();
+            let rhs = state.imm_bv(*imm);
+            state.set_register(*rd, lhs.bvsub(&rhs));
+        }
+        X86Instruction::AndReg { rd, rs } => {
+            let lhs = state.get_register(*rd).clone();
+            let rhs = state.get_register(*rs).clone();
+            state.set_register(*rd, lhs.bvand(&rhs));
+        }
+        X86Instruction::AndImm { rd, imm } => {
+            let lhs = state.get_register(*rd).clone();
+            let rhs = state.imm_bv(*imm);
+            state.set_register(*rd, lhs.bvand(&rhs));
+        }
+        X86Instruction::OrReg { rd, rs } => {
+            let lhs = state.get_register(*rd).clone();
+            let rhs = state.get_register(*rs).clone();
+            state.set_register(*rd, lhs.bvor(&rhs));
+        }
+        X86Instruction::OrImm { rd, imm } => {
+            let lhs = state.get_register(*rd).clone();
+            let rhs = state.imm_bv(*imm);
+            state.set_register(*rd, lhs.bvor(&rhs));
+        }
+        X86Instruction::XorReg { rd, rs } => {
+            let lhs = state.get_register(*rd).clone();
+            let rhs = state.get_register(*rs).clone();
+            state.set_register(*rd, lhs.bvxor(&rhs));
+        }
+        X86Instruction::XorImm { rd, imm } => {
+            let lhs = state.get_register(*rd).clone();
+            let rhs = state.imm_bv(*imm);
+            state.set_register(*rd, lhs.bvxor(&rhs));
+        }
+        // CMP sets EFLAGS only — not modelled here. Mirrors AArch64 path.
+        X86Instruction::CmpReg { .. } | X86Instruction::CmpImm { .. } => {}
+    }
+    state
+}
+
+pub fn apply_sequence(
+    mut state: MachineStateX86,
+    instructions: &[X86Instruction],
+) -> MachineStateX86 {
+    for instr in instructions {
+        state = apply_instruction(state, instr);
+    }
+    state
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use z3::{SatResult, Solver};
+
+    #[test]
+    fn new_symbolic_has_16_registers_at_width() {
+        let state = MachineStateX86::new_symbolic("s", 64);
+        assert_eq!(state.width(), 64);
+        for i in 0..16u8 {
+            let r = X86Register::from_index(i).unwrap();
+            assert_eq!(state.get_register(r).get_size(), 64);
+        }
+    }
+
+    #[test]
+    fn new_symbolic_32bit_uses_32_wide_bvs() {
+        let state = MachineStateX86::new_symbolic("s", 32);
+        assert_eq!(state.width(), 32);
+        for i in 0..16u8 {
+            let r = X86Register::from_index(i).unwrap();
+            assert_eq!(state.get_register(r).get_size(), 32);
+        }
+    }
+
+    #[test]
+    fn movimm_then_addreg_produces_known_value() {
+        // mov rax, 5 ; mov rbx, 7 ; add rax, rbx  =>  rax == 12
+        let s0 = MachineStateX86::new_symbolic("s", 64);
+        let s1 = apply_sequence(
+            s0,
+            &[
+                X86Instruction::MovImm {
+                    rd: X86Register::RAX,
+                    imm: 5,
+                },
+                X86Instruction::MovImm {
+                    rd: X86Register::RBX,
+                    imm: 7,
+                },
+                X86Instruction::AddReg {
+                    rd: X86Register::RAX,
+                    rs: X86Register::RBX,
+                },
+            ],
+        );
+        // Z3 should be able to prove rax == 12.
+        let solver = Solver::new();
+        let actual = s1.get_register(X86Register::RAX);
+        solver.assert(&actual.eq(&BV::from_i64(12, 64)).not());
+        // If the negation is unsatisfiable, the original equality is a theorem.
+        assert_eq!(solver.check(), SatResult::Unsat);
+    }
+
+    #[test]
+    fn xor_self_provably_zero() {
+        // The canonical zeroing idiom must be provably equal to zero in Z3.
+        let s0 = MachineStateX86::new_symbolic("s", 64);
+        let s1 = apply_instruction(
+            s0,
+            &X86Instruction::XorReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RAX,
+            },
+        );
+        let solver = Solver::new();
+        let actual = s1.get_register(X86Register::RAX);
+        solver.assert(&actual.eq(&BV::from_i64(0, 64)).not());
+        assert_eq!(solver.check(), SatResult::Unsat);
+    }
+
+    #[test]
+    fn cmp_does_not_change_register_state() {
+        let s0 = MachineStateX86::new_symbolic("s", 64);
+        let rax_before = s0.get_register(X86Register::RAX).clone();
+        let s1 = apply_instruction(
+            s0,
+            &X86Instruction::CmpReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+        );
+        let solver = Solver::new();
+        solver.assert(&s1.get_register(X86Register::RAX).eq(&rax_before).not());
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "CMP must leave RAX symbolically unchanged"
+        );
+    }
+}

--- a/src/semantics/state.rs
+++ b/src/semantics/state.rs
@@ -4,7 +4,7 @@
 
 use crate::ir::Register;
 use crate::ir::types::Condition;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 
 /// NZCV condition flags (Negative, Zero, Carry, oVerflow)
@@ -83,6 +83,123 @@ impl ConditionFlags {
             Condition::AL => true,                          // Always
             Condition::NV => false,                         // Never (reserved, treat as false)
         }
+    }
+}
+
+/// x86 EFLAGS bits relevant to the minimal core ISA (CMP, ADD, SUB, AND,
+/// OR, XOR).
+///
+/// Distinct from `ConditionFlags` (AArch64 NZCV) because x86's CF
+/// polarity on subtraction is inverted compared to AArch64 (x86 CF is
+/// "borrow occurred", AArch64 C is "no-borrow"), and x86 has additional
+/// bits (PF, AF) with their own semantics.
+///
+/// `af` is left as `false` for the initial scope — Intel documents it as
+/// "undefined" after most logical ops, and the minimal instruction set
+/// does not include any BCD or condition-code-reading instructions that
+/// observe AF.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct Eflags {
+    pub cf: bool, // Carry: unsigned overflow on add, borrow on sub
+    pub pf: bool, // Parity: low byte has even parity
+    pub af: bool, // Auxiliary carry (BCD); modelled as false for now
+    pub zf: bool, // Zero
+    pub sf: bool, // Sign (MSB of result)
+    pub of: bool, // Overflow (signed)
+}
+
+impl Eflags {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Parity of the low 8 bits of `result` (PF semantics).
+    fn parity8(result: u64) -> bool {
+        (result as u8).count_ones().is_multiple_of(2)
+    }
+
+    /// Flags from `lhs + rhs == result` at width `width`. CF is set on
+    /// unsigned overflow (low-`width` bits wrap).
+    pub fn from_add(lhs: u64, rhs: u64, result: u64, width: u32) -> Self {
+        let lhs_w = mask_to_width(lhs, width);
+        let rhs_w = mask_to_width(rhs, width);
+        let result_w = mask_to_width(result, width);
+        // Unsigned carry: result < either operand (mod width).
+        let cf = result_w < lhs_w || result_w < rhs_w;
+        let zf = result_w == 0;
+        let sf = top_bit(result, width);
+        // Signed overflow on addition: input signs match AND result sign differs.
+        let of = {
+            let l = top_bit(lhs, width);
+            let r = top_bit(rhs, width);
+            let res = top_bit(result, width);
+            (l == r) && (l != res)
+        };
+        Self {
+            cf,
+            pf: Self::parity8(result),
+            af: false,
+            zf,
+            sf,
+            of,
+        }
+    }
+
+    /// Flags from a logical op (AND/OR/XOR). CF and OF are always cleared
+    /// per x86 spec; SF/ZF/PF reflect the result.
+    pub fn from_logical(result: u64, width: u32) -> Self {
+        Self {
+            cf: false,
+            pf: Self::parity8(result),
+            af: false,
+            zf: mask_to_width(result, width) == 0,
+            sf: top_bit(result, width),
+            of: false,
+        }
+    }
+
+    /// Flags from `lhs - rhs == result` (CMP and SUB at width `width`).
+    /// CF is set if a borrow occurred (lhs < rhs at the operand width) —
+    /// opposite of AArch64.
+    pub fn from_sub(lhs: u64, rhs: u64, result: u64, width: u32) -> Self {
+        let cf = mask_to_width(lhs, width) < mask_to_width(rhs, width);
+        let zf = mask_to_width(result, width) == 0;
+        let sf = top_bit(result, width);
+        // Signed overflow on subtraction: signs differ AND lhs sign != result sign.
+        let of = {
+            let l = top_bit(lhs, width);
+            let r = top_bit(rhs, width);
+            let res = top_bit(result, width);
+            (l != r) && (l != res)
+        };
+        Self {
+            cf,
+            pf: Self::parity8(result),
+            af: false,
+            zf,
+            sf,
+            of,
+        }
+    }
+}
+
+fn mask_to_width(value: u64, width: u32) -> u64 {
+    match width {
+        64 => value,
+        32 => value & 0xffff_ffff,
+        16 => value & 0xffff,
+        8 => value & 0xff,
+        _ => value,
+    }
+}
+
+fn top_bit(value: u64, width: u32) -> bool {
+    match width {
+        64 => (value as i64) < 0,
+        32 => (value & 0x8000_0000) != 0,
+        16 => (value & 0x8000) != 0,
+        8 => (value & 0x80) != 0,
+        _ => (value as i64) < 0,
     }
 }
 
@@ -215,6 +332,111 @@ impl fmt::Display for ConcreteMachineState {
     }
 }
 
+/// Concrete machine state for the x86 backend.
+///
+/// Width-tagged: writes are masked to the low `width` bits so the same
+/// struct can model both x86-64 (width=64) and x86-32 (width=32). All 16
+/// GPRs are present in the backing map; x86-32 callers simply never
+/// reference R8..R15.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct X86ConcreteMachineState {
+    registers: HashMap<crate::isa::x86::X86Register, ConcreteValue>,
+    flags: Eflags,
+    width: u32,
+}
+
+impl X86ConcreteMachineState {
+    pub fn new_zeroed(width: u32) -> Self {
+        let mut registers = HashMap::new();
+        for i in 0..16u8 {
+            if let Some(r) = crate::isa::x86::X86Register::from_index(i) {
+                registers.insert(r, ConcreteValue::new(0));
+            }
+        }
+        X86ConcreteMachineState {
+            registers,
+            flags: Eflags::new(),
+            width,
+        }
+    }
+
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    pub fn get_register(&self, reg: crate::isa::x86::X86Register) -> ConcreteValue {
+        *self.registers.get(&reg).unwrap_or(&ConcreteValue::new(0))
+    }
+
+    /// Set a register value, masking to the low `width` bits.
+    pub fn set_register(&mut self, reg: crate::isa::x86::X86Register, value: ConcreteValue) {
+        let masked = mask_to_width(value.as_u64(), self.width);
+        self.registers.insert(reg, ConcreteValue::new(masked));
+    }
+
+    pub fn get_flags(&self) -> Eflags {
+        self.flags
+    }
+
+    pub fn set_flags(&mut self, flags: Eflags) {
+        self.flags = flags;
+    }
+
+    pub fn registers(&self) -> &HashMap<crate::isa::x86::X86Register, ConcreteValue> {
+        &self.registers
+    }
+}
+
+/// Live-out mask for the x86 backend. Keyed on `X86Register` and carries
+/// a `flags_live` flag indicating whether the equivalence check must
+/// also compare EFLAGS.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct X86LiveOutMask {
+    registers: HashSet<crate::isa::x86::X86Register>,
+    flags_live: bool,
+}
+
+impl X86LiveOutMask {
+    pub fn empty() -> Self {
+        Self {
+            registers: HashSet::new(),
+            flags_live: false,
+        }
+    }
+
+    pub fn from_registers(regs: Vec<crate::isa::x86::X86Register>) -> Self {
+        Self {
+            registers: regs.into_iter().collect(),
+            flags_live: false,
+        }
+    }
+
+    pub fn with_flags(mut self, flags_live: bool) -> Self {
+        self.flags_live = flags_live;
+        self
+    }
+
+    pub fn contains(&self, reg: crate::isa::x86::X86Register) -> bool {
+        self.registers.contains(&reg)
+    }
+
+    pub fn flags_live(&self) -> bool {
+        self.flags_live
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &crate::isa::x86::X86Register> {
+        self.registers.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.registers.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.registers.is_empty()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -262,5 +484,155 @@ mod tests {
         let mut state = ConcreteMachineState::new_zeroed();
         state.set_register(Register::XZR, ConcreteValue::new(123));
         assert_eq!(state.get_register(Register::XZR).as_u64(), 0);
+    }
+    #[test]
+    fn x86_state_new_zeroed_has_all_gprs() {
+        use crate::isa::x86::X86Register;
+        let state = X86ConcreteMachineState::new_zeroed(64);
+        for i in 0..16u8 {
+            let r = X86Register::from_index(i).unwrap();
+            assert_eq!(state.get_register(r).as_u64(), 0);
+        }
+        assert_eq!(state.get_flags(), Eflags::default());
+        assert_eq!(state.width(), 64);
+    }
+
+    #[test]
+    fn x86_state_register_get_set_round_trip() {
+        use crate::isa::x86::X86Register;
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RDI, ConcreteValue::new(0xdead_beef));
+        assert_eq!(state.get_register(X86Register::RDI).as_u64(), 0xdead_beef);
+        assert_eq!(state.get_register(X86Register::RAX).as_u64(), 0);
+    }
+
+    #[test]
+    fn x86_state_writes_mask_to_width_32() {
+        use crate::isa::x86::X86Register;
+        let mut state = X86ConcreteMachineState::new_zeroed(32);
+        // Writing a 64-bit value when the ISA is 32-bit must truncate.
+        state.set_register(X86Register::RAX, ConcreteValue::new(0x1234_5678_9abc_def0));
+        assert_eq!(
+            state.get_register(X86Register::RAX).as_u64(),
+            0x9abc_def0,
+            "32-bit ISA must truncate writes to low 32 bits"
+        );
+    }
+
+    #[test]
+    fn x86_state_flag_set_round_trip() {
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        let flags = Eflags {
+            cf: true,
+            pf: false,
+            af: false,
+            zf: true,
+            sf: true,
+            of: false,
+        };
+        state.set_flags(flags);
+        assert_eq!(state.get_flags(), flags);
+    }
+
+    #[test]
+    fn eflags_from_add_carry_on_unsigned_wrap() {
+        // u64::MAX + 1 wraps to 0, CF=1.
+        let lhs = u64::MAX;
+        let rhs = 1u64;
+        let result = lhs.wrapping_add(rhs);
+        let f = Eflags::from_add(lhs, rhs, result, 64);
+        assert!(f.cf, "carry expected on unsigned wrap");
+        assert!(f.zf, "result is 0");
+        assert!(!f.sf);
+        assert!(!f.of, "0xff..ff + 1 = 0 is not a signed overflow");
+    }
+
+    #[test]
+    fn eflags_from_add_no_carry() {
+        let f = Eflags::from_add(1, 2, 3, 64);
+        assert!(!f.cf);
+        assert!(!f.zf);
+        assert!(!f.sf);
+        assert!(!f.of);
+    }
+
+    #[test]
+    fn eflags_from_add_signed_overflow() {
+        // INT64_MAX + 1 -> INT64_MIN ; signed overflow.
+        let lhs = (1u64 << 63) - 1; // INT64_MAX
+        let rhs = 1u64;
+        let result = lhs.wrapping_add(rhs);
+        let f = Eflags::from_add(lhs, rhs, result, 64);
+        assert!(f.of, "signed overflow expected");
+        assert!(!f.cf, "no unsigned overflow");
+        assert!(f.sf, "result is negative");
+    }
+
+    #[test]
+    fn eflags_from_logical_clears_cf_and_of() {
+        let f = Eflags::from_logical(0, 64);
+        assert!(!f.cf, "logical ops clear CF");
+        assert!(!f.of, "logical ops clear OF");
+        assert!(f.zf);
+        assert!(!f.sf);
+        // Result is 0, so PF for 0x00 is even parity → true.
+        assert!(f.pf);
+    }
+
+    #[test]
+    fn eflags_from_logical_nonzero_sign_set() {
+        // High-bit set in 64-bit width.
+        let f = Eflags::from_logical(1u64 << 63, 64);
+        assert!(!f.zf);
+        assert!(f.sf);
+        assert!(!f.cf);
+        assert!(!f.of);
+    }
+
+    #[test]
+    fn eflags_from_sub_zero_result_sets_zf() {
+        // 5 - 5 = 0 with no borrow, no overflow, sign 0, parity even.
+        let f = Eflags::from_sub(5, 5, 0, 64);
+        assert!(f.zf, "zf expected");
+        assert!(!f.cf, "no borrow");
+        assert!(!f.sf, "non-negative");
+        assert!(!f.of, "no signed overflow");
+        assert!(f.pf, "0x00 has even parity");
+    }
+
+    #[test]
+    fn eflags_from_sub_borrow_sets_cf() {
+        // 3 - 5 = -2 (wrap to 2^64 - 2). Unsigned: borrow occurred.
+        let result = 3u64.wrapping_sub(5);
+        let f = Eflags::from_sub(3, 5, result, 64);
+        assert!(f.cf, "borrow expected");
+        assert!(f.sf, "sign bit set (-2 in 64-bit signed)");
+        assert!(!f.zf);
+        // 3 (pos) - 5 (pos) = -2 with same input signs ⇒ no signed overflow.
+        assert!(!f.of);
+    }
+
+    #[test]
+    fn eflags_from_sub_signed_overflow() {
+        // INT64_MIN - 1 overflows signed bounds.
+        let lhs = 1u64 << 63;
+        let rhs = 1u64;
+        let result = lhs.wrapping_sub(rhs);
+        let f = Eflags::from_sub(lhs, rhs, result, 64);
+        assert!(f.of, "signed overflow expected");
+        // INT64_MIN < 1 unsigned -> no borrow.
+        assert!(!f.cf);
+        assert!(!f.sf, "result is INT64_MAX, MSB clear");
+    }
+
+    #[test]
+    fn eflags_from_sub_32bit_width_uses_low_32() {
+        // In 32-bit mode, the borrow/overflow check uses the low 32 bits.
+        // 0x0000_0001 - 0x0000_0002 = 0xFFFF_FFFF (treated as -1 in 32-bit).
+        let result = 1u32.wrapping_sub(2) as u64;
+        let f = Eflags::from_sub(1, 2, result, 32);
+        assert!(f.cf, "borrow");
+        assert!(f.sf, "32-bit MSB set");
+        assert!(!f.zf);
     }
 }

--- a/tests/integration/disasm_test.rs
+++ b/tests/integration/disasm_test.rs
@@ -163,6 +163,40 @@ fn test_disasm_functions_binary() {
     );
 }
 
+/// Disassemble an x86-64 binary if build_tests.sh has produced one. We
+/// only assert that s11 exits successfully and reports the architecture
+/// header — we don't pin specific instruction mnemonics because the
+/// compiler is free to choose any encoding it wants.
+#[test]
+fn test_disasm_x86_64_binary_if_present() {
+    let binary = get_binary_path();
+    let test_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("binaries")
+        .join("x86_64")
+        .join("simple_debug");
+    if !test_elf.exists() {
+        eprintln!(
+            "Skipping x86-64 disasm test: {:?} not present (run build_tests.sh on x86_64 host)",
+            test_elf
+        );
+        return;
+    }
+    let output = Command::new(binary)
+        .arg("disasm")
+        .arg(&test_elf)
+        .output()
+        .expect("Failed to execute s11");
+    assert!(
+        output.status.success(),
+        "s11 disasm failed on x86-64 binary: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // stdout in disasm mode is the per-instruction listing — should not
+    // contain the architecture header.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("0x"), "expected hex addresses in output");
+}
+
 #[test]
 fn test_disasm_requires_binary() {
     let binary = get_binary_path();


### PR DESCRIPTION
## Summary

- Full vertical slice for x86-64 (primary) and x86-32 (secondary): IR + concrete + SMT semantics + cost + dynasm assembler + ELF patching + CLI dispatch + enumerative search.
- 14 instruction variants (7 mnemonics × reg/imm forms): MOV, ADD, SUB, AND, OR, XOR, CMP.
- 349 unit tests + 14 integration tests passing.
- Planned in `.ultraplan/x86-backend.md`; that file is also part of the PR for review context.

## Architecture decision

x86 ships as a **parallel pipeline** alongside the existing AArch64 path, not a generic refactor of the trait surface. The AArch64 code path is unchanged; an x86 sibling is added next to it (`concrete_x86.rs`, `smt_x86.rs`, `cost_x86.rs`, `candidate_x86.rs`, `assembler/x86.rs`). Trade-off: some duplication; benefit: zero risk of regressing AArch64.

The `ISA`/`InstructionType`/etc. traits in `src/isa/traits.rs` remain aspirational — the existing AArch64 code bypasses them too. A future PR can generalise all three backends onto the trait surface; that is filed as a follow-up issue.

## Critical x86-specific correctness fixes baked in

These were caught by the adversarial-review pass during planning and addressed in the implementation:

- **`source_registers()` divergence**: x86's two-operand destructive form (`add rd, rs` reads AND writes rd) requires `rd` in the source list for liveness to be correct. AArch64/RISC-V exclude the destination. The divergence is documented at the top of `enum X86Instruction`.
- **EFLAGS soundness for CMP-shortening**: the fast-path equivalence comparator auto-engages EFLAGS comparison whenever any CMP appears in either sequence. Without this, the search could drop a target's trailing CMP and incorrectly call the shorter sequence equivalent.
- **EFLAGS soundness for flag-setting rewrites**: `flags_live=true` whenever the target has any flag-writing instruction, not just CMP. Conservative; tracked at #95 for proper liveness analysis.
- **Z3 BV width threading**: `X86EquivalenceConfig` carries width (64 for x86-64, 32 for x86-32). Mixed-width BVs would panic at solve time; the config prevents this by construction.
- **Window-boundary validation**: x86 is variable-length; `optimize_elf_binary_x86` refuses windows that don't end on a decoded instruction boundary (so the patcher can never overwrite part of the next instruction).
- **NOP padding**: per-arch nop_bytes() slice + loop bound; AArch64 stays 4-byte (`0xd5_03_20_1f`), x86 is 1-byte (`0x90`).
- **`general_registers()`**: returns all 16 GPRs (matches RISC-V convention); CLI filters RSP at use-site.
- **RBP not marked special**: modern SysV ABI doesn't require a frame pointer, so RBP stays in the search pool.

## Scope: what x86 v1 does NOT include (filed as follow-up issues)

- Stochastic / Symbolic / Hybrid / LLM search for x86 — only enumerative (tracked #73).
- CMOVcc / Jcc and symbolic EFLAGS plumbing (tracked #74).
- Sub-register aliasing (AL/AH/AX/EAX/RAX writes that preserve high bits) (tracked #75).
- Multi-byte NOP padding in ELF patcher (tracked #76).
- RISC-V activation (still scaffold-only, same as before this PR).
- Refactor of AArch64/RISC-V/x86 onto the `src/isa/traits.rs` surface (tracked #77).
- Window-external EFLAGS liveness analysis (tracked #95).
- Other tracked follow-ups: #82–#84, #88–#91, #96–#97.

## Test plan

- [x] `cargo fmt -- --check` clean
- [x] `cargo build --bins` clean
- [x] `cargo test --bins` — 349 unit tests passing
- [x] `cargo test --test integration_tests` — 14 integration tests passing
- [x] `./build_tests.sh` produces AArch64, x86-64, and x86-32 binaries
- [x] `./test_all.sh` AArch64 suite passes
- [x] `./ci_check.sh` — all checks green
- [x] Manual smoke: `s11 disasm --arch x86-64 binaries/x86_64/simple_debug` produces correct Intel-syntax output

## Rebase / history note

This branch was rebased onto the current `origin/main` (commit `4ed2fc7`), which includes 8 dependency / refactor commits since the original branch base (dynasmrt 4→5, dynasm 4→5, z3 0.19→0.20, rand 0.9→0.10, rand_chacha 0.9→0.10, rayon 1.11→1.12, plus the `LiveOutMask → LiveOut` rename in `494bd09` / `4ed2fc7`).

The original 33-commit incremental history (preserved in earlier force-pushes of this branch) was squashed to one commit during the second rebase, to make the `LiveOutMask → LiveOut` rename resolvable in a single conflict-resolution pass instead of replaying per-commit. The squash matches what GitHub's squash-merge would produce. The original commit messages remain visible in the squashed commit body.

All 7 actual workflow jobs (`test`, `clippy`, `CodeQL`, `Analyze (rust)`, `Analyze (actions)`, `Run rust-clippy analyzing`, `claude-review`) pass on the rebased HEAD.