### PR TITLE
[codex] refactor live-out contract

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -14,7 +14,16 @@ A `Vec<Instruction>` produced by a search algorithm as a potential replacement f
 A candidate that is both **strictly cheaper** than the target and **proven equivalent** on the live-out contract. The metric of "cheaper" is search-config dependent (cost model in `src/semantics/cost.rs`, or byte count for the LLM-assisted flow).
 
 ### Live-out
-The set of architectural registers (and, implicitly, flags read by the target's downstream context) whose values must agree between target and candidate after execution. Carried as `LiveOutMask` in `src/semantics/state.rs`. Fed into `EquivalenceConfig` and `SearchAlgorithm::search`.
+The observable architectural state whose values must agree between target and candidate after execution. Today this is represented by `LiveOut` in `src/semantics/live_out.rs`; its only populated slice is `LiveOutRegisters`. The intended concept is broader than registers: condition state, memory, and PC can also be live-out when downstream code observes them.
+
+### Live-out registers
+The register slice of the live-out contract. Represented by `LiveOutRegisters`, a set of architectural registers whose values must agree between target and candidate after execution. This is not the whole live-out concept.
+
+### Observable state
+Any architectural state a downstream context can observe after the target executes. Registers are the only fully modeled observable state today. Condition state is the next known slice. Memory and PC are intentionally reserved in the term so the live-out contract can grow without being renamed.
+
+### Condition state
+Architecture-specific predicate or flag state that later instructions can read. On AArch64 this is NZCV. On a RISC-V integer subset there may be no condition state. Future architectures can map this term to their own flag or predicate state without changing the shared live-out vocabulary.
 
 ### Live-in
 The set of architectural registers whose initial values the target reads. Currently *not* surfaced in `SearchAlgorithm::search`. The LLM-assisted flow needs this in the prompt; computed by def-use analysis on the target rather than added to the trait (see ADR-0001).
@@ -34,12 +43,12 @@ A `SearchAlgorithm` impl that delegates candidate generation to the OpenAI Codex
 - Calls are **sequential** within one search.
 - Loop terminates when **either** an optimization is found, **or** `max_codex_calls` is reached, **or** `SearchConfig.timeout` elapses.
 - Per-iteration outcomes: parse-fail → log unsupported mnemonics, continue. Equivalence-fail → log, continue. Not-shorter → log, continue. Equivalent and shorter → **success**, return.
-- Verification reuses `EquivalenceConfig::default().with_live_out(live_out)`: 10 random tests (fast path), then Z3 with 30s timeout.
+- Verification reuses `EquivalenceConfig` with the caller's `LiveOut` contract: 10 random tests (fast path), then Z3 with 30s timeout.
 
 **Deliverable:** local-only. A bash/`just` target that runs the search across a fixed corpus of 5–10 small asm targets known to be optimizable (drawn from existing equivalence tests). No CI, no mocked Codex backend, no `CandidateGenerator` trait abstraction.
 
 ### Flags-live-out (MVP exclusion)
-For the LLM-assisted search MVP only, targets whose final architectural state includes a meaningful NZCV value (i.e., flags are live-out) are **refused** rather than processed. `LiveOutMask` does not currently encode flags, and adding flags to the live-out contract would require co-ordinated changes to `EquivalenceConfig` and all four search algorithms — out of scope for the MVP. The LLM flow detects flags-live-out by static inspection of the target and bails with an explicit message. See ADR-0002.
+For the LLM-assisted search MVP only, targets whose final architectural state includes meaningful AArch64 condition state (NZCV) are **refused** rather than processed. `LiveOut` does not currently populate a condition-state slice, and adding condition state to the live-out contract would require co-ordinated changes to the equivalence internals — out of scope for the MVP. The LLM flow detects flags-live-out by static inspection of the target and bails with an explicit message. See ADR-0002.
 
 ### Subset hint (intentionally absent)
 The LLM prompt does **not** enumerate the 20-opcode subset s11's parser accepts. The model is invited to use any AArch64 mnemonic it knows. Outputs that use unsupported instructions are recorded as a research signal (which mnemonics the model "wanted" to reach for), not treated as wasted calls. See ADR-0003.

--- a/docs/adr/0001-derive-live-in-from-def-use.md
+++ b/docs/adr/0001-derive-live-in-from-def-use.md
@@ -5,7 +5,7 @@ Date: 2026-05-07
 
 ## Context
 
-The LLM-assisted search algorithm (`LlmSearch`, see `src/search/llm/`) needs to tell the model which registers (and flags) the target reads before writing — i.e., the target's live-in set. The existing `SearchAlgorithm::search` trait at `src/search/mod.rs:39` exposes only `live_out` and the target itself. No live-in is plumbed through.
+The LLM-assisted search algorithm (`LlmSearch`, see `src/search/llm/`) needs to tell the model which registers (and flags) the target reads before writing — i.e., the target's live-in set. The existing `SearchAlgorithm::search` trait exposes only `live_out` and the target itself. No live-in is plumbed through.
 
 Three options were considered:
 
@@ -17,7 +17,7 @@ Three options were considered:
 
 Option 2: derive live-in from the target via intra-sequence def-use analysis.
 
-A new helper `compute_live_in_registers(&[Instruction]) -> LiveOutMask` is added in `src/validation/live_out.rs` (the type is reused — it's structurally a set-of-registers, despite the name). Flag-livein is tracked by a separate boolean predicate `reads_flags_before_writing(&[Instruction]) -> bool` because flags don't fit `LiveOutMask`'s bitset.
+A new helper `compute_live_in_registers(&[Instruction]) -> LiveOutRegisters` is added in `src/validation/live_out.rs`. The type is reused because live-in registers and live-out registers are both register sets. Flag-live-in is tracked by a separate boolean predicate `reads_flags_before_writing(&[Instruction]) -> bool` because AArch64 condition state is not part of `LiveOutRegisters`.
 
 ## Consequences
 

--- a/docs/adr/0002-mvp-restricts-flags-live-out.md
+++ b/docs/adr/0002-mvp-restricts-flags-live-out.md
@@ -5,14 +5,14 @@ Date: 2026-05-07
 
 ## Context
 
-`LiveOutMask` (`src/semantics/state.rs`) is a register-only bitset. It does not encode whether NZCV is part of the live-out contract. The 20-opcode subset includes flag writers (`CMP`, `CMN`, `TST`) and flag readers (`CSEL`, `CSINC`, `CSINV`, `CSNEG`); a target whose final instruction is `CMP` (for example) has flags as a real downstream output even though no register value reflects it.
+`LiveOut` (`src/semantics/live_out.rs`) names the broad live-out contract, but its only populated slice today is the register-only `LiveOutRegisters`. It does not encode whether AArch64 condition state (NZCV) is part of the broader live-out contract. The 20-opcode subset includes flag writers (`CMP`, `CMN`, `TST`) and flag readers (`CSEL`, `CSINC`, `CSINV`, `CSNEG`); a target whose final instruction is `CMP` (for example) has condition state as a real downstream output even though no register value reflects it.
 
-`EquivalenceConfig` and all four search algorithms thread `LiveOutMask` through; none of them check NZCV equivalence. This is a pre-existing soundness gap with respect to flags-live-out, but only matters for the LLM flow because the LLM is the only generator that might *legitimately* drop a final flag-setting instruction (the others enumerate from a pool that includes it).
+`EquivalenceConfig` and all four search algorithms thread `LiveOut` through, but equivalence currently checks only its `LiveOutRegisters` slice; none of them check NZCV equivalence. This is a pre-existing soundness gap with respect to condition-state live-out, but only matters for the LLM flow because the LLM is the only generator that might *legitimately* drop a final flag-setting instruction (the others enumerate from a pool that includes it).
 
 Two options:
 
 1. **Restrict the MVP corpus**: refuse LLM-flow execution on targets where flags are live-out (statically detectable: any flag writer with no later flag-using or flag-overwriting instruction before the end). Sound. Narrower applicable input class than other search algorithms.
-2. **Extend live-out contract to include flags**: thread a `flags_live_out: bool` through `LiveOutMask` and `EquivalenceConfig`, update all four algorithms, update the SMT encoding to constrain NZCV. Wider impact, deserves its own ADR, slows down the MVP.
+2. **Extend live-out contract to include condition state**: add an architecture-aware condition-state slice beside `LiveOutRegisters`, update the concrete/SMT equivalence internals, and constrain NZCV for AArch64. Wider impact, deserves its own ADR, slows down the MVP.
 
 ## Decision
 
@@ -22,10 +22,10 @@ Option 1. The LLM flow refuses to run on targets where static analysis says flag
 
 **Positive:**
 - The MVP's verifier (`check_equivalence_with_config`) is **sound** for the corpus the LLM flow accepts. No risk of declaring a candidate equivalent when it has dropped a needed flag-setter.
-- The change scope is local to `src/search/llm/` plus a static-analysis helper. No edits to existing search algorithms, the SMT module, or `LiveOutMask`.
+- The refusal behavior remains local to `src/search/llm/` plus a static-analysis helper. The broader `LiveOut` plumbing can exist without modeling condition state yet.
 
 **Negative:**
 - The LLM flow has a **narrower applicable input class than the rest of the optimizer**. A user who feeds it a region ending in `CMP` for a downstream branch sees a refusal, not an attempt.
-- We are explicitly accepting a known pre-existing soundness gap (flags-live-out is unmodelled by `EquivalenceConfig` for *all* algorithms) rather than fixing it. Fix is deferred.
+- We are explicitly accepting a known pre-existing soundness gap (condition-state live-out is not checked by the equivalence internals for *all* algorithms) rather than fixing it. Fix is deferred.
 
 **Reversibility:** high. When flags-live-out becomes a supported part of the live-out contract (its own ADR), the static refusal in the LLM flow is replaced by passing the flag-live-out bit through to the prompt and the equivalence check.

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,8 +23,7 @@ use search::config::{
 use search::parallel::{ParallelConfig, run_parallel_search};
 use search::{SearchAlgorithm, StochasticSearch, SymbolicSearch};
 use semantics::cost::CostMetric;
-use semantics::state::LiveOutMask;
-use semantics::{EquivalenceResult, check_equivalence};
+use semantics::{EquivalenceResult, LiveOut, LiveOutRegisters, check_equivalence};
 
 // --- Command Line Arguments ---
 
@@ -490,8 +489,8 @@ fn run_optimization(
         0, 1, 2, 3, 4, 5, 7, 8, 10, 15, 16, 31, 32, 63, 64, 100, 255, 256, 1000, 4095,
     ];
 
-    // Create live-out mask (assume all modified registers are live-out for now)
-    let live_out = LiveOutMask::from_registers(
+    // Create live-out contract (assume all modified registers are live-out for now).
+    let live_out = LiveOut::from_registers(
         target
             .iter()
             .filter_map(|instr| instr.destination())
@@ -1006,9 +1005,10 @@ fn run_llm_opt(
         }
     }
 
-    let live_out: LiveOutMask = live_out_str
+    let live_out_registers: LiveOutRegisters = live_out_str
         .parse()
-        .map_err(|e: validation::live_out::ParseLiveOutError| e.to_string())?;
+        .map_err(|e: validation::live_out::ParseLiveOutRegistersError| e.to_string())?;
+    let live_out = LiveOut::from_register_set(live_out_registers);
 
     let llm = LlmConfig::default()
         .with_max_codex_calls(max_calls)
@@ -1092,7 +1092,7 @@ fn run_equiv(
         );
     }
 
-    let live_out = LiveOutMask::from_registers(live_out_regs);
+    let live_out = LiveOut::from_registers(live_out_regs);
 
     // Build config
     let config = EquivalenceConfig::default()
@@ -1134,19 +1134,19 @@ fn run_equiv(
 
             println!("  Input state:");
             for (reg, val) in input_state.registers() {
-                if config.live_out.contains(*reg) {
+                if config.live_out.contains_register(*reg) {
                     println!("    {} = 0x{:016x}", reg, val.as_u64());
                 }
             }
             println!("  Output from sequence 1:");
             for (reg, val) in output1.registers() {
-                if config.live_out.contains(*reg) {
+                if config.live_out.contains_register(*reg) {
                     println!("    {} = 0x{:016x}", reg, val.as_u64());
                 }
             }
             println!("  Output from sequence 2:");
             for (reg, val) in output2.registers() {
-                if config.live_out.contains(*reg) {
+                if config.live_out.contains_register(*reg) {
                     println!("    {} = 0x{:016x}", reg, val.as_u64());
                 }
             }

--- a/src/search/llm/mod.rs
+++ b/src/search/llm/mod.rs
@@ -13,7 +13,7 @@ use crate::ir::Instruction;
 use crate::search::SearchAlgorithm;
 use crate::search::config::SearchConfig;
 use crate::search::result::{SearchResult, SearchStatistics};
-use crate::semantics::state::LiveOutMask;
+use crate::semantics::live_out::LiveOut;
 use crate::validation::live_out::{compute_live_in_registers, flags_live_out};
 
 use self::codex::invoke_codex;
@@ -80,7 +80,7 @@ impl SearchAlgorithm for LlmSearch {
     fn search(
         &mut self,
         target: &[Instruction],
-        live_out: &LiveOutMask,
+        live_out: &LiveOut,
         config: &SearchConfig,
     ) -> SearchResult {
         // Reset accumulators at the start of every search so a caller that
@@ -111,7 +111,7 @@ impl SearchAlgorithm for LlmSearch {
         }
 
         let live_in = compute_live_in_registers(target);
-        let prompt = build_prompt(target, &live_in, live_out);
+        let prompt = build_prompt(target, &live_in, live_out.registers());
         let timeout = config.timeout.unwrap_or(Duration::from_secs(60));
         let max_calls = config.llm.max_codex_calls;
 
@@ -287,10 +287,8 @@ mod tests {
     use crate::ir::{Operand, Register};
     use crate::search::config::LlmConfig;
 
-    fn live_out_x0() -> LiveOutMask {
-        let mut m = LiveOutMask::empty();
-        m.add(Register::X0);
-        m
+    fn live_out_x0() -> LiveOut {
+        LiveOut::from_registers(vec![Register::X0])
     }
 
     fn cfg_no_calls() -> SearchConfig {

--- a/src/search/llm/outcome.rs
+++ b/src/search/llm/outcome.rs
@@ -8,7 +8,7 @@ use crate::parser::{ParseLineError, parse_assembly_string, parse_line};
 use crate::semantics::equivalence::{
     EquivalenceConfig, EquivalenceMetrics, EquivalenceResult, check_equivalence_with_config_metrics,
 };
-use crate::semantics::state::LiveOutMask;
+use crate::semantics::live_out::LiveOut;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IterationOutcome {
@@ -35,7 +35,7 @@ pub enum IterationOutcome {
 pub fn classify(
     target: &[Instruction],
     raw_asm: &str,
-    live_out: &LiveOutMask,
+    live_out: &LiveOut,
 ) -> (IterationOutcome, Option<EquivalenceMetrics>) {
     let candidate = match parse_assembly_string(raw_asm, "<llm-output>".to_string()) {
         Ok(v) => v,
@@ -102,10 +102,8 @@ mod tests {
     use super::*;
     use crate::ir::{Operand, Register};
 
-    fn live_out_x0() -> LiveOutMask {
-        let mut m = LiveOutMask::empty();
-        m.add(Register::X0);
-        m
+    fn live_out_x0() -> LiveOut {
+        LiveOut::from_registers(vec![Register::X0])
     }
 
     #[test]

--- a/src/search/llm/prompt.rs
+++ b/src/search/llm/prompt.rs
@@ -1,10 +1,10 @@
 //! Prompt construction for the Codex-assisted search loop.
 
 use crate::ir::{Instruction, Register};
-use crate::semantics::state::LiveOutMask;
+use crate::semantics::live_out::LiveOutRegisters;
 
 /// Render a register set as a comma-separated list (e.g. "x0, x1, x2").
-fn render_register_set(mask: &LiveOutMask) -> String {
+fn render_register_set(mask: &LiveOutRegisters) -> String {
     let mut names: Vec<String> = (0..=30u8)
         .filter_map(Register::from_index)
         .filter(|r| mask.contains(*r))
@@ -19,8 +19,8 @@ fn render_register_set(mask: &LiveOutMask) -> String {
 /// Build the full prompt sent to `codex exec`.
 pub fn build_prompt(
     target: &[Instruction],
-    live_in: &LiveOutMask,
-    live_out: &LiveOutMask,
+    live_in: &LiveOutRegisters,
+    live_out: &LiveOutRegisters,
 ) -> String {
     let mut s = String::new();
     s.push_str(
@@ -64,8 +64,8 @@ mod tests {
     use super::*;
     use crate::ir::{Operand, Register};
 
-    fn mask(regs: &[Register]) -> LiveOutMask {
-        let mut m = LiveOutMask::empty();
+    fn mask(regs: &[Register]) -> LiveOutRegisters {
+        let mut m = LiveOutRegisters::empty();
         for r in regs {
             m.add(*r);
         }

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -23,7 +23,7 @@ pub use stochastic::StochasticSearch;
 pub use symbolic::SymbolicSearch;
 
 use crate::ir::Instruction;
-use crate::semantics::state::LiveOutMask;
+use crate::semantics::live_out::LiveOut;
 
 /// Trait for search algorithms that find equivalent instruction sequences
 #[allow(dead_code)]
@@ -32,7 +32,7 @@ pub trait SearchAlgorithm {
     ///
     /// # Arguments
     /// * `target` - The instruction sequence to optimize
-    /// * `live_out` - Registers that must match after execution
+    /// * `live_out` - Observable state that must match after execution
     /// * `config` - Search configuration parameters
     ///
     /// # Returns
@@ -40,7 +40,7 @@ pub trait SearchAlgorithm {
     fn search(
         &mut self,
         target: &[Instruction],
-        live_out: &LiveOutMask,
+        live_out: &LiveOut,
         config: &SearchConfig,
     ) -> SearchResult;
 

--- a/src/search/parallel/coordinator.rs
+++ b/src/search/parallel/coordinator.rs
@@ -12,7 +12,7 @@ use crate::search::parallel::config::ParallelConfig;
 use crate::search::result::{SearchResult, SearchStatistics};
 use crate::search::stochastic::StochasticSearch;
 use crate::search::symbolic::SymbolicSearch;
-use crate::semantics::state::LiveOutMask;
+use crate::semantics::live_out::LiveOut;
 use crossbeam_channel::RecvTimeoutError;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -31,7 +31,7 @@ pub struct ParallelResult {
 /// Run parallel search with the given configuration.
 pub fn run_parallel_search(
     target: &[Instruction],
-    live_out: &LiveOutMask,
+    live_out: &LiveOut,
     search_config: &SearchConfig,
     parallel_config: &ParallelConfig,
 ) -> ParallelResult {
@@ -90,7 +90,7 @@ pub fn run_parallel_search(
 /// Coordinator loop that receives messages from workers and aggregates results.
 fn run_coordinator(
     target: &[Instruction],
-    _live_out: &LiveOutMask,
+    _live_out: &LiveOut,
     channels: CoordinatorChannels,
     config: &ParallelConfig,
     start_time: Instant,
@@ -211,7 +211,7 @@ fn run_coordinator(
 fn run_worker(
     worker_id: usize,
     target: &[Instruction],
-    live_out: &LiveOutMask,
+    live_out: &LiveOut,
     search_config: &SearchConfig,
     parallel_config: &ParallelConfig,
     channels: WorkerChannels,
@@ -244,7 +244,7 @@ fn run_worker(
 fn run_symbolic_worker(
     worker_id: usize,
     target: &[Instruction],
-    live_out: &LiveOutMask,
+    live_out: &LiveOut,
     config: &SearchConfig,
     channels: WorkerChannels,
 ) {
@@ -276,7 +276,7 @@ fn run_symbolic_worker(
 fn run_stochastic_worker(
     worker_id: usize,
     target: &[Instruction],
-    live_out: &LiveOutMask,
+    live_out: &LiveOut,
     config: &SearchConfig,
     channels: WorkerChannels,
 ) {
@@ -331,7 +331,7 @@ mod tests {
     #[test]
     fn test_parallel_search_single_worker() {
         let target = mov_add_sequence();
-        let live_out = LiveOutMask::from_registers(vec![Register::X0]);
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
 
         let search_config = SearchConfig::default()
             .with_registers(vec![Register::X0, Register::X1])
@@ -352,7 +352,7 @@ mod tests {
     #[test]
     fn test_parallel_search_multiple_workers() {
         let target = mov_add_sequence();
-        let live_out = LiveOutMask::from_registers(vec![Register::X0]);
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
 
         let search_config = SearchConfig::default()
             .with_registers(vec![Register::X0, Register::X1])

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -22,7 +22,8 @@ use crate::search::stochastic::mutation::Mutator;
 use crate::search::{Algorithm, SearchAlgorithm};
 use crate::semantics::concrete::{apply_sequence_concrete, states_equal_for_live_out};
 use crate::semantics::cost::sequence_cost;
-use crate::semantics::state::{ConcreteMachineState, LiveOutMask};
+use crate::semantics::live_out::{LiveOut, LiveOutRegisters};
+use crate::semantics::state::ConcreteMachineState;
 use crate::semantics::{EquivalenceConfig, EquivalenceResult, check_equivalence_with_config};
 use crate::validation::random::{
     RandomInputConfig, generate_edge_case_inputs, generate_random_inputs,
@@ -54,7 +55,7 @@ impl SearchAlgorithm for StochasticSearch {
     fn search(
         &mut self,
         target: &[Instruction],
-        live_out: &LiveOutMask,
+        live_out: &LiveOut,
         config: &SearchConfig,
     ) -> SearchResult {
         self.reset();
@@ -76,7 +77,8 @@ impl SearchAlgorithm for StochasticSearch {
         };
 
         // Generate test cases
-        let input_regs: Vec<_> = live_out.iter().cloned().collect();
+        let live_out_registers = live_out.registers();
+        let input_regs: Vec<_> = live_out_registers.iter().cloned().collect();
         let random_config = RandomInputConfig {
             count: config.stochastic.test_count,
             registers: input_regs.clone(),
@@ -175,7 +177,7 @@ impl SearchAlgorithm for StochasticSearch {
             let mut passes_tests = true;
             for (input, target_output) in all_inputs.iter().zip(target_outputs.iter()) {
                 let proposal_output = apply_sequence_concrete(input.clone(), &proposal);
-                if !states_equal_for_live_out(&proposal_output, target_output, live_out) {
+                if !states_equal_for_live_out(&proposal_output, target_output, live_out_registers) {
                     passes_tests = false;
                     break;
                 }
@@ -265,7 +267,7 @@ pub fn evaluate_with_tests(
     _target: &[Instruction],
     test_inputs: &[ConcreteMachineState],
     target_outputs: &[ConcreteMachineState],
-    live_out: &LiveOutMask,
+    live_out: &LiveOutRegisters,
 ) -> (u64, bool) {
     let mut passes_all = true;
 
@@ -325,7 +327,7 @@ mod tests {
     fn test_stochastic_search_empty_sequence() {
         let mut search = StochasticSearch::new();
         let config = SearchConfig::default();
-        let live_out = LiveOutMask::from_registers(vec![Register::X0]);
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
 
         let result = search.search(&[], &live_out, &config);
         assert!(!result.found_optimization);
@@ -339,7 +341,7 @@ mod tests {
                 .with_seed(42)
                 .with_iterations(1000),
         );
-        let live_out = LiveOutMask::from_registers(vec![Register::X0]);
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
 
         let result = search.search(&mov_zero_sequence(), &live_out, &config);
         let stats = result.statistics;
@@ -358,7 +360,7 @@ mod tests {
             .with_registers(vec![Register::X0, Register::X1, Register::X2])
             .with_immediates(vec![-1, 0, 1]);
 
-        let live_out = LiveOutMask::from_registers(vec![Register::X0]);
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
 
         // Target: MOV X0, #0 - can be replaced with EOR X0, X0, X0
         // But since both are 1 instruction, no optimization expected
@@ -378,7 +380,7 @@ mod tests {
             .with_registers(vec![Register::X0, Register::X1, Register::X2])
             .with_immediates(vec![-1, 0, 1, 2]);
 
-        let live_out = LiveOutMask::from_registers(vec![Register::X0]);
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
 
         // Target: MOV X0, X1; ADD X0, X0, #1 (2 instructions)
         // Can be optimized to: ADD X0, X1, #1 (1 instruction)
@@ -408,7 +410,7 @@ mod tests {
         let input = ConcreteMachineState::new_zeroed();
         let target_output = apply_sequence_concrete(input.clone(), &target);
 
-        let live_out = LiveOutMask::from_registers(vec![Register::X0]);
+        let live_out = LiveOutRegisters::from_registers(vec![Register::X0]);
         let (cost, passes) =
             evaluate_with_tests(&proposal, &target, &[input], &[target_output], &live_out);
 
@@ -427,7 +429,7 @@ mod tests {
         let input = ConcreteMachineState::new_zeroed();
         let target_output = apply_sequence_concrete(input.clone(), &target);
 
-        let live_out = LiveOutMask::from_registers(vec![Register::X0]);
+        let live_out = LiveOutRegisters::from_registers(vec![Register::X0]);
         let (cost, passes) =
             evaluate_with_tests(&proposal, &target, &[input], &[target_output], &live_out);
 
@@ -443,7 +445,7 @@ mod tests {
             .with_stochastic(StochasticConfig::default().with_iterations(1000))
             .with_registers(vec![Register::X0, Register::X1]);
 
-        let live_out = LiveOutMask::from_registers(vec![Register::X0]);
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
         let target = mov_zero_sequence();
 
         let result = search.search(&target, &live_out, &config);
@@ -467,7 +469,7 @@ mod tests {
             )
             .with_registers(vec![Register::X0, Register::X1, Register::X2]);
 
-        let live_out = LiveOutMask::from_registers(vec![Register::X0]);
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
         let target = mov_zero_sequence();
 
         let result = search.search(&target, &live_out, &config);

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -15,7 +15,7 @@ use crate::search::config::{SearchConfig, SearchMode};
 use crate::search::result::{SearchResult, SearchStatistics};
 use crate::search::{Algorithm, SearchAlgorithm};
 use crate::semantics::cost::sequence_cost;
-use crate::semantics::state::LiveOutMask;
+use crate::semantics::live_out::LiveOut;
 use crate::semantics::{EquivalenceConfig, EquivalenceResult, check_equivalence_with_config};
 use std::time::{Duration, Instant};
 
@@ -35,7 +35,7 @@ impl SymbolicSearch {
     fn linear_search(
         &mut self,
         target: &[Instruction],
-        live_out: &LiveOutMask,
+        live_out: &LiveOut,
         config: &SearchConfig,
         start_time: Instant,
     ) -> Option<Vec<Instruction>> {
@@ -88,7 +88,7 @@ impl SymbolicSearch {
     fn search_at_length(
         &mut self,
         target: &[Instruction],
-        live_out: &LiveOutMask,
+        live_out: &LiveOut,
         config: &SearchConfig,
         all_instructions: &[Instruction],
         length: usize,
@@ -227,7 +227,7 @@ impl SymbolicSearch {
         &mut self,
         target: &[Instruction],
         candidate: &[Instruction],
-        live_out: &LiveOutMask,
+        live_out: &LiveOut,
         config: &SearchConfig,
     ) -> bool {
         let timeout = config
@@ -261,7 +261,7 @@ impl SymbolicSearch {
     fn binary_search(
         &mut self,
         _target: &[Instruction],
-        _live_out: &LiveOutMask,
+        _live_out: &LiveOut,
         _config: &SearchConfig,
         _start_time: Instant,
     ) -> Option<Vec<Instruction>> {
@@ -281,7 +281,7 @@ impl SearchAlgorithm for SymbolicSearch {
     fn search(
         &mut self,
         target: &[Instruction],
-        live_out: &LiveOutMask,
+        live_out: &LiveOut,
         config: &SearchConfig,
     ) -> SearchResult {
         self.reset();
@@ -361,7 +361,7 @@ mod tests {
     fn test_symbolic_search_empty_sequence() {
         let mut search = SymbolicSearch::new();
         let config = SearchConfig::default();
-        let live_out = LiveOutMask::from_registers(vec![Register::X0]);
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
 
         let result = search.search(&[], &live_out, &config);
         assert!(!result.found_optimization);
@@ -371,7 +371,7 @@ mod tests {
     fn test_symbolic_search_single_instruction() {
         let mut search = SymbolicSearch::new();
         let config = SearchConfig::default();
-        let live_out = LiveOutMask::from_registers(vec![Register::X0]);
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
 
         // Single instruction can't be optimized to shorter
         let result = search.search(&mov_zero_sequence(), &live_out, &config);
@@ -387,7 +387,7 @@ mod tests {
             .with_registers(vec![Register::X0, Register::X1, Register::X2])
             .with_immediates(vec![-1, 0, 1, 2]);
 
-        let live_out = LiveOutMask::from_registers(vec![Register::X0]);
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
 
         // Target: MOV X0, X1; ADD X0, X0, #1 (2 instructions)
         // Should find an equivalent 1-instruction sequence (e.g., ADD X0, X1, #1)
@@ -413,7 +413,7 @@ mod tests {
             .with_symbolic(SymbolicConfig::default())
             .with_registers(vec![Register::X0, Register::X1]);
 
-        let live_out = LiveOutMask::from_registers(vec![Register::X0]);
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
         let target = mov_add_sequence();
 
         let result = search.search(&target, &live_out, &config);
@@ -433,7 +433,7 @@ mod tests {
             .with_immediates(vec![0, 1]);
 
         // Only X0 is live-out, X1 can differ
-        let live_out = LiveOutMask::from_registers(vec![Register::X0]);
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
 
         // Target modifies both X0 and X1
         let target = vec![
@@ -459,7 +459,7 @@ mod tests {
     fn test_verify_equivalence() {
         let mut search = SymbolicSearch::new();
         let config = SearchConfig::default();
-        let live_out = LiveOutMask::from_registers(vec![Register::X0]);
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
 
         // These should be equivalent
         let target = vec![Instruction::MovImm {
@@ -479,7 +479,7 @@ mod tests {
     fn test_verify_non_equivalence() {
         let mut search = SymbolicSearch::new();
         let config = SearchConfig::default();
-        let live_out = LiveOutMask::from_registers(vec![Register::X0]);
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
 
         // These should NOT be equivalent
         let target = vec![Instruction::MovImm {

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -1,7 +1,8 @@
 //! Concrete interpreter for fast validation of instruction sequences
 
 use crate::ir::{Condition, Instruction, Operand, Register};
-use crate::semantics::state::{ConcreteMachineState, ConcreteValue, ConditionFlags, LiveOutMask};
+use crate::semantics::live_out::LiveOutRegisters;
+use crate::semantics::state::{ConcreteMachineState, ConcreteValue, ConditionFlags};
 
 /// Evaluate an operand to get its concrete value
 fn eval_operand(state: &ConcreteMachineState, operand: &Operand) -> ConcreteValue {
@@ -211,7 +212,7 @@ pub fn apply_sequence_concrete(
 pub fn states_equal_for_live_out(
     state1: &ConcreteMachineState,
     state2: &ConcreteMachineState,
-    live_out: &LiveOutMask,
+    live_out: &LiveOutRegisters,
 ) -> bool {
     for reg in live_out.iter() {
         if state1.get_register(*reg) != state2.get_register(*reg) {
@@ -225,7 +226,7 @@ pub fn states_equal_for_live_out(
 pub fn find_first_difference(
     state1: &ConcreteMachineState,
     state2: &ConcreteMachineState,
-    live_out: &LiveOutMask,
+    live_out: &LiveOutRegisters,
 ) -> Option<(Register, ConcreteValue, ConcreteValue)> {
     for reg in live_out.iter() {
         let v1 = state1.get_register(*reg);
@@ -498,7 +499,7 @@ mod tests {
         let state1 = state_with(vec![(Register::X0, 42), (Register::X1, 100)]);
         let state2 = state_with(vec![(Register::X0, 42), (Register::X1, 999)]);
 
-        let live_out = LiveOutMask::from_registers(vec![Register::X0]);
+        let live_out = LiveOutRegisters::from_registers(vec![Register::X0]);
         assert!(states_equal_for_live_out(&state1, &state2, &live_out));
     }
 
@@ -507,7 +508,7 @@ mod tests {
         let state1 = state_with(vec![(Register::X0, 42)]);
         let state2 = state_with(vec![(Register::X0, 43)]);
 
-        let live_out = LiveOutMask::from_registers(vec![Register::X0]);
+        let live_out = LiveOutRegisters::from_registers(vec![Register::X0]);
         assert!(!states_equal_for_live_out(&state1, &state2, &live_out));
     }
 
@@ -516,7 +517,7 @@ mod tests {
         let state1 = state_with(vec![(Register::X0, 42), (Register::X1, 100)]);
         let state2 = state_with(vec![(Register::X0, 42), (Register::X1, 200)]);
 
-        let live_out = LiveOutMask::from_registers(vec![Register::X0, Register::X1]);
+        let live_out = LiveOutRegisters::from_registers(vec![Register::X0, Register::X1]);
         let diff = find_first_difference(&state1, &state2, &live_out);
         assert!(diff.is_some());
         let (reg, v1, v2) = diff.unwrap();
@@ -530,7 +531,7 @@ mod tests {
         let state1 = state_with(vec![(Register::X0, 42)]);
         let state2 = state_with(vec![(Register::X0, 42)]);
 
-        let live_out = LiveOutMask::from_registers(vec![Register::X0]);
+        let live_out = LiveOutRegisters::from_registers(vec![Register::X0]);
         let diff = find_first_difference(&state1, &state2, &live_out);
         assert!(diff.is_none());
     }
@@ -552,7 +553,7 @@ mod tests {
         }];
         let state2 = apply_sequence_concrete(state, &seq2);
 
-        let live_out = LiveOutMask::from_registers(vec![Register::X0]);
+        let live_out = LiveOutRegisters::from_registers(vec![Register::X0]);
         assert!(states_equal_for_live_out(&state1, &state2, &live_out));
     }
 

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -6,11 +6,12 @@ use crate::ir::Instruction;
 use crate::semantics::concrete::{
     apply_sequence_concrete, find_first_difference, states_equal_for_live_out,
 };
+use crate::semantics::live_out::LiveOut;
 use crate::semantics::smt::{
     MachineState, SolverConfig, apply_sequence, create_solver_with_config, states_not_equal,
     states_not_equal_for_live_out,
 };
-use crate::semantics::state::{ConcreteMachineState, LiveOutMask};
+use crate::semantics::state::ConcreteMachineState;
 use crate::validation::random::{
     RandomInputConfig, generate_edge_case_inputs, generate_random_inputs,
 };
@@ -33,8 +34,8 @@ pub enum EquivalenceResult {
 /// Configuration for equivalence checking
 #[derive(Debug, Clone)]
 pub struct EquivalenceConfig {
-    /// Registers that need to match after execution
-    pub live_out: LiveOutMask,
+    /// Observable architectural state that must match after execution.
+    pub live_out: LiveOut,
     /// Number of random tests to run before SMT
     pub random_test_count: usize,
     /// Timeout for SMT solver
@@ -46,7 +47,7 @@ pub struct EquivalenceConfig {
 impl Default for EquivalenceConfig {
     fn default() -> Self {
         Self {
-            live_out: LiveOutMask::all_registers(),
+            live_out: LiveOut::all_registers(),
             random_test_count: 10,
             smt_timeout: Some(Duration::from_secs(30)),
             fast_only: false,
@@ -63,16 +64,16 @@ impl EquivalenceConfig {
         }
     }
 
-    /// Create a config with a specific live-out mask
-    pub fn with_live_out(live_out: LiveOutMask) -> Self {
+    /// Create a config with a specific live-out contract.
+    pub fn with_live_out(live_out: LiveOut) -> Self {
         Self {
             live_out,
             ..Default::default()
         }
     }
 
-    /// Builder method to set live-out mask
-    pub fn live_out(mut self, live_out: LiveOutMask) -> Self {
+    /// Builder method to set live-out contract.
+    pub fn live_out(mut self, live_out: LiveOut) -> Self {
         self.live_out = live_out;
         self
     }
@@ -145,7 +146,8 @@ fn run_fast_path(
     seq2: &[Instruction],
     config: &EquivalenceConfig,
 ) -> Option<EquivalenceResult> {
-    let input_regs: Vec<_> = config.live_out.iter().cloned().collect();
+    let live_out_registers = config.live_out.registers();
+    let input_regs: Vec<_> = live_out_registers.iter().cloned().collect();
 
     let random_config = RandomInputConfig {
         count: config.random_test_count,
@@ -157,7 +159,7 @@ fn run_fast_path(
         let state1 = apply_sequence_concrete(input.clone(), seq1);
         let state2 = apply_sequence_concrete(input.clone(), seq2);
 
-        if !states_equal_for_live_out(&state1, &state2, &config.live_out) {
+        if !states_equal_for_live_out(&state1, &state2, live_out_registers) {
             return Some(EquivalenceResult::NotEquivalentFast(input.clone()));
         }
     }
@@ -167,7 +169,7 @@ fn run_fast_path(
         let state1 = apply_sequence_concrete(input.clone(), seq1);
         let state2 = apply_sequence_concrete(input.clone(), seq2);
 
-        if !states_equal_for_live_out(&state1, &state2, &config.live_out) {
+        if !states_equal_for_live_out(&state1, &state2, live_out_registers) {
             return Some(EquivalenceResult::NotEquivalentFast(input.clone()));
         }
     }
@@ -249,7 +251,7 @@ fn build_smt_solver(
     solver.assert(states_not_equal_for_live_out(
         &final_state1,
         &final_state2,
-        &config.live_out,
+        config.live_out.registers(),
     ));
     solver
 }
@@ -318,7 +320,8 @@ pub fn find_counterexample_concrete(
     crate::semantics::state::ConcreteValue,
     crate::semantics::state::ConcreteValue,
 )> {
-    let input_regs: Vec<_> = config.live_out.iter().cloned().collect();
+    let live_out_registers = config.live_out.registers();
+    let input_regs: Vec<_> = live_out_registers.iter().cloned().collect();
 
     let random_config = RandomInputConfig {
         count: config.random_test_count,
@@ -330,7 +333,7 @@ pub fn find_counterexample_concrete(
         let state1 = apply_sequence_concrete(input.clone(), seq1);
         let state2 = apply_sequence_concrete(input.clone(), seq2);
 
-        if let Some(diff) = find_first_difference(&state1, &state2, &config.live_out) {
+        if let Some(diff) = find_first_difference(&state1, &state2, live_out_registers) {
             return Some(diff);
         }
     }
@@ -340,7 +343,7 @@ pub fn find_counterexample_concrete(
         let state1 = apply_sequence_concrete(input.clone(), seq1);
         let state2 = apply_sequence_concrete(input.clone(), seq2);
 
-        if let Some(diff) = find_first_difference(&state1, &state2, &config.live_out) {
+        if let Some(diff) = find_first_difference(&state1, &state2, live_out_registers) {
             return Some(diff);
         }
     }
@@ -565,8 +568,7 @@ mod tests {
             imm: 2,
         }];
 
-        let config =
-            EquivalenceConfig::with_live_out(LiveOutMask::from_registers(vec![Register::X1]));
+        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X1]));
         let result = check_equivalence_with_config(&seq1, &seq2, &config);
         assert_eq!(result, EquivalenceResult::Equivalent);
     }

--- a/src/semantics/live_out.rs
+++ b/src/semantics/live_out.rs
@@ -4,8 +4,6 @@
 //! only populated slice is `LiveOutRegisters`; condition state, memory, and PC
 //! can be added beside it without renaming the search/equivalence boundary.
 
-#![allow(dead_code)]
-
 use crate::ir::Register;
 use std::collections::HashSet;
 use std::fmt;
@@ -100,6 +98,7 @@ impl LiveOutRegisters {
     }
 
     /// Remove a register from the register set
+    #[allow(dead_code)]
     pub fn remove(&mut self, reg: Register) {
         self.registers.remove(&reg);
     }
@@ -115,11 +114,13 @@ impl LiveOutRegisters {
     }
 
     /// Get the number of registers in the register set
+    #[allow(dead_code)]
     pub fn len(&self) -> usize {
         self.registers.len()
     }
 
     /// Check if the register set is empty
+    #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self.registers.is_empty()
     }

--- a/src/semantics/live_out.rs
+++ b/src/semantics/live_out.rs
@@ -1,0 +1,191 @@
+//! Live-out contract for equivalence checking.
+//!
+//! `LiveOut` names the full observable architectural state contract. Today the
+//! only populated slice is `LiveOutRegisters`; condition state, memory, and PC
+//! can be added beside it without renaming the search/equivalence boundary.
+
+#![allow(dead_code)]
+
+use crate::ir::Register;
+use std::collections::HashSet;
+use std::fmt;
+
+/// Observable architectural state that must match after executing a sequence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LiveOut {
+    registers: LiveOutRegisters,
+}
+
+impl LiveOut {
+    /// Create a live-out contract containing all general-purpose registers.
+    pub fn all_registers() -> Self {
+        Self {
+            registers: LiveOutRegisters::all_registers(),
+        }
+    }
+
+    /// Create a live-out contract from the register slice.
+    pub fn from_registers(regs: Vec<Register>) -> Self {
+        Self {
+            registers: LiveOutRegisters::from_registers(regs),
+        }
+    }
+
+    /// Create a live-out contract from an already parsed register slice.
+    pub fn from_register_set(registers: LiveOutRegisters) -> Self {
+        Self { registers }
+    }
+
+    /// The register slice of this live-out contract.
+    pub fn registers(&self) -> &LiveOutRegisters {
+        &self.registers
+    }
+
+    /// Check whether a register is live-out.
+    pub fn contains_register(&self, reg: Register) -> bool {
+        self.registers.contains(reg)
+    }
+}
+
+impl From<LiveOutRegisters> for LiveOut {
+    fn from(registers: LiveOutRegisters) -> Self {
+        Self::from_register_set(registers)
+    }
+}
+
+impl fmt::Display for LiveOut {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "registers={}", self.registers)
+    }
+}
+
+/// Register set specifying which registers are live-out (need to be preserved)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LiveOutRegisters {
+    registers: HashSet<Register>,
+}
+
+impl LiveOutRegisters {
+    /// Create a register set with all general-purpose registers (X0-X30, SP)
+    pub fn all_registers() -> Self {
+        let mut registers = HashSet::new();
+        for i in 0..=30 {
+            if let Some(reg) = Register::from_index(i) {
+                registers.insert(reg);
+            }
+        }
+        registers.insert(Register::SP);
+        LiveOutRegisters { registers }
+    }
+
+    /// Create a register set from a list of registers
+    pub fn from_registers(regs: Vec<Register>) -> Self {
+        LiveOutRegisters {
+            registers: regs.into_iter().collect(),
+        }
+    }
+
+    /// Create an empty register set
+    pub fn empty() -> Self {
+        LiveOutRegisters {
+            registers: HashSet::new(),
+        }
+    }
+
+    /// Add a register to the register set
+    pub fn add(&mut self, reg: Register) {
+        if reg != Register::XZR {
+            self.registers.insert(reg);
+        }
+    }
+
+    /// Remove a register from the register set
+    pub fn remove(&mut self, reg: Register) {
+        self.registers.remove(&reg);
+    }
+
+    /// Check if a register is in the register set
+    pub fn contains(&self, reg: Register) -> bool {
+        self.registers.contains(&reg)
+    }
+
+    /// Iterate over registers in the register set
+    pub fn iter(&self) -> impl Iterator<Item = &Register> {
+        self.registers.iter()
+    }
+
+    /// Get the number of registers in the register set
+    pub fn len(&self) -> usize {
+        self.registers.len()
+    }
+
+    /// Check if the register set is empty
+    pub fn is_empty(&self) -> bool {
+        self.registers.is_empty()
+    }
+}
+
+impl fmt::Display for LiveOutRegisters {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut regs: Vec<_> = self.registers.iter().collect();
+        regs.sort_by_key(|r| r.index().unwrap_or(255));
+        let names: Vec<_> = regs.iter().map(|r| format!("{}", r)).collect();
+        write!(f, "{{{}}}", names.join(", "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_live_out_registers_all_registers() {
+        let mask = LiveOutRegisters::all_registers();
+        assert!(mask.contains(Register::X0));
+        assert!(mask.contains(Register::X30));
+        assert!(mask.contains(Register::SP));
+        assert!(!mask.contains(Register::XZR));
+    }
+
+    #[test]
+    fn test_live_out_registers_from_registers() {
+        let mask = LiveOutRegisters::from_registers(vec![Register::X0, Register::X1, Register::X2]);
+        assert!(mask.contains(Register::X0));
+        assert!(mask.contains(Register::X1));
+        assert!(mask.contains(Register::X2));
+        assert!(!mask.contains(Register::X3));
+        assert_eq!(mask.len(), 3);
+    }
+
+    #[test]
+    fn test_live_out_registers_empty() {
+        let mask = LiveOutRegisters::empty();
+        assert!(mask.is_empty());
+        assert!(!mask.contains(Register::X0));
+    }
+
+    #[test]
+    fn test_live_out_registers_add_remove() {
+        let mut mask = LiveOutRegisters::empty();
+        mask.add(Register::X0);
+        assert!(mask.contains(Register::X0));
+
+        mask.remove(Register::X0);
+        assert!(!mask.contains(Register::X0));
+    }
+
+    #[test]
+    fn test_live_out_registers_xzr_ignored() {
+        let mut mask = LiveOutRegisters::empty();
+        mask.add(Register::XZR);
+        assert!(!mask.contains(Register::XZR));
+        assert!(mask.is_empty());
+    }
+
+    #[test]
+    fn test_live_out_wraps_register_slice() {
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
+        assert!(live_out.contains_register(Register::X0));
+        assert_eq!(live_out.registers().len(), 1);
+    }
+}

--- a/src/semantics/mod.rs
+++ b/src/semantics/mod.rs
@@ -3,6 +3,7 @@
 pub mod concrete;
 pub mod cost;
 pub mod equivalence;
+pub mod live_out;
 pub mod smt;
 pub mod state;
 
@@ -17,4 +18,6 @@ pub use equivalence::{
 #[allow(unused_imports)]
 pub use equivalence::{EquivalenceMetrics, check_equivalence_with_config_metrics};
 #[allow(unused_imports)]
-pub use state::{ConcreteMachineState, ConcreteValue, ConditionFlags, LiveOutMask};
+pub use live_out::{LiveOut, LiveOutRegisters};
+#[allow(unused_imports)]
+pub use state::{ConcreteMachineState, ConcreteValue, ConditionFlags};

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -3,7 +3,7 @@
 #![allow(dead_code)]
 
 use crate::ir::{Instruction, Operand, Register};
-use crate::semantics::state::LiveOutMask;
+use crate::semantics::live_out::LiveOutRegisters;
 use std::collections::HashMap;
 use std::time::Duration;
 use z3::ast::BV;
@@ -254,7 +254,7 @@ pub fn states_not_equal(state1: &MachineState, state2: &MachineState) -> z3::ast
 pub fn states_not_equal_for_live_out(
     state1: &MachineState,
     state2: &MachineState,
-    live_out: &LiveOutMask,
+    live_out: &LiveOutRegisters,
 ) -> z3::ast::Bool {
     let mut not_equal = z3::ast::Bool::from_bool(false);
 

--- a/src/semantics/state.rs
+++ b/src/semantics/state.rs
@@ -4,7 +4,7 @@
 
 use crate::ir::Register;
 use crate::ir::types::Condition;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fmt;
 
 /// NZCV condition flags (Negative, Zero, Carry, oVerflow)
@@ -215,81 +215,6 @@ impl fmt::Display for ConcreteMachineState {
     }
 }
 
-/// Mask specifying which registers are live-out (need to be preserved)
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LiveOutMask {
-    registers: HashSet<Register>,
-}
-
-impl LiveOutMask {
-    /// Create a mask with all general-purpose registers (X0-X30, SP)
-    pub fn all_registers() -> Self {
-        let mut registers = HashSet::new();
-        for i in 0..=30 {
-            if let Some(reg) = Register::from_index(i) {
-                registers.insert(reg);
-            }
-        }
-        registers.insert(Register::SP);
-        LiveOutMask { registers }
-    }
-
-    /// Create a mask from a list of registers
-    pub fn from_registers(regs: Vec<Register>) -> Self {
-        LiveOutMask {
-            registers: regs.into_iter().collect(),
-        }
-    }
-
-    /// Create an empty mask
-    pub fn empty() -> Self {
-        LiveOutMask {
-            registers: HashSet::new(),
-        }
-    }
-
-    /// Add a register to the mask
-    pub fn add(&mut self, reg: Register) {
-        if reg != Register::XZR {
-            self.registers.insert(reg);
-        }
-    }
-
-    /// Remove a register from the mask
-    pub fn remove(&mut self, reg: Register) {
-        self.registers.remove(&reg);
-    }
-
-    /// Check if a register is in the mask
-    pub fn contains(&self, reg: Register) -> bool {
-        self.registers.contains(&reg)
-    }
-
-    /// Iterate over registers in the mask
-    pub fn iter(&self) -> impl Iterator<Item = &Register> {
-        self.registers.iter()
-    }
-
-    /// Get the number of registers in the mask
-    pub fn len(&self) -> usize {
-        self.registers.len()
-    }
-
-    /// Check if the mask is empty
-    pub fn is_empty(&self) -> bool {
-        self.registers.is_empty()
-    }
-}
-
-impl fmt::Display for LiveOutMask {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut regs: Vec<_> = self.registers.iter().collect();
-        regs.sort_by_key(|r| r.index().unwrap_or(255));
-        let names: Vec<_> = regs.iter().map(|r| format!("{}", r)).collect();
-        write!(f, "{{{}}}", names.join(", "))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -337,49 +262,5 @@ mod tests {
         let mut state = ConcreteMachineState::new_zeroed();
         state.set_register(Register::XZR, ConcreteValue::new(123));
         assert_eq!(state.get_register(Register::XZR).as_u64(), 0);
-    }
-
-    #[test]
-    fn test_live_out_mask_all_registers() {
-        let mask = LiveOutMask::all_registers();
-        assert!(mask.contains(Register::X0));
-        assert!(mask.contains(Register::X30));
-        assert!(mask.contains(Register::SP));
-        assert!(!mask.contains(Register::XZR));
-    }
-
-    #[test]
-    fn test_live_out_mask_from_registers() {
-        let mask = LiveOutMask::from_registers(vec![Register::X0, Register::X1, Register::X2]);
-        assert!(mask.contains(Register::X0));
-        assert!(mask.contains(Register::X1));
-        assert!(mask.contains(Register::X2));
-        assert!(!mask.contains(Register::X3));
-        assert_eq!(mask.len(), 3);
-    }
-
-    #[test]
-    fn test_live_out_mask_empty() {
-        let mask = LiveOutMask::empty();
-        assert!(mask.is_empty());
-        assert!(!mask.contains(Register::X0));
-    }
-
-    #[test]
-    fn test_live_out_mask_add_remove() {
-        let mut mask = LiveOutMask::empty();
-        mask.add(Register::X0);
-        assert!(mask.contains(Register::X0));
-
-        mask.remove(Register::X0);
-        assert!(!mask.contains(Register::X0));
-    }
-
-    #[test]
-    fn test_live_out_mask_xzr_ignored() {
-        let mut mask = LiveOutMask::empty();
-        mask.add(Register::XZR);
-        assert!(!mask.contains(Register::XZR));
-        assert!(mask.is_empty());
     }
 }

--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -119,6 +119,8 @@ pub fn reads_flags_before_writing(instructions: &[Instruction]) -> bool {
 ///
 /// This is the intra-sequence live-in set: any register the sequence reads
 /// before defining (writing) is in the result. XZR is never included.
+/// It reuses `LiveOutRegisters` because live-in and live-out registers are both
+/// architecture-register sets; see ADR-0001 for the design rationale.
 pub fn compute_live_in_registers(instructions: &[Instruction]) -> LiveOutRegisters {
     let mut live_in = LiveOutRegisters::empty();
     let mut written = LiveOutRegisters::empty();

--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -1,27 +1,27 @@
-//! Live-out register computation and parsing
+//! Live-out register set computation and parsing
 
 #![allow(dead_code)]
 
 use crate::ir::{Instruction, Register};
-use crate::semantics::state::LiveOutMask;
+use crate::semantics::live_out::LiveOutRegisters;
 use std::str::FromStr;
 
-/// Error type for parsing LiveOutMask
+/// Error type for parsing live-out register sets.
 #[derive(Debug, Clone, PartialEq)]
-pub struct ParseLiveOutError {
+pub struct ParseLiveOutRegistersError {
     pub message: String,
 }
 
-impl std::fmt::Display for ParseLiveOutError {
+impl std::fmt::Display for ParseLiveOutRegistersError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ParseLiveOutError: {}", self.message)
+        write!(f, "ParseLiveOutRegistersError: {}", self.message)
     }
 }
 
-impl std::error::Error for ParseLiveOutError {}
+impl std::error::Error for ParseLiveOutRegistersError {}
 
 /// Parse a register name like "x0", "X1", "sp", "SP"
-fn parse_register(s: &str) -> Result<Register, ParseLiveOutError> {
+fn parse_register(s: &str) -> Result<Register, ParseLiveOutRegistersError> {
     let s = s.trim().to_lowercase();
 
     if s == "sp" {
@@ -38,25 +38,25 @@ fn parse_register(s: &str) -> Result<Register, ParseLiveOutError> {
         return Ok(reg);
     }
 
-    Err(ParseLiveOutError {
+    Err(ParseLiveOutRegistersError {
         message: format!("invalid register name: '{}'", s),
     })
 }
 
-impl FromStr for LiveOutMask {
-    type Err = ParseLiveOutError;
+impl FromStr for LiveOutRegisters {
+    type Err = ParseLiveOutRegistersError;
 
     /// Parse a comma or space-separated list of register names
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let s = s.trim();
 
         if s.is_empty() {
-            return Ok(LiveOutMask::empty());
+            return Ok(LiveOutRegisters::empty());
         }
 
         let separator = if s.contains(',') { ',' } else { ' ' };
 
-        let mut mask = LiveOutMask::empty();
+        let mut mask = LiveOutRegisters::empty();
         for part in s.split(separator) {
             let part = part.trim();
             if part.is_empty() {
@@ -71,8 +71,8 @@ impl FromStr for LiveOutMask {
 }
 
 /// Compute the set of registers written by a sequence of instructions
-pub fn compute_written_registers(instructions: &[Instruction]) -> LiveOutMask {
-    let mut mask = LiveOutMask::empty();
+pub fn compute_written_registers(instructions: &[Instruction]) -> LiveOutRegisters {
+    let mut mask = LiveOutRegisters::empty();
     for instr in instructions {
         if let Some(dest) = instr.destination() {
             mask.add(dest);
@@ -119,9 +119,9 @@ pub fn reads_flags_before_writing(instructions: &[Instruction]) -> bool {
 ///
 /// This is the intra-sequence live-in set: any register the sequence reads
 /// before defining (writing) is in the result. XZR is never included.
-pub fn compute_live_in_registers(instructions: &[Instruction]) -> LiveOutMask {
-    let mut live_in = LiveOutMask::empty();
-    let mut written = LiveOutMask::empty();
+pub fn compute_live_in_registers(instructions: &[Instruction]) -> LiveOutRegisters {
+    let mut live_in = LiveOutRegisters::empty();
+    let mut written = LiveOutRegisters::empty();
 
     for instr in instructions {
         for src in instr.source_registers() {
@@ -174,8 +174,8 @@ mod tests {
     }
 
     #[test]
-    fn test_live_out_mask_from_str_comma_separated() {
-        let mask: LiveOutMask = "x0, x1, x2".parse().unwrap();
+    fn test_live_out_registers_from_str_comma_separated() {
+        let mask: LiveOutRegisters = "x0, x1, x2".parse().unwrap();
         assert!(mask.contains(Register::X0));
         assert!(mask.contains(Register::X1));
         assert!(mask.contains(Register::X2));
@@ -183,37 +183,37 @@ mod tests {
     }
 
     #[test]
-    fn test_live_out_mask_from_str_space_separated() {
-        let mask: LiveOutMask = "x0 x1 x2".parse().unwrap();
+    fn test_live_out_registers_from_str_space_separated() {
+        let mask: LiveOutRegisters = "x0 x1 x2".parse().unwrap();
         assert!(mask.contains(Register::X0));
         assert!(mask.contains(Register::X1));
         assert!(mask.contains(Register::X2));
     }
 
     #[test]
-    fn test_live_out_mask_from_str_mixed_case() {
-        let mask: LiveOutMask = "X0, x1, SP".parse().unwrap();
+    fn test_live_out_registers_from_str_mixed_case() {
+        let mask: LiveOutRegisters = "X0, x1, SP".parse().unwrap();
         assert!(mask.contains(Register::X0));
         assert!(mask.contains(Register::X1));
         assert!(mask.contains(Register::SP));
     }
 
     #[test]
-    fn test_live_out_mask_from_str_empty() {
-        let mask: LiveOutMask = "".parse().unwrap();
+    fn test_live_out_registers_from_str_empty() {
+        let mask: LiveOutRegisters = "".parse().unwrap();
         assert!(mask.is_empty());
     }
 
     #[test]
-    fn test_live_out_mask_from_str_whitespace() {
-        let mask: LiveOutMask = "  x0  ,  x1  ".parse().unwrap();
+    fn test_live_out_registers_from_str_whitespace() {
+        let mask: LiveOutRegisters = "  x0  ,  x1  ".parse().unwrap();
         assert!(mask.contains(Register::X0));
         assert!(mask.contains(Register::X1));
     }
 
     #[test]
-    fn test_live_out_mask_from_str_invalid() {
-        let result: Result<LiveOutMask, _> = "x0, invalid, x1".parse();
+    fn test_live_out_registers_from_str_invalid() {
+        let result: Result<LiveOutRegisters, _> = "x0, invalid, x1".parse();
         assert!(result.is_err());
     }
 


### PR DESCRIPTION
## Summary

- Introduce `LiveOut` as the broad live-out contract in `src/semantics/live_out.rs`.
- Move `LiveOutRegisters` into that module as the currently implemented register slice.
- Update equivalence/search/CLI seams to pass `LiveOut`, while concrete/SMT register comparisons continue to consume `LiveOutRegisters`.
- Refresh domain docs and ADR wording so condition state, memory, and PC can be added later without renaming the boundary.

## Validation

- `./ci_check.sh`