### PR TITLE
AArch64 ADDS/SUBS: accept SP as rn; document AND/ORR/EOR random-gen register-only choice

### DIFF
--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -629,17 +629,8 @@ fn register_to_dynasm(reg: Register) -> Result<u8, String> {
         .ok_or_else(|| format!("Register {:?} not supported in dynasm encoding", reg))
 }
 
-/// Map a register to the index used in the `Xn|SP` encoding slot (`XSP(...)`
-/// in dynasm). Index 31 means SP — XZR is **not** valid in this slot.
-///
-/// Use this wherever the encoding decodes register 31 as SP rather than XZR
-/// (currently the immediate-form ADDS/SUBS arms; the pre-existing ADD/SUB
-/// immediate arms have the same encoding shape and should migrate to this
-/// helper too — tracked as a follow-up).
-///
-/// We can't just call `reg.index().ok_or_else(...)` here: `Register::XZR`
-/// has `index() == Some(31)`, so a delegating implementation would silently
-/// alias XZR to SP in the Xn|SP slot, producing inverted semantics.
+/// Map a register to the `Xn|SP` encoding slot. Returns Err for XZR —
+/// `Register::XZR.index() == Some(31)` would otherwise silently alias to SP.
 fn register_to_dynasm_xsp(reg: Register) -> Result<u8, String> {
     match reg {
         Register::XZR => {
@@ -1206,6 +1197,22 @@ mod tests {
             }])
             .expect("ADDS imm with SP rn should encode");
         disassemble_and_verify(&bytes, "adds", &["x0", "sp", "#8"]);
+    }
+
+    /// SUBS counterpart to `test_adds_imm_sp_rn_roundtrip`. The encoding
+    /// logic is shared via `register_to_dynasm_xsp` but a regression
+    /// specific to SUBS would otherwise go unnoticed.
+    #[test]
+    fn test_subs_imm_sp_rn_roundtrip() {
+        let mut assembler = AArch64Assembler::new();
+        let bytes = assembler
+            .assemble_instructions(&[Instruction::Subs {
+                rd: Register::X0,
+                rn: Register::SP,
+                rm: Operand::Immediate(8),
+            }])
+            .expect("SUBS imm with SP rn should encode");
+        disassemble_and_verify(&bytes, "subs", &["x0", "sp", "#8"]);
     }
 
     /// Defense-in-depth: SP as `rd` for ADDS/SUBS is rejected. Architecturally,

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -496,9 +496,11 @@ impl AArch64Assembler {
             }
             Instruction::Adds { rd, rn, rm } => {
                 let rd_reg = register_to_dynasm(*rd)?;
-                let rn_reg = register_to_dynasm(*rn)?;
                 match rm {
                     Operand::Register(r) => {
+                        // Register-form encoding decodes 31 as XZR, so use
+                        // the plain X-mapping for `rn`.
+                        let rn_reg = register_to_dynasm(*rn)?;
                         let rm_reg = register_to_dynasm(*r)?;
                         dynasm!(ops ; .arch aarch64 ; adds X(rd_reg), X(rn_reg), X(rm_reg));
                         Ok(())
@@ -507,15 +509,12 @@ impl AArch64Assembler {
                         if *imm < 0 || *imm > 0xFFF {
                             return Err(format!("Immediate {} out of range for ADDS", imm));
                         }
-                        // The immediate-form encoding uses the `Xn|SP` register
-                        // class, which dynasm spells `XSP(...)`. Register index
-                        // 31 decodes as SP, not XZR — so we must refuse XZR as
-                        // `rn` here or we'd emit `ADDS Xd, SP, #imm`.
-                        if *rn == Register::XZR {
-                            return Err(
-                                "ADDS immediate with XZR as `rn` is not encodable (encoding slot is Xn|SP)".to_string(),
-                            );
-                        }
+                        // The immediate-form encoding uses the `Xn|SP` slot —
+                        // 31 decodes as SP, not XZR. `register_to_dynasm_xsp`
+                        // accepts SP and rejects XZR, keeping the encoding
+                        // unambiguous and consistent with what the parser /
+                        // is_encodable_aarch64 admit.
+                        let rn_reg = register_to_dynasm_xsp(*rn)?;
                         let imm = *imm as u32;
                         dynasm!(ops ; .arch aarch64 ; adds X(rd_reg), XSP(rn_reg), imm);
                         Ok(())
@@ -524,9 +523,9 @@ impl AArch64Assembler {
             }
             Instruction::Subs { rd, rn, rm } => {
                 let rd_reg = register_to_dynasm(*rd)?;
-                let rn_reg = register_to_dynasm(*rn)?;
                 match rm {
                     Operand::Register(r) => {
+                        let rn_reg = register_to_dynasm(*rn)?;
                         let rm_reg = register_to_dynasm(*r)?;
                         dynasm!(ops ; .arch aarch64 ; subs X(rd_reg), X(rn_reg), X(rm_reg));
                         Ok(())
@@ -535,11 +534,7 @@ impl AArch64Assembler {
                         if *imm < 0 || *imm > 0xFFF {
                             return Err(format!("Immediate {} out of range for SUBS", imm));
                         }
-                        if *rn == Register::XZR {
-                            return Err(
-                                "SUBS immediate with XZR as `rn` is not encodable (encoding slot is Xn|SP)".to_string(),
-                            );
-                        }
+                        let rn_reg = register_to_dynasm_xsp(*rn)?;
                         let imm = *imm as u32;
                         dynasm!(ops ; .arch aarch64 ; subs X(rd_reg), XSP(rn_reg), imm);
                         Ok(())
@@ -628,6 +623,25 @@ impl Default for AArch64Assembler {
 fn register_to_dynasm(reg: Register) -> Result<u8, String> {
     reg.index()
         .ok_or_else(|| format!("Register {:?} not supported in dynasm encoding", reg))
+}
+
+/// Map a register to the index used in the `Xn|SP` encoding slot (`XSP(...)`
+/// in dynasm). Index 31 means SP — XZR is **not** valid in this slot, so the
+/// XZR variant returns Err. Use this in immediate-form ADDS/SUBS/ADD/SUB
+/// where the encoding decodes 31 as SP.
+fn register_to_dynasm_xsp(reg: Register) -> Result<u8, String> {
+    match reg {
+        Register::XZR => {
+            Err("XZR is not encodable in the Xn|SP register slot (would decode as SP)".to_string())
+        }
+        Register::SP => Ok(31),
+        other => other.index().ok_or_else(|| {
+            format!(
+                "Register {:?} not supported in dynasm Xn|SP encoding",
+                other
+            )
+        }),
+    }
 }
 
 #[cfg(test)]
@@ -1135,6 +1149,36 @@ mod tests {
             .assemble_instructions(&instructions)
             .expect("CSETM encoding should succeed");
         disassemble_and_verify(&bytes, "csetm", &["x3", "ne"]);
+    }
+
+    /// ADDS/SUBS immediate-form accepts SP as `rn` (the `Xn|SP` encoding
+    /// slot decodes 31 as SP). The parser and `is_encodable_aarch64` both
+    /// admit this — the encoder must too.
+    #[test]
+    fn test_adds_subs_imm_accept_sp_rn() {
+        let mut assembler = AArch64Assembler::new();
+        for instr in [
+            Instruction::Adds {
+                rd: Register::X0,
+                rn: Register::SP,
+                rm: Operand::Immediate(8),
+            },
+            Instruction::Subs {
+                rd: Register::X0,
+                rn: Register::SP,
+                rm: Operand::Immediate(8),
+            },
+        ] {
+            let bytes = assembler
+                .assemble_instructions(&[instr])
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "Expected SP-as-rn to encode, got Err({}) for {:?}",
+                        e, instr
+                    )
+                });
+            assert_eq!(bytes.len(), 4);
+        }
     }
 
     /// Defense-in-depth: ADDS/SUBS with immediate `rm` and XZR as `rn` would

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -498,8 +498,8 @@ impl AArch64Assembler {
                 let rd_reg = register_to_dynasm(*rd)?;
                 match rm {
                     Operand::Register(r) => {
-                        // Register-form encoding decodes 31 as XZR, so use
-                        // the plain X-mapping for `rn`.
+                        // Shifted-register form: slot 31 = XZR; plain
+                        // `register_to_dynasm` mapping is correct.
                         let rn_reg = register_to_dynasm(*rn)?;
                         let rm_reg = register_to_dynasm(*r)?;
                         dynasm!(ops ; .arch aarch64 ; adds X(rd_reg), X(rn_reg), X(rm_reg));
@@ -525,6 +525,7 @@ impl AArch64Assembler {
                 let rd_reg = register_to_dynasm(*rd)?;
                 match rm {
                     Operand::Register(r) => {
+                        // Shifted-register form: slot 31 = XZR.
                         let rn_reg = register_to_dynasm(*rn)?;
                         let rm_reg = register_to_dynasm(*r)?;
                         dynasm!(ops ; .arch aarch64 ; subs X(rd_reg), X(rn_reg), X(rm_reg));
@@ -534,6 +535,9 @@ impl AArch64Assembler {
                         if *imm < 0 || *imm > 0xFFF {
                             return Err(format!("Immediate {} out of range for SUBS", imm));
                         }
+                        // Immediate form uses the Xn|SP slot — same caveat
+                        // as ADDS above; `register_to_dynasm_xsp` accepts SP
+                        // and rejects XZR.
                         let rn_reg = register_to_dynasm_xsp(*rn)?;
                         let imm = *imm as u32;
                         dynasm!(ops ; .arch aarch64 ; subs X(rd_reg), XSP(rn_reg), imm);
@@ -626,9 +630,16 @@ fn register_to_dynasm(reg: Register) -> Result<u8, String> {
 }
 
 /// Map a register to the index used in the `Xn|SP` encoding slot (`XSP(...)`
-/// in dynasm). Index 31 means SP — XZR is **not** valid in this slot, so the
-/// XZR variant returns Err. Use this in immediate-form ADDS/SUBS/ADD/SUB
-/// where the encoding decodes 31 as SP.
+/// in dynasm). Index 31 means SP — XZR is **not** valid in this slot.
+///
+/// Use this wherever the encoding decodes register 31 as SP rather than XZR
+/// (currently the immediate-form ADDS/SUBS arms; the pre-existing ADD/SUB
+/// immediate arms have the same encoding shape and should migrate to this
+/// helper too — tracked as a follow-up).
+///
+/// We can't just call `reg.index().ok_or_else(...)` here: `Register::XZR`
+/// has `index() == Some(31)`, so a delegating implementation would silently
+/// alias XZR to SP in the Xn|SP slot, producing inverted semantics.
 fn register_to_dynasm_xsp(reg: Register) -> Result<u8, String> {
     match reg {
         Register::XZR => {
@@ -1178,6 +1189,52 @@ mod tests {
                     )
                 });
             assert_eq!(bytes.len(), 4);
+        }
+    }
+
+    /// Capstone round-trip for ADDS with SP as `rn` — guards against silent
+    /// off-by-one in the encoded slot. Capstone must disassemble back to
+    /// `adds` with `sp` in the rn position.
+    #[test]
+    fn test_adds_imm_sp_rn_roundtrip() {
+        let mut assembler = AArch64Assembler::new();
+        let bytes = assembler
+            .assemble_instructions(&[Instruction::Adds {
+                rd: Register::X0,
+                rn: Register::SP,
+                rm: Operand::Immediate(8),
+            }])
+            .expect("ADDS imm with SP rn should encode");
+        disassemble_and_verify(&bytes, "adds", &["x0", "sp", "#8"]);
+    }
+
+    /// Defense-in-depth: SP as `rd` for ADDS/SUBS is rejected. Architecturally,
+    /// the `rd` slot is `Xd|XZR` (decodes 31 as XZR), so dynasm's `X(31)`
+    /// maps to XZR — but `Register::SP` has `index() == None`, so
+    /// `register_to_dynasm(SP)` returns Err and the encoder bails early.
+    /// Test that this remains the case.
+    #[test]
+    fn test_adds_subs_imm_reject_sp_rd() {
+        let mut assembler = AArch64Assembler::new();
+        for instr in [
+            Instruction::Adds {
+                rd: Register::SP,
+                rn: Register::X0,
+                rm: Operand::Immediate(8),
+            },
+            Instruction::Subs {
+                rd: Register::SP,
+                rn: Register::X0,
+                rm: Operand::Immediate(8),
+            },
+        ] {
+            let result = assembler.assemble_instructions(&[instr]);
+            assert!(
+                result.is_err(),
+                "Expected encoder to reject SP as rd, got {:?} for {:?}",
+                result,
+                instr
+            );
         }
     }
 

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -200,12 +200,13 @@ pub fn generate_random_instruction<R: rand::RngExt>(
         }
         // AND / ORR / EOR are deliberately register-only here. AArch64's
         // bitmask-immediate encoding for these is not supported by the
-        // assembler (see `src/assembler/mod.rs:139-156` — `Err("...
-        // immediate encoding not yet supported")` for the immediate arm),
-        // so any `Operand::Immediate` candidate would be silently rejected
-        // at encoding time. Picking only register-form here keeps the
-        // stochastic search emitting candidates the encoder actually
-        // accepts.
+        // assembler — the `Instruction::And { rm: Operand::Immediate(_) }`
+        // arm in `src/assembler/mod.rs` returns
+        // `Err("AND immediate encoding not yet supported")` (and likewise
+        // for ORR/EOR), so any `Operand::Immediate` candidate would be
+        // silently rejected at encoding time. Picking only register-form
+        // here keeps the stochastic search emitting candidates the encoder
+        // actually accepts.
         4 => {
             let rn = pick_reg(rng);
             let rm = Operand::Register(pick_reg(rng));

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -198,6 +198,14 @@ pub fn generate_random_instruction<R: rand::RngExt>(
             let rm = random_operand(rng, registers, immediates);
             Instruction::Sub { rd, rn, rm }
         }
+        // AND / ORR / EOR are deliberately register-only here. AArch64's
+        // bitmask-immediate encoding for these is not supported by the
+        // assembler (see `src/assembler/mod.rs:139-156` — `Err("...
+        // immediate encoding not yet supported")` for the immediate arm),
+        // so any `Operand::Immediate` candidate would be silently rejected
+        // at encoding time. Picking only register-form here keeps the
+        // stochastic search emitting candidates the encoder actually
+        // accepts.
         4 => {
             let rn = pick_reg(rng);
             let rm = Operand::Register(pick_reg(rng));


### PR DESCRIPTION
## Summary

Follow-up to PR #72 (which was merged). Two small fixes flagged by the post-merge review iteration that didn't land before #72 merged.

- **ADDS/SUBS immediate-form accepts SP as `rn`** (`src/assembler/mod.rs`). The previous code called `register_to_dynasm(*rn)` unconditionally, which returns `Err` for `Register::SP` (its `index()` is `None`). Yet the parser and `is_encodable_aarch64` both admit `adds x0, sp, #8`, so the encoder errored out on a valid construction. Restructured to defer `rn` resolution into each branch and added a new `register_to_dynasm_xsp` helper that maps SP→31 (the `Xn|SP` slot decodes 31 as SP) and explicitly rejects XZR (preserving the earlier defense-in-depth check). Now `adds x0, sp, #8` and `subs x0, sp, #8` round-trip. New regression test `test_adds_subs_imm_accept_sp_rn`.

  Note: pre-existing ADD/SUB share the same limitation and are intentionally left alone here — to be tracked separately.

- **AND/ORR/EOR random-gen comment** (`src/search/candidate.rs`). `generate_random_instruction`'s AND/ORR/EOR arms emit register-only `rm`. Added a comment documenting that this is deliberate — the assembler's immediate arm for these returns `Err("... immediate encoding not yet supported")`, so emitting `Operand::Immediate` would just burn search iterations on un-encodable candidates.

## Out of scope (tracked separately)

- Codex P2 ([discussion_r3232064930](https://github.com/pmatos/s11/pull/72#discussion_r3232064930)) — preserved CSEL family instructions get independent fresh BVs in SMT, blocking any optimization that leaves them in place. Proper fix needs symbolic flag state in `MachineState` plus a CSEL UF. Tracked as #99.
- Pre-existing ADD/SUB immediate-form encoder also rejects SP-as-`rn`. Same root cause, same fix shape; will file separately.

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo build`
- [x] `cargo test` — adds 1 test for the SP encoding case (`test_adds_subs_imm_accept_sp_rn`).
- [x] `./ci_check.sh` — full suite passes.
- [x] Manual: `adds x0, sp, #8` and `subs x0, sp, #8` now disassemble correctly via Capstone.