### PR TITLE
Add 14 Tier 1 AArch64 instructions + fix CSEL encoder & SMT soundness

### DIFF
--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -1067,7 +1067,9 @@ mod tests {
         let bytes = assembler
             .assemble_instructions(&instructions)
             .expect("ROR imm encoding should succeed");
-        disassemble_and_verify(&bytes, "ror", &["x0", "x1"]);
+        // Include the literal shift amount: an off-by-one in the encoded
+        // immediate would otherwise slip through.
+        disassemble_and_verify(&bytes, "ror", &["x0", "x1", "#5"]);
     }
 
     #[test]

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -505,6 +505,15 @@ impl AArch64Assembler {
                         if *imm < 0 || *imm > 0xFFF {
                             return Err(format!("Immediate {} out of range for ADDS", imm));
                         }
+                        // The immediate-form encoding uses the `Xn|SP` register
+                        // class, which dynasm spells `XSP(...)`. Register index
+                        // 31 decodes as SP, not XZR — so we must refuse XZR as
+                        // `rn` here or we'd emit `ADDS Xd, SP, #imm`.
+                        if *rn == Register::XZR {
+                            return Err(
+                                "ADDS immediate with XZR as `rn` is not encodable (encoding slot is Xn|SP)".to_string(),
+                            );
+                        }
                         let imm = *imm as u32;
                         dynasm!(ops ; .arch aarch64 ; adds X(rd_reg), XSP(rn_reg), imm);
                         Ok(())
@@ -523,6 +532,11 @@ impl AArch64Assembler {
                     Operand::Immediate(imm) => {
                         if *imm < 0 || *imm > 0xFFF {
                             return Err(format!("Immediate {} out of range for SUBS", imm));
+                        }
+                        if *rn == Register::XZR {
+                            return Err(
+                                "SUBS immediate with XZR as `rn` is not encodable (encoding slot is Xn|SP)".to_string(),
+                            );
                         }
                         let imm = *imm as u32;
                         dynasm!(ops ; .arch aarch64 ; subs X(rd_reg), XSP(rn_reg), imm);
@@ -1056,10 +1070,12 @@ mod tests {
         let bytes = assembler
             .assemble_instructions(&instructions)
             .expect("MOVN encoding should succeed");
-        // Capstone may render this as `mov x0, #-65536` (canonicalises movn → mov #-N)
-        // so we only assert that the instruction is exactly 4 bytes and not zero.
-        assert_eq!(bytes.len(), 4);
-        assert_ne!(bytes, [0, 0, 0, 0]);
+        // Exact byte-level check. MOVN 64-bit base is 0x92800000; imm16<<5
+        // for #0xFFFF gives 0x1FFFE0; Rd=0 contributes nothing → word
+        // 0x929FFFE0, little-endian = [0xE0, 0xFF, 0x9F, 0x92]. An off-by-one
+        // in either the imm16 or hw bits would fail this rather than slip
+        // through a Capstone mnemonic check.
+        assert_eq!(bytes, [0xE0, 0xFF, 0x9F, 0x92]);
     }
 
     #[test]
@@ -1119,6 +1135,43 @@ mod tests {
         disassemble_and_verify(&bytes, "csetm", &["x3", "ne"]);
     }
 
+    /// Defense-in-depth: ADDS/SUBS with immediate `rm` and XZR as `rn` would
+    /// encode to `ADDS Xd, SP, #imm` because the immediate-form encoding
+    /// slot is `Xn|SP` (where register 31 means SP, not XZR). The encoder
+    /// must refuse this construction rather than silently using SP.
+    #[test]
+    fn test_adds_subs_imm_reject_xzr_rn() {
+        let mut assembler = AArch64Assembler::new();
+        for instr in [
+            Instruction::Adds {
+                rd: Register::X0,
+                rn: Register::XZR,
+                rm: Operand::Immediate(1),
+            },
+            Instruction::Subs {
+                rd: Register::X0,
+                rn: Register::XZR,
+                rm: Operand::Immediate(1),
+            },
+        ] {
+            let result = assembler.assemble_instructions(&[instr]);
+            assert!(
+                result.is_err(),
+                "Expected encoder to reject {:?}, got {:?}",
+                instr,
+                result
+            );
+        }
+        // Register-form ADDS/SUBS with XZR as rn must still succeed — the
+        // register-form encoding decodes 31 as XZR correctly.
+        let ok = assembler.assemble_instructions(&[Instruction::Adds {
+            rd: Register::X0,
+            rn: Register::XZR,
+            rm: Operand::Register(Register::X1),
+        }]);
+        assert!(ok.is_ok(), "register-form ADDS with XZR should encode");
+    }
+
     /// Defense-in-depth: assembler must refuse CSET/CSETM with AL or NV,
     /// even if a caller bypasses `is_encodable_aarch64`. Lowering
     /// `Cset { cond: AL }` to the alias would emit `csinc ..., nv` (because
@@ -1167,7 +1220,9 @@ mod tests {
         let bytes = assembler
             .assemble_instructions(&instructions)
             .expect("MOVN encoding with shift should succeed");
-        assert_eq!(bytes.len(), 4);
+        // Base 0x92800000 | hw=1<<21 (shift/16=1) = 0x200000 | imm16=1<<5 = 0x20
+        // → 0x92A00020, little-endian = [0x20, 0x00, 0xA0, 0x92].
+        assert_eq!(bytes, [0x20, 0x00, 0xA0, 0x92]);
     }
 
     /// Ensures we emit the 64-bit (sf=1) form, not the 32-bit Wn form —

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -2,6 +2,32 @@ use crate::ir::types::Condition;
 use crate::ir::{Instruction, Operand, Register};
 use dynasmrt::{DynasmApi, dynasm};
 
+/// Emits one of the four CSEL-family mnemonics with the given register
+/// indices and a runtime `Condition` value. dynasm-rs requires the condition
+/// suffix to be a compile-time literal, so we dispatch via a 16-arm match.
+macro_rules! emit_csel {
+    ($ops:expr, $mnem:ident, $rd:expr, $rn:expr, $rm:expr, $cond:expr) => {{
+        match $cond {
+            Condition::EQ => dynasm!($ops ; .arch aarch64 ; $mnem X($rd), X($rn), X($rm), eq),
+            Condition::NE => dynasm!($ops ; .arch aarch64 ; $mnem X($rd), X($rn), X($rm), ne),
+            Condition::CS => dynasm!($ops ; .arch aarch64 ; $mnem X($rd), X($rn), X($rm), cs),
+            Condition::CC => dynasm!($ops ; .arch aarch64 ; $mnem X($rd), X($rn), X($rm), cc),
+            Condition::MI => dynasm!($ops ; .arch aarch64 ; $mnem X($rd), X($rn), X($rm), mi),
+            Condition::PL => dynasm!($ops ; .arch aarch64 ; $mnem X($rd), X($rn), X($rm), pl),
+            Condition::VS => dynasm!($ops ; .arch aarch64 ; $mnem X($rd), X($rn), X($rm), vs),
+            Condition::VC => dynasm!($ops ; .arch aarch64 ; $mnem X($rd), X($rn), X($rm), vc),
+            Condition::HI => dynasm!($ops ; .arch aarch64 ; $mnem X($rd), X($rn), X($rm), hi),
+            Condition::LS => dynasm!($ops ; .arch aarch64 ; $mnem X($rd), X($rn), X($rm), ls),
+            Condition::GE => dynasm!($ops ; .arch aarch64 ; $mnem X($rd), X($rn), X($rm), ge),
+            Condition::LT => dynasm!($ops ; .arch aarch64 ; $mnem X($rd), X($rn), X($rm), lt),
+            Condition::GT => dynasm!($ops ; .arch aarch64 ; $mnem X($rd), X($rn), X($rm), gt),
+            Condition::LE => dynasm!($ops ; .arch aarch64 ; $mnem X($rd), X($rn), X($rm), le),
+            Condition::AL => dynasm!($ops ; .arch aarch64 ; $mnem X($rd), X($rn), X($rm), al),
+            Condition::NV => dynasm!($ops ; .arch aarch64 ; $mnem X($rd), X($rn), X($rm), nv),
+        }
+    }};
+}
+
 pub struct AArch64Assembler;
 
 impl AArch64Assembler {
@@ -352,14 +378,207 @@ impl AArch64Assembler {
                     }
                 }
             }
-            Instruction::Csel { .. } => {
-                // TODO: dynasm doesn't easily support condition code operands
-                // This requires raw encoding or dynasm macro extension
-                Err("CSEL encoding not yet supported".to_string())
+            Instruction::Csel { rd, rn, rm, cond } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                let rm_reg = register_to_dynasm(*rm)?;
+                emit_csel!(ops, csel, rd_reg, rn_reg, rm_reg, *cond);
+                Ok(())
             }
-            Instruction::Csinc { .. } => Err("CSINC encoding not yet supported".to_string()),
-            Instruction::Csinv { .. } => Err("CSINV encoding not yet supported".to_string()),
-            Instruction::Csneg { .. } => Err("CSNEG encoding not yet supported".to_string()),
+            Instruction::Csinc { rd, rn, rm, cond } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                let rm_reg = register_to_dynasm(*rm)?;
+                emit_csel!(ops, csinc, rd_reg, rn_reg, rm_reg, *cond);
+                Ok(())
+            }
+            Instruction::Csinv { rd, rn, rm, cond } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                let rm_reg = register_to_dynasm(*rm)?;
+                emit_csel!(ops, csinv, rd_reg, rn_reg, rm_reg, *cond);
+                Ok(())
+            }
+            Instruction::Csneg { rd, rn, rm, cond } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                let rm_reg = register_to_dynasm(*rm)?;
+                emit_csel!(ops, csneg, rd_reg, rn_reg, rm_reg, *cond);
+                Ok(())
+            }
+            Instruction::Mvn { rd, rm } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rm_reg = register_to_dynasm(*rm)?;
+                dynasm!(ops ; .arch aarch64 ; mvn X(rd_reg), X(rm_reg));
+                Ok(())
+            }
+            Instruction::Neg { rd, rm } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rm_reg = register_to_dynasm(*rm)?;
+                dynasm!(ops ; .arch aarch64 ; neg X(rd_reg), X(rm_reg));
+                Ok(())
+            }
+            Instruction::Negs { rd, rm } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rm_reg = register_to_dynasm(*rm)?;
+                dynasm!(ops ; .arch aarch64 ; negs X(rd_reg), X(rm_reg));
+                Ok(())
+            }
+            Instruction::MovN { rd, imm, shift } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let imm = *imm as u32;
+                match shift {
+                    0 => dynasm!(ops ; .arch aarch64 ; movn X(rd_reg), imm),
+                    16 => dynasm!(ops ; .arch aarch64 ; movn X(rd_reg), imm, lsl #16),
+                    32 => dynasm!(ops ; .arch aarch64 ; movn X(rd_reg), imm, lsl #32),
+                    48 => dynasm!(ops ; .arch aarch64 ; movn X(rd_reg), imm, lsl #48),
+                    other => return Err(format!("MOVN shift {} out of range", other)),
+                }
+                Ok(())
+            }
+            Instruction::Bic { rd, rn, rm } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                match rm {
+                    Operand::Register(r) => {
+                        let rm_reg = register_to_dynasm(*r)?;
+                        dynasm!(ops ; .arch aarch64 ; bic X(rd_reg), X(rn_reg), X(rm_reg));
+                        Ok(())
+                    }
+                    Operand::Immediate(_) => {
+                        Err("BIC immediate encoding not supported".to_string())
+                    }
+                }
+            }
+            Instruction::Bics { rd, rn, rm } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                match rm {
+                    Operand::Register(r) => {
+                        let rm_reg = register_to_dynasm(*r)?;
+                        dynasm!(ops ; .arch aarch64 ; bics X(rd_reg), X(rn_reg), X(rm_reg));
+                        Ok(())
+                    }
+                    Operand::Immediate(_) => {
+                        Err("BICS immediate encoding not supported".to_string())
+                    }
+                }
+            }
+            Instruction::Orn { rd, rn, rm } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                match rm {
+                    Operand::Register(r) => {
+                        let rm_reg = register_to_dynasm(*r)?;
+                        dynasm!(ops ; .arch aarch64 ; orn X(rd_reg), X(rn_reg), X(rm_reg));
+                        Ok(())
+                    }
+                    Operand::Immediate(_) => {
+                        Err("ORN immediate encoding not supported".to_string())
+                    }
+                }
+            }
+            Instruction::Eon { rd, rn, rm } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                match rm {
+                    Operand::Register(r) => {
+                        let rm_reg = register_to_dynasm(*r)?;
+                        dynasm!(ops ; .arch aarch64 ; eon X(rd_reg), X(rn_reg), X(rm_reg));
+                        Ok(())
+                    }
+                    Operand::Immediate(_) => {
+                        Err("EON immediate encoding not supported".to_string())
+                    }
+                }
+            }
+            Instruction::Adds { rd, rn, rm } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                match rm {
+                    Operand::Register(r) => {
+                        let rm_reg = register_to_dynasm(*r)?;
+                        dynasm!(ops ; .arch aarch64 ; adds X(rd_reg), X(rn_reg), X(rm_reg));
+                        Ok(())
+                    }
+                    Operand::Immediate(imm) => {
+                        if *imm < 0 || *imm > 0xFFF {
+                            return Err(format!("Immediate {} out of range for ADDS", imm));
+                        }
+                        let imm = *imm as u32;
+                        dynasm!(ops ; .arch aarch64 ; adds X(rd_reg), XSP(rn_reg), imm);
+                        Ok(())
+                    }
+                }
+            }
+            Instruction::Subs { rd, rn, rm } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                match rm {
+                    Operand::Register(r) => {
+                        let rm_reg = register_to_dynasm(*r)?;
+                        dynasm!(ops ; .arch aarch64 ; subs X(rd_reg), X(rn_reg), X(rm_reg));
+                        Ok(())
+                    }
+                    Operand::Immediate(imm) => {
+                        if *imm < 0 || *imm > 0xFFF {
+                            return Err(format!("Immediate {} out of range for SUBS", imm));
+                        }
+                        let imm = *imm as u32;
+                        dynasm!(ops ; .arch aarch64 ; subs X(rd_reg), XSP(rn_reg), imm);
+                        Ok(())
+                    }
+                }
+            }
+            Instruction::Ands { rd, rn, rm } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                match rm {
+                    Operand::Register(r) => {
+                        let rm_reg = register_to_dynasm(*r)?;
+                        dynasm!(ops ; .arch aarch64 ; ands X(rd_reg), X(rn_reg), X(rm_reg));
+                        Ok(())
+                    }
+                    Operand::Immediate(_) => {
+                        Err("ANDS immediate encoding not supported".to_string())
+                    }
+                }
+            }
+            // CSET / CSETM lower to CSINC/CSINV with XZR sources and inverted cond.
+            // Capstone canonicalises the disassembly back to `cset`/`csetm`.
+            Instruction::Cset { rd, cond } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let xzr: u8 = 31;
+                let inv = cond.invert();
+                emit_csel!(ops, csinc, rd_reg, xzr, xzr, inv);
+                Ok(())
+            }
+            Instruction::Csetm { rd, cond } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let xzr: u8 = 31;
+                let inv = cond.invert();
+                emit_csel!(ops, csinv, rd_reg, xzr, xzr, inv);
+                Ok(())
+            }
+            Instruction::Ror { rd, rn, shift } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                match shift {
+                    Operand::Register(r) => {
+                        let rm_reg = register_to_dynasm(*r)?;
+                        dynasm!(ops ; .arch aarch64 ; ror X(rd_reg), X(rn_reg), X(rm_reg));
+                        Ok(())
+                    }
+                    Operand::Immediate(imm) => {
+                        if *imm < 0 || *imm > 63 {
+                            return Err(format!("ROR shift {} out of range", imm));
+                        }
+                        let imm = *imm as u32;
+                        dynasm!(ops ; .arch aarch64 ; ror X(rd_reg), X(rn_reg), imm);
+                        Ok(())
+                    }
+                }
+            }
         }
     }
 }
@@ -373,28 +592,6 @@ impl Default for AArch64Assembler {
 fn register_to_dynasm(reg: Register) -> Result<u8, String> {
     reg.index()
         .ok_or_else(|| format!("Register {:?} not supported in dynasm encoding", reg))
-}
-
-#[allow(dead_code)]
-fn condition_to_dynasm(cond: Condition) -> Result<u8, String> {
-    Ok(match cond {
-        Condition::EQ => 0b0000,
-        Condition::NE => 0b0001,
-        Condition::CS => 0b0010,
-        Condition::CC => 0b0011,
-        Condition::MI => 0b0100,
-        Condition::PL => 0b0101,
-        Condition::VS => 0b0110,
-        Condition::VC => 0b0111,
-        Condition::HI => 0b1000,
-        Condition::LS => 0b1001,
-        Condition::GE => 0b1010,
-        Condition::LT => 0b1011,
-        Condition::GT => 0b1100,
-        Condition::LE => 0b1101,
-        Condition::AL => 0b1110,
-        Condition::NV => 0b1111,
-    })
 }
 
 #[cfg(test)]
@@ -727,5 +924,227 @@ mod tests {
             .assemble_instructions(&instructions)
             .expect("LSL register encoding should succeed");
         disassemble_and_verify(&bytes, "lsl", &["x0", "x1", "x2"]);
+    }
+
+    #[test]
+    fn test_csel_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Csel {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+            cond: Condition::EQ,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("CSEL encoding should succeed");
+        disassemble_and_verify(&bytes, "csel", &["x0", "x1", "x2", "eq"]);
+    }
+
+    #[test]
+    fn test_csinc_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Csinc {
+            rd: Register::X3,
+            rn: Register::X4,
+            rm: Register::X5,
+            cond: Condition::NE,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("CSINC encoding should succeed");
+        disassemble_and_verify(&bytes, "csinc", &["x3", "x4", "x5", "ne"]);
+    }
+
+    #[test]
+    fn test_csinv_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Csinv {
+            rd: Register::X10,
+            rn: Register::X11,
+            rm: Register::X12,
+            cond: Condition::LT,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("CSINV encoding should succeed");
+        disassemble_and_verify(&bytes, "csinv", &["x10", "x11", "x12", "lt"]);
+    }
+
+    #[test]
+    fn test_csneg_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Csneg {
+            rd: Register::X20,
+            rn: Register::X21,
+            rm: Register::X22,
+            cond: Condition::GE,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("CSNEG encoding should succeed");
+        disassemble_and_verify(&bytes, "csneg", &["x20", "x21", "x22", "ge"]);
+    }
+
+    #[test]
+    fn test_mvn_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Mvn {
+            rd: Register::X0,
+            rm: Register::X1,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("MVN encoding should succeed");
+        disassemble_and_verify(&bytes, "mvn", &["x0", "x1"]);
+    }
+
+    #[test]
+    fn test_neg_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Neg {
+            rd: Register::X0,
+            rm: Register::X1,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("NEG encoding should succeed");
+        disassemble_and_verify(&bytes, "neg", &["x0", "x1"]);
+    }
+
+    #[test]
+    fn test_negs_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Negs {
+            rd: Register::X0,
+            rm: Register::X1,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("NEGS encoding should succeed");
+        disassemble_and_verify(&bytes, "negs", &["x0", "x1"]);
+    }
+
+    #[test]
+    fn test_movn_correctness_shift_0() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::MovN {
+            rd: Register::X0,
+            imm: 0xFFFF,
+            shift: 0,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("MOVN encoding should succeed");
+        // Capstone may render this as `mov x0, #-65536` (canonicalises movn → mov #-N)
+        // so we only assert that the instruction is exactly 4 bytes and not zero.
+        assert_eq!(bytes.len(), 4);
+        assert_ne!(bytes, [0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn test_cset_disassembles_to_cset() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Cset {
+            rd: Register::X0,
+            cond: Condition::EQ,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("CSET encoding should succeed");
+        // Capstone canonicalises `csinc x0, xzr, xzr, ne` back to `cset x0, eq`
+        disassemble_and_verify(&bytes, "cset", &["x0", "eq"]);
+    }
+
+    #[test]
+    fn test_ror_imm_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Ror {
+            rd: Register::X0,
+            rn: Register::X1,
+            shift: Operand::Immediate(5),
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("ROR imm encoding should succeed");
+        disassemble_and_verify(&bytes, "ror", &["x0", "x1"]);
+    }
+
+    #[test]
+    fn test_ror_reg_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Ror {
+            rd: Register::X0,
+            rn: Register::X1,
+            shift: Operand::Register(Register::X2),
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("ROR reg encoding should succeed");
+        disassemble_and_verify(&bytes, "ror", &["x0", "x1", "x2"]);
+    }
+
+    #[test]
+    fn test_csetm_disassembles_to_csetm() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Csetm {
+            rd: Register::X3,
+            cond: Condition::NE,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("CSETM encoding should succeed");
+        disassemble_and_verify(&bytes, "csetm", &["x3", "ne"]);
+    }
+
+    #[test]
+    fn test_movn_correctness_shift_16() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::MovN {
+            rd: Register::X0,
+            imm: 1,
+            shift: 16,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("MOVN encoding with shift should succeed");
+        assert_eq!(bytes.len(), 4);
+    }
+
+    /// Ensures we emit the 64-bit (sf=1) form, not the 32-bit Wn form —
+    /// regression for the encoding bit-pattern error.
+    #[test]
+    fn test_csinv_is_xform_not_wform() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Csinv {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+            cond: Condition::EQ,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("CSINV encoding should succeed");
+        // disassemble_and_verify asserts mnemonic and operand presence; here
+        // we additionally assert the operands are xN, not wN.
+        use capstone::prelude::*;
+        let cs = Capstone::new()
+            .arm64()
+            .mode(arch::arm64::ArchMode::Arm)
+            .build()
+            .expect("Capstone");
+        let insns = cs.disasm_all(&bytes, 0).expect("disasm");
+        let insn = insns.iter().next().expect("instruction");
+        let op_str = insn.op_str().expect("op_str");
+        assert!(
+            op_str.contains("x0") && op_str.contains("x1") && op_str.contains("x2"),
+            "Expected 64-bit Xn form, got: {}",
+            op_str
+        );
+        assert!(
+            !op_str.contains("w0") && !op_str.contains("w1") && !op_str.contains("w2"),
+            "Got 32-bit Wn form (sf-bit error); op_str: {}",
+            op_str
+        );
     }
 }

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -546,7 +546,21 @@ impl AArch64Assembler {
             }
             // CSET / CSETM lower to CSINC/CSINV with XZR sources and inverted cond.
             // Capstone canonicalises the disassembly back to `cset`/`csetm`.
+            //
+            // Defense-in-depth: reject AL/NV here too. `is_encodable_aarch64`
+            // already filters them at the IR level, but a caller could
+            // construct the variant directly and bypass that check. Without
+            // this guard, `Cset { cond: AL }` would lower to `csinc ..., nv`
+            // (because invert(AL) = NV), which on AArch64 writes 0 — the
+            // opposite of the IR's "always 1" semantics. CSETM has the
+            // symmetric issue.
             Instruction::Cset { rd, cond } => {
+                if matches!(cond, Condition::AL | Condition::NV) {
+                    return Err(format!(
+                        "CSET with {} is not encodable (AL/NV reserved)",
+                        cond
+                    ));
+                }
                 let rd_reg = register_to_dynasm(*rd)?;
                 let xzr: u8 = 31;
                 let inv = cond.invert();
@@ -554,6 +568,12 @@ impl AArch64Assembler {
                 Ok(())
             }
             Instruction::Csetm { rd, cond } => {
+                if matches!(cond, Condition::AL | Condition::NV) {
+                    return Err(format!(
+                        "CSETM with {} is not encodable (AL/NV reserved)",
+                        cond
+                    ));
+                }
                 let rd_reg = register_to_dynasm(*rd)?;
                 let xzr: u8 = 31;
                 let inv = cond.invert();
@@ -1097,6 +1117,43 @@ mod tests {
             .assemble_instructions(&instructions)
             .expect("CSETM encoding should succeed");
         disassemble_and_verify(&bytes, "csetm", &["x3", "ne"]);
+    }
+
+    /// Defense-in-depth: assembler must refuse CSET/CSETM with AL or NV,
+    /// even if a caller bypasses `is_encodable_aarch64`. Lowering
+    /// `Cset { cond: AL }` to the alias would emit `csinc ..., nv` (because
+    /// invert(AL) = NV), which on AArch64 writes 0 — the opposite of the
+    /// IR's "always 1" semantics.
+    #[test]
+    fn test_cset_rejects_al_at_encoder() {
+        let mut assembler = AArch64Assembler::new();
+        let cases = [
+            Instruction::Cset {
+                rd: Register::X0,
+                cond: Condition::AL,
+            },
+            Instruction::Cset {
+                rd: Register::X0,
+                cond: Condition::NV,
+            },
+            Instruction::Csetm {
+                rd: Register::X0,
+                cond: Condition::AL,
+            },
+            Instruction::Csetm {
+                rd: Register::X0,
+                cond: Condition::NV,
+            },
+        ];
+        for instr in cases {
+            let result = assembler.assemble_instructions(&[instr]);
+            assert!(
+                result.is_err(),
+                "Expected encoder to reject {:?}, got {:?}",
+                instr,
+                result
+            );
+        }
     }
 
     #[test]

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -247,7 +247,6 @@ impl Instruction {
     /// can co-occur with `destination().is_some()` — those write both a
     /// register and the NZCV flags. Earlier callers that assumed
     /// "flag-setter ⇒ no destination" must be re-verified.
-    #[allow(dead_code)]
     pub fn modifies_flags(&self) -> bool {
         matches!(
             self,

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -119,6 +119,85 @@ pub enum Instruction {
         rm: Register,
         cond: Condition,
     },
+
+    // Bitwise NOT (alias of ORN with XZR)
+    Mvn {
+        rd: Register,
+        rm: Register,
+    },
+    // Two's-complement negation (alias of SUB from XZR)
+    Neg {
+        rd: Register,
+        rm: Register,
+    },
+    // Flag-setting negation (alias of SUBS from XZR)
+    Negs {
+        rd: Register,
+        rm: Register,
+    },
+    // Move-negated immediate: rd = !((imm as u64) << shift), shift ∈ {0,16,32,48}
+    MovN {
+        rd: Register,
+        imm: u16,
+        shift: u8,
+    },
+
+    // Inverted-logical (second operand bitwise-NOTed before the op)
+    Bic {
+        rd: Register,
+        rn: Register,
+        rm: Operand,
+    },
+    Bics {
+        rd: Register,
+        rn: Register,
+        rm: Operand,
+    },
+    Orn {
+        rd: Register,
+        rn: Register,
+        rm: Operand,
+    },
+    Eon {
+        rd: Register,
+        rn: Register,
+        rm: Operand,
+    },
+
+    // Flag-setting arithmetic / logical
+    Adds {
+        rd: Register,
+        rn: Register,
+        rm: Operand,
+    },
+    Subs {
+        rd: Register,
+        rn: Register,
+        rm: Operand,
+    },
+    Ands {
+        rd: Register,
+        rn: Register,
+        rm: Operand,
+    },
+
+    // Conditional set: rd = (cond holds) ? 1 : 0
+    Cset {
+        rd: Register,
+        cond: Condition,
+    },
+    // Conditional set mask: rd = (cond holds) ? -1 : 0
+    Csetm {
+        rd: Register,
+        cond: Condition,
+    },
+
+    // Rotate right (immediate or register form)
+    Ror {
+        rd: Register,
+        rn: Register,
+        shift: Operand,
+    },
 }
 
 impl Instruction {
@@ -142,18 +221,44 @@ impl Instruction {
             | Instruction::Csel { rd, .. }
             | Instruction::Csinc { rd, .. }
             | Instruction::Csinv { rd, .. }
-            | Instruction::Csneg { rd, .. } => Some(*rd),
+            | Instruction::Csneg { rd, .. }
+            | Instruction::Mvn { rd, .. }
+            | Instruction::Neg { rd, .. }
+            | Instruction::Negs { rd, .. }
+            | Instruction::MovN { rd, .. }
+            | Instruction::Bic { rd, .. }
+            | Instruction::Bics { rd, .. }
+            | Instruction::Orn { rd, .. }
+            | Instruction::Eon { rd, .. }
+            | Instruction::Adds { rd, .. }
+            | Instruction::Subs { rd, .. }
+            | Instruction::Ands { rd, .. }
+            | Instruction::Cset { rd, .. }
+            | Instruction::Csetm { rd, .. }
+            | Instruction::Ror { rd, .. } => Some(*rd),
             // Comparison instructions only set flags, no destination register
             Instruction::Cmp { .. } | Instruction::Cmn { .. } | Instruction::Tst { .. } => None,
         }
     }
 
-    /// Returns true if this instruction modifies NZCV flags
+    /// Returns true if this instruction modifies NZCV flags.
+    ///
+    /// Note: for flag-setting variants (NEGS, ADDS, SUBS, ANDS, BICS), this
+    /// can co-occur with `destination().is_some()` — those write both a
+    /// register and the NZCV flags. Earlier callers that assumed
+    /// "flag-setter ⇒ no destination" must be re-verified.
     #[allow(dead_code)]
     pub fn modifies_flags(&self) -> bool {
         matches!(
             self,
-            Instruction::Cmp { .. } | Instruction::Cmn { .. } | Instruction::Tst { .. }
+            Instruction::Cmp { .. }
+                | Instruction::Cmn { .. }
+                | Instruction::Tst { .. }
+                | Instruction::Negs { .. }
+                | Instruction::Bics { .. }
+                | Instruction::Adds { .. }
+                | Instruction::Subs { .. }
+                | Instruction::Ands { .. }
         )
     }
 
@@ -166,6 +271,8 @@ impl Instruction {
                 | Instruction::Csinc { .. }
                 | Instruction::Csinv { .. }
                 | Instruction::Csneg { .. }
+                | Instruction::Cset { .. }
+                | Instruction::Csetm { .. }
         )
     }
 
@@ -222,6 +329,38 @@ impl Instruction {
             | Instruction::Csinc { .. }
             | Instruction::Csinv { .. }
             | Instruction::Csneg { .. } => true,
+
+            // MVN / NEG / NEGS: always encodable (register-only)
+            Instruction::Mvn { .. } | Instruction::Neg { .. } | Instruction::Negs { .. } => true,
+
+            // MOVN: shift must be one of {0, 16, 32, 48}; u16 imm is always in range.
+            Instruction::MovN { shift, .. } => matches!(shift, 0 | 16 | 32 | 48),
+
+            // BIC / BICS / ORN / EON: register-only (matching AND precedent).
+            Instruction::Bic { rm, .. }
+            | Instruction::Bics { rm, .. }
+            | Instruction::Orn { rm, .. }
+            | Instruction::Eon { rm, .. } => matches!(rm, Operand::Register(_)),
+
+            // ADDS/SUBS: imm 0..=0xFFF (same as ADD/SUB).
+            Instruction::Adds { rm, .. } | Instruction::Subs { rm, .. } => match rm {
+                Operand::Register(_) => true,
+                Operand::Immediate(imm) => *imm >= 0 && *imm <= 0xFFF,
+            },
+            // ANDS: register-only (same as AND).
+            Instruction::Ands { rm, .. } => matches!(rm, Operand::Register(_)),
+
+            // CSET / CSETM: reject AL (always true ⇒ unconditional 1/-1) and
+            // NV (reserved). All other 14 conditions are encodable.
+            Instruction::Cset { cond, .. } | Instruction::Csetm { cond, .. } => {
+                !matches!(cond, Condition::AL | Condition::NV)
+            }
+
+            // ROR: shift amount 0..=63 (same as LSL/LSR/ASR).
+            Instruction::Ror { shift, .. } => match shift {
+                Operand::Register(_) => true,
+                Operand::Immediate(amt) => *amt >= 0 && *amt <= 63,
+            },
         }
     }
 
@@ -269,6 +408,36 @@ impl Instruction {
             | Instruction::Csinc { rn, rm, .. }
             | Instruction::Csinv { rn, rm, .. }
             | Instruction::Csneg { rn, rm, .. } => vec![*rn, *rm],
+            // Unary
+            Instruction::Mvn { rm, .. }
+            | Instruction::Neg { rm, .. }
+            | Instruction::Negs { rm, .. } => vec![*rm],
+            // MOVN takes no register source
+            Instruction::MovN { .. } => vec![],
+            // Inverted-logical (BIC / BICS / ORN / EON) and flag-setting arith/logical
+            Instruction::Bic { rn, rm, .. }
+            | Instruction::Bics { rn, rm, .. }
+            | Instruction::Orn { rn, rm, .. }
+            | Instruction::Eon { rn, rm, .. }
+            | Instruction::Adds { rn, rm, .. }
+            | Instruction::Subs { rn, rm, .. }
+            | Instruction::Ands { rn, rm, .. } => {
+                let mut regs = vec![*rn];
+                if let Operand::Register(r) = rm {
+                    regs.push(*r);
+                }
+                regs
+            }
+            // CSET / CSETM have no source registers (read flags, not regs).
+            Instruction::Cset { .. } | Instruction::Csetm { .. } => vec![],
+            // ROR reads rn and shift (if register)
+            Instruction::Ror { rn, shift, .. } => {
+                let mut regs = vec![*rn];
+                if let Operand::Register(r) = shift {
+                    regs.push(*r);
+                }
+                regs
+            }
         }
     }
 }
@@ -306,6 +475,26 @@ impl fmt::Display for Instruction {
             Instruction::Csneg { rd, rn, rm, cond } => {
                 write!(f, "csneg {}, {}, {}, {}", rd, rn, rm, cond)
             }
+            Instruction::Mvn { rd, rm } => write!(f, "mvn {}, {}", rd, rm),
+            Instruction::Neg { rd, rm } => write!(f, "neg {}, {}", rd, rm),
+            Instruction::Negs { rd, rm } => write!(f, "negs {}, {}", rd, rm),
+            Instruction::MovN { rd, imm, shift } => {
+                if *shift == 0 {
+                    write!(f, "movn {}, #{}", rd, imm)
+                } else {
+                    write!(f, "movn {}, #{}, lsl #{}", rd, imm, shift)
+                }
+            }
+            Instruction::Bic { rd, rn, rm } => write!(f, "bic {}, {}, {}", rd, rn, rm),
+            Instruction::Bics { rd, rn, rm } => write!(f, "bics {}, {}, {}", rd, rn, rm),
+            Instruction::Orn { rd, rn, rm } => write!(f, "orn {}, {}, {}", rd, rn, rm),
+            Instruction::Eon { rd, rn, rm } => write!(f, "eon {}, {}, {}", rd, rn, rm),
+            Instruction::Adds { rd, rn, rm } => write!(f, "adds {}, {}, {}", rd, rn, rm),
+            Instruction::Subs { rd, rn, rm } => write!(f, "subs {}, {}, {}", rd, rn, rm),
+            Instruction::Ands { rd, rn, rm } => write!(f, "ands {}, {}, {}", rd, rn, rm),
+            Instruction::Cset { rd, cond } => write!(f, "cset {}, {}", rd, cond),
+            Instruction::Csetm { rd, cond } => write!(f, "csetm {}, {}", rd, cond),
+            Instruction::Ror { rd, rn, shift } => write!(f, "ror {}, {}, {}", rd, rn, shift),
         }
     }
 }
@@ -566,6 +755,20 @@ mod tests {
             }
             .is_encodable_aarch64()
         );
+    }
+
+    #[test]
+    fn test_mvn_display_and_helpers() {
+        let mvn = Instruction::Mvn {
+            rd: Register::X0,
+            rm: Register::X1,
+        };
+        assert_eq!(format!("{}", mvn), "mvn x0, x1");
+        assert_eq!(mvn.destination(), Some(Register::X0));
+        assert_eq!(mvn.source_registers(), vec![Register::X1]);
+        assert!(!mvn.modifies_flags());
+        assert!(!mvn.reads_flags());
+        assert!(mvn.is_encodable_aarch64());
     }
 
     #[test]

--- a/src/ir/types.rs
+++ b/src/ir/types.rs
@@ -225,12 +225,31 @@ impl fmt::Display for Condition {
     }
 }
 
+/// The 14 condition codes that are sensible operands for CSET / CSETM /
+/// stochastic mutation. AL (always true) and NV (reserved) are excluded —
+/// see `Condition::invert()` for the underlying AArch64 pairing rule.
+pub const NORMAL_CONDITIONS: [Condition; 14] = [
+    Condition::EQ,
+    Condition::NE,
+    Condition::CS,
+    Condition::CC,
+    Condition::MI,
+    Condition::PL,
+    Condition::VS,
+    Condition::VC,
+    Condition::HI,
+    Condition::LS,
+    Condition::GE,
+    Condition::LT,
+    Condition::GT,
+    Condition::LE,
+];
+
 impl Condition {
     /// Returns the logical inverse of a condition code. AArch64 encodes the
     /// invert by toggling the low bit of the 4-bit condition field, so pairs
     /// are: EQ↔NE, CS↔CC, MI↔PL, VS↔VC, HI↔LS, GE↔LT, GT↔LE, AL↔NV.
     #[must_use]
-    #[allow(dead_code)] // used by Phase 4 CSET/CSETM encoder
     pub fn invert(self) -> Condition {
         match self {
             Condition::EQ => Condition::NE,
@@ -250,6 +269,14 @@ impl Condition {
             Condition::AL => Condition::NV,
             Condition::NV => Condition::AL,
         }
+    }
+
+    /// Pick a random condition code from [`NORMAL_CONDITIONS`] (excludes
+    /// AL / NV — those are encoder-rejected by `is_encodable_aarch64` for
+    /// CSET / CSETM and have no real meaning for stochastic mutation).
+    #[must_use]
+    pub fn random_normal<R: rand::RngExt>(rng: &mut R) -> Condition {
+        NORMAL_CONDITIONS[rng.random_range(0..NORMAL_CONDITIONS.len())]
     }
 }
 

--- a/src/ir/types.rs
+++ b/src/ir/types.rs
@@ -225,6 +225,34 @@ impl fmt::Display for Condition {
     }
 }
 
+impl Condition {
+    /// Returns the logical inverse of a condition code. AArch64 encodes the
+    /// invert by toggling the low bit of the 4-bit condition field, so pairs
+    /// are: EQ↔NE, CS↔CC, MI↔PL, VS↔VC, HI↔LS, GE↔LT, GT↔LE, AL↔NV.
+    #[must_use]
+    #[allow(dead_code)] // used by Phase 4 CSET/CSETM encoder
+    pub fn invert(self) -> Condition {
+        match self {
+            Condition::EQ => Condition::NE,
+            Condition::NE => Condition::EQ,
+            Condition::CS => Condition::CC,
+            Condition::CC => Condition::CS,
+            Condition::MI => Condition::PL,
+            Condition::PL => Condition::MI,
+            Condition::VS => Condition::VC,
+            Condition::VC => Condition::VS,
+            Condition::HI => Condition::LS,
+            Condition::LS => Condition::HI,
+            Condition::GE => Condition::LT,
+            Condition::LT => Condition::GE,
+            Condition::GT => Condition::LE,
+            Condition::LE => Condition::GT,
+            Condition::AL => Condition::NV,
+            Condition::NV => Condition::AL,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -257,5 +285,53 @@ mod tests {
         assert_eq!(format!("{}", Operand::Register(Register::X5)), "x5");
         assert_eq!(format!("{}", Operand::Immediate(42)), "#42");
         assert_eq!(format!("{}", Operand::Immediate(-1)), "#-1");
+    }
+
+    #[test]
+    fn test_condition_invert_pairs() {
+        let pairs = [
+            (Condition::EQ, Condition::NE),
+            (Condition::CS, Condition::CC),
+            (Condition::MI, Condition::PL),
+            (Condition::VS, Condition::VC),
+            (Condition::HI, Condition::LS),
+            (Condition::GE, Condition::LT),
+            (Condition::GT, Condition::LE),
+            (Condition::AL, Condition::NV),
+        ];
+        for (a, b) in pairs {
+            assert_eq!(a.invert(), b, "{:?}.invert() should be {:?}", a, b);
+            assert_eq!(b.invert(), a, "{:?}.invert() should be {:?}", b, a);
+        }
+    }
+
+    #[test]
+    fn test_condition_invert_is_involution() {
+        for c in [
+            Condition::EQ,
+            Condition::NE,
+            Condition::CS,
+            Condition::CC,
+            Condition::MI,
+            Condition::PL,
+            Condition::VS,
+            Condition::VC,
+            Condition::HI,
+            Condition::LS,
+            Condition::GE,
+            Condition::LT,
+            Condition::GT,
+            Condition::LE,
+            Condition::AL,
+            Condition::NV,
+        ] {
+            assert_eq!(
+                c.invert().invert(),
+                c,
+                "{:?}.invert().invert() != {:?}",
+                c,
+                c
+            );
+        }
     }
 }

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -182,13 +182,6 @@ impl InstructionType for Instruction {
     }
 }
 
-/// Pick a random condition code excluding AL/NV (the two reserved-for-CSET-rejection cases).
-fn random_normal_condition<R: rand::RngExt>(rng: &mut R) -> Condition {
-    use crate::ir::types::Condition::*;
-    const NORMAL: [Condition; 14] = [EQ, NE, CS, CC, MI, PL, VS, VC, HI, LS, GE, LT, GT, LE];
-    NORMAL[rng.random_range(0..NORMAL.len())]
-}
-
 /// AArch64 instruction generator
 #[derive(Clone, Debug, Default)]
 pub struct AArch64InstructionGenerator;
@@ -587,7 +580,16 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                         Instruction::Negs { rd, rm: new_rm }
                     }
                     Instruction::MovN { rd, shift, .. } => {
-                        // Mutate just the immediate; keep shift legal.
+                        // "Change source operand" strategy: for MOVN the only
+                        // source operand is `imm`. The `shift` field is part
+                        // of the encoding form, not the source-operand set,
+                        // so we leave it alone here.
+                        //
+                        // The more granular per-field mutator in
+                        // `search/stochastic/mutation.rs` (mutate_operand)
+                        // also covers `shift` because it picks among rd,
+                        // imm, and shift uniformly. Both paths are
+                        // intentionally distinct.
                         let new_imm = (rng.random::<u32>() & 0xFFFF) as u16;
                         Instruction::MovN {
                             rd,
@@ -632,11 +634,11 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     // Pick from the 14 sensible conditions (skip AL/NV).
                     Instruction::Cset { rd, .. } => Instruction::Cset {
                         rd,
-                        cond: random_normal_condition(rng),
+                        cond: Condition::random_normal(rng),
                     },
                     Instruction::Csetm { rd, .. } => Instruction::Csetm {
                         rd,
-                        cond: random_normal_condition(rng),
+                        cond: Condition::random_normal(rng),
                     },
                     Instruction::Ror { rd, rn, shift } => {
                         let new_shift = mutate_shift_operand(rng, shift, registers);

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -4,6 +4,7 @@
 
 #![allow(dead_code)]
 
+use crate::ir::types::Condition;
 use crate::ir::{Instruction, Operand, Register};
 use crate::isa::traits::{ISA, InstructionGenerator, InstructionType, OperandType, RegisterType};
 
@@ -121,6 +122,20 @@ impl InstructionType for Instruction {
             Instruction::Csinc { .. } => 17,
             Instruction::Csinv { .. } => 18,
             Instruction::Csneg { .. } => 19,
+            Instruction::Mvn { .. } => 20,
+            Instruction::Neg { .. } => 21,
+            Instruction::Negs { .. } => 22,
+            Instruction::MovN { .. } => 23,
+            Instruction::Bic { .. } => 24,
+            Instruction::Bics { .. } => 25,
+            Instruction::Orn { .. } => 26,
+            Instruction::Eon { .. } => 27,
+            Instruction::Adds { .. } => 28,
+            Instruction::Subs { .. } => 29,
+            Instruction::Ands { .. } => 30,
+            Instruction::Cset { .. } => 31,
+            Instruction::Csetm { .. } => 32,
+            Instruction::Ror { .. } => 33,
         }
     }
 
@@ -145,12 +160,33 @@ impl InstructionType for Instruction {
             Instruction::Csinc { .. } => "csinc",
             Instruction::Csinv { .. } => "csinv",
             Instruction::Csneg { .. } => "csneg",
+            Instruction::Mvn { .. } => "mvn",
+            Instruction::Neg { .. } => "neg",
+            Instruction::Negs { .. } => "negs",
+            Instruction::MovN { .. } => "movn",
+            Instruction::Bic { .. } => "bic",
+            Instruction::Bics { .. } => "bics",
+            Instruction::Orn { .. } => "orn",
+            Instruction::Eon { .. } => "eon",
+            Instruction::Adds { .. } => "adds",
+            Instruction::Subs { .. } => "subs",
+            Instruction::Ands { .. } => "ands",
+            Instruction::Cset { .. } => "cset",
+            Instruction::Csetm { .. } => "csetm",
+            Instruction::Ror { .. } => "ror",
         }
     }
 
     fn has_side_effects(&self) -> bool {
         false // Current instructions have no side effects
     }
+}
+
+/// Pick a random condition code excluding AL/NV (the two reserved-for-CSET-rejection cases).
+fn random_normal_condition<R: rand::RngExt>(rng: &mut R) -> Condition {
+    use crate::ir::types::Condition::*;
+    const NORMAL: [Condition; 14] = [EQ, NE, CS, CC, MI, PL, VS, VC, HI, LS, GE, LT, GT, LE];
+    NORMAL[rng.random_range(0..NORMAL.len())]
 }
 
 /// AArch64 instruction generator
@@ -392,6 +428,28 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                         rm,
                         cond,
                     },
+                    Instruction::Mvn { rm, .. } => Instruction::Mvn { rd: new_rd, rm },
+                    Instruction::Neg { rm, .. } => Instruction::Neg { rd: new_rd, rm },
+                    Instruction::Negs { rm, .. } => Instruction::Negs { rd: new_rd, rm },
+                    Instruction::MovN { imm, shift, .. } => Instruction::MovN {
+                        rd: new_rd,
+                        imm,
+                        shift,
+                    },
+                    Instruction::Bic { rn, rm, .. } => Instruction::Bic { rd: new_rd, rn, rm },
+                    Instruction::Bics { rn, rm, .. } => Instruction::Bics { rd: new_rd, rn, rm },
+                    Instruction::Orn { rn, rm, .. } => Instruction::Orn { rd: new_rd, rn, rm },
+                    Instruction::Eon { rn, rm, .. } => Instruction::Eon { rd: new_rd, rn, rm },
+                    Instruction::Adds { rn, rm, .. } => Instruction::Adds { rd: new_rd, rn, rm },
+                    Instruction::Subs { rn, rm, .. } => Instruction::Subs { rd: new_rd, rn, rm },
+                    Instruction::Ands { rn, rm, .. } => Instruction::Ands { rd: new_rd, rn, rm },
+                    Instruction::Cset { cond, .. } => Instruction::Cset { rd: new_rd, cond },
+                    Instruction::Csetm { cond, .. } => Instruction::Csetm { rd: new_rd, cond },
+                    Instruction::Ror { rn, shift, .. } => Instruction::Ror {
+                        rd: new_rd,
+                        rn,
+                        shift,
+                    },
                 }
             }
             2 => {
@@ -516,6 +574,78 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                             cond,
                         }
                     }
+                    Instruction::Mvn { rd, .. } => {
+                        let new_rm = registers[rng.random_range(0..registers.len())];
+                        Instruction::Mvn { rd, rm: new_rm }
+                    }
+                    Instruction::Neg { rd, .. } => {
+                        let new_rm = registers[rng.random_range(0..registers.len())];
+                        Instruction::Neg { rd, rm: new_rm }
+                    }
+                    Instruction::Negs { rd, .. } => {
+                        let new_rm = registers[rng.random_range(0..registers.len())];
+                        Instruction::Negs { rd, rm: new_rm }
+                    }
+                    Instruction::MovN { rd, shift, .. } => {
+                        // Mutate just the immediate; keep shift legal.
+                        let new_imm = (rng.random::<u32>() & 0xFFFF) as u16;
+                        Instruction::MovN {
+                            rd,
+                            imm: new_imm,
+                            shift,
+                        }
+                    }
+                    Instruction::Bic { rd, rn, rm: _ } => {
+                        let new_rm =
+                            Operand::Register(registers[rng.random_range(0..registers.len())]);
+                        Instruction::Bic { rd, rn, rm: new_rm }
+                    }
+                    Instruction::Bics { rd, rn, rm: _ } => {
+                        let new_rm =
+                            Operand::Register(registers[rng.random_range(0..registers.len())]);
+                        Instruction::Bics { rd, rn, rm: new_rm }
+                    }
+                    Instruction::Orn { rd, rn, rm: _ } => {
+                        let new_rm =
+                            Operand::Register(registers[rng.random_range(0..registers.len())]);
+                        Instruction::Orn { rd, rn, rm: new_rm }
+                    }
+                    Instruction::Eon { rd, rn, rm: _ } => {
+                        let new_rm =
+                            Operand::Register(registers[rng.random_range(0..registers.len())]);
+                        Instruction::Eon { rd, rn, rm: new_rm }
+                    }
+                    Instruction::Adds { rd, rn, rm } => {
+                        let new_rm = mutate_operand(rng, rm, registers, immediates);
+                        Instruction::Adds { rd, rn, rm: new_rm }
+                    }
+                    Instruction::Subs { rd, rn, rm } => {
+                        let new_rm = mutate_operand(rng, rm, registers, immediates);
+                        Instruction::Subs { rd, rn, rm: new_rm }
+                    }
+                    Instruction::Ands { rd, rn, rm: _ } => {
+                        let new_rm =
+                            Operand::Register(registers[rng.random_range(0..registers.len())]);
+                        Instruction::Ands { rd, rn, rm: new_rm }
+                    }
+                    // CSET / CSETM: only thing to "change as operand" is the cond.
+                    // Pick from the 14 sensible conditions (skip AL/NV).
+                    Instruction::Cset { rd, .. } => Instruction::Cset {
+                        rd,
+                        cond: random_normal_condition(rng),
+                    },
+                    Instruction::Csetm { rd, .. } => Instruction::Csetm {
+                        rd,
+                        cond: random_normal_condition(rng),
+                    },
+                    Instruction::Ror { rd, rn, shift } => {
+                        let new_shift = mutate_shift_operand(rng, shift, registers);
+                        Instruction::Ror {
+                            rd,
+                            rn,
+                            shift: new_shift,
+                        }
+                    }
                 }
             }
             _ => unreachable!(),
@@ -523,7 +653,8 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
     }
 
     fn opcode_count(&self) -> u8 {
-        20 // MovReg, MovImm, Add, Sub, And, Orr, Eor, Lsl, Lsr, Asr, Mul, Sdiv, Udiv, Cmp, Cmn, Tst, Csel, Csinc, Csinv, Csneg
+        34 // 20 original + 14 Tier 1: MVN, NEG, NEGS, MovN, BIC, BICS, ORN, EON,
+        //                          ADDS, SUBS, ANDS, CSET, CSETM, ROR.
     }
 }
 
@@ -679,7 +810,7 @@ mod tests {
         for _ in 0..100 {
             let instr = generator.generate_random(&mut rng, &regs, &imms);
             // Just verify it doesn't panic and produces valid instructions
-            assert!(instr.opcode_id() < 13);
+            assert!(instr.opcode_id() < 34);
         }
     }
 

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -805,6 +805,12 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
         }
     }
 
+    /// Total number of distinct opcode *families* (the upper bound on
+    /// `opcode_id()`). Not the same as `generate_random`'s slot count —
+    /// `generate_random` samples 24 top-level slots and folds ANDS, CSET,
+    /// CSETM, and ROR into a sub-multiplexer on slot 23 to keep the slot
+    /// table small. So `opcode_id < opcode_count` always holds, but the
+    /// random-generation distribution is not uniform across all 34 IDs.
     fn opcode_count(&self) -> u8 {
         34 // 20 original + 14 Tier 1: MVN, NEG, NEGS, MovN, BIC, BICS, ORN, EON,
         //                          ADDS, SUBS, ANDS, CSET, CSETM, ROR.

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -285,6 +285,64 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
             }
         }
 
+        // Tier 1 inverted-logical / flag-setting binary ops (register form).
+        for &rd in registers {
+            for &rn in registers {
+                for &rm in registers {
+                    let rm_op = Operand::Register(rm);
+                    instructions.push(Instruction::Bic { rd, rn, rm: rm_op });
+                    instructions.push(Instruction::Bics { rd, rn, rm: rm_op });
+                    instructions.push(Instruction::Orn { rd, rn, rm: rm_op });
+                    instructions.push(Instruction::Eon { rd, rn, rm: rm_op });
+                    instructions.push(Instruction::Adds { rd, rn, rm: rm_op });
+                    instructions.push(Instruction::Subs { rd, rn, rm: rm_op });
+                    instructions.push(Instruction::Ands { rd, rn, rm: rm_op });
+                }
+                // ADDS / SUBS immediate forms (ANDS is register-only).
+                for &imm in immediates {
+                    let imm_op = Operand::Immediate(imm);
+                    instructions.push(Instruction::Adds { rd, rn, rm: imm_op });
+                    instructions.push(Instruction::Subs { rd, rn, rm: imm_op });
+                }
+                // ROR with register and immediate shift.
+                for &rm in registers {
+                    instructions.push(Instruction::Ror {
+                        rd,
+                        rn,
+                        shift: Operand::Register(rm),
+                    });
+                }
+                for &shift in &shift_amounts {
+                    instructions.push(Instruction::Ror {
+                        rd,
+                        rn,
+                        shift: Operand::Immediate(shift),
+                    });
+                }
+            }
+
+            // Tier 1 unary: MVN / NEG / NEGS.
+            for &rm in registers {
+                instructions.push(Instruction::Mvn { rd, rm });
+                instructions.push(Instruction::Neg { rd, rm });
+                instructions.push(Instruction::Negs { rd, rm });
+            }
+
+            // MOVN: small representative imm × {0,16,32,48} shift table —
+            // mirrors `search::candidate::generate_all_instructions`.
+            for imm in [0u16, 1, 0xFF, 0xFFFF] {
+                for shift in [0u8, 16, 32, 48] {
+                    instructions.push(Instruction::MovN { rd, imm, shift });
+                }
+            }
+
+            // CSET / CSETM: 14 non-AL/NV conditions from ir::types.
+            for cond in crate::ir::types::NORMAL_CONDITIONS {
+                instructions.push(Instruction::Cset { rd, cond });
+                instructions.push(Instruction::Csetm { rd, cond });
+            }
+        }
+
         instructions
     }
 
@@ -294,22 +352,25 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
         registers: &[Register],
         immediates: &[i64],
     ) -> Instruction {
-        let opcode = rng.random_range(0..13);
+        // 24 opcode slots: 0..13 original, 13..23 Tier 1, 23 = ROR.
+        let opcode = rng.random_range(0..24);
         let rd = registers[rng.random_range(0..registers.len())];
         let rn = registers[rng.random_range(0..registers.len())];
+        let pick_reg = |rng: &mut R| registers[rng.random_range(0..registers.len())];
+        let pick_imm = |rng: &mut R| immediates[rng.random_range(0..immediates.len())];
 
         match opcode {
             0 => Instruction::MovReg { rd, rn },
-            1 => {
-                let imm = immediates[rng.random_range(0..immediates.len())];
-                Instruction::MovImm { rd, imm }
-            }
+            1 => Instruction::MovImm {
+                rd,
+                imm: pick_imm(rng),
+            },
             2..=6 => {
                 let use_imm = rng.random_bool(0.5);
                 let rm = if use_imm && (opcode == 2 || opcode == 3) {
-                    Operand::Immediate(immediates[rng.random_range(0..immediates.len())])
+                    Operand::Immediate(pick_imm(rng))
                 } else {
-                    Operand::Register(registers[rng.random_range(0..registers.len())])
+                    Operand::Register(pick_reg(rng))
                 };
                 match opcode {
                     2 => Instruction::Add { rd, rn, rm },
@@ -323,10 +384,10 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
             7..=9 => {
                 let use_imm = rng.random_bool(0.5);
                 let shift = if use_imm {
-                    let amounts = [0, 1, 2, 4, 8, 16, 32];
+                    let amounts = [0i64, 1, 2, 4, 8, 16, 32];
                     Operand::Immediate(amounts[rng.random_range(0..amounts.len())])
                 } else {
-                    Operand::Register(registers[rng.random_range(0..registers.len())])
+                    Operand::Register(pick_reg(rng))
                 };
                 match opcode {
                     7 => Instruction::Lsl { rd, rn, shift },
@@ -336,12 +397,102 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                 }
             }
             10..=12 => {
-                let rm = registers[rng.random_range(0..registers.len())];
+                let rm = pick_reg(rng);
                 match opcode {
                     10 => Instruction::Mul { rd, rn, rm },
                     11 => Instruction::Sdiv { rd, rn, rm },
                     12 => Instruction::Udiv { rd, rn, rm },
                     _ => unreachable!(),
+                }
+            }
+            // Tier 1: unary
+            13 => Instruction::Mvn {
+                rd,
+                rm: pick_reg(rng),
+            },
+            14 => Instruction::Neg {
+                rd,
+                rm: pick_reg(rng),
+            },
+            15 => Instruction::Negs {
+                rd,
+                rm: pick_reg(rng),
+            },
+            16 => {
+                let imm = (rng.random::<u32>() & 0xFFFF) as u16;
+                let shifts = [0u8, 16, 32, 48];
+                Instruction::MovN {
+                    rd,
+                    imm,
+                    shift: shifts[rng.random_range(0..shifts.len())],
+                }
+            }
+            // Tier 1: inverted-logical (register-only)
+            17 => Instruction::Bic {
+                rd,
+                rn,
+                rm: Operand::Register(pick_reg(rng)),
+            },
+            18 => Instruction::Bics {
+                rd,
+                rn,
+                rm: Operand::Register(pick_reg(rng)),
+            },
+            19 => Instruction::Orn {
+                rd,
+                rn,
+                rm: Operand::Register(pick_reg(rng)),
+            },
+            20 => Instruction::Eon {
+                rd,
+                rn,
+                rm: Operand::Register(pick_reg(rng)),
+            },
+            // Tier 1: flag-setting arith (ADDS/SUBS imm, ANDS reg-only)
+            21 => {
+                let rm = if rng.random_bool(0.5) {
+                    Operand::Immediate(pick_imm(rng))
+                } else {
+                    Operand::Register(pick_reg(rng))
+                };
+                Instruction::Adds { rd, rn, rm }
+            }
+            22 => {
+                let rm = if rng.random_bool(0.5) {
+                    Operand::Immediate(pick_imm(rng))
+                } else {
+                    Operand::Register(pick_reg(rng))
+                };
+                Instruction::Subs { rd, rn, rm }
+            }
+            // ANDS: choose register-only.
+            // CSET / CSETM share the next slot pair.
+            23 => {
+                // Branch between ANDS, CSET, CSETM, ROR — three "small" Tier 1
+                // families fit here. Even split.
+                match rng.random_range(0..4) {
+                    0 => Instruction::Ands {
+                        rd,
+                        rn,
+                        rm: Operand::Register(pick_reg(rng)),
+                    },
+                    1 => Instruction::Cset {
+                        rd,
+                        cond: Condition::random_normal(rng),
+                    },
+                    2 => Instruction::Csetm {
+                        rd,
+                        cond: Condition::random_normal(rng),
+                    },
+                    _ => {
+                        let shift = if rng.random_bool(0.5) {
+                            let amounts = [0i64, 1, 2, 4, 8, 16, 32];
+                            Operand::Immediate(amounts[rng.random_range(0..amounts.len())])
+                        } else {
+                            Operand::Register(pick_reg(rng))
+                        };
+                        Instruction::Ror { rd, rn, shift }
+                    }
                 }
             }
             _ => unreachable!(),
@@ -833,7 +984,7 @@ mod tests {
         // Mutate several times and verify we get valid instructions
         for _ in 0..100 {
             let mutated = generator.mutate(&mut rng, &original, &regs, &imms);
-            assert!(mutated.opcode_id() < 13);
+            assert!(mutated.opcode_id() < generator.opcode_count());
         }
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -252,6 +252,189 @@ fn parse_mov(operands: &[&str]) -> Result<Instruction, String> {
     }
 }
 
+/// Parse MVN instruction
+fn parse_mvn(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() != 2 {
+        return Err(format!("mvn requires 2 operands, got {}", operands.len()));
+    }
+    let rd = parse_register(operands[0])?;
+    let rm = parse_register(operands[1])?;
+    Ok(Instruction::Mvn { rd, rm })
+}
+
+/// Parse NEG instruction
+fn parse_neg(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() != 2 {
+        return Err(format!("neg requires 2 operands, got {}", operands.len()));
+    }
+    let rd = parse_register(operands[0])?;
+    let rm = parse_register(operands[1])?;
+    Ok(Instruction::Neg { rd, rm })
+}
+
+/// Parse NEGS instruction
+fn parse_negs(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() != 2 {
+        return Err(format!("negs requires 2 operands, got {}", operands.len()));
+    }
+    let rd = parse_register(operands[0])?;
+    let rm = parse_register(operands[1])?;
+    Ok(Instruction::Negs { rd, rm })
+}
+
+/// Parse BIC instruction (register-only rm)
+fn parse_bic(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() != 3 {
+        return Err(format!("bic requires 3 operands, got {}", operands.len()));
+    }
+    let rd = parse_register(operands[0])?;
+    let rn = parse_register(operands[1])?;
+    let rm = parse_operand(operands[2])?;
+    Ok(Instruction::Bic { rd, rn, rm })
+}
+
+/// Parse BICS instruction (register-only rm)
+fn parse_bics(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() != 3 {
+        return Err(format!("bics requires 3 operands, got {}", operands.len()));
+    }
+    let rd = parse_register(operands[0])?;
+    let rn = parse_register(operands[1])?;
+    let rm = parse_operand(operands[2])?;
+    Ok(Instruction::Bics { rd, rn, rm })
+}
+
+/// Parse ORN instruction (register-only rm)
+fn parse_orn(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() != 3 {
+        return Err(format!("orn requires 3 operands, got {}", operands.len()));
+    }
+    let rd = parse_register(operands[0])?;
+    let rn = parse_register(operands[1])?;
+    let rm = parse_operand(operands[2])?;
+    Ok(Instruction::Orn { rd, rn, rm })
+}
+
+/// Parse EON instruction (register-only rm)
+fn parse_eon(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() != 3 {
+        return Err(format!("eon requires 3 operands, got {}", operands.len()));
+    }
+    let rd = parse_register(operands[0])?;
+    let rn = parse_register(operands[1])?;
+    let rm = parse_operand(operands[2])?;
+    Ok(Instruction::Eon { rd, rn, rm })
+}
+
+/// Parse ADDS instruction
+fn parse_adds(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() != 3 {
+        return Err(format!("adds requires 3 operands, got {}", operands.len()));
+    }
+    let rd = parse_register(operands[0])?;
+    let rn = parse_register(operands[1])?;
+    let rm = parse_operand(operands[2])?;
+    Ok(Instruction::Adds { rd, rn, rm })
+}
+
+/// Parse SUBS instruction
+fn parse_subs(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() != 3 {
+        return Err(format!("subs requires 3 operands, got {}", operands.len()));
+    }
+    let rd = parse_register(operands[0])?;
+    let rn = parse_register(operands[1])?;
+    let rm = parse_operand(operands[2])?;
+    Ok(Instruction::Subs { rd, rn, rm })
+}
+
+/// Parse ANDS instruction (register-only rm)
+fn parse_ands(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() != 3 {
+        return Err(format!("ands requires 3 operands, got {}", operands.len()));
+    }
+    let rd = parse_register(operands[0])?;
+    let rn = parse_register(operands[1])?;
+    let rm = parse_operand(operands[2])?;
+    Ok(Instruction::Ands { rd, rn, rm })
+}
+
+/// Parse CSET instruction: `cset rd, cond`
+fn parse_cset(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() != 2 {
+        return Err(format!("cset requires 2 operands, got {}", operands.len()));
+    }
+    let rd = parse_register(operands[0])?;
+    let cond = parse_condition(operands[1])?;
+    Ok(Instruction::Cset { rd, cond })
+}
+
+/// Parse CSETM instruction: `csetm rd, cond`
+fn parse_csetm(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() != 2 {
+        return Err(format!("csetm requires 2 operands, got {}", operands.len()));
+    }
+    let rd = parse_register(operands[0])?;
+    let cond = parse_condition(operands[1])?;
+    Ok(Instruction::Csetm { rd, cond })
+}
+
+/// Parse ROR instruction: `ror rd, rn, #imm` or `ror rd, rn, rm`
+fn parse_ror(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() != 3 {
+        return Err(format!("ror requires 3 operands, got {}", operands.len()));
+    }
+    let rd = parse_register(operands[0])?;
+    let rn = parse_register(operands[1])?;
+    let shift = parse_operand(operands[2])?;
+    Ok(Instruction::Ror { rd, rn, shift })
+}
+
+/// Parse MOVN instruction: `movn rd, #imm` or `movn rd, #imm, lsl #shift`.
+/// Operands are comma-split, so the LSL-with-shift form arrives as
+/// `["rd", "#imm", "lsl #shift"]` (3 entries, the third internally has the
+/// `lsl` keyword and the shift expression).
+fn parse_movn(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() != 2 && operands.len() != 3 {
+        return Err(format!(
+            "movn requires 2 or 3 operands (rd, #imm[, lsl #shift]), got {}",
+            operands.len()
+        ));
+    }
+    let rd = parse_register(operands[0])?;
+    let imm_val = match parse_operand(operands[1])? {
+        Operand::Immediate(v) => v,
+        Operand::Register(_) => return Err("movn second operand must be an immediate".to_string()),
+    };
+    if !(0..=0xFFFF).contains(&imm_val) {
+        return Err(format!("movn immediate {} out of u16 range", imm_val));
+    }
+    let imm = imm_val as u16;
+
+    let shift = if operands.len() == 2 {
+        0u8
+    } else {
+        // Expect form "lsl #N" (whitespace-separated within the 3rd operand).
+        let tail = operands[2].trim();
+        let mut parts = tail.splitn(2, char::is_whitespace);
+        let kw = parts.next().unwrap_or("").trim();
+        let rest = parts.next().unwrap_or("").trim();
+        if !kw.eq_ignore_ascii_case("lsl") {
+            return Err(format!("movn shift form must be `lsl #N`, got `{}`", tail));
+        }
+        let s = match parse_operand(rest)? {
+            Operand::Immediate(v) => v,
+            Operand::Register(_) => return Err("movn shift must be an immediate".to_string()),
+        };
+        if !matches!(s, 0 | 16 | 32 | 48) {
+            return Err(format!("movn shift {} must be one of 0/16/32/48", s));
+        }
+        s as u8
+    };
+
+    Ok(Instruction::MovN { rd, imm, shift })
+}
+
 /// Parse ADD instruction
 fn parse_add(operands: &[&str]) -> Result<Instruction, String> {
     if operands.len() != 3 {
@@ -543,6 +726,20 @@ pub fn parse_line(line: &str) -> Result<LineResult, ParseLineError> {
         "csinc" => parse_csinc(&operands).map_err(ParseLineError::Other)?,
         "csinv" => parse_csinv(&operands).map_err(ParseLineError::Other)?,
         "csneg" => parse_csneg(&operands).map_err(ParseLineError::Other)?,
+        "mvn" => parse_mvn(&operands).map_err(ParseLineError::Other)?,
+        "neg" => parse_neg(&operands).map_err(ParseLineError::Other)?,
+        "negs" => parse_negs(&operands).map_err(ParseLineError::Other)?,
+        "movn" => parse_movn(&operands).map_err(ParseLineError::Other)?,
+        "bic" => parse_bic(&operands).map_err(ParseLineError::Other)?,
+        "bics" => parse_bics(&operands).map_err(ParseLineError::Other)?,
+        "orn" => parse_orn(&operands).map_err(ParseLineError::Other)?,
+        "eon" => parse_eon(&operands).map_err(ParseLineError::Other)?,
+        "adds" => parse_adds(&operands).map_err(ParseLineError::Other)?,
+        "subs" => parse_subs(&operands).map_err(ParseLineError::Other)?,
+        "ands" => parse_ands(&operands).map_err(ParseLineError::Other)?,
+        "cset" => parse_cset(&operands).map_err(ParseLineError::Other)?,
+        "csetm" => parse_csetm(&operands).map_err(ParseLineError::Other)?,
+        "ror" => parse_ror(&operands).map_err(ParseLineError::Other)?,
         _ => return Err(ParseLineError::UnknownInstruction(opcode)),
     };
 
@@ -790,5 +987,99 @@ mod tests {
         let asm = "// just a comment\n.text\n";
         let result = parse_assembly_string(asm, "test".to_string());
         assert!(result.is_err());
+    }
+
+    /// Round-trip Display → parser for every Tier 1 mnemonic.
+    #[test]
+    fn test_tier1_display_parser_roundtrip() {
+        use crate::ir::types::Condition;
+        let cases: Vec<Instruction> = vec![
+            Instruction::Mvn {
+                rd: Register::X0,
+                rm: Register::X1,
+            },
+            Instruction::Neg {
+                rd: Register::X0,
+                rm: Register::X1,
+            },
+            Instruction::Negs {
+                rd: Register::X0,
+                rm: Register::X1,
+            },
+            Instruction::MovN {
+                rd: Register::X0,
+                imm: 0xFFFF,
+                shift: 0,
+            },
+            Instruction::MovN {
+                rd: Register::X0,
+                imm: 1,
+                shift: 16,
+            },
+            Instruction::Bic {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Register(Register::X2),
+            },
+            Instruction::Bics {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Register(Register::X2),
+            },
+            Instruction::Orn {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Register(Register::X2),
+            },
+            Instruction::Eon {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Register(Register::X2),
+            },
+            Instruction::Adds {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Immediate(5),
+            },
+            Instruction::Subs {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Register(Register::X2),
+            },
+            Instruction::Ands {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Register(Register::X2),
+            },
+            Instruction::Cset {
+                rd: Register::X0,
+                cond: Condition::EQ,
+            },
+            Instruction::Csetm {
+                rd: Register::X3,
+                cond: Condition::NE,
+            },
+            Instruction::Ror {
+                rd: Register::X0,
+                rn: Register::X1,
+                shift: Operand::Immediate(5),
+            },
+            Instruction::Ror {
+                rd: Register::X0,
+                rn: Register::X1,
+                shift: Operand::Register(Register::X2),
+            },
+        ];
+        for instr in cases {
+            let printed = format!("{}", instr);
+            match parse_line(&printed) {
+                Ok(LineResult::Instruction(parsed)) => assert_eq!(
+                    parsed, instr,
+                    "Round-trip mismatch: printed `{}` parsed back as `{}`",
+                    printed, parsed
+                ),
+                other => panic!("Failed to parse `{}` round-trip: {:?}", printed, other),
+            }
+        }
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -289,7 +289,7 @@ fn parse_bic(operands: &[&str]) -> Result<Instruction, String> {
     }
     let rd = parse_register(operands[0])?;
     let rn = parse_register(operands[1])?;
-    let rm = parse_operand(operands[2])?;
+    let rm = Operand::Register(parse_register(operands[2])?);
     Ok(Instruction::Bic { rd, rn, rm })
 }
 
@@ -300,7 +300,7 @@ fn parse_bics(operands: &[&str]) -> Result<Instruction, String> {
     }
     let rd = parse_register(operands[0])?;
     let rn = parse_register(operands[1])?;
-    let rm = parse_operand(operands[2])?;
+    let rm = Operand::Register(parse_register(operands[2])?);
     Ok(Instruction::Bics { rd, rn, rm })
 }
 
@@ -311,7 +311,7 @@ fn parse_orn(operands: &[&str]) -> Result<Instruction, String> {
     }
     let rd = parse_register(operands[0])?;
     let rn = parse_register(operands[1])?;
-    let rm = parse_operand(operands[2])?;
+    let rm = Operand::Register(parse_register(operands[2])?);
     Ok(Instruction::Orn { rd, rn, rm })
 }
 
@@ -322,7 +322,7 @@ fn parse_eon(operands: &[&str]) -> Result<Instruction, String> {
     }
     let rd = parse_register(operands[0])?;
     let rn = parse_register(operands[1])?;
-    let rm = parse_operand(operands[2])?;
+    let rm = Operand::Register(parse_register(operands[2])?);
     Ok(Instruction::Eon { rd, rn, rm })
 }
 
@@ -355,7 +355,7 @@ fn parse_ands(operands: &[&str]) -> Result<Instruction, String> {
     }
     let rd = parse_register(operands[0])?;
     let rn = parse_register(operands[1])?;
-    let rm = parse_operand(operands[2])?;
+    let rm = Operand::Register(parse_register(operands[2])?);
     Ok(Instruction::Ands { rd, rn, rm })
 }
 

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -92,7 +92,67 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
                     rn,
                     shift: shift_op,
                 });
+                // ROR also accepts the same shift-amount table.
+                instrs.push(Instruction::Ror {
+                    rd,
+                    rn,
+                    shift: shift_op,
+                });
             }
+
+            // ROR with register shift amount.
+            for &rm in registers {
+                instrs.push(Instruction::Ror {
+                    rd,
+                    rn,
+                    shift: Operand::Register(rm),
+                });
+            }
+
+            // Tier 1 inverted-logical and flag-setting binary ops (register form).
+            for &rm in registers {
+                let rm_op = Operand::Register(rm);
+                instrs.push(Instruction::Bic { rd, rn, rm: rm_op });
+                instrs.push(Instruction::Bics { rd, rn, rm: rm_op });
+                instrs.push(Instruction::Orn { rd, rn, rm: rm_op });
+                instrs.push(Instruction::Eon { rd, rn, rm: rm_op });
+                instrs.push(Instruction::Adds { rd, rn, rm: rm_op });
+                instrs.push(Instruction::Subs { rd, rn, rm: rm_op });
+                instrs.push(Instruction::Ands { rd, rn, rm: rm_op });
+            }
+            // ADDS / SUBS also accept the same 12-bit-class immediate table
+            // ADD / SUB does — keep them in sync. ANDS is register-only.
+            for &imm in immediates {
+                let imm_op = Operand::Immediate(imm);
+                instrs.push(Instruction::Adds { rd, rn, rm: imm_op });
+                instrs.push(Instruction::Subs { rd, rn, rm: imm_op });
+            }
+        }
+
+        // Tier 1 unary ops: MVN / NEG / NEGS — one source register, no rn.
+        for &rm in registers {
+            instrs.push(Instruction::Mvn { rd, rm });
+            instrs.push(Instruction::Neg { rd, rm });
+            instrs.push(Instruction::Negs { rd, rm });
+        }
+
+        // MOVN: small representative imm set × four legal shift positions.
+        // Keep this small — the full u16 × 4-shift space would balloon the
+        // candidate count. The same parsimony rationale applies as the
+        // immediate-table choice above.
+        for imm in [0u16, 1, 0xFF, 0xFFFF] {
+            for shift in [0u8, 16, 32, 48] {
+                instrs.push(Instruction::MovN { rd, imm, shift });
+            }
+        }
+
+        // CSET / CSETM: the 14 non-AL/NV conditions defined in
+        // `ir::types::NORMAL_CONDITIONS`. `is_encodable_aarch64` rejects
+        // AL/NV at the encoder boundary; the exhaustive set here enumerates
+        // only the encodable subset.
+        for cond in crate::ir::types::NORMAL_CONDITIONS {
+            instrs.push(Instruction::Cset { rd, cond });
+            instrs.push(Instruction::Csetm { rd, cond });
         }
     }
 
@@ -113,7 +173,6 @@ pub fn generate_random_instruction<R: rand::RngExt>(
     }
 
     let rd = registers[rng.random_range(0..registers.len())];
-    let pick_rn = |rng: &mut R| registers[rng.random_range(0..registers.len())];
     let pick_reg = |rng: &mut R| registers[rng.random_range(0..registers.len())];
 
     match rng.random_range(0..24) {
@@ -127,45 +186,45 @@ pub fn generate_random_instruction<R: rand::RngExt>(
         }
         1 => Instruction::MovReg {
             rd,
-            rn: pick_rn(rng),
+            rn: pick_reg(rng),
         },
         2 => {
-            let rn = pick_rn(rng);
+            let rn = pick_reg(rng);
             let rm = random_operand(rng, registers, immediates);
             Instruction::Add { rd, rn, rm }
         }
         3 => {
-            let rn = pick_rn(rng);
+            let rn = pick_reg(rng);
             let rm = random_operand(rng, registers, immediates);
             Instruction::Sub { rd, rn, rm }
         }
         4 => {
-            let rn = pick_rn(rng);
+            let rn = pick_reg(rng);
             let rm = Operand::Register(pick_reg(rng));
             Instruction::And { rd, rn, rm }
         }
         5 => {
-            let rn = pick_rn(rng);
+            let rn = pick_reg(rng);
             let rm = Operand::Register(pick_reg(rng));
             Instruction::Orr { rd, rn, rm }
         }
         6 => {
-            let rn = pick_rn(rng);
+            let rn = pick_reg(rng);
             let rm = Operand::Register(pick_reg(rng));
             Instruction::Eor { rd, rn, rm }
         }
         7 => {
-            let rn = pick_rn(rng);
+            let rn = pick_reg(rng);
             let shift = random_shift_operand(rng, registers);
             Instruction::Lsl { rd, rn, shift }
         }
         8 => {
-            let rn = pick_rn(rng);
+            let rn = pick_reg(rng);
             let shift = random_shift_operand(rng, registers);
             Instruction::Lsr { rd, rn, shift }
         }
         9 => {
-            let rn = pick_rn(rng);
+            let rn = pick_reg(rng);
             let shift = random_shift_operand(rng, registers);
             Instruction::Asr { rd, rn, shift }
         }
@@ -189,62 +248,54 @@ pub fn generate_random_instruction<R: rand::RngExt>(
             Instruction::MovN { rd, imm, shift }
         }
         14 => {
-            let rn = pick_rn(rng);
+            let rn = pick_reg(rng);
             let rm = Operand::Register(pick_reg(rng));
             Instruction::Bic { rd, rn, rm }
         }
         15 => {
-            let rn = pick_rn(rng);
+            let rn = pick_reg(rng);
             let rm = Operand::Register(pick_reg(rng));
             Instruction::Bics { rd, rn, rm }
         }
         16 => {
-            let rn = pick_rn(rng);
+            let rn = pick_reg(rng);
             let rm = Operand::Register(pick_reg(rng));
             Instruction::Orn { rd, rn, rm }
         }
         17 => {
-            let rn = pick_rn(rng);
+            let rn = pick_reg(rng);
             let rm = Operand::Register(pick_reg(rng));
             Instruction::Eon { rd, rn, rm }
         }
         18 => {
-            let rn = pick_rn(rng);
+            let rn = pick_reg(rng);
             let rm = random_operand(rng, registers, immediates);
             Instruction::Adds { rd, rn, rm }
         }
         19 => {
-            let rn = pick_rn(rng);
+            let rn = pick_reg(rng);
             let rm = random_operand(rng, registers, immediates);
             Instruction::Subs { rd, rn, rm }
         }
         20 => {
-            let rn = pick_rn(rng);
+            let rn = pick_reg(rng);
             let rm = Operand::Register(pick_reg(rng));
             Instruction::Ands { rd, rn, rm }
         }
         21 => Instruction::Cset {
             rd,
-            cond: random_normal_cond_cand(rng),
+            cond: crate::ir::types::Condition::random_normal(rng),
         },
         22 => Instruction::Csetm {
             rd,
-            cond: random_normal_cond_cand(rng),
+            cond: crate::ir::types::Condition::random_normal(rng),
         },
         _ => {
-            let rn = pick_rn(rng);
+            let rn = pick_reg(rng);
             let shift = random_shift_operand(rng, registers);
             Instruction::Ror { rd, rn, shift }
         }
     }
-}
-
-/// Pick a random condition code excluding AL/NV (for CSET/CSETM).
-fn random_normal_cond_cand<R: rand::RngExt>(rng: &mut R) -> crate::ir::types::Condition {
-    use crate::ir::types::Condition::*;
-    const NORMAL: [crate::ir::types::Condition; 14] =
-        [EQ, NE, CS, CC, MI, PL, VS, VC, HI, LS, GE, LT, GT, LE];
-    NORMAL[rng.random_range(0..NORMAL.len())]
 }
 
 fn random_operand<R: rand::RngExt>(

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -113,10 +113,11 @@ pub fn generate_random_instruction<R: rand::RngExt>(
     }
 
     let rd = registers[rng.random_range(0..registers.len())];
+    let pick_rn = |rng: &mut R| registers[rng.random_range(0..registers.len())];
+    let pick_reg = |rng: &mut R| registers[rng.random_range(0..registers.len())];
 
-    match rng.random_range(0..10) {
+    match rng.random_range(0..24) {
         0 => {
-            // MovImm
             let imm = if immediates.is_empty() {
                 0
             } else {
@@ -124,60 +125,126 @@ pub fn generate_random_instruction<R: rand::RngExt>(
             };
             Instruction::MovImm { rd, imm }
         }
-        1 => {
-            // MovReg
-            let rn = registers[rng.random_range(0..registers.len())];
-            Instruction::MovReg { rd, rn }
-        }
+        1 => Instruction::MovReg {
+            rd,
+            rn: pick_rn(rng),
+        },
         2 => {
-            // Add
-            let rn = registers[rng.random_range(0..registers.len())];
+            let rn = pick_rn(rng);
             let rm = random_operand(rng, registers, immediates);
             Instruction::Add { rd, rn, rm }
         }
         3 => {
-            // Sub
-            let rn = registers[rng.random_range(0..registers.len())];
+            let rn = pick_rn(rng);
             let rm = random_operand(rng, registers, immediates);
             Instruction::Sub { rd, rn, rm }
         }
         4 => {
-            // And
-            let rn = registers[rng.random_range(0..registers.len())];
-            let rm = random_operand(rng, registers, immediates);
+            let rn = pick_rn(rng);
+            let rm = Operand::Register(pick_reg(rng));
             Instruction::And { rd, rn, rm }
         }
         5 => {
-            // Orr
-            let rn = registers[rng.random_range(0..registers.len())];
-            let rm = random_operand(rng, registers, immediates);
+            let rn = pick_rn(rng);
+            let rm = Operand::Register(pick_reg(rng));
             Instruction::Orr { rd, rn, rm }
         }
         6 => {
-            // Eor
-            let rn = registers[rng.random_range(0..registers.len())];
-            let rm = random_operand(rng, registers, immediates);
+            let rn = pick_rn(rng);
+            let rm = Operand::Register(pick_reg(rng));
             Instruction::Eor { rd, rn, rm }
         }
         7 => {
-            // Lsl
-            let rn = registers[rng.random_range(0..registers.len())];
+            let rn = pick_rn(rng);
             let shift = random_shift_operand(rng, registers);
             Instruction::Lsl { rd, rn, shift }
         }
         8 => {
-            // Lsr
-            let rn = registers[rng.random_range(0..registers.len())];
+            let rn = pick_rn(rng);
             let shift = random_shift_operand(rng, registers);
             Instruction::Lsr { rd, rn, shift }
         }
-        _ => {
-            // Asr
-            let rn = registers[rng.random_range(0..registers.len())];
+        9 => {
+            let rn = pick_rn(rng);
             let shift = random_shift_operand(rng, registers);
             Instruction::Asr { rd, rn, shift }
         }
+        // New: unary / inverted-logical / flag-setting / cond-set / ror
+        10 => Instruction::Mvn {
+            rd,
+            rm: pick_reg(rng),
+        },
+        11 => Instruction::Neg {
+            rd,
+            rm: pick_reg(rng),
+        },
+        12 => Instruction::Negs {
+            rd,
+            rm: pick_reg(rng),
+        },
+        13 => {
+            let imm = (rng.random::<u32>() & 0xFFFF) as u16;
+            let shifts = [0u8, 16, 32, 48];
+            let shift = shifts[rng.random_range(0..shifts.len())];
+            Instruction::MovN { rd, imm, shift }
+        }
+        14 => {
+            let rn = pick_rn(rng);
+            let rm = Operand::Register(pick_reg(rng));
+            Instruction::Bic { rd, rn, rm }
+        }
+        15 => {
+            let rn = pick_rn(rng);
+            let rm = Operand::Register(pick_reg(rng));
+            Instruction::Bics { rd, rn, rm }
+        }
+        16 => {
+            let rn = pick_rn(rng);
+            let rm = Operand::Register(pick_reg(rng));
+            Instruction::Orn { rd, rn, rm }
+        }
+        17 => {
+            let rn = pick_rn(rng);
+            let rm = Operand::Register(pick_reg(rng));
+            Instruction::Eon { rd, rn, rm }
+        }
+        18 => {
+            let rn = pick_rn(rng);
+            let rm = random_operand(rng, registers, immediates);
+            Instruction::Adds { rd, rn, rm }
+        }
+        19 => {
+            let rn = pick_rn(rng);
+            let rm = random_operand(rng, registers, immediates);
+            Instruction::Subs { rd, rn, rm }
+        }
+        20 => {
+            let rn = pick_rn(rng);
+            let rm = Operand::Register(pick_reg(rng));
+            Instruction::Ands { rd, rn, rm }
+        }
+        21 => Instruction::Cset {
+            rd,
+            cond: random_normal_cond_cand(rng),
+        },
+        22 => Instruction::Csetm {
+            rd,
+            cond: random_normal_cond_cand(rng),
+        },
+        _ => {
+            let rn = pick_rn(rng);
+            let shift = random_shift_operand(rng, registers);
+            Instruction::Ror { rd, rn, shift }
+        }
     }
+}
+
+/// Pick a random condition code excluding AL/NV (for CSET/CSETM).
+fn random_normal_cond_cand<R: rand::RngExt>(rng: &mut R) -> crate::ir::types::Condition {
+    use crate::ir::types::Condition::*;
+    const NORMAL: [crate::ir::types::Condition; 14] =
+        [EQ, NE, CS, CC, MI, PL, VS, VC, HI, LS, GE, LT, GT, LE];
+    NORMAL[rng.random_range(0..NORMAL.len())]
 }
 
 fn random_operand<R: rand::RngExt>(
@@ -244,6 +311,20 @@ pub fn opcode_id(instr: &Instruction) -> u8 {
         Instruction::Csinc { .. } => 17,
         Instruction::Csinv { .. } => 18,
         Instruction::Csneg { .. } => 19,
+        Instruction::Mvn { .. } => 20,
+        Instruction::Neg { .. } => 21,
+        Instruction::Negs { .. } => 22,
+        Instruction::MovN { .. } => 23,
+        Instruction::Bic { .. } => 24,
+        Instruction::Bics { .. } => 25,
+        Instruction::Orn { .. } => 26,
+        Instruction::Eon { .. } => 27,
+        Instruction::Adds { .. } => 28,
+        Instruction::Subs { .. } => 29,
+        Instruction::Ands { .. } => 30,
+        Instruction::Cset { .. } => 31,
+        Instruction::Csetm { .. } => 32,
+        Instruction::Ror { .. } => 33,
     }
 }
 
@@ -261,6 +342,10 @@ pub fn supports_immediate(instr: &Instruction) -> bool {
             | Instruction::Lsl { .. }
             | Instruction::Lsr { .. }
             | Instruction::Asr { .. }
+            | Instruction::MovN { .. }
+            | Instruction::Adds { .. }
+            | Instruction::Subs { .. }
+            | Instruction::Ror { .. }
     )
 }
 
@@ -274,6 +359,13 @@ pub fn is_binary_op(instr: &Instruction) -> bool {
             | Instruction::And { .. }
             | Instruction::Orr { .. }
             | Instruction::Eor { .. }
+            | Instruction::Bic { .. }
+            | Instruction::Bics { .. }
+            | Instruction::Orn { .. }
+            | Instruction::Eon { .. }
+            | Instruction::Adds { .. }
+            | Instruction::Subs { .. }
+            | Instruction::Ands { .. }
     )
 }
 
@@ -282,7 +374,10 @@ pub fn is_binary_op(instr: &Instruction) -> bool {
 pub fn is_shift_op(instr: &Instruction) -> bool {
     matches!(
         instr,
-        Instruction::Lsl { .. } | Instruction::Lsr { .. } | Instruction::Asr { .. }
+        Instruction::Lsl { .. }
+            | Instruction::Lsr { .. }
+            | Instruction::Asr { .. }
+            | Instruction::Ror { .. }
     )
 }
 
@@ -291,7 +386,7 @@ pub fn is_shift_op(instr: &Instruction) -> bool {
 pub fn is_move_op(instr: &Instruction) -> bool {
     matches!(
         instr,
-        Instruction::MovReg { .. } | Instruction::MovImm { .. }
+        Instruction::MovReg { .. } | Instruction::MovImm { .. } | Instruction::MovN { .. }
     )
 }
 

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -8,10 +8,18 @@
 
 #![allow(dead_code)]
 
+use crate::ir::types::Condition;
 use crate::ir::{Instruction, Operand, Register};
 use crate::search::candidate::generate_random_instruction;
 use crate::search::config::MutationWeights;
 use rand::RngExt;
+
+/// Pick a random condition code excluding AL/NV.
+fn random_normal_cond_local<R: RngExt>(rng: &mut R) -> Condition {
+    use Condition::*;
+    const NORMAL: [Condition; 14] = [EQ, NE, CS, CC, MI, PL, VS, VC, HI, LS, GE, LT, GT, LE];
+    NORMAL[rng.random_range(0..NORMAL.len())]
+}
 
 /// Mutation operator types
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -160,6 +168,72 @@ impl Mutator {
                     _ => *rm = self.random_register(rng),
                 }
             }
+            // Unary: MVN, NEG, NEGS
+            Instruction::Mvn { rd, rm }
+            | Instruction::Neg { rd, rm }
+            | Instruction::Negs { rd, rm } => {
+                if rng.random_bool(0.5) {
+                    *rd = self.random_register(rng);
+                } else {
+                    *rm = self.random_register(rng);
+                }
+            }
+            // MOVN: mutate rd, imm, or shift
+            Instruction::MovN { rd, imm, shift } => match rng.random_range(0..3) {
+                0 => *rd = self.random_register(rng),
+                1 => *imm = (rng.random::<u32>() & 0xFFFF) as u16,
+                _ => {
+                    let shifts = [0u8, 16, 32, 48];
+                    *shift = shifts[rng.random_range(0..shifts.len())];
+                }
+            },
+            // Inverted-logical: BIC / BICS / ORN / EON — register-only rm
+            Instruction::Bic { rd, rn, rm }
+            | Instruction::Bics { rd, rn, rm }
+            | Instruction::Orn { rd, rn, rm }
+            | Instruction::Eon { rd, rn, rm } => {
+                let choice = rng.random_range(0..3);
+                match choice {
+                    0 => *rd = self.random_register(rng),
+                    1 => *rn = self.random_register(rng),
+                    _ => *rm = Operand::Register(self.random_register(rng)),
+                }
+            }
+            // Flag-setting arith/logical: ADDS/SUBS allow imm; ANDS register-only
+            Instruction::Adds { rd, rn, rm } | Instruction::Subs { rd, rn, rm } => {
+                let choice = rng.random_range(0..3);
+                match choice {
+                    0 => *rd = self.random_register(rng),
+                    1 => *rn = self.random_register(rng),
+                    _ => *rm = self.random_operand(rng),
+                }
+            }
+            Instruction::Ands { rd, rn, rm } => {
+                let choice = rng.random_range(0..3);
+                match choice {
+                    0 => *rd = self.random_register(rng),
+                    1 => *rn = self.random_register(rng),
+                    _ => *rm = Operand::Register(self.random_register(rng)),
+                }
+            }
+            // CSET / CSETM: only rd and cond can change; cond from the 14
+            // non-AL/NV options.
+            Instruction::Cset { rd, cond } | Instruction::Csetm { rd, cond } => {
+                if rng.random_bool(0.5) {
+                    *rd = self.random_register(rng);
+                } else {
+                    *cond = random_normal_cond_local(rng);
+                }
+            }
+            // ROR: same operand shape as LSL/LSR/ASR
+            Instruction::Ror { rd, rn, shift } => {
+                let choice = rng.random_range(0..3);
+                match choice {
+                    0 => *rd = self.random_register(rng),
+                    1 => *rn = self.random_register(rng),
+                    _ => *shift = self.random_shift_operand(rng),
+                }
+            }
         }
     }
 
@@ -301,6 +375,93 @@ impl Mutator {
                 1 => Instruction::Csinc { rd, rn, rm, cond },
                 2 => Instruction::Csinv { rd, rn, rm, cond },
                 _ => Instruction::Csneg { rd, rn, rm, cond },
+            },
+            // Unary peer-mutation cluster: MVN ↔ NEG ↔ NEGS
+            Instruction::Mvn { rd, rm } => match rng.random_range(0..3) {
+                0 => Instruction::Neg { rd, rm },
+                1 => Instruction::Negs { rd, rm },
+                _ => Instruction::Mvn { rd, rm },
+            },
+            Instruction::Neg { rd, rm } => match rng.random_range(0..3) {
+                0 => Instruction::Mvn { rd, rm },
+                1 => Instruction::Negs { rd, rm },
+                _ => Instruction::Neg { rd, rm },
+            },
+            Instruction::Negs { rd, rm } => match rng.random_range(0..3) {
+                0 => Instruction::Mvn { rd, rm },
+                1 => Instruction::Neg { rd, rm },
+                _ => Instruction::Negs { rd, rm },
+            },
+            // MOVN sits alongside MovImm as the only other immediate-move op.
+            Instruction::MovN { rd, imm, shift } => match rng.random_range(0..2) {
+                0 => Instruction::MovImm {
+                    rd,
+                    imm: imm as i64,
+                },
+                _ => Instruction::MovN { rd, imm, shift },
+            },
+            // Inverted-logical join the AND/ORR/EOR cluster.
+            Instruction::Bic { rd, rn, rm } => match rng.random_range(0..7) {
+                0 => Instruction::And { rd, rn, rm },
+                1 => Instruction::Orr { rd, rn, rm },
+                2 => Instruction::Eor { rd, rn, rm },
+                3 => Instruction::Bics { rd, rn, rm },
+                4 => Instruction::Orn { rd, rn, rm },
+                5 => Instruction::Eon { rd, rn, rm },
+                _ => Instruction::Bic { rd, rn, rm },
+            },
+            Instruction::Bics { rd, rn, rm } => match rng.random_range(0..2) {
+                0 => Instruction::Bic { rd, rn, rm },
+                _ => Instruction::Bics { rd, rn, rm },
+            },
+            Instruction::Orn { rd, rn, rm } => match rng.random_range(0..5) {
+                0 => Instruction::And { rd, rn, rm },
+                1 => Instruction::Orr { rd, rn, rm },
+                2 => Instruction::Bic { rd, rn, rm },
+                3 => Instruction::Eon { rd, rn, rm },
+                _ => Instruction::Orn { rd, rn, rm },
+            },
+            Instruction::Eon { rd, rn, rm } => match rng.random_range(0..5) {
+                0 => Instruction::And { rd, rn, rm },
+                1 => Instruction::Eor { rd, rn, rm },
+                2 => Instruction::Bic { rd, rn, rm },
+                3 => Instruction::Orn { rd, rn, rm },
+                _ => Instruction::Eon { rd, rn, rm },
+            },
+            // Flag-setting cluster: ADDS↔SUBS↔ANDS, and into/out of ADD/SUB/AND.
+            Instruction::Adds { rd, rn, rm } => match rng.random_range(0..4) {
+                0 => Instruction::Add { rd, rn, rm },
+                1 => Instruction::Subs { rd, rn, rm },
+                2 => Instruction::Ands { rd, rn, rm },
+                _ => Instruction::Adds { rd, rn, rm },
+            },
+            Instruction::Subs { rd, rn, rm } => match rng.random_range(0..4) {
+                0 => Instruction::Sub { rd, rn, rm },
+                1 => Instruction::Adds { rd, rn, rm },
+                2 => Instruction::Ands { rd, rn, rm },
+                _ => Instruction::Subs { rd, rn, rm },
+            },
+            Instruction::Ands { rd, rn, rm } => match rng.random_range(0..4) {
+                0 => Instruction::And { rd, rn, rm },
+                1 => Instruction::Adds { rd, rn, rm },
+                2 => Instruction::Subs { rd, rn, rm },
+                _ => Instruction::Ands { rd, rn, rm },
+            },
+            // CSET ↔ CSETM
+            Instruction::Cset { rd, cond } => match rng.random_range(0..2) {
+                0 => Instruction::Csetm { rd, cond },
+                _ => Instruction::Cset { rd, cond },
+            },
+            Instruction::Csetm { rd, cond } => match rng.random_range(0..2) {
+                0 => Instruction::Cset { rd, cond },
+                _ => Instruction::Csetm { rd, cond },
+            },
+            // ROR joins the shift cluster LSL/LSR/ASR.
+            Instruction::Ror { rd, rn, shift } => match rng.random_range(0..4) {
+                0 => Instruction::Lsl { rd, rn, shift },
+                1 => Instruction::Lsr { rd, rn, shift },
+                2 => Instruction::Asr { rd, rn, shift },
+                _ => Instruction::Ror { rd, rn, shift },
             },
         };
     }

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -420,8 +420,17 @@ impl Mutator {
                 5 => Instruction::Eon { rd, rn, rm },
                 _ => Instruction::Bic { rd, rn, rm },
             },
-            Instruction::Bics { rd, rn, rm } => match rng.random_range(0..2) {
-                0 => Instruction::Bic { rd, rn, rm },
+            // Bics now mirrors Bic's 6-peer logical cluster so MCMC chains
+            // starting at BICS have the same ergodicity as those starting at
+            // BIC. The original 1-peer version made BICS effectively a
+            // dead-end neighbour, slowing convergence.
+            Instruction::Bics { rd, rn, rm } => match rng.random_range(0..7) {
+                0 => Instruction::And { rd, rn, rm },
+                1 => Instruction::Orr { rd, rn, rm },
+                2 => Instruction::Eor { rd, rn, rm },
+                3 => Instruction::Bic { rd, rn, rm },
+                4 => Instruction::Orn { rd, rn, rm },
+                5 => Instruction::Eon { rd, rn, rm },
                 _ => Instruction::Bics { rd, rn, rm },
             },
             Instruction::Orn { rd, rn, rm } => match rng.random_range(0..5) {

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -14,13 +14,6 @@ use crate::search::candidate::generate_random_instruction;
 use crate::search::config::MutationWeights;
 use rand::RngExt;
 
-/// Pick a random condition code excluding AL/NV.
-fn random_normal_cond_local<R: RngExt>(rng: &mut R) -> Condition {
-    use Condition::*;
-    const NORMAL: [Condition; 14] = [EQ, NE, CS, CC, MI, PL, VS, VC, HI, LS, GE, LT, GT, LE];
-    NORMAL[rng.random_range(0..NORMAL.len())]
-}
-
 /// Mutation operator types
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MutationType {
@@ -222,7 +215,7 @@ impl Mutator {
                 if rng.random_bool(0.5) {
                     *rd = self.random_register(rng);
                 } else {
-                    *cond = random_normal_cond_local(rng);
+                    *cond = Condition::random_normal(rng);
                 }
             }
             // ROR: same operand shape as LSL/LSR/ASR

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -14,6 +14,23 @@ use crate::search::candidate::generate_random_instruction;
 use crate::search::config::MutationWeights;
 use rand::RngExt;
 
+/// If `rm` is already a register, keep it; if it's an immediate, replace it
+/// with a random register from `registers`. Used when mutating an
+/// immediate-accepting opcode (ADDS/SUBS) into a register-only opcode
+/// (ANDS) — keeps the resulting instruction encodable.
+fn clamp_to_register<R: RngExt>(rm: Operand, registers: &[Register], rng: &mut R) -> Operand {
+    match rm {
+        Operand::Register(_) => rm,
+        Operand::Immediate(_) => {
+            if registers.is_empty() {
+                rm
+            } else {
+                Operand::Register(registers[rng.random_range(0..registers.len())])
+            }
+        }
+    }
+}
+
 /// Mutation operator types
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MutationType {
@@ -422,16 +439,32 @@ impl Mutator {
                 _ => Instruction::Eon { rd, rn, rm },
             },
             // Flag-setting cluster: ADDS↔SUBS↔ANDS, and into/out of ADD/SUB/AND.
+            //
+            // Note: ADDS/SUBS accept `Operand::Immediate` (12-bit), but ANDS
+            // and AND are register-only (bitmask-immediate encoding is not
+            // supported). Forwarding an Immediate `rm` directly into ANDS
+            // would produce an un-encodable instruction that is_encodable
+            // silently rejects, burning search iterations. When mutating
+            // into ANDS, clamp `rm` to a register; the same logic applies
+            // when mutating into AND.
             Instruction::Adds { rd, rn, rm } => match rng.random_range(0..4) {
                 0 => Instruction::Add { rd, rn, rm },
                 1 => Instruction::Subs { rd, rn, rm },
-                2 => Instruction::Ands { rd, rn, rm },
+                2 => Instruction::Ands {
+                    rd,
+                    rn,
+                    rm: clamp_to_register(rm, &self.registers, rng),
+                },
                 _ => Instruction::Adds { rd, rn, rm },
             },
             Instruction::Subs { rd, rn, rm } => match rng.random_range(0..4) {
                 0 => Instruction::Sub { rd, rn, rm },
                 1 => Instruction::Adds { rd, rn, rm },
-                2 => Instruction::Ands { rd, rn, rm },
+                2 => Instruction::Ands {
+                    rd,
+                    rn,
+                    rm: clamp_to_register(rm, &self.registers, rng),
+                },
                 _ => Instruction::Subs { rd, rn, rm },
             },
             Instruction::Ands { rd, rn, rm } => match rng.random_range(0..4) {

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -170,6 +170,106 @@ pub fn apply_instruction_concrete(
             };
             state.set_register(*rd, result);
         }
+        // MVN: bitwise NOT (rd = !rm)
+        Instruction::Mvn { rd, rm } => {
+            let result = !state.get_register(*rm).as_u64();
+            state.set_register(*rd, ConcreteValue::new(result));
+        }
+        // NEG: two's-complement negation (rd = -rm)
+        Instruction::Neg { rd, rm } => {
+            let result = state.get_register(*rm).as_i64().wrapping_neg();
+            state.set_register(*rd, ConcreteValue::from_i64(result));
+        }
+        // NEGS: NEG with flag side-effect, same as `SUBS rd, XZR, rm`
+        Instruction::Negs { rd, rm } => {
+            let rhs = state.get_register(*rm).as_u64();
+            let result = 0_u64.wrapping_sub(rhs);
+            state.set_register(*rd, ConcreteValue::new(result));
+            let flags = ConditionFlags::from_sub(0, rhs, result);
+            state.set_flags(flags);
+        }
+        // MOVN: rd = !((imm as u64) << shift)
+        Instruction::MovN { rd, imm, shift } => {
+            let value = !(((*imm as u64) << (*shift as u32)) as u64);
+            state.set_register(*rd, ConcreteValue::new(value));
+        }
+        // BIC: rd = rn & !rm
+        Instruction::Bic { rd, rn, rm } => {
+            let lhs = state.get_register(*rn).as_u64();
+            let rhs = eval_operand(&state, rm).as_u64();
+            state.set_register(*rd, ConcreteValue::new(lhs & !rhs));
+        }
+        // BICS: BIC with flag side-effect via from_logical
+        Instruction::Bics { rd, rn, rm } => {
+            let lhs = state.get_register(*rn).as_u64();
+            let rhs = eval_operand(&state, rm).as_u64();
+            let result = lhs & !rhs;
+            state.set_register(*rd, ConcreteValue::new(result));
+            state.set_flags(ConditionFlags::from_logical(result));
+        }
+        // ORN: rd = rn | !rm
+        Instruction::Orn { rd, rn, rm } => {
+            let lhs = state.get_register(*rn).as_u64();
+            let rhs = eval_operand(&state, rm).as_u64();
+            state.set_register(*rd, ConcreteValue::new(lhs | !rhs));
+        }
+        // EON: rd = rn ^ !rm
+        Instruction::Eon { rd, rn, rm } => {
+            let lhs = state.get_register(*rn).as_u64();
+            let rhs = eval_operand(&state, rm).as_u64();
+            state.set_register(*rd, ConcreteValue::new(lhs ^ !rhs));
+        }
+        // Flag-setting arithmetic / logical
+        Instruction::Adds { rd, rn, rm } => {
+            let lhs = state.get_register(*rn).as_u64();
+            let rhs = eval_operand(&state, rm).as_u64();
+            let result = lhs.wrapping_add(rhs);
+            state.set_register(*rd, ConcreteValue::new(result));
+            state.set_flags(ConditionFlags::from_add(lhs, rhs, result));
+        }
+        Instruction::Subs { rd, rn, rm } => {
+            let lhs = state.get_register(*rn).as_u64();
+            let rhs = eval_operand(&state, rm).as_u64();
+            let result = lhs.wrapping_sub(rhs);
+            state.set_register(*rd, ConcreteValue::new(result));
+            state.set_flags(ConditionFlags::from_sub(lhs, rhs, result));
+        }
+        Instruction::Ands { rd, rn, rm } => {
+            let lhs = state.get_register(*rn).as_u64();
+            let rhs = eval_operand(&state, rm).as_u64();
+            let result = lhs & rhs;
+            state.set_register(*rd, ConcreteValue::new(result));
+            state.set_flags(ConditionFlags::from_logical(result));
+        }
+        // CSET / CSETM: AArch64-spec defines them as aliases of CSINC/CSINV
+        // with XZR sources and inverted condition. The observable result is
+        // simply "if cond holds then 1/-1 else 0". Note: `evaluate_condition`
+        // at concrete.rs:177-197 has an NV=true quirk that disagrees with
+        // state.rs:84 (NV=false); is_encodable_aarch64 rejects NV so this
+        // path is unreachable for NV at runtime.
+        Instruction::Cset { rd, cond } => {
+            let result = if evaluate_condition(&state, *cond) {
+                1
+            } else {
+                0
+            };
+            state.set_register(*rd, ConcreteValue::new(result));
+        }
+        Instruction::Csetm { rd, cond } => {
+            let result: u64 = if evaluate_condition(&state, *cond) {
+                u64::MAX
+            } else {
+                0
+            };
+            state.set_register(*rd, ConcreteValue::new(result));
+        }
+        // ROR: imm form rotates by `imm`; reg form rotates by `rm & 63`
+        // (hardware uses low 6 bits).
+        Instruction::Ror { rd, rn, shift } => {
+            let value = state.get_register(*rn).as_u64();
+            let amount = (eval_operand(&state, shift).as_u64() & 63) as u32;
+            state.set_register(*rd, ConcreteValue::new(value.rotate_right(amount)));
+        }
     }
     state
 }
@@ -673,5 +773,414 @@ mod tests {
         };
         let new_state = apply_instruction_concrete(state, &instr);
         assert_eq!(new_state.get_register(Register::X0).as_u64(), u64::MAX / 3);
+    }
+
+    #[test]
+    fn test_ror_imm_matches_rotate_right() {
+        // ROR rd, rn, #imm — match against u64::rotate_right
+        for shift in [0u64, 1, 4, 16, 63] {
+            let input: u64 = 0xDEAD_BEEF_DEAD_BEEF;
+            let state = state_with(vec![(Register::X1, input)]);
+            let instr = Instruction::Ror {
+                rd: Register::X0,
+                rn: Register::X1,
+                shift: Operand::Immediate(shift as i64),
+            };
+            let new_state = apply_instruction_concrete(state, &instr);
+            assert_eq!(
+                new_state.get_register(Register::X0).as_u64(),
+                input.rotate_right(shift as u32),
+                "ROR(#{:#x}, #{}) wrong",
+                input,
+                shift
+            );
+        }
+    }
+
+    #[test]
+    fn test_ror_reg_masks_amount_to_low_6_bits() {
+        // ROR rd, rn, rm uses rm[5:0]; rotate by 64 ≡ rotate by 0
+        let input: u64 = 0x1234_5678_9ABC_DEF0;
+        let state = state_with(vec![(Register::X1, input), (Register::X2, 64)]);
+        let instr = Instruction::Ror {
+            rd: Register::X0,
+            rn: Register::X1,
+            shift: Operand::Register(Register::X2),
+        };
+        let new_state = apply_instruction_concrete(state, &instr);
+        // ROR by 64 wraps to ROR by 0 → input unchanged
+        assert_eq!(new_state.get_register(Register::X0).as_u64(), input);
+    }
+
+    #[test]
+    fn test_cset_writes_1_when_cond_true_0_otherwise() {
+        // Set Z=1 via CMP X1, X1 (rn == rm)
+        let pre = state_with(vec![(Register::X1, 5)]);
+        let after_cmp = apply_instruction_concrete(
+            pre,
+            &Instruction::Cmp {
+                rn: Register::X1,
+                rm: Operand::Register(Register::X1),
+            },
+        );
+        let after_cset = apply_instruction_concrete(
+            after_cmp,
+            &Instruction::Cset {
+                rd: Register::X0,
+                cond: Condition::EQ,
+            },
+        );
+        assert_eq!(after_cset.get_register(Register::X0).as_u64(), 1);
+
+        // Set Z=0 via CMP X1, X2 with X1=5, X2=6
+        let pre = state_with(vec![(Register::X1, 5), (Register::X2, 6)]);
+        let after_cmp = apply_instruction_concrete(
+            pre,
+            &Instruction::Cmp {
+                rn: Register::X1,
+                rm: Operand::Register(Register::X2),
+            },
+        );
+        let after_cset = apply_instruction_concrete(
+            after_cmp,
+            &Instruction::Cset {
+                rd: Register::X0,
+                cond: Condition::EQ,
+            },
+        );
+        assert_eq!(after_cset.get_register(Register::X0).as_u64(), 0);
+    }
+
+    #[test]
+    fn test_csetm_writes_all_ones_when_cond_true() {
+        let pre = state_with(vec![(Register::X1, 5)]);
+        let after_cmp = apply_instruction_concrete(
+            pre,
+            &Instruction::Cmp {
+                rn: Register::X1,
+                rm: Operand::Register(Register::X1),
+            },
+        );
+        let after_csetm = apply_instruction_concrete(
+            after_cmp,
+            &Instruction::Csetm {
+                rd: Register::X0,
+                cond: Condition::EQ,
+            },
+        );
+        assert_eq!(after_csetm.get_register(Register::X0).as_u64(), u64::MAX);
+    }
+
+    #[test]
+    fn test_cset_rejects_al_and_nv() {
+        // CSET with AL or NV is nonsensical; is_encodable_aarch64 must refuse.
+        assert!(
+            !Instruction::Cset {
+                rd: Register::X0,
+                cond: Condition::AL,
+            }
+            .is_encodable_aarch64()
+        );
+        assert!(
+            !Instruction::Cset {
+                rd: Register::X0,
+                cond: Condition::NV,
+            }
+            .is_encodable_aarch64()
+        );
+        assert!(
+            !Instruction::Csetm {
+                rd: Register::X0,
+                cond: Condition::AL,
+            }
+            .is_encodable_aarch64()
+        );
+    }
+
+    #[test]
+    fn test_adds_overflow_sets_v_flag() {
+        // ADDS(i64::MAX, 1) overflows: result wraps to INT_MIN; V=1, N=1
+        let state = state_with(vec![(Register::X1, i64::MAX as u64), (Register::X2, 1)]);
+        let instr = Instruction::Adds {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        };
+        let new_state = apply_instruction_concrete(state, &instr);
+        assert_eq!(new_state.get_register(Register::X0).as_i64(), i64::MIN);
+        let f = new_state.get_flags();
+        assert!(f.n, "ADDS overflow: N should be 1");
+        assert!(!f.z, "ADDS overflow: Z should be 0");
+        assert!(f.v, "ADDS overflow: V should be 1");
+    }
+
+    #[test]
+    fn test_subs_carry_is_no_borrow() {
+        // SUBS(rn, rm): C=1 when no borrow (rn >= rm unsigned)
+        let state = state_with(vec![(Register::X1, 5), (Register::X2, 5)]);
+        let instr = Instruction::Subs {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        };
+        let new_state = apply_instruction_concrete(state, &instr);
+        assert_eq!(new_state.get_register(Register::X0).as_u64(), 0);
+        let f = new_state.get_flags();
+        assert_eq!((f.n, f.z, f.c, f.v), (false, true, true, false));
+
+        // SUBS where rn < rm unsigned → C=0 (borrow occurred)
+        let state = state_with(vec![(Register::X1, 3), (Register::X2, 5)]);
+        let instr = Instruction::Subs {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        };
+        let new_state = apply_instruction_concrete(state, &instr);
+        let f = new_state.get_flags();
+        assert!(!f.c, "SUBS(3, 5): C=0 (borrow)");
+    }
+
+    #[test]
+    fn test_ands_clears_c_and_v() {
+        let state = state_with(vec![(Register::X1, 0), (Register::X2, 0xFF)]);
+        let instr = Instruction::Ands {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        };
+        let new_state = apply_instruction_concrete(state, &instr);
+        assert_eq!(new_state.get_register(Register::X0).as_u64(), 0);
+        let f = new_state.get_flags();
+        // Logical ops: N from result, Z from result, C=0, V=0
+        assert_eq!((f.n, f.z, f.c, f.v), (false, true, false, false));
+    }
+
+    #[test]
+    fn test_orn_or_with_inverted_rm() {
+        // ORN x, x = !0 (all ones)
+        let state = state_with(vec![(Register::X1, 0xDEAD_BEEF)]);
+        let instr = Instruction::Orn {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X1),
+        };
+        let new_state = apply_instruction_concrete(state, &instr);
+        assert_eq!(new_state.get_register(Register::X0).as_u64(), u64::MAX);
+    }
+
+    #[test]
+    fn test_eon_xor_with_inverted_rm() {
+        // EON x, x = !0 (all ones)
+        let state = state_with(vec![(Register::X1, 0xDEAD_BEEF)]);
+        let instr = Instruction::Eon {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X1),
+        };
+        let new_state = apply_instruction_concrete(state, &instr);
+        assert_eq!(new_state.get_register(Register::X0).as_u64(), u64::MAX);
+    }
+
+    #[test]
+    fn test_bics_clears_bits_and_sets_flags() {
+        // BICS: rd = rn & !rm; flags via from_logical (Z=result==0, N=high bit, C=V=0).
+        // Case 1: result is zero → Z=1
+        let state = state_with(vec![
+            (Register::X1, 0xFF),
+            (Register::X2, 0xFF), // mask off all of rn → 0
+        ]);
+        let instr = Instruction::Bics {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        };
+        let new_state = apply_instruction_concrete(state, &instr);
+        assert_eq!(new_state.get_register(Register::X0).as_u64(), 0);
+        let f = new_state.get_flags();
+        assert_eq!((f.n, f.z, f.c, f.v), (false, true, false, false));
+    }
+
+    #[test]
+    fn test_bic_clears_bits_set_in_rm() {
+        // BIC rd, rn, rm  →  rd = rn & !rm
+        let state = state_with(vec![
+            (Register::X1, 0b1111_1010),
+            (Register::X2, 0b0000_1100),
+        ]);
+        let instr = Instruction::Bic {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        };
+        let new_state = apply_instruction_concrete(state, &instr);
+        // 0b11111010 & ~0b00001100 = 0b11111010 & 0b...11110011 = 0b11110010
+        assert_eq!(new_state.get_register(Register::X0).as_u64(), 0b1111_0010);
+    }
+
+    #[test]
+    fn test_movn_inverts_shifted_immediate() {
+        // MOVN rd, #imm, lsl #shift → rd = !((imm as u64) << shift)
+        struct Case {
+            imm: u16,
+            shift: u8,
+            expected: u64,
+        }
+        let cases = [
+            Case {
+                imm: 0,
+                shift: 0,
+                expected: u64::MAX,
+            }, // !(0<<0) = all ones
+            Case {
+                imm: 0xFFFF,
+                shift: 0,
+                expected: !0xFFFF_u64,
+            }, // 0xFFFF_FFFF_FFFF_0000
+            Case {
+                imm: 1,
+                shift: 16,
+                expected: !(1_u64 << 16),
+            }, // 0xFFFF_FFFF_FFFE_FFFF
+            Case {
+                imm: 0xFFFF,
+                shift: 48,
+                expected: !(0xFFFF_u64 << 48),
+            }, // 0x0000_FFFF_FFFF_FFFF
+        ];
+        for case in &cases {
+            let state = ConcreteMachineState::new_zeroed();
+            let instr = Instruction::MovN {
+                rd: Register::X0,
+                imm: case.imm,
+                shift: case.shift,
+            };
+            let new_state = apply_instruction_concrete(state, &instr);
+            assert_eq!(
+                new_state.get_register(Register::X0).as_u64(),
+                case.expected,
+                "MOVN(#{:#x}, lsl #{}) should be {:#x}",
+                case.imm,
+                case.shift,
+                case.expected
+            );
+        }
+    }
+
+    #[test]
+    fn test_negs_sets_flags_and_value() {
+        // NEGS = SUBS rd, XZR, rm — so flag rule is `from_sub(0, rm, result)`.
+        // - NEGS(0)        → result=0,        Z=1, N=0, C=1 (no borrow: 0>=0), V=0
+        // - NEGS(1)        → result=-1,       Z=0, N=1, C=0 (borrow),         V=0
+        // - NEGS(INT64_MIN)→ result=INT64_MIN, Z=0, N=1, C=0,                  V=1 (signed overflow)
+        struct Case {
+            input: i64,
+            expected_result: i64,
+            n: bool,
+            z: bool,
+            c: bool,
+            v: bool,
+        }
+        let cases = [
+            Case {
+                input: 0,
+                expected_result: 0,
+                n: false,
+                z: true,
+                c: true,
+                v: false,
+            },
+            Case {
+                input: 1,
+                expected_result: -1,
+                n: true,
+                z: false,
+                c: false,
+                v: false,
+            },
+            Case {
+                input: i64::MIN,
+                expected_result: i64::MIN,
+                n: true,
+                z: false,
+                c: false,
+                v: true,
+            },
+        ];
+        for case in &cases {
+            let state = state_with(vec![(Register::X1, case.input as u64)]);
+            let instr = Instruction::Negs {
+                rd: Register::X0,
+                rm: Register::X1,
+            };
+            let new_state = apply_instruction_concrete(state, &instr);
+            assert_eq!(
+                new_state.get_register(Register::X0).as_i64(),
+                case.expected_result,
+                "NEGS({}) value wrong",
+                case.input
+            );
+            let f = new_state.get_flags();
+            assert_eq!(
+                (f.n, f.z, f.c, f.v),
+                (case.n, case.z, case.c, case.v),
+                "NEGS({}) flags wrong: got NZCV={:?}, expected NZCV={:?}",
+                case.input,
+                (f.n, f.z, f.c, f.v),
+                (case.n, case.z, case.c, case.v)
+            );
+        }
+    }
+
+    #[test]
+    fn test_neg_two_complement() {
+        let cases: &[(i64, i64)] = &[
+            (0, 0),
+            (1, -1),
+            (-1, 1),
+            (i64::MIN, i64::MIN), // wraps
+            (42, -42),
+            (-42, 42),
+        ];
+        for (input, expected) in cases {
+            let state = state_with(vec![(Register::X1, *input as u64)]);
+            let instr = Instruction::Neg {
+                rd: Register::X0,
+                rm: Register::X1,
+            };
+            let new_state = apply_instruction_concrete(state, &instr);
+            assert_eq!(
+                new_state.get_register(Register::X0).as_i64(),
+                *expected,
+                "NEG({}) should be {}",
+                input,
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn test_mvn_inverts_bits() {
+        // MVN x0, x1 sets x0 = !x1 (bitwise NOT)
+        let cases: &[(u64, u64)] = &[
+            (0, u64::MAX),
+            (u64::MAX, 0),
+            (0xFF, !0xFF_u64),
+            (0xDEAD_BEEF_DEAD_BEEF, !0xDEAD_BEEF_DEAD_BEEF_u64),
+        ];
+        for (input, expected) in cases {
+            let state = state_with(vec![(Register::X1, *input)]);
+            let instr = Instruction::Mvn {
+                rd: Register::X0,
+                rm: Register::X1,
+            };
+            let new_state = apply_instruction_concrete(state, &instr);
+            assert_eq!(
+                new_state.get_register(Register::X0).as_u64(),
+                *expected,
+                "MVN({:#x}) should be {:#x}",
+                input,
+                expected
+            );
+        }
     }
 }

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -190,7 +190,7 @@ pub fn apply_instruction_concrete(
         }
         // MOVN: rd = !((imm as u64) << shift)
         Instruction::MovN { rd, imm, shift } => {
-            let value = !(((*imm as u64) << (*shift as u32)) as u64);
+            let value = !((*imm as u64) << (*shift as u32));
             state.set_register(*rd, ConcreteValue::new(value));
         }
         // BIC: rd = rn & !rm

--- a/src/semantics/cost.rs
+++ b/src/semantics/cost.rs
@@ -43,6 +43,22 @@ fn instruction_latency(instr: &Instruction) -> u64 {
         | Instruction::Csinc { .. }
         | Instruction::Csinv { .. }
         | Instruction::Csneg { .. } => 1,
+        // Unary bitwise / negation / move-negated immediate
+        Instruction::Mvn { .. }
+        | Instruction::Neg { .. }
+        | Instruction::Negs { .. }
+        | Instruction::MovN { .. } => 1,
+        // Inverted-logical
+        Instruction::Bic { .. }
+        | Instruction::Bics { .. }
+        | Instruction::Orn { .. }
+        | Instruction::Eon { .. } => 1,
+        // Flag-setting arith / logical
+        Instruction::Adds { .. } | Instruction::Subs { .. } | Instruction::Ands { .. } => 1,
+        // Conditional set aliases
+        Instruction::Cset { .. } | Instruction::Csetm { .. } => 1,
+        // Rotate right
+        Instruction::Ror { .. } => 1,
     }
 }
 

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -770,8 +770,7 @@ mod tests {
                 rm: Operand::Register(Register::X3),
             },
         ];
-        let config =
-            EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
+        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
         assert_eq!(
             check_equivalence_with_config(&seq1, &seq2, &config),
             EquivalenceResult::Equivalent
@@ -797,8 +796,7 @@ mod tests {
                 rm: Operand::Register(Register::X3),
             },
         ];
-        let config =
-            EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
+        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
         assert_eq!(
             check_equivalence_with_config(&seq1, &seq2, &config),
             EquivalenceResult::Equivalent
@@ -824,8 +822,7 @@ mod tests {
                 rm: Operand::Register(Register::X3),
             },
         ];
-        let config =
-            EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
+        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
         assert_eq!(
             check_equivalence_with_config(&seq1, &seq2, &config),
             EquivalenceResult::Equivalent
@@ -852,8 +849,7 @@ mod tests {
         ];
         // X2 differs between the two sequences (NEG doesn't touch X2 but the
         // 2-op form sets X2 to 0). Restrict equivalence to live-out X0.
-        let config =
-            EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
+        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
         assert_eq!(
             check_equivalence_with_config(&seq1, &seq2, &config),
             EquivalenceResult::Equivalent
@@ -877,8 +873,7 @@ mod tests {
             rn: Register::X1,
             rm: Operand::Immediate(1),
         }];
-        let config =
-            EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
+        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
         assert_eq!(
             check_equivalence_with_config(&adds, &add, &config),
             EquivalenceResult::NotEquivalent,
@@ -905,8 +900,7 @@ mod tests {
             rn: Register::X1,
             rm: Operand::Register(Register::X2),
         }];
-        let config =
-            EquivalenceConfig::with_live_out(LiveOutMask::from_registers(vec![Register::X0]));
+        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
         assert_eq!(
             check_equivalence_with_config(&bics, &bic, &config),
             EquivalenceResult::NotEquivalent
@@ -928,8 +922,7 @@ mod tests {
             rd: Register::X0,
             rm: Register::X1,
         }];
-        let config =
-            EquivalenceConfig::with_live_out(LiveOutMask::from_registers(vec![Register::X0]));
+        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
         assert_eq!(
             check_equivalence_with_config(&negs, &neg, &config),
             EquivalenceResult::NotEquivalent
@@ -966,8 +959,7 @@ mod tests {
             rn: Register::X1,
             rm: Operand::Immediate(1),
         }];
-        let config =
-            EquivalenceConfig::with_live_out(LiveOutMask::from_registers(vec![Register::X0]));
+        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
         assert_eq!(
             check_equivalence_with_config(&target, &candidate, &config),
             EquivalenceResult::NotEquivalent,

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -12,11 +12,25 @@ use crate::semantics::smt::{
     states_not_equal_for_live_out,
 };
 use crate::semantics::state::ConcreteMachineState;
+use crate::validation::live_out::flags_live_out;
 use crate::validation::random::{
     RandomInputConfig, generate_edge_case_inputs, generate_random_inputs,
 };
 use std::time::Duration;
 use z3::SatResult;
+
+/// Soundness guard: SMT does not model NZCV, so a rewrite that drops a
+/// flag-writing instruction present in the target sequence cannot be proved
+/// equivalent — a downstream conditional branch (or CSEL chain) would
+/// observe different flags. Equivalent in registers ≠ equivalent in flags.
+///
+/// Conservative: returns `true` whenever the target contains any
+/// flag-writer that the candidate lacks. Reject (return NotEquivalent) when
+/// this is the case before invoking SMT. Over-approximation matches the
+/// posture documented on `flags_live_out`.
+fn drops_target_flag_writer(target: &[Instruction], candidate: &[Instruction]) -> bool {
+    flags_live_out(target) && !flags_live_out(candidate)
+}
 
 /// Result of equivalence checking
 #[derive(Debug, Clone, PartialEq)]
@@ -108,6 +122,11 @@ impl EquivalenceConfig {
 /// Returns true if for all possible initial states, both sequences
 /// produce the same final state.
 pub fn check_equivalence(seq1: &[Instruction], seq2: &[Instruction]) -> EquivalenceResult {
+    // Soundness guard before SMT: see `drops_target_flag_writer`.
+    if drops_target_flag_writer(seq1, seq2) {
+        return EquivalenceResult::NotEquivalent;
+    }
+
     let solver_config = SolverConfig::default();
     let solver = create_solver_with_config(&solver_config);
 
@@ -187,6 +206,11 @@ pub fn check_equivalence_with_config(
     seq2: &[Instruction],
     config: &EquivalenceConfig,
 ) -> EquivalenceResult {
+    // Soundness guard before SMT: see `drops_target_flag_writer`.
+    if drops_target_flag_writer(seq1, seq2) {
+        return EquivalenceResult::NotEquivalent;
+    }
+
     if let Some(fast) = run_fast_path(seq1, seq2, config) {
         return fast;
     }
@@ -210,6 +234,11 @@ pub fn check_equivalence_with_config_metrics(
     config: &EquivalenceConfig,
 ) -> (EquivalenceResult, EquivalenceMetrics) {
     let metrics = EquivalenceMetrics::default();
+
+    // Soundness guard before SMT: see `drops_target_flag_writer`.
+    if drops_target_flag_writer(seq1, seq2) {
+        return (EquivalenceResult::NotEquivalent, metrics);
+    }
 
     if let Some(fast) = run_fast_path(seq1, seq2, config) {
         return (fast, metrics);
@@ -654,10 +683,10 @@ mod tests {
     }
 
     #[test]
-    fn test_movn_zero_equivalent_to_csetm_al() {
-        // MOVN x0, #0 = all ones.
-        // We can't test CSETM with AL (it's rejected by is_encodable), but
-        // we can prove MOVN x0,#0 ≡ EON x0,x1,x1.
+    fn test_movn_zero_equivalent_to_eon_self() {
+        // MOVN x0, #0 = all ones, which also equals `x1 XOR ~x1` for any x1.
+        // (CSETM with AL would also produce all-ones but is_encodable rejects
+        //  AL, so we use EON-with-self as the comparison sequence.)
         let seq1 = vec![Instruction::MovN {
             rd: Register::X0,
             imm: 0,
@@ -717,7 +746,7 @@ mod tests {
             },
         ];
         let config =
-            EquivalenceConfig::with_live_out(LiveOutMask::from_registers(vec![Register::X0]));
+            EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
         assert_eq!(
             check_equivalence_with_config(&seq1, &seq2, &config),
             EquivalenceResult::Equivalent
@@ -744,7 +773,7 @@ mod tests {
             },
         ];
         let config =
-            EquivalenceConfig::with_live_out(LiveOutMask::from_registers(vec![Register::X0]));
+            EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
         assert_eq!(
             check_equivalence_with_config(&seq1, &seq2, &config),
             EquivalenceResult::Equivalent
@@ -771,7 +800,7 @@ mod tests {
             },
         ];
         let config =
-            EquivalenceConfig::with_live_out(LiveOutMask::from_registers(vec![Register::X0]));
+            EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
         assert_eq!(
             check_equivalence_with_config(&seq1, &seq2, &config),
             EquivalenceResult::Equivalent
@@ -799,10 +828,54 @@ mod tests {
         // X2 differs between the two sequences (NEG doesn't touch X2 but the
         // 2-op form sets X2 to 0). Restrict equivalence to live-out X0.
         let config =
-            EquivalenceConfig::with_live_out(LiveOutMask::from_registers(vec![Register::X0]));
+            EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
         assert_eq!(
             check_equivalence_with_config(&seq1, &seq2, &config),
             EquivalenceResult::Equivalent
         );
+    }
+
+    /// Soundness regression for the flag-drop guard: ADDS x0, x1, #1 ≡ ADD
+    /// x0, x1, #1 is unsound because the flag side-effect is silently
+    /// dropped. SMT alone cannot rule this out (it models registers only).
+    /// `check_equivalence_with_config` and `check_equivalence` must reject
+    /// such rewrites before reaching the solver.
+    #[test]
+    fn test_adds_to_add_rewrite_rejected_even_with_register_live_out() {
+        let adds = vec![Instruction::Adds {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Immediate(1),
+        }];
+        let add = vec![Instruction::Add {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Immediate(1),
+        }];
+        let config =
+            EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
+        assert_eq!(
+            check_equivalence_with_config(&adds, &add, &config),
+            EquivalenceResult::NotEquivalent,
+            "Dropping a flag-writer must not be certified as equivalent"
+        );
+        assert_eq!(
+            check_equivalence(&adds, &add),
+            EquivalenceResult::NotEquivalent,
+            "Same guard must apply to the simple entry point"
+        );
+    }
+
+    /// ADDS ≡ ADDS (same op) must still succeed — the flag guard fires only
+    /// when the candidate drops a writer the target had.
+    #[test]
+    fn test_adds_equivalent_to_adds() {
+        let s1 = vec![Instruction::Adds {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Immediate(1),
+        }];
+        let s2 = s1.clone();
+        assert_eq!(check_equivalence(&s1, &s2), EquivalenceResult::Equivalent);
     }
 }

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -19,17 +19,38 @@ use crate::validation::random::{
 use std::time::Duration;
 use z3::SatResult;
 
-/// Soundness guard: SMT does not model NZCV, so a rewrite that drops a
-/// flag-writing instruction present in the target sequence cannot be proved
-/// equivalent — a downstream conditional branch (or CSEL chain) would
-/// observe different flags. Equivalent in registers ≠ equivalent in flags.
+/// Soundness guard: SMT does not model NZCV, so any rewrite that disturbs
+/// the flag-writing trace cannot be proved equivalent — a downstream
+/// conditional branch (or CSEL chain) would observe different flags.
+/// Equivalent in registers ≠ equivalent in flags.
 ///
-/// Conservative: returns `true` whenever the target contains any
-/// flag-writer that the candidate lacks. Reject (return NotEquivalent) when
-/// this is the case before invoking SMT. Over-approximation matches the
-/// posture documented on `flags_live_out`.
-fn drops_target_flag_writer(target: &[Instruction], candidate: &[Instruction]) -> bool {
-    flags_live_out(target) && !flags_live_out(candidate)
+/// This guard fires when the sub-sequence of flag-writing instructions in
+/// `target` differs in any way from the sub-sequence in `candidate` — drop,
+/// swap, reorder, or replace-with-different-flag-writer all count. The
+/// comparison is `Instruction`-level structural equality, so a `CMP x2, #0`
+/// in target vs `ADDS x0, x1, #1` in candidate (both modify NZCV but with
+/// different operands and different flag-setting rules) is correctly
+/// rejected — see the regression tests below.
+///
+/// Conservative on purpose: some valid rewrites that happen to produce
+/// identical final NZCV from different flag-writers will be wrongly
+/// rejected here. Closing that gap requires full NZCV modelling in SMT,
+/// which is tracked as a separate follow-up.
+fn flag_writers_diverge(target: &[Instruction], candidate: &[Instruction]) -> bool {
+    // Fast paths: most rewrites involve no flag writers at all.
+    let tw = flags_live_out(target);
+    let cw = flags_live_out(candidate);
+    if !tw && !cw {
+        return false;
+    }
+    if tw != cw {
+        return true; // target writes flags, candidate doesn't (or vice versa)
+    }
+    let target_flag_writers: Vec<&Instruction> =
+        target.iter().filter(|i| i.modifies_flags()).collect();
+    let candidate_flag_writers: Vec<&Instruction> =
+        candidate.iter().filter(|i| i.modifies_flags()).collect();
+    target_flag_writers != candidate_flag_writers
 }
 
 /// Result of equivalence checking
@@ -122,8 +143,8 @@ impl EquivalenceConfig {
 /// Returns true if for all possible initial states, both sequences
 /// produce the same final state.
 pub fn check_equivalence(seq1: &[Instruction], seq2: &[Instruction]) -> EquivalenceResult {
-    // Soundness guard before SMT: see `drops_target_flag_writer`.
-    if drops_target_flag_writer(seq1, seq2) {
+    // Soundness guard before SMT: see `flag_writers_diverge`.
+    if flag_writers_diverge(seq1, seq2) {
         return EquivalenceResult::NotEquivalent;
     }
 
@@ -206,8 +227,8 @@ pub fn check_equivalence_with_config(
     seq2: &[Instruction],
     config: &EquivalenceConfig,
 ) -> EquivalenceResult {
-    // Soundness guard before SMT: see `drops_target_flag_writer`.
-    if drops_target_flag_writer(seq1, seq2) {
+    // Soundness guard before SMT: see `flag_writers_diverge`.
+    if flag_writers_diverge(seq1, seq2) {
         return EquivalenceResult::NotEquivalent;
     }
 
@@ -235,8 +256,8 @@ pub fn check_equivalence_with_config_metrics(
 ) -> (EquivalenceResult, EquivalenceMetrics) {
     let metrics = EquivalenceMetrics::default();
 
-    // Soundness guard before SMT: see `drops_target_flag_writer`.
-    if drops_target_flag_writer(seq1, seq2) {
+    // Soundness guard before SMT: see `flag_writers_diverge`.
+    if flag_writers_diverge(seq1, seq2) {
         return (EquivalenceResult::NotEquivalent, metrics);
     }
 
@@ -866,8 +887,47 @@ mod tests {
         );
     }
 
+    /// Soundness regression for the strengthened flag-writer guard:
+    /// `ADD x0, x1, #1; CMP x2, #0` (writes flags from `CMP x2, #0`) vs
+    /// `ADDS x0, x1, #1` (writes flags from `ADDS x0, x1, #1`). Both
+    /// sequences write X0 to x1+1 and both have a flag-writer, so the SMT
+    /// register check would pass and the old "any writer present" guard
+    /// would also pass — but the post-sequence NZCV differs. The
+    /// strengthened guard rejects on structural flag-writer-sequence
+    /// inequality.
+    #[test]
+    fn test_swapped_flag_writer_rewrite_rejected() {
+        let target = vec![
+            Instruction::Add {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Immediate(1),
+            },
+            Instruction::Cmp {
+                rn: Register::X2,
+                rm: Operand::Immediate(0),
+            },
+        ];
+        let candidate = vec![Instruction::Adds {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Immediate(1),
+        }];
+        let config =
+            EquivalenceConfig::with_live_out(LiveOutMask::from_registers(vec![Register::X0]));
+        assert_eq!(
+            check_equivalence_with_config(&target, &candidate, &config),
+            EquivalenceResult::NotEquivalent,
+            "Replacing one flag-writer with a different flag-writer changes NZCV"
+        );
+        assert_eq!(
+            check_equivalence(&target, &candidate),
+            EquivalenceResult::NotEquivalent
+        );
+    }
+
     /// ADDS ≡ ADDS (same op) must still succeed — the flag guard fires only
-    /// when the candidate drops a writer the target had.
+    /// when the flag-writer sequence diverges.
     #[test]
     fn test_adds_equivalent_to_adds() {
         let s1 = vec![Instruction::Adds {

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -612,4 +612,197 @@ mod tests {
         assert_eq!(v1.as_u64(), 5);
         assert_eq!(v2.as_u64(), 10);
     }
+
+    // --- Tier 1 algebraic identities --------------------------------------
+
+    #[test]
+    fn test_eor_self_equivalent_to_bic_self() {
+        // EOR x0, x0, x0 ≡ BIC x0, x0, x0 (both produce 0)
+        let seq1 = vec![Instruction::Eor {
+            rd: Register::X0,
+            rn: Register::X0,
+            rm: Operand::Register(Register::X0),
+        }];
+        let seq2 = vec![Instruction::Bic {
+            rd: Register::X0,
+            rn: Register::X0,
+            rm: Operand::Register(Register::X0),
+        }];
+        assert_eq!(
+            check_equivalence(&seq1, &seq2),
+            EquivalenceResult::Equivalent
+        );
+    }
+
+    #[test]
+    fn test_orn_self_is_all_ones() {
+        // ORN x0, x1, x1 = x1 | !x1 = all ones, matches MOVN x0, #0
+        let seq1 = vec![Instruction::Orn {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X1),
+        }];
+        let seq2 = vec![Instruction::MovN {
+            rd: Register::X0,
+            imm: 0,
+            shift: 0,
+        }];
+        assert_eq!(
+            check_equivalence(&seq1, &seq2),
+            EquivalenceResult::Equivalent
+        );
+    }
+
+    #[test]
+    fn test_movn_zero_equivalent_to_csetm_al() {
+        // MOVN x0, #0 = all ones.
+        // We can't test CSETM with AL (it's rejected by is_encodable), but
+        // we can prove MOVN x0,#0 ≡ EON x0,x1,x1.
+        let seq1 = vec![Instruction::MovN {
+            rd: Register::X0,
+            imm: 0,
+            shift: 0,
+        }];
+        let seq2 = vec![Instruction::Eon {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X1),
+        }];
+        assert_eq!(
+            check_equivalence(&seq1, &seq2),
+            EquivalenceResult::Equivalent
+        );
+    }
+
+    #[test]
+    fn test_mvn_twice_is_identity() {
+        // MVN x0, x1; MVN x0, x0 ≡ MOV x0, x1
+        let seq1 = vec![
+            Instruction::Mvn {
+                rd: Register::X0,
+                rm: Register::X1,
+            },
+            Instruction::Mvn {
+                rd: Register::X0,
+                rm: Register::X0,
+            },
+        ];
+        let seq2 = vec![Instruction::MovReg {
+            rd: Register::X0,
+            rn: Register::X1,
+        }];
+        assert_eq!(
+            check_equivalence(&seq1, &seq2),
+            EquivalenceResult::Equivalent
+        );
+    }
+
+    /// BIC x0, x1, x2 ≡ MVN x3, x2; AND x0, x1, x3 (live-out X0)
+    #[test]
+    fn test_bic_lowered_to_mvn_and() {
+        let seq1 = vec![Instruction::Bic {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        }];
+        let seq2 = vec![
+            Instruction::Mvn {
+                rd: Register::X3,
+                rm: Register::X2,
+            },
+            Instruction::And {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Register(Register::X3),
+            },
+        ];
+        let config =
+            EquivalenceConfig::with_live_out(LiveOutMask::from_registers(vec![Register::X0]));
+        assert_eq!(
+            check_equivalence_with_config(&seq1, &seq2, &config),
+            EquivalenceResult::Equivalent
+        );
+    }
+
+    /// ORN x0, x1, x2 ≡ MVN x3, x2; ORR x0, x1, x3 (live-out X0)
+    #[test]
+    fn test_orn_lowered_to_mvn_orr() {
+        let seq1 = vec![Instruction::Orn {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        }];
+        let seq2 = vec![
+            Instruction::Mvn {
+                rd: Register::X3,
+                rm: Register::X2,
+            },
+            Instruction::Orr {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Register(Register::X3),
+            },
+        ];
+        let config =
+            EquivalenceConfig::with_live_out(LiveOutMask::from_registers(vec![Register::X0]));
+        assert_eq!(
+            check_equivalence_with_config(&seq1, &seq2, &config),
+            EquivalenceResult::Equivalent
+        );
+    }
+
+    /// EON x0, x1, x2 ≡ MVN x3, x2; EOR x0, x1, x3 (live-out X0)
+    #[test]
+    fn test_eon_lowered_to_mvn_eor() {
+        let seq1 = vec![Instruction::Eon {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        }];
+        let seq2 = vec![
+            Instruction::Mvn {
+                rd: Register::X3,
+                rm: Register::X2,
+            },
+            Instruction::Eor {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Register(Register::X3),
+            },
+        ];
+        let config =
+            EquivalenceConfig::with_live_out(LiveOutMask::from_registers(vec![Register::X0]));
+        assert_eq!(
+            check_equivalence_with_config(&seq1, &seq2, &config),
+            EquivalenceResult::Equivalent
+        );
+    }
+
+    #[test]
+    fn test_neg_equivalent_to_sub_from_zero() {
+        // NEG x0, x1 ≡ MOV x2, #0; SUB x0, x2, x1
+        let seq1 = vec![Instruction::Neg {
+            rd: Register::X0,
+            rm: Register::X1,
+        }];
+        let seq2 = vec![
+            Instruction::MovImm {
+                rd: Register::X2,
+                imm: 0,
+            },
+            Instruction::Sub {
+                rd: Register::X0,
+                rn: Register::X2,
+                rm: Operand::Register(Register::X1),
+            },
+        ];
+        // X2 differs between the two sequences (NEG doesn't touch X2 but the
+        // 2-op form sets X2 to 0). Restrict equivalence to live-out X0.
+        let config =
+            EquivalenceConfig::with_live_out(LiveOutMask::from_registers(vec![Register::X0]));
+        assert_eq!(
+            check_equivalence_with_config(&seq1, &seq2, &config),
+            EquivalenceResult::Equivalent
+        );
+    }
 }

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -34,8 +34,12 @@ use z3::SatResult;
 ///
 /// Conservative on purpose: some valid rewrites that happen to produce
 /// identical final NZCV from different flag-writers will be wrongly
-/// rejected here. Closing that gap requires full NZCV modelling in SMT,
-/// which is tracked as a separate follow-up.
+/// rejected here. A symmetric incompleteness also remains — when both
+/// sequences contain the same structural flag-writer but with different
+/// upstream operands feeding it (e.g. `mov x1,#0; cmp x1,#0` vs
+/// `mov x1,#5; cmp x1,#0`), the guard does not detect the divergence.
+/// Closing either gap requires full NZCV modelling in SMT, tracked as
+/// issue #92.
 fn flag_writers_diverge(target: &[Instruction], candidate: &[Instruction]) -> bool {
     // Fast paths: most rewrites involve no flag writers at all.
     let tw = flags_live_out(target);
@@ -884,6 +888,55 @@ mod tests {
             check_equivalence(&adds, &add),
             EquivalenceResult::NotEquivalent,
             "Same guard must apply to the simple entry point"
+        );
+    }
+
+    /// Soundness regression: `BICS x0, x1, x2` → `BIC x0, x1, x2` drops the
+    /// NZCV side-effect. Must be rejected by the flag-writer guard.
+    #[test]
+    fn test_bics_to_bic_rewrite_rejected() {
+        let bics = vec![Instruction::Bics {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        }];
+        let bic = vec![Instruction::Bic {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        }];
+        let config =
+            EquivalenceConfig::with_live_out(LiveOutMask::from_registers(vec![Register::X0]));
+        assert_eq!(
+            check_equivalence_with_config(&bics, &bic, &config),
+            EquivalenceResult::NotEquivalent
+        );
+        assert_eq!(
+            check_equivalence(&bics, &bic),
+            EquivalenceResult::NotEquivalent
+        );
+    }
+
+    /// Soundness regression: `NEGS x0, x1` → `NEG x0, x1` drops NZCV.
+    #[test]
+    fn test_negs_to_neg_rewrite_rejected() {
+        let negs = vec![Instruction::Negs {
+            rd: Register::X0,
+            rm: Register::X1,
+        }];
+        let neg = vec![Instruction::Neg {
+            rd: Register::X0,
+            rm: Register::X1,
+        }];
+        let config =
+            EquivalenceConfig::with_live_out(LiveOutMask::from_registers(vec![Register::X0]));
+        assert_eq!(
+            check_equivalence_with_config(&negs, &neg, &config),
+            EquivalenceResult::NotEquivalent
+        );
+        assert_eq!(
+            check_equivalence(&negs, &neg),
+            EquivalenceResult::NotEquivalent
         );
     }
 

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -57,6 +57,21 @@ fn flag_writers_diverge(target: &[Instruction], candidate: &[Instruction]) -> bo
     target_flag_writers != candidate_flag_writers
 }
 
+/// Combined pre-SMT soundness guard. Single source of truth for the
+/// short-circuit applied at every public entry point — returning `Some(r)`
+/// here means callers must return `r` (or the metrics-wrapped equivalent)
+/// before invoking the solver. Returning `None` means proceed to SMT.
+///
+/// Today this is just the flag-writer trace check, but the shape leaves
+/// room to add more pre-SMT guards (e.g. memory ops, control flow) without
+/// touching every call site.
+fn pre_smt_guard(target: &[Instruction], candidate: &[Instruction]) -> Option<EquivalenceResult> {
+    if flag_writers_diverge(target, candidate) {
+        return Some(EquivalenceResult::NotEquivalent);
+    }
+    None
+}
+
 /// Result of equivalence checking
 #[derive(Debug, Clone, PartialEq)]
 pub enum EquivalenceResult {
@@ -147,9 +162,8 @@ impl EquivalenceConfig {
 /// Returns true if for all possible initial states, both sequences
 /// produce the same final state.
 pub fn check_equivalence(seq1: &[Instruction], seq2: &[Instruction]) -> EquivalenceResult {
-    // Soundness guard before SMT: see `flag_writers_diverge`.
-    if flag_writers_diverge(seq1, seq2) {
-        return EquivalenceResult::NotEquivalent;
+    if let Some(early) = pre_smt_guard(seq1, seq2) {
+        return early;
     }
 
     let solver_config = SolverConfig::default();
@@ -231,9 +245,8 @@ pub fn check_equivalence_with_config(
     seq2: &[Instruction],
     config: &EquivalenceConfig,
 ) -> EquivalenceResult {
-    // Soundness guard before SMT: see `flag_writers_diverge`.
-    if flag_writers_diverge(seq1, seq2) {
-        return EquivalenceResult::NotEquivalent;
+    if let Some(early) = pre_smt_guard(seq1, seq2) {
+        return early;
     }
 
     if let Some(fast) = run_fast_path(seq1, seq2, config) {
@@ -260,9 +273,8 @@ pub fn check_equivalence_with_config_metrics(
 ) -> (EquivalenceResult, EquivalenceMetrics) {
     let metrics = EquivalenceMetrics::default();
 
-    // Soundness guard before SMT: see `flag_writers_diverge`.
-    if flag_writers_diverge(seq1, seq2) {
-        return (EquivalenceResult::NotEquivalent, metrics);
+    if let Some(early) = pre_smt_guard(seq1, seq2) {
+        return (early, metrics);
     }
 
     if let Some(fast) = run_fast_path(seq1, seq2, config) {

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -5,9 +5,20 @@
 use crate::ir::{Instruction, Operand, Register};
 use crate::semantics::live_out::LiveOutRegisters;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use z3::ast::BV;
 use z3::{Params, Solver};
+
+/// Monotonic counter used to generate unique names for fresh symbolic values
+/// produced when modelling instructions whose result depends on state we do
+/// not symbolically track (currently: the CSEL family, which reads NZCV).
+static FRESH_BV_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn fresh_bv(prefix: &str) -> BV {
+    let id = FRESH_BV_COUNTER.fetch_add(1, Ordering::Relaxed);
+    BV::new_const(format!("{}_{}", prefix, id), 64)
+}
 
 /// Configuration for the SMT solver
 #[derive(Debug, Clone)]
@@ -202,18 +213,90 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             // These only affect flags, which we don't model symbolically yet
             // No register state changes
         }
-        // Conditional select instructions depend on flags, which we don't model yet
-        // For now, we model them as selecting rn (conservative approximation)
-        // TODO: Add full flags support for proper SMT modeling
-        Instruction::Csel { rd, rn, .. }
-        | Instruction::Csinc { rd, rn, .. }
-        | Instruction::Csinv { rd, rn, .. }
-        | Instruction::Csneg { rd, rn, .. } => {
-            // Without flags, we can't determine the condition result
-            // For equivalence checking purposes, we use a fresh symbolic value
-            // This is sound but incomplete - it may miss some optimizations
-            let rn_val = state.get_register(*rn).clone();
-            state.set_register(*rd, rn_val);
+        // CSEL family depends on NZCV, which we don't model symbolically.
+        // Emit a fresh, unconstrained BV per use site so the solver can never
+        // prove equivalence across the conditional select. Sound (cannot
+        // wrongly accept) but uninformative (cannot prove valid rewrites that
+        // span CSEL chains). Flag-aware modelling is deferred.
+        Instruction::Csel { rd, .. }
+        | Instruction::Csinc { rd, .. }
+        | Instruction::Csinv { rd, .. }
+        | Instruction::Csneg { rd, .. } => {
+            state.set_register(*rd, fresh_bv("csel_result"));
+        }
+        Instruction::Mvn { rd, rm } => {
+            let value = state.get_register(*rm).bvnot();
+            state.set_register(*rd, value);
+        }
+        Instruction::Neg { rd, rm } => {
+            let value = state.get_register(*rm).bvneg();
+            state.set_register(*rd, value);
+        }
+        // NEGS writes rd just like NEG; flag side-effects are not modelled
+        // symbolically (matches CMP/CMN/TST). Soundness barrier: callers must
+        // refuse to drop flag-writers when flags are live-out.
+        Instruction::Negs { rd, rm } => {
+            let value = state.get_register(*rm).bvneg();
+            state.set_register(*rd, value);
+        }
+        Instruction::MovN { rd, imm, shift } => {
+            let value = !(((*imm as u64) << (*shift as u32)) as u64);
+            state.set_register(*rd, BV::from_u64(value, 64));
+        }
+        Instruction::Bic { rd, rn, rm } | Instruction::Bics { rd, rn, rm } => {
+            let lhs = state.get_register(*rn).clone();
+            let rhs = state.eval_operand(rm);
+            let result = lhs.bvand(&rhs.bvnot());
+            state.set_register(*rd, result);
+        }
+        Instruction::Orn { rd, rn, rm } => {
+            let lhs = state.get_register(*rn).clone();
+            let rhs = state.eval_operand(rm);
+            let result = lhs.bvor(&rhs.bvnot());
+            state.set_register(*rd, result);
+        }
+        Instruction::Eon { rd, rn, rm } => {
+            let lhs = state.get_register(*rn).clone();
+            let rhs = state.eval_operand(rm);
+            let result = lhs.bvxor(&rhs.bvnot());
+            state.set_register(*rd, result);
+        }
+        // Flag-setting arith/logical: rd is modelled symbolically (same as
+        // ADD/SUB/AND); flag side-effects are NOT modelled (matches CMP/CMN/TST).
+        // Soundness barrier: callers must refuse to drop flag-writers when
+        // flags are live-out (see `flags_live_out` and `modifies_flags`).
+        Instruction::Adds { rd, rn, rm } => {
+            let lhs = state.get_register(*rn).clone();
+            let rhs = state.eval_operand(rm);
+            state.set_register(*rd, lhs.bvadd(&rhs));
+        }
+        Instruction::Subs { rd, rn, rm } => {
+            let lhs = state.get_register(*rn).clone();
+            let rhs = state.eval_operand(rm);
+            state.set_register(*rd, lhs.bvsub(&rhs));
+        }
+        Instruction::Ands { rd, rn, rm } => {
+            let lhs = state.get_register(*rn).clone();
+            let rhs = state.eval_operand(rm);
+            state.set_register(*rd, lhs.bvand(&rhs));
+        }
+        // CSET / CSETM: depend on NZCV, which we don't model symbolically.
+        // Emit a fresh symbolic value per use (matches CSEL family policy).
+        Instruction::Cset { rd, .. } | Instruction::Csetm { rd, .. } => {
+            state.set_register(*rd, fresh_bv("cset_result"));
+        }
+        // ROR: no native bvror in z3-rust; compose
+        // `(x lshr n) | (x shl (64 - n))`. For reg form, mask shift to 6 bits.
+        Instruction::Ror { rd, rn, shift } => {
+            let value = state.get_register(*rn).clone();
+            let n = state.eval_operand(shift);
+            let mask = BV::from_u64(63, 64);
+            let n_masked = n.bvand(&mask);
+            let sixty_four = BV::from_u64(64, 64);
+            let complement = sixty_four.bvsub(&n_masked);
+            let lo = value.bvlshr(&n_masked);
+            let hi = value.bvshl(&complement);
+            state.set_register(*rd, lo.bvor(&hi));
         }
     }
     state
@@ -325,5 +408,75 @@ mod tests {
         let solver = Solver::new();
         solver.assert(&x0_val.eq(&expected).not());
         assert_eq!(solver.check(), SatResult::Unsat);
+    }
+
+    #[test]
+    fn test_mvn_smt_inverts_bits() {
+        // Prove MVN x0, x1 ≡ EOR x0, x1, #(all-ones) — but the IR has no EOR
+        // with a 64-bit immediate, so instead prove the simpler identity that
+        // applying MVN twice gives back the original value:
+        // MVN x0, x1; MVN x0, x0  ⇒  x0 == original x1.
+        let initial = MachineState::new_symbolic("pre");
+        let initial_x1 = initial.get_register(Register::X1).clone();
+
+        let seq = vec![
+            Instruction::Mvn {
+                rd: Register::X0,
+                rm: Register::X1,
+            },
+            Instruction::Mvn {
+                rd: Register::X0,
+                rm: Register::X0,
+            },
+        ];
+        let final_state = apply_sequence(initial, &seq);
+        let final_x0 = final_state.get_register(Register::X0);
+
+        let solver = Solver::new();
+        solver.assert(&final_x0.eq(&initial_x1).not());
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "MVN is an involution: MVN(MVN(x)) must equal x"
+        );
+    }
+
+    /// Soundness regression: CSEL must NOT be proved equivalent to MOV.
+    /// The condition's value depends on NZCV which we don't model; the SMT
+    /// result must be unconstrained so the solver can find inputs where they
+    /// differ.
+    #[test]
+    fn test_csel_not_equivalent_to_mov() {
+        use crate::ir::types::Condition;
+
+        let initial_state = MachineState::new_symbolic("pre");
+
+        // CSEL X0, X1, X2, EQ — should NOT be the same as MOV X0, X1
+        // (it depends on flags; without flag modeling, we must remain
+        // conservative — i.e. uninformative, never wrongly equivalent).
+        let csel = vec![Instruction::Csel {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+            cond: Condition::EQ,
+        }];
+        let state_csel = apply_sequence(initial_state.clone(), &csel);
+
+        let mov = vec![Instruction::MovReg {
+            rd: Register::X0,
+            rn: Register::X1,
+        }];
+        let state_mov = apply_sequence(initial_state, &mov);
+
+        // states_not_equal SAT ⇒ solver found inputs where they differ
+        //                       ⇒ the two sequences are NOT proved equivalent
+        // states_not_equal UNSAT ⇒ they are always equal ⇒ unsound for CSEL
+        let solver = Solver::new();
+        solver.assert(&states_not_equal(&state_csel, &state_mov));
+        assert_eq!(
+            solver.check(),
+            SatResult::Sat,
+            "CSEL must not be proved equivalent to MOV — SMT model is unsound"
+        );
     }
 }

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -245,7 +245,7 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
         }
         // BIC: rd = rn & !rm. BICS shares the SMT body — the flag effect is
         // not modelled (matches CMP/CMN/TST and ADDS/SUBS/ANDS). The
-        // soundness barrier lives in `equivalence::drops_target_flag_writer`,
+        // soundness barrier lives in `equivalence::flag_writers_diverge`,
         // which refuses any rewrite that drops a flag-writer the target had.
         Instruction::Bic { rd, rn, rm } | Instruction::Bics { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -240,25 +240,29 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             state.set_register(*rd, value);
         }
         Instruction::MovN { rd, imm, shift } => {
-            let value = !(((*imm as u64) << (*shift as u32)) as u64);
+            let value = !((*imm as u64) << (*shift as u32));
             state.set_register(*rd, BV::from_u64(value, 64));
         }
+        // BIC: rd = rn & !rm. BICS shares the SMT body — the flag effect is
+        // not modelled (matches CMP/CMN/TST and ADDS/SUBS/ANDS). The
+        // soundness barrier lives in `equivalence::drops_target_flag_writer`,
+        // which refuses any rewrite that drops a flag-writer the target had.
         Instruction::Bic { rd, rn, rm } | Instruction::Bics { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.eval_operand(rm);
-            let result = lhs.bvand(&rhs.bvnot());
+            let result = lhs.bvand(rhs.bvnot());
             state.set_register(*rd, result);
         }
         Instruction::Orn { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.eval_operand(rm);
-            let result = lhs.bvor(&rhs.bvnot());
+            let result = lhs.bvor(rhs.bvnot());
             state.set_register(*rd, result);
         }
         Instruction::Eon { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.eval_operand(rm);
-            let result = lhs.bvxor(&rhs.bvnot());
+            let result = lhs.bvxor(rhs.bvnot());
             state.set_register(*rd, result);
         }
         // Flag-setting arith/logical: rd is modelled symbolically (same as
@@ -287,6 +291,12 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
         }
         // ROR: no native bvror in z3-rust; compose
         // `(x lshr n) | (x shl (64 - n))`. For reg form, mask shift to 6 bits.
+        //
+        // Edge case at n == 0: `complement` evaluates to 64, and SMTLIB2
+        // bit-vector semantics define `bvshl(x, 64) = 0` (any shift ≥ the
+        // bit-width zeroes the value). So `hi = 0` and the result is just
+        // `value lshr 0 = value`. Do **not** add a guard for n == 0 — it
+        // would mis-handle the symbolic case where n is unknown.
         Instruction::Ror { rd, rn, shift } => {
             let value = state.get_register(*rn).clone();
             let n = state.eval_operand(shift);

--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -83,15 +83,16 @@ pub fn compute_written_registers(instructions: &[Instruction]) -> LiveOutRegiste
 
 /// Returns true if NZCV may be observable after the sequence executes.
 ///
-/// Static check: returns true iff **any** flag-writing instruction is
-/// present in the sequence.
+/// Static check: returns true iff **any** flag-writing instruction appears
+/// in the sequence.
 ///
-/// **Exact (not over-approximate) for the current 20-opcode subset.** No
-/// instruction in the subset clears NZCV without also setting it, so any
-/// sequence containing a flag-writer always has live-out flags at the end.
-/// If a flag-clobbering or flag-clearing instruction (e.g. an explicit
-/// `MSR NZCV, ...`) is added later, this predicate becomes a conservative
-/// over-approximation and may need revisiting.
+/// **Over-approximate.** This predicate fires whenever a flag-writer is
+/// present, regardless of whether a later instruction actually reads NZCV.
+/// That conservative posture is the only soundness barrier preventing the
+/// equivalence checker from accepting a rewrite that silently drops a
+/// flag-side-effect — SMT semantics for ADDS/SUBS/ANDS/NEGS/BICS/CMP/CMN/TST
+/// model the register write but not the flag effect. A tighter "flag-writer
+/// AND later read" form is tracked as a separate follow-up.
 pub fn flags_live_out(instructions: &[Instruction]) -> bool {
     instructions.iter().any(|i| i.modifies_flags())
 }


### PR DESCRIPTION
## Summary

- Adds 14 instructions to the IR (Tier 1 from #55–#61 design discussion): **MVN, NEG, NEGS, MOVN, BIC, BICS, ORN, EON, ADDS, SUBS, ANDS, CSET, CSETM, ROR** (imm + reg).
- Fixes a pre-existing stub: CSEL/CSINC/CSINV/CSNEG encoders at `src/assembler/mod.rs:355-362` were returning `unimplemented!()`; they now emit machine code via dynasm 4.0.1 (dispatched on the runtime `Condition` through a new `emit_csel!` macro).
- Fixes a pre-existing SMT soundness bug: the CSEL-family symbolic semantics at `src/semantics/smt.rs:208-217` claimed "fresh symbolic value" in a comment but actually did `rd = rn`, which made `CSEL ≡ MOV` provable. CSET lowered naively to `CSINC ZR, ZR, !cond` would have collapsed to "always 0". Replaced with `BV::new_const("csel_result_N", 64)` via a monotonic counter.

Each new instruction is threaded through the IR enum + 6 helpers, concrete and SMT semantics, cost model, encoder, parser, ISA metadata, and stochastic mutation tables.

## Highlights

- `Condition::invert()` (EQ↔NE, CS↔CC, MI↔PL, VS↔VC, HI↔LS, GE↔LT, GT↔LE, AL↔NV) added; CSET/CSETM use it to lower to CSINC/CSINV with XZR sources.
- `MovN { rd, imm: u16, shift: u8 ∈ {0,16,32,48} }` — distinct variant because `MovImm` is fixed at `imm ∈ [0,0xFFFF]` and cannot represent the inverted-and-shifted constant.
- `is_encodable_aarch64` rejects `Cset`/`Csetm` with `cond ∈ {AL, NV}` (nonsensical / reserved).
- `opcode_count`: 20 → 34. Test caps `opcode_id() < 13` bumped to `< 34`.
- `flags_live_out` doc-comment reworded from "exact" to "over-approximate" — ADDS/SUBS/ANDS/NEGS/BICS make "writer present but unread" cases real. Tightening to "writer + later reader" is deferred to a separate issue.
- All 14 mnemonics emit via dynasm directly — no raw `.u32` encoding needed anywhere.

## Out of scope

- Shifted-register operand form (Tier 3, tracked in #59).
- Full NZCV modeling in SMT.
- Capstone-bytes → Instruction translator.
- Refining `flags_live_out` past the over-approximation.
- Extending `src/search/symbolic/sketch.rs` `NUM_OPCODES` (still 10).

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo build`
- [x] `cargo test` — 272 → 315 (+43 new tests)
- [x] `./ci_check.sh` — full suite (fmt, build, unit tests, test binaries, full test suite) passes
- [x] CSEL family round-trips through Capstone in the X (64-bit) form, not W form — explicit regression test at `test_csinv_is_xform_not_wform`
- [x] CSET/CSETM disassemble back to `cset`/`csetm` (not the underlying `csinc`/`csinv`) — Capstone canonicalisation verified
- [x] Parser↔Display round-trip for every new mnemonic
- [x] SMT-level proofs: `MVN(MVN(x)) = x`, `BIC ≡ MVN+AND`, `ORN ≡ MVN+ORR`, `EON ≡ MVN+EOR`, `NEG ≡ SUB-from-XZR`, `MOVN 0 ≡ EON(x,x)`, `CSEL ≢ MOV` (soundness regression)