### PR TITLE
ci: add cargo-llvm-cov coverage with Codecov upload

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,6 +10,8 @@ env:
   CARGO_TERM_COLOR: always
   # Avoid incremental compilation for more reliable coverage data and smaller caches.
   CARGO_INCREMENTAL: 0
+  # Fail the build on any warning so unused imports / dead code can't slip in.
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   coverage:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   # Avoid incremental compilation for more reliable coverage data and smaller caches.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,51 @@
+name: Coverage
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+  # Avoid incremental compilation for more reliable coverage data and smaller caches.
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  coverage:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcapstone-dev gcc-aarch64-linux-gnu z3 libz3-dev
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
+
+      - name: Setup Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable --component llvm-tools-preview
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Build AArch64 test binaries
+        run: ./build_tests.sh
+
+      - name: Collect coverage (unit + integration tests)
+        run: |
+          cargo llvm-cov --workspace --all-features \
+            --lcov --output-path lcov.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          fail_ci_if_error: true
+          verbose: true

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -47,6 +47,7 @@ jobs:
         run:
           cargo clippy
           --all-features
+          --all-targets
           --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
         continue-on-error: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Fail the build on any warning so unused imports / dead code can't slip in.
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   test:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,24 @@ This prevents pushing code that will fail CI checks.
 
 Note: Clippy linting is run separately in the `rust-clippy.yml` workflow which performs security analysis and uploads results to GitHub's security tab.
 
+### Code Coverage
+
+Source-based coverage uses [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov). Install once with:
+
+```
+rustup component add llvm-tools-preview
+cargo install cargo-llvm-cov
+```
+
+Local recipes:
+
+- `just coverage` — HTML report at `target/llvm-cov/html/index.html`.
+- `just coverage-lcov` — LCOV at `target/llvm-cov/lcov.info` (CI format).
+
+Both recipes depend on `build-tests` so that AArch64 integration-test binaries are present.
+
+In CI, `.github/workflows/coverage.yml` runs on PRs and pushes to `main`, collects LCOV across unit + integration tests, and uploads to [Codecov](https://codecov.io/) using the `CODECOV_TOKEN` repo secret. Project/patch thresholds live in `codecov.yml`.
+
 ### Mutation Testing (informational, local-only)
 
 Mutation testing runs via [cargo-mutants](https://mutants.rs/) and is **informational only** — it does not gate merges. It is **not** wired into CI to keep GitHub Actions minutes for the test/clippy/CodeQL workflows.

--- a/Justfile
+++ b/Justfile
@@ -93,6 +93,7 @@ coverage: build-tests
 # Emit an LCOV report at target/llvm-cov/lcov.info — the format consumed by CI/Codecov.
 coverage-lcov: build-tests
     @echo "Collecting coverage (LCOV)..."
+    @mkdir -p target/llvm-cov
     cargo llvm-cov --workspace --all-features --lcov --output-path target/llvm-cov/lcov.info
 
 # Help message (can be more detailed than just listing)

--- a/Justfile
+++ b/Justfile
@@ -84,6 +84,17 @@ llm-demo: build
 mutants *ARGS:
     ./scripts/run-mutants.sh {{ARGS}}
 
+# Generate an HTML coverage report locally (open target/llvm-cov/html/index.html).
+# Requires `cargo install cargo-llvm-cov` and the `llvm-tools-preview` rustup component.
+coverage: build-tests
+    @echo "Collecting coverage (HTML)..."
+    cargo llvm-cov --workspace --all-features --html
+
+# Emit an LCOV report at target/llvm-cov/lcov.info — the format consumed by CI/Codecov.
+coverage-lcov: build-tests
+    @echo "Collecting coverage (LCOV)..."
+    cargo llvm-cov --workspace --all-features --lcov --output-path target/llvm-cov/lcov.info
+
 # Help message (can be more detailed than just listing)
 help:
     @echo "Available commands for AArch64 Super-Optimizer MVP (run with 'just <command>'):"
@@ -96,6 +107,8 @@ help:
     @echo "  build-tests   - Build AArch64 test binaries"
     @echo "  test-all      - Run complete test suite"
     @echo "  mutants       - Run cargo-mutants locally (slow; informational)"
+    @echo "  coverage      - Generate HTML coverage report via cargo-llvm-cov"
+    @echo "  coverage-lcov - Generate LCOV coverage report (CI format)"
     @echo "  clean         - Remove build artifacts from the target directory"
     @echo "  check         - Check the code for errors without compiling"
     @echo "  fmt           - Format the Rust code"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,25 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: false
+    patch:
+      default:
+        target: 80%
+        threshold: 5%
+        informational: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "tests/"
+  - "target/"
+  - "binaries/"
+  - "external/"
+  - "scripts/"
+  - "**/*.rs.bk"

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -578,7 +578,6 @@ fn mutate_shift_operand<R: RngExt>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::isa::InstructionType as _;
     use rand::SeedableRng;
     use rand_chacha::ChaCha8Rng;
 

--- a/src/isa/riscv.rs
+++ b/src/isa/riscv.rs
@@ -811,7 +811,6 @@ impl InstructionGenerator<RiscVInstruction> for RiscVInstructionGenerator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::isa::InstructionType as _;
     use rand::SeedableRng;
     use rand_chacha::ChaCha8Rng;
 

--- a/tests/integration/disasm_test.rs
+++ b/tests/integration/disasm_test.rs
@@ -20,11 +20,7 @@ fn check_test_binary(path: &PathBuf) {
 }
 
 fn get_binary_path() -> PathBuf {
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.push("target");
-    path.push("debug");
-    path.push("s11");
-    path
+    PathBuf::from(env!("CARGO_BIN_EXE_s11"))
 }
 
 #[test]

--- a/tests/integration/opt_test.rs
+++ b/tests/integration/opt_test.rs
@@ -21,11 +21,7 @@ fn check_test_binary(path: &PathBuf) {
 }
 
 fn get_binary_path() -> PathBuf {
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.push("target");
-    path.push("debug");
-    path.push("s11");
-    path
+    PathBuf::from(env!("CARGO_BIN_EXE_s11"))
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add a `Coverage` GitHub Actions workflow that runs on PRs and pushes to `main`, collects source-based coverage with [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov) over unit + integration tests, and uploads LCOV to [Codecov](https://codecov.io/) via `codecov/codecov-action@v5`.
- Add `just coverage` (HTML) and `just coverage-lcov` recipes for local runs; both depend on `build-tests` so AArch64 integration coverage works out of the box.
- Add `codecov.yml` with project/patch thresholds and ignores for `tests/`, `binaries/`, `external/`, `scripts/`.
- Document the install steps and CI flow in `CLAUDE.md`.

## One-time setup required
- Add a `CODECOV_TOKEN` secret in **Settings → Secrets and variables → Actions**. The workflow has `fail_ci_if_error: true`, so without the token the upload step (and the job) will fail loudly rather than silently rot.

## Test plan
- [ ] Confirm `CODECOV_TOKEN` is set in repo secrets before merging.
- [ ] CI: `Coverage` workflow runs green on this PR.
- [ ] Codecov: PR comment appears with project/patch numbers; report is browsable at codecov.io.
- [ ] Local: `just coverage` produces `target/llvm-cov/html/index.html`; `just coverage-lcov` produces `target/llvm-cov/lcov.info`.
- [ ] After merge to `main`: a fresh upload appears on Codecov tagged to the `main` branch, establishing the baseline future PRs compare against.