### PR TITLE
Add MOVZ and MOVK to materialize arbitrary 64-bit constants

### DIFF
--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -438,6 +438,30 @@ impl AArch64Assembler {
                 }
                 Ok(())
             }
+            Instruction::MovZ { rd, imm, shift } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let imm = *imm as u32;
+                match shift {
+                    0 => dynasm!(ops ; .arch aarch64 ; movz X(rd_reg), imm),
+                    16 => dynasm!(ops ; .arch aarch64 ; movz X(rd_reg), imm, lsl #16),
+                    32 => dynasm!(ops ; .arch aarch64 ; movz X(rd_reg), imm, lsl #32),
+                    48 => dynasm!(ops ; .arch aarch64 ; movz X(rd_reg), imm, lsl #48),
+                    other => return Err(format!("MOVZ shift {} out of range", other)),
+                }
+                Ok(())
+            }
+            Instruction::MovK { rd, imm, shift } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let imm = *imm as u32;
+                match shift {
+                    0 => dynasm!(ops ; .arch aarch64 ; movk X(rd_reg), imm),
+                    16 => dynasm!(ops ; .arch aarch64 ; movk X(rd_reg), imm, lsl #16),
+                    32 => dynasm!(ops ; .arch aarch64 ; movk X(rd_reg), imm, lsl #32),
+                    48 => dynasm!(ops ; .arch aarch64 ; movk X(rd_reg), imm, lsl #48),
+                    other => return Err(format!("MOVK shift {} out of range", other)),
+                }
+                Ok(())
+            }
             Instruction::Bic { rd, rn, rm } => {
                 let rd_reg = register_to_dynasm(*rd)?;
                 let rn_reg = register_to_dynasm(*rn)?;
@@ -1472,6 +1496,46 @@ mod tests {
                 imm: 3,
                 shift: 48,
             },
+            Instruction::MovZ {
+                rd: Register::X0,
+                imm: 0xABCD,
+                shift: 0,
+            },
+            Instruction::MovZ {
+                rd: Register::X0,
+                imm: 0xABCD,
+                shift: 16,
+            },
+            Instruction::MovZ {
+                rd: Register::X0,
+                imm: 0xABCD,
+                shift: 32,
+            },
+            Instruction::MovZ {
+                rd: Register::X0,
+                imm: 0xABCD,
+                shift: 48,
+            },
+            Instruction::MovK {
+                rd: Register::X0,
+                imm: 0xABCD,
+                shift: 0,
+            },
+            Instruction::MovK {
+                rd: Register::X0,
+                imm: 0xABCD,
+                shift: 16,
+            },
+            Instruction::MovK {
+                rd: Register::X0,
+                imm: 0xABCD,
+                shift: 32,
+            },
+            Instruction::MovK {
+                rd: Register::X0,
+                imm: 0xABCD,
+                shift: 48,
+            },
             Instruction::Bic {
                 rd: Register::X0,
                 rn: Register::X1,
@@ -1596,6 +1660,16 @@ mod tests {
                 rd: Register::X0,
                 imm: 1,
                 shift: 8,
+            },
+            Instruction::MovZ {
+                rd: Register::X0,
+                imm: 1,
+                shift: 8,
+            },
+            Instruction::MovK {
+                rd: Register::X0,
+                imm: 1,
+                shift: 24,
             },
             Instruction::Bic {
                 rd: Register::X0,

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -141,6 +141,20 @@ pub enum Instruction {
         imm: u16,
         shift: u8,
     },
+    // Move-wide-zero immediate: rd = (imm as u64) << shift, shift ∈ {0,16,32,48}
+    MovZ {
+        rd: Register,
+        imm: u16,
+        shift: u8,
+    },
+    // Move-wide-keep immediate: writes one 16-bit chunk, preserving the rest.
+    // rd = (rd & ~(0xFFFF << shift)) | ((imm as u64) << shift), shift ∈ {0,16,32,48}.
+    // Unlike MovN/MovZ this reads rd, so the rd register must be live-in.
+    MovK {
+        rd: Register,
+        imm: u16,
+        shift: u8,
+    },
 
     // Inverted-logical (second operand bitwise-NOTed before the op)
     Bic {
@@ -226,6 +240,8 @@ impl Instruction {
             | Instruction::Neg { rd, .. }
             | Instruction::Negs { rd, .. }
             | Instruction::MovN { rd, .. }
+            | Instruction::MovZ { rd, .. }
+            | Instruction::MovK { rd, .. }
             | Instruction::Bic { rd, .. }
             | Instruction::Bics { rd, .. }
             | Instruction::Orn { rd, .. }
@@ -332,8 +348,11 @@ impl Instruction {
             // MVN / NEG / NEGS: always encodable (register-only)
             Instruction::Mvn { .. } | Instruction::Neg { .. } | Instruction::Negs { .. } => true,
 
-            // MOVN: shift must be one of {0, 16, 32, 48}; u16 imm is always in range.
-            Instruction::MovN { shift, .. } => matches!(shift, 0 | 16 | 32 | 48),
+            // MOVN / MOVZ / MOVK: shift must be one of {0, 16, 32, 48};
+            // u16 imm is always in range.
+            Instruction::MovN { shift, .. }
+            | Instruction::MovZ { shift, .. }
+            | Instruction::MovK { shift, .. } => matches!(shift, 0 | 16 | 32 | 48),
 
             // BIC / BICS / ORN / EON: register-only (matching AND precedent).
             Instruction::Bic { rm, .. }
@@ -411,8 +430,10 @@ impl Instruction {
             Instruction::Mvn { rm, .. }
             | Instruction::Neg { rm, .. }
             | Instruction::Negs { rm, .. } => vec![*rm],
-            // MOVN takes no register source
-            Instruction::MovN { .. } => vec![],
+            // MOVN / MOVZ take no register source
+            Instruction::MovN { .. } | Instruction::MovZ { .. } => vec![],
+            // MOVK reads rd (preserves the unmodified 16-bit lanes)
+            Instruction::MovK { rd, .. } => vec![*rd],
             // Inverted-logical (BIC / BICS / ORN / EON) and flag-setting arith/logical
             Instruction::Bic { rn, rm, .. }
             | Instruction::Bics { rn, rm, .. }
@@ -482,6 +503,20 @@ impl fmt::Display for Instruction {
                     write!(f, "movn {}, #{}", rd, imm)
                 } else {
                     write!(f, "movn {}, #{}, lsl #{}", rd, imm, shift)
+                }
+            }
+            Instruction::MovZ { rd, imm, shift } => {
+                if *shift == 0 {
+                    write!(f, "movz {}, #{}", rd, imm)
+                } else {
+                    write!(f, "movz {}, #{}, lsl #{}", rd, imm, shift)
+                }
+            }
+            Instruction::MovK { rd, imm, shift } => {
+                if *shift == 0 {
+                    write!(f, "movk {}, #{}", rd, imm)
+                } else {
+                    write!(f, "movk {}, #{}, lsl #{}", rd, imm, shift)
                 }
             }
             Instruction::Bic { rd, rn, rm } => write!(f, "bic {}, {}, {}", rd, rn, rm),
@@ -934,6 +969,16 @@ mod tests {
                 rd: Register::X0,
                 imm: 1,
                 shift: 16,
+            },
+            Instruction::MovZ {
+                rd: Register::X0,
+                imm: 1,
+                shift: 32,
+            },
+            Instruction::MovK {
+                rd: Register::X0,
+                imm: 1,
+                shift: 48,
             },
             Instruction::Bic {
                 rd: Register::X0,

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -3,6 +3,12 @@
 use crate::ir::types::{Condition, Operand, Register};
 use std::fmt;
 
+/// Legal `lsl` amounts for the move-wide immediate family (MOVN / MOVZ / MOVK).
+/// Single source of truth shared by `is_encodable_aarch64`, the parser, and
+/// every random-generation / mutation site so the four positions cannot drift
+/// out of sync across the codebase.
+pub const MOVW_LEGAL_SHIFTS: [u8; 4] = [0, 16, 32, 48];
+
 /// AArch64 instructions supported by the IR
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[allow(dead_code)]
@@ -348,11 +354,11 @@ impl Instruction {
             // MVN / NEG / NEGS: always encodable (register-only)
             Instruction::Mvn { .. } | Instruction::Neg { .. } | Instruction::Negs { .. } => true,
 
-            // MOVN / MOVZ / MOVK: shift must be one of {0, 16, 32, 48};
+            // MOVN / MOVZ / MOVK: shift must be one of MOVW_LEGAL_SHIFTS;
             // u16 imm is always in range.
             Instruction::MovN { shift, .. }
             | Instruction::MovZ { shift, .. }
-            | Instruction::MovK { shift, .. } => matches!(shift, 0 | 16 | 32 | 48),
+            | Instruction::MovK { shift, .. } => MOVW_LEGAL_SHIFTS.contains(shift),
 
             // BIC / BICS / ORN / EON: register-only (matching AND precedent).
             Instruction::Bic { rm, .. }

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -4,6 +4,7 @@
 
 #![allow(dead_code)]
 
+use crate::ir::instructions::MOVW_LEGAL_SHIFTS;
 use crate::ir::types::Condition;
 use crate::ir::{Instruction, Operand, Register};
 use crate::isa::traits::{ISA, InstructionGenerator, InstructionType, OperandType, RegisterType};
@@ -337,7 +338,7 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
             // MOVZ/MOVK — the full u16 × 4-shift space would balloon
             // candidate counts.
             for imm in [0u16, 1, 0xFF, 0xFFFF] {
-                for shift in [0u8, 16, 32, 48] {
+                for shift in MOVW_LEGAL_SHIFTS {
                     instructions.push(Instruction::MovN { rd, imm, shift });
                     instructions.push(Instruction::MovZ { rd, imm, shift });
                     instructions.push(Instruction::MovK { rd, imm, shift });
@@ -430,7 +431,7 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
             },
             16 => {
                 let imm = (rng.random::<u32>() & 0xFFFF) as u16;
-                let shifts = [0u8, 16, 32, 48];
+                let shifts = MOVW_LEGAL_SHIFTS;
                 Instruction::MovN {
                     rd,
                     imm,
@@ -507,7 +508,7 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
             }
             24 => {
                 let imm = (rng.random::<u32>() & 0xFFFF) as u16;
-                let shifts = [0u8, 16, 32, 48];
+                let shifts = MOVW_LEGAL_SHIFTS;
                 Instruction::MovZ {
                     rd,
                     imm,
@@ -516,7 +517,7 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
             }
             25 => {
                 let imm = (rng.random::<u32>() & 0xFFFF) as u16;
-                let shifts = [0u8, 16, 32, 48];
+                let shifts = MOVW_LEGAL_SHIFTS;
                 Instruction::MovK {
                     rd,
                     imm,

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -136,6 +136,8 @@ impl InstructionType for Instruction {
             Instruction::Cset { .. } => 31,
             Instruction::Csetm { .. } => 32,
             Instruction::Ror { .. } => 33,
+            Instruction::MovZ { .. } => 34,
+            Instruction::MovK { .. } => 35,
         }
     }
 
@@ -174,6 +176,8 @@ impl InstructionType for Instruction {
             Instruction::Cset { .. } => "cset",
             Instruction::Csetm { .. } => "csetm",
             Instruction::Ror { .. } => "ror",
+            Instruction::MovZ { .. } => "movz",
+            Instruction::MovK { .. } => "movk",
         }
     }
 
@@ -328,11 +332,15 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                 instructions.push(Instruction::Negs { rd, rm });
             }
 
-            // MOVN: small representative imm × {0,16,32,48} shift table —
-            // mirrors `search::candidate::generate_all_instructions`.
+            // MOVN / MOVZ / MOVK: small representative imm × {0,16,32,48}
+            // shift table. The same parsimony rationale as MOVN applies for
+            // MOVZ/MOVK — the full u16 × 4-shift space would balloon
+            // candidate counts.
             for imm in [0u16, 1, 0xFF, 0xFFFF] {
                 for shift in [0u8, 16, 32, 48] {
                     instructions.push(Instruction::MovN { rd, imm, shift });
+                    instructions.push(Instruction::MovZ { rd, imm, shift });
+                    instructions.push(Instruction::MovK { rd, imm, shift });
                 }
             }
 
@@ -352,8 +360,10 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
         registers: &[Register],
         immediates: &[i64],
     ) -> Instruction {
-        // 24 opcode slots: 0..13 original, 13..23 Tier 1, 23 = ROR.
-        let opcode = rng.random_range(0..24);
+        // 26 opcode slots: 0..13 original, 13..23 Tier 1 (slot 23 is a
+        // 4-way sub-multiplexer for ANDS/CSET/CSETM/ROR), 24 = MOVZ,
+        // 25 = MOVK.
+        let opcode = rng.random_range(0..26);
         let rd = registers[rng.random_range(0..registers.len())];
         let rn = registers[rng.random_range(0..registers.len())];
         let pick_reg = |rng: &mut R| registers[rng.random_range(0..registers.len())];
@@ -495,6 +505,24 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     }
                 }
             }
+            24 => {
+                let imm = (rng.random::<u32>() & 0xFFFF) as u16;
+                let shifts = [0u8, 16, 32, 48];
+                Instruction::MovZ {
+                    rd,
+                    imm,
+                    shift: shifts[rng.random_range(0..shifts.len())],
+                }
+            }
+            25 => {
+                let imm = (rng.random::<u32>() & 0xFFFF) as u16;
+                let shifts = [0u8, 16, 32, 48];
+                Instruction::MovK {
+                    rd,
+                    imm,
+                    shift: shifts[rng.random_range(0..shifts.len())],
+                }
+            }
             _ => unreachable!(),
         }
     }
@@ -576,6 +604,16 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     Instruction::Neg { rm, .. } => Instruction::Neg { rd: new_rd, rm },
                     Instruction::Negs { rm, .. } => Instruction::Negs { rd: new_rd, rm },
                     Instruction::MovN { imm, shift, .. } => Instruction::MovN {
+                        rd: new_rd,
+                        imm,
+                        shift,
+                    },
+                    Instruction::MovZ { imm, shift, .. } => Instruction::MovZ {
+                        rd: new_rd,
+                        imm,
+                        shift,
+                    },
+                    Instruction::MovK { imm, shift, .. } => Instruction::MovK {
                         rd: new_rd,
                         imm,
                         shift,
@@ -748,6 +786,27 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                             shift,
                         }
                     }
+                    // MOVZ / MOVK: same rationale as MOVN — `imm` is the only
+                    // source operand; `shift` is left alone here. MOVK also
+                    // reads `rd`, but `rd` is the destination, not a source
+                    // operand we mutate in this strategy (the "change
+                    // destination register" branch above already handles it).
+                    Instruction::MovZ { rd, shift, .. } => {
+                        let new_imm = (rng.random::<u32>() & 0xFFFF) as u16;
+                        Instruction::MovZ {
+                            rd,
+                            imm: new_imm,
+                            shift,
+                        }
+                    }
+                    Instruction::MovK { rd, shift, .. } => {
+                        let new_imm = (rng.random::<u32>() & 0xFFFF) as u16;
+                        Instruction::MovK {
+                            rd,
+                            imm: new_imm,
+                            shift,
+                        }
+                    }
                     Instruction::Bic { rd, rn, rm: _ } => {
                         let new_rm =
                             Operand::Register(registers[rng.random_range(0..registers.len())]);
@@ -807,13 +866,14 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
 
     /// Total number of distinct opcode *families* (the upper bound on
     /// `opcode_id()`). Not the same as `generate_random`'s slot count —
-    /// `generate_random` samples 24 top-level slots and folds ANDS, CSET,
+    /// `generate_random` samples 26 top-level slots and folds ANDS, CSET,
     /// CSETM, and ROR into a sub-multiplexer on slot 23 to keep the slot
     /// table small. So `opcode_id < opcode_count` always holds, but the
-    /// random-generation distribution is not uniform across all 34 IDs.
+    /// random-generation distribution is not uniform across all 36 IDs.
     fn opcode_count(&self) -> u8 {
-        34 // 20 original + 14 Tier 1: MVN, NEG, NEGS, MovN, BIC, BICS, ORN, EON,
-        //                          ADDS, SUBS, ANDS, CSET, CSETM, ROR.
+        36 // 20 original + 14 Tier 1 (MVN, NEG, NEGS, MovN, BIC, BICS, ORN, EON,
+        //                          ADDS, SUBS, ANDS, CSET, CSETM, ROR)
+        //                          + 2 MOVK/MOVZ (issue #55).
     }
 }
 
@@ -990,6 +1050,16 @@ mod tests {
                 imm: 0x55aa,
                 shift: 16,
             },
+            Instruction::MovZ {
+                rd: Register::X0,
+                imm: 0x55aa,
+                shift: 32,
+            },
+            Instruction::MovK {
+                rd: Register::X0,
+                imm: 0x55aa,
+                shift: 48,
+            },
             Instruction::Bic {
                 rd: Register::X0,
                 rn: Register::X1,
@@ -1146,7 +1216,7 @@ mod tests {
         for _ in 0..100 {
             let instr = generator.generate_random(&mut rng, &regs, &imms);
             // Just verify it doesn't panic and produces valid instructions
-            assert!(instr.opcode_id() < 34);
+            assert!(instr.opcode_id() < generator.opcode_count());
         }
     }
 
@@ -1240,6 +1310,16 @@ mod tests {
                 imm: 1,
                 shift: 16,
             },
+            Instruction::MovZ {
+                rd: Register::X0,
+                imm: 1,
+                shift: 16,
+            },
+            Instruction::MovK {
+                rd: Register::X0,
+                imm: 1,
+                shift: 16,
+            },
             Instruction::Cset {
                 rd: Register::X0,
                 cond: Condition::EQ,
@@ -1282,6 +1362,16 @@ mod tests {
                 rm: Register::X2,
             },
             Instruction::MovN {
+                rd: Register::X0,
+                imm: 1,
+                shift: 0,
+            },
+            Instruction::MovZ {
+                rd: Register::X0,
+                imm: 1,
+                shift: 0,
+            },
+            Instruction::MovK {
                 rd: Register::X0,
                 imm: 1,
                 shift: 0,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5,6 +5,7 @@
 use std::fmt;
 use std::path::Path;
 
+use crate::ir::instructions::MOVW_LEGAL_SHIFTS;
 use crate::ir::{Condition, Instruction, Operand, Register};
 
 /// Parse error with location information
@@ -433,10 +434,11 @@ fn parse_movw_operands(mnem: &str, operands: &[&str]) -> Result<(Register, u16, 
             Operand::Immediate(v) => v,
             Operand::Register(_) => return Err(format!("{} shift must be an immediate", mnem)),
         };
-        if !matches!(s, 0 | 16 | 32 | 48) {
+        let s_u8 = u8::try_from(s).ok();
+        if !s_u8.is_some_and(|v| MOVW_LEGAL_SHIFTS.contains(&v)) {
             return Err(format!("{} shift {} must be one of 0/16/32/48", mnem, s));
         }
-        s as u8
+        s_u8.unwrap()
     };
 
     Ok((rd, imm, shift))

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -390,24 +390,28 @@ fn parse_ror(operands: &[&str]) -> Result<Instruction, String> {
     Ok(Instruction::Ror { rd, rn, shift })
 }
 
-/// Parse MOVN instruction: `movn rd, #imm` or `movn rd, #imm, lsl #shift`.
-/// Operands are comma-split, so the LSL-with-shift form arrives as
-/// `["rd", "#imm", "lsl #shift"]` (3 entries, the third internally has the
-/// `lsl` keyword and the shift expression).
-fn parse_movn(operands: &[&str]) -> Result<Instruction, String> {
+/// Parse the operand list for a move-wide-immediate mnemonic (MOVN / MOVZ /
+/// MOVK). All three share the same operand grammar:
+/// `<mnem> rd, #imm` or `<mnem> rd, #imm, lsl #shift`. The `mnem` argument is
+/// used only in error messages so the diagnostic still names the original
+/// mnemonic the user typed.
+fn parse_movw_operands(mnem: &str, operands: &[&str]) -> Result<(Register, u16, u8), String> {
     if operands.len() != 2 && operands.len() != 3 {
         return Err(format!(
-            "movn requires 2 or 3 operands (rd, #imm[, lsl #shift]), got {}",
+            "{} requires 2 or 3 operands (rd, #imm[, lsl #shift]), got {}",
+            mnem,
             operands.len()
         ));
     }
     let rd = parse_register(operands[0])?;
     let imm_val = match parse_operand(operands[1])? {
         Operand::Immediate(v) => v,
-        Operand::Register(_) => return Err("movn second operand must be an immediate".to_string()),
+        Operand::Register(_) => {
+            return Err(format!("{} second operand must be an immediate", mnem));
+        }
     };
     if !(0..=0xFFFF).contains(&imm_val) {
-        return Err(format!("movn immediate {} out of u16 range", imm_val));
+        return Err(format!("{} immediate {} out of u16 range", mnem, imm_val));
     }
     let imm = imm_val as u16;
 
@@ -420,19 +424,42 @@ fn parse_movn(operands: &[&str]) -> Result<Instruction, String> {
         let kw = parts.next().unwrap_or("").trim();
         let rest = parts.next().unwrap_or("").trim();
         if !kw.eq_ignore_ascii_case("lsl") {
-            return Err(format!("movn shift form must be `lsl #N`, got `{}`", tail));
+            return Err(format!(
+                "{} shift form must be `lsl #N`, got `{}`",
+                mnem, tail
+            ));
         }
         let s = match parse_operand(rest)? {
             Operand::Immediate(v) => v,
-            Operand::Register(_) => return Err("movn shift must be an immediate".to_string()),
+            Operand::Register(_) => return Err(format!("{} shift must be an immediate", mnem)),
         };
         if !matches!(s, 0 | 16 | 32 | 48) {
-            return Err(format!("movn shift {} must be one of 0/16/32/48", s));
+            return Err(format!("{} shift {} must be one of 0/16/32/48", mnem, s));
         }
         s as u8
     };
 
+    Ok((rd, imm, shift))
+}
+
+/// Parse MOVN instruction: `movn rd, #imm` or `movn rd, #imm, lsl #shift`.
+fn parse_movn(operands: &[&str]) -> Result<Instruction, String> {
+    let (rd, imm, shift) = parse_movw_operands("movn", operands)?;
     Ok(Instruction::MovN { rd, imm, shift })
+}
+
+/// Parse MOVZ instruction: `movz rd, #imm` or `movz rd, #imm, lsl #shift`.
+fn parse_movz(operands: &[&str]) -> Result<Instruction, String> {
+    let (rd, imm, shift) = parse_movw_operands("movz", operands)?;
+    Ok(Instruction::MovZ { rd, imm, shift })
+}
+
+/// Parse MOVK instruction: `movk rd, #imm` or `movk rd, #imm, lsl #shift`.
+/// MOVK preserves the unmodified 16-bit lanes of rd, so callers must treat
+/// rd as live-in.
+fn parse_movk(operands: &[&str]) -> Result<Instruction, String> {
+    let (rd, imm, shift) = parse_movw_operands("movk", operands)?;
+    Ok(Instruction::MovK { rd, imm, shift })
 }
 
 /// Parse ADD instruction
@@ -730,6 +757,8 @@ pub fn parse_line(line: &str) -> Result<LineResult, ParseLineError> {
         "neg" => parse_neg(&operands).map_err(ParseLineError::Other)?,
         "negs" => parse_negs(&operands).map_err(ParseLineError::Other)?,
         "movn" => parse_movn(&operands).map_err(ParseLineError::Other)?,
+        "movz" => parse_movz(&operands).map_err(ParseLineError::Other)?,
+        "movk" => parse_movk(&operands).map_err(ParseLineError::Other)?,
         "bic" => parse_bic(&operands).map_err(ParseLineError::Other)?,
         "bics" => parse_bics(&operands).map_err(ParseLineError::Other)?,
         "orn" => parse_orn(&operands).map_err(ParseLineError::Other)?,
@@ -1161,8 +1190,9 @@ mod tests {
     fn parse_line_wrong_arity_reaches_each_parser_error() {
         for mnemonic in [
             "mov", "mvn", "neg", "negs", "bic", "bics", "orn", "eon", "adds", "subs", "ands",
-            "cset", "csetm", "ror", "movn", "add", "sub", "and", "orr", "eor", "lsl", "lsr", "asr",
-            "mul", "sdiv", "udiv", "cmp", "cmn", "tst", "csel", "csinc", "csinv", "csneg",
+            "cset", "csetm", "ror", "movn", "movz", "movk", "add", "sub", "and", "orr", "eor",
+            "lsl", "lsr", "asr", "mul", "sdiv", "udiv", "cmp", "cmn", "tst", "csel", "csinc",
+            "csinv", "csneg",
         ] {
             assert!(
                 matches!(parse_line(mnemonic), Err(ParseLineError::Other(_))),
@@ -1185,6 +1215,43 @@ mod tests {
             "movn x0, #1, asr #16",
             "movn x0, #1, lsl x2",
             "movn x0, #1, lsl #8",
+        ] {
+            assert!(parse_line(line).is_err(), "{} should fail", line);
+        }
+    }
+
+    #[test]
+    fn parse_movz_and_movk_accept_canonical_forms() {
+        let cases = [
+            ("movz x0, #0x1234", "movz x0, #4660"),
+            ("movz x0, #0xFFFF, lsl #48", "movz x0, #65535, lsl #48"),
+            ("movk x1, #0", "movk x1, #0"),
+            ("movk x1, #0x5678, lsl #16", "movk x1, #22136, lsl #16"),
+        ];
+        for (line, display) in cases {
+            let parsed = match parse_line(line).unwrap() {
+                LineResult::Instruction(instr) => instr,
+                LineResult::Skip => panic!("unexpected skip for {}", line),
+            };
+            assert_eq!(format!("{}", parsed), display);
+        }
+    }
+
+    #[test]
+    fn parse_movz_and_movk_reject_bad_forms() {
+        // Same grammar as MOVN: out-of-range imm, illegal shift, illegal
+        // shift kind, register shift operand, and missing operands all fail.
+        for line in [
+            "movz x0",
+            "movk x0",
+            "movz x0, x1",
+            "movk x0, x1",
+            "movz x0, #65536",
+            "movk x0, #65536",
+            "movz x0, #1, lsl #8",
+            "movk x0, #1, lsl #24",
+            "movz x0, #1, asr #16",
+            "movk x0, #1, lsl x2",
         ] {
             assert!(parse_line(line).is_err(), "{} should fail", line);
         }

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -136,13 +136,15 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
             instrs.push(Instruction::Negs { rd, rm });
         }
 
-        // MOVN: small representative imm set × four legal shift positions.
-        // Keep this small — the full u16 × 4-shift space would balloon the
-        // candidate count. The same parsimony rationale applies as the
-        // immediate-table choice above.
+        // MOVN / MOVZ / MOVK: small representative imm set × four legal shift
+        // positions. Keep this small — the full u16 × 4-shift space would
+        // balloon the candidate count. The same parsimony rationale applies
+        // as the immediate-table choice above.
         for imm in [0u16, 1, 0xFF, 0xFFFF] {
             for shift in [0u8, 16, 32, 48] {
                 instrs.push(Instruction::MovN { rd, imm, shift });
+                instrs.push(Instruction::MovZ { rd, imm, shift });
+                instrs.push(Instruction::MovK { rd, imm, shift });
             }
         }
 
@@ -175,7 +177,7 @@ pub fn generate_random_instruction<R: rand::RngExt>(
     let rd = registers[rng.random_range(0..registers.len())];
     let pick_reg = |rng: &mut R| registers[rng.random_range(0..registers.len())];
 
-    match rng.random_range(0..24) {
+    match rng.random_range(0..26) {
         0 => {
             let imm = if immediates.is_empty() {
                 0
@@ -299,10 +301,22 @@ pub fn generate_random_instruction<R: rand::RngExt>(
             rd,
             cond: crate::ir::types::Condition::random_normal(rng),
         },
-        _ => {
+        23 => {
             let rn = pick_reg(rng);
             let shift = random_shift_operand(rng, registers);
             Instruction::Ror { rd, rn, shift }
+        }
+        24 => {
+            let imm = (rng.random::<u32>() & 0xFFFF) as u16;
+            let shifts = [0u8, 16, 32, 48];
+            let shift = shifts[rng.random_range(0..shifts.len())];
+            Instruction::MovZ { rd, imm, shift }
+        }
+        _ => {
+            let imm = (rng.random::<u32>() & 0xFFFF) as u16;
+            let shifts = [0u8, 16, 32, 48];
+            let shift = shifts[rng.random_range(0..shifts.len())];
+            Instruction::MovK { rd, imm, shift }
         }
     }
 }
@@ -385,6 +399,8 @@ pub fn opcode_id(instr: &Instruction) -> u8 {
         Instruction::Cset { .. } => 31,
         Instruction::Csetm { .. } => 32,
         Instruction::Ror { .. } => 33,
+        Instruction::MovZ { .. } => 34,
+        Instruction::MovK { .. } => 35,
     }
 }
 
@@ -403,6 +419,8 @@ pub fn supports_immediate(instr: &Instruction) -> bool {
             | Instruction::Lsr { .. }
             | Instruction::Asr { .. }
             | Instruction::MovN { .. }
+            | Instruction::MovZ { .. }
+            | Instruction::MovK { .. }
             | Instruction::Adds { .. }
             | Instruction::Subs { .. }
             | Instruction::Ror { .. }
@@ -446,7 +464,11 @@ pub fn is_shift_op(instr: &Instruction) -> bool {
 pub fn is_move_op(instr: &Instruction) -> bool {
     matches!(
         instr,
-        Instruction::MovReg { .. } | Instruction::MovImm { .. } | Instruction::MovN { .. }
+        Instruction::MovReg { .. }
+            | Instruction::MovImm { .. }
+            | Instruction::MovN { .. }
+            | Instruction::MovZ { .. }
+            | Instruction::MovK { .. }
     )
 }
 

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -1,5 +1,6 @@
 //! Instruction generation utilities for search algorithms
 
+use crate::ir::instructions::MOVW_LEGAL_SHIFTS;
 use crate::ir::{Instruction, Operand, Register};
 
 /// Check if all instructions in a sequence can be encoded in AArch64 machine code.
@@ -141,7 +142,7 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
         // balloon the candidate count. The same parsimony rationale applies
         // as the immediate-table choice above.
         for imm in [0u16, 1, 0xFF, 0xFFFF] {
-            for shift in [0u8, 16, 32, 48] {
+            for shift in MOVW_LEGAL_SHIFTS {
                 instrs.push(Instruction::MovN { rd, imm, shift });
                 instrs.push(Instruction::MovZ { rd, imm, shift });
                 instrs.push(Instruction::MovK { rd, imm, shift });
@@ -254,7 +255,7 @@ pub fn generate_random_instruction<R: rand::RngExt>(
         },
         13 => {
             let imm = (rng.random::<u32>() & 0xFFFF) as u16;
-            let shifts = [0u8, 16, 32, 48];
+            let shifts = MOVW_LEGAL_SHIFTS;
             let shift = shifts[rng.random_range(0..shifts.len())];
             Instruction::MovN { rd, imm, shift }
         }
@@ -308,13 +309,13 @@ pub fn generate_random_instruction<R: rand::RngExt>(
         }
         24 => {
             let imm = (rng.random::<u32>() & 0xFFFF) as u16;
-            let shifts = [0u8, 16, 32, 48];
+            let shifts = MOVW_LEGAL_SHIFTS;
             let shift = shifts[rng.random_range(0..shifts.len())];
             Instruction::MovZ { rd, imm, shift }
         }
         _ => {
             let imm = (rng.random::<u32>() & 0xFFFF) as u16;
-            let shifts = [0u8, 16, 32, 48];
+            let shifts = MOVW_LEGAL_SHIFTS;
             let shift = shifts[rng.random_range(0..shifts.len())];
             Instruction::MovK { rd, imm, shift }
         }

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -8,6 +8,7 @@
 
 #![allow(dead_code)]
 
+use crate::ir::instructions::MOVW_LEGAL_SHIFTS;
 use crate::ir::types::Condition;
 use crate::ir::{Instruction, Operand, Register};
 use crate::search::candidate::generate_random_instruction;
@@ -197,8 +198,7 @@ impl Mutator {
                 0 => *rd = self.random_register(rng),
                 1 => *imm = (rng.random::<u32>() & 0xFFFF) as u16,
                 _ => {
-                    let shifts = [0u8, 16, 32, 48];
-                    *shift = shifts[rng.random_range(0..shifts.len())];
+                    *shift = MOVW_LEGAL_SHIFTS[rng.random_range(0..MOVW_LEGAL_SHIFTS.len())];
                 }
             },
             // Inverted-logical: BIC / BICS / ORN / EON — register-only rm

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -188,8 +188,12 @@ impl Mutator {
                     *rm = self.random_register(rng);
                 }
             }
-            // MOVN: mutate rd, imm, or shift
-            Instruction::MovN { rd, imm, shift } => match rng.random_range(0..3) {
+            // MOVN / MOVZ / MOVK: mutate rd, imm, or shift. MOVK reads rd, so
+            // mutating rd here additionally changes the upper-lanes source —
+            // that's intentional and matches the other dest-mutating arms.
+            Instruction::MovN { rd, imm, shift }
+            | Instruction::MovZ { rd, imm, shift }
+            | Instruction::MovK { rd, imm, shift } => match rng.random_range(0..3) {
                 0 => *rd = self.random_register(rng),
                 1 => *imm = (rng.random::<u32>() & 0xFFFF) as u16,
                 _ => {
@@ -402,13 +406,28 @@ impl Mutator {
                 1 => Instruction::Neg { rd, rm },
                 _ => Instruction::Negs { rd, rm },
             },
-            // MOVN sits alongside MovImm as the only other immediate-move op.
-            Instruction::MovN { rd, imm, shift } => match rng.random_range(0..2) {
-                0 => Instruction::MovImm {
+            // Move-wide cluster: MOVN ↔ MOVZ ↔ MOVK (all share rd/imm/shift),
+            // plus a bridge to MovImm (only for shift=0 forms, since MovImm
+            // has no shift field). The bridge lets MCMC chains drift into and
+            // out of the simpler MovImm encoding.
+            Instruction::MovN { rd, imm, shift } => match rng.random_range(0..3) {
+                0 => Instruction::MovZ { rd, imm, shift },
+                1 => Instruction::MovK { rd, imm, shift },
+                _ => Instruction::MovN { rd, imm, shift },
+            },
+            Instruction::MovZ { rd, imm, shift } => match rng.random_range(0..4) {
+                0 => Instruction::MovN { rd, imm, shift },
+                1 => Instruction::MovK { rd, imm, shift },
+                2 => Instruction::MovImm {
                     rd,
                     imm: imm as i64,
                 },
-                _ => Instruction::MovN { rd, imm, shift },
+                _ => Instruction::MovZ { rd, imm, shift },
+            },
+            Instruction::MovK { rd, imm, shift } => match rng.random_range(0..3) {
+                0 => Instruction::MovN { rd, imm, shift },
+                1 => Instruction::MovZ { rd, imm, shift },
+                _ => Instruction::MovK { rd, imm, shift },
             },
             // Inverted-logical join the AND/ORR/EOR cluster.
             Instruction::Bic { rd, rn, rm } => match rng.random_range(0..7) {

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -407,9 +407,17 @@ impl Mutator {
                 _ => Instruction::Negs { rd, rm },
             },
             // Move-wide cluster: MOVN ↔ MOVZ ↔ MOVK (all share rd/imm/shift),
-            // plus a bridge to MovImm (only for shift=0 forms, since MovImm
-            // has no shift field). The bridge lets MCMC chains drift into and
-            // out of the simpler MovImm encoding.
+            // plus a single MovImm bridge anchored at MOVZ.
+            //
+            // Topology note: before this PR, MOVN had a direct MOVN ↔ MovImm
+            // edge. We removed it so MOVN now reaches MovImm via two hops
+            // (MOVN → MOVZ → MovImm). Ergodicity is preserved — every move
+            // family member can still reach every other — but mixing time
+            // along the MOVN/MovImm corridor is one step longer. The trade
+            // is intentional: MOVZ is the natural pivot, since `MovZ {imm,
+            // shift=0}` is exactly the bit pattern MovImm holds, so the
+            // MOVZ ↔ MovImm bridge has a clear semantic anchor that a direct
+            // MOVN ↔ MovImm bridge lacked.
             Instruction::MovN { rd, imm, shift } => match rng.random_range(0..3) {
                 0 => Instruction::MovZ { rd, imm, shift },
                 1 => Instruction::MovK { rd, imm, shift },

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -418,6 +418,13 @@ impl Mutator {
             Instruction::MovZ { rd, imm, shift } => match rng.random_range(0..4) {
                 0 => Instruction::MovN { rd, imm, shift },
                 1 => Instruction::MovK { rd, imm, shift },
+                // MovZ → MovImm uses the raw u16 `imm`, NOT `imm << shift`. We
+                // deliberately discard the shift here: MCMC is exploring the
+                // value space, and binding the new MovImm to the shifted bit
+                // pattern would only widen `MovImm`'s effective range beyond
+                // its 0..=0xFFFF encoding window. The neighbouring MovImm has
+                // its own per-field mutator that will refine `imm` on later
+                // steps.
                 2 => Instruction::MovImm {
                     rd,
                     imm: imm as i64,

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -187,6 +187,18 @@ pub fn apply_instruction_concrete(
             let value = !((*imm as u64) << (*shift as u32));
             state.set_register(*rd, ConcreteValue::new(value));
         }
+        // MOVZ: rd = (imm as u64) << shift (other lanes cleared to zero)
+        Instruction::MovZ { rd, imm, shift } => {
+            let value = (*imm as u64) << (*shift as u32);
+            state.set_register(*rd, ConcreteValue::new(value));
+        }
+        // MOVK: write one 16-bit chunk of rd, preserving the others.
+        Instruction::MovK { rd, imm, shift } => {
+            let prev = state.get_register(*rd).as_u64();
+            let mask = !(0xFFFF_u64 << (*shift as u32));
+            let value = (prev & mask) | ((*imm as u64) << (*shift as u32));
+            state.set_register(*rd, ConcreteValue::new(value));
+        }
         // BIC: rd = rn & !rm
         Instruction::Bic { rd, rn, rm } => {
             let lhs = state.get_register(*rn).as_u64();
@@ -1056,6 +1068,66 @@ mod tests {
                 case.imm,
                 case.shift,
                 case.expected
+            );
+        }
+    }
+
+    #[test]
+    fn test_movz_concrete_lifts_imm_into_shifted_chunk() {
+        let cases: [(u16, u8, u64); 4] = [
+            (0xABCD, 0, 0xABCD),
+            (0x1234, 16, 0x1234_0000),
+            (0x5678, 32, 0x5678_0000_0000),
+            (0xFFFF, 48, 0xFFFF_0000_0000_0000),
+        ];
+        for (imm, shift, expected) in cases {
+            let state = ConcreteMachineState::new_zeroed();
+            let instr = Instruction::MovZ {
+                rd: Register::X0,
+                imm,
+                shift,
+            };
+            let new_state = apply_instruction_concrete(state, &instr);
+            assert_eq!(
+                new_state.get_register(Register::X0).as_u64(),
+                expected,
+                "MOVZ(#{:#x}, lsl #{}) should be {:#x}",
+                imm,
+                shift,
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn test_movk_concrete_preserves_unwritten_lanes() {
+        // Pre-seed x0 with a known full 64-bit pattern; MOVK should rewrite
+        // exactly one 16-bit lane and leave the others untouched.
+        let mut state = ConcreteMachineState::new_zeroed();
+        state.set_register(
+            Register::X0,
+            crate::semantics::state::ConcreteValue::new(0x1111_2222_3333_4444),
+        );
+        let cases: [(u16, u8, u64); 4] = [
+            (0xAAAA, 0, 0x1111_2222_3333_AAAA),
+            (0xBBBB, 16, 0x1111_2222_BBBB_4444),
+            (0xCCCC, 32, 0x1111_CCCC_3333_4444),
+            (0xDDDD, 48, 0xDDDD_2222_3333_4444),
+        ];
+        for (imm, shift, expected) in cases {
+            let instr = Instruction::MovK {
+                rd: Register::X0,
+                imm,
+                shift,
+            };
+            let new_state = apply_instruction_concrete(state.clone(), &instr);
+            assert_eq!(
+                new_state.get_register(Register::X0).as_u64(),
+                expected,
+                "MOVK(#{:#x}, lsl #{}) should be {:#x}",
+                imm,
+                shift,
+                expected
             );
         }
     }

--- a/src/semantics/cost.rs
+++ b/src/semantics/cost.rs
@@ -43,11 +43,13 @@ fn instruction_latency(instr: &Instruction) -> u64 {
         | Instruction::Csinc { .. }
         | Instruction::Csinv { .. }
         | Instruction::Csneg { .. } => 1,
-        // Unary bitwise / negation / move-negated immediate
+        // Unary bitwise / negation / move-wide-immediate family
         Instruction::Mvn { .. }
         | Instruction::Neg { .. }
         | Instruction::Negs { .. }
-        | Instruction::MovN { .. } => 1,
+        | Instruction::MovN { .. }
+        | Instruction::MovZ { .. }
+        | Instruction::MovK { .. } => 1,
         // Inverted-logical
         Instruction::Bic { .. }
         | Instruction::Bics { .. }

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -974,6 +974,98 @@ mod tests {
         );
     }
 
+    /// Issue #55 acceptance: MOVZ x0,#a; MOVK x0,#b,LSL #16 builds (b<<16)|a.
+    /// We prove the materialised constant equals an explicit immediate by
+    /// comparing it to a sequence that lifts the same bit pattern via shift +
+    /// orr. With concrete values a=0x1234 and b=0x5678, the target constant is
+    /// 0x56781234.
+    #[test]
+    fn test_movz_movk_materialises_32bit_constant() {
+        let seq1 = vec![
+            Instruction::MovZ {
+                rd: Register::X0,
+                imm: 0x1234,
+                shift: 0,
+            },
+            Instruction::MovK {
+                rd: Register::X0,
+                imm: 0x5678,
+                shift: 16,
+            },
+        ];
+        // Reference: build the same value via MovImm(low) + MovImm(high<<16
+        // synthesised by a second MOVK from an empty MOVZ).
+        let seq2 = vec![
+            Instruction::MovZ {
+                rd: Register::X0,
+                imm: 0x5678,
+                shift: 16,
+            },
+            Instruction::MovK {
+                rd: Register::X0,
+                imm: 0x1234,
+                shift: 0,
+            },
+        ];
+        assert_eq!(
+            check_equivalence(&seq1, &seq2),
+            EquivalenceResult::Equivalent
+        );
+    }
+
+    /// MOVZ with shift=0 collapses to MovImm — useful sanity check that the
+    /// new variant is wired through SMT with the same semantics.
+    #[test]
+    fn test_movz_shift0_equivalent_to_mov_imm() {
+        let seq1 = vec![Instruction::MovZ {
+            rd: Register::X0,
+            imm: 0xABCD,
+            shift: 0,
+        }];
+        let seq2 = vec![Instruction::MovImm {
+            rd: Register::X0,
+            imm: 0xABCD,
+        }];
+        assert_eq!(
+            check_equivalence(&seq1, &seq2),
+            EquivalenceResult::Equivalent
+        );
+    }
+
+    /// MOVK preserves the upper 48 bits of rd: starting from x0=0xFFFF_FFFF
+    /// (built via MOVZ #0xFFFF, lsl #16 + MOVK #0xFFFF), then MOVK #0,#0
+    /// must leave the upper 16 bits intact (final value 0xFFFF_0000).
+    #[test]
+    fn test_movk_preserves_unwritten_lanes() {
+        let seq1 = vec![
+            Instruction::MovZ {
+                rd: Register::X0,
+                imm: 0xFFFF,
+                shift: 16,
+            },
+            Instruction::MovK {
+                rd: Register::X0,
+                imm: 0xFFFF,
+                shift: 0,
+            },
+            Instruction::MovK {
+                rd: Register::X0,
+                imm: 0,
+                shift: 0,
+            },
+        ];
+        // Equivalent: MOVZ x0, #0xFFFF, LSL #16 alone yields 0xFFFF_0000.
+        let seq2 = vec![Instruction::MovZ {
+            rd: Register::X0,
+            imm: 0xFFFF,
+            shift: 16,
+        }];
+        assert_eq!(
+            check_equivalence(&seq1, &seq2),
+            EquivalenceResult::Equivalent
+        );
+    }
+
     #[test]
     fn test_mvn_twice_is_identity() {
         // MVN x0, x1; MVN x0, x0 ≡ MOV x0, x1

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -243,6 +243,20 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let value = !((*imm as u64) << (*shift as u32));
             state.set_register(*rd, BV::from_u64(value, 64));
         }
+        Instruction::MovZ { rd, imm, shift } => {
+            let value = (*imm as u64) << (*shift as u32);
+            state.set_register(*rd, BV::from_u64(value, 64));
+        }
+        // MOVK keeps the 48 unwritten bits of rd. Encode as
+        // `(rd_old & ~mask) | new_chunk` so the solver sees the data-flow
+        // dependence on the prior rd value.
+        Instruction::MovK { rd, imm, shift } => {
+            let prev = state.get_register(*rd).clone();
+            let mask = BV::from_u64(!(0xFFFF_u64 << (*shift as u32)), 64);
+            let new_chunk = BV::from_u64((*imm as u64) << (*shift as u32), 64);
+            let result = prev.bvand(&mask).bvor(&new_chunk);
+            state.set_register(*rd, result);
+        }
         // BIC: rd = rn & !rm. BICS shares the SMT body — the flag effect is
         // not modelled (matches CMP/CMN/TST and ADDS/SUBS/ANDS). The
         // soundness barrier lives in `equivalence::flag_writers_diverge`,


### PR DESCRIPTION
## Summary

- Adds `MovZ { rd, imm: u16, shift: u8 }` and `MovK { rd, imm: u16, shift: u8 }` to the AArch64 IR alongside the existing `MovN`, with full pipeline coverage: parser, encoder (dynasm `movz`/`movk` with shift ∈ {0,16,32,48}), concrete + SMT semantics, cost model, and enumerative + stochastic candidate generation.
- `MovK` reads `rd` (preserves the unmodified 16-bit lanes), so `source_registers()` returns `[rd]` for it — the first instruction in the IR with read-modify-write semantics on its destination register.
- Stochastic mutation peers MOVN/MOVZ/MOVK and bridges MOVZ↔MovImm so MCMC chains can drift across move-wide encodings without losing ergodicity.

Fixes #55

## Test plan

- [x] `./ci_check.sh` — fmt, build, unit tests (462 passing), integration tests (14 passing), end-to-end suite
- [x] SMT acceptance test: `MOVZ x0,#0x1234 ; MOVK x0,#0x5678,LSL #16` proves equivalent to the reverse-order materialisation
- [x] Concrete-semantics tests cover all four shift positions for MOVZ and confirm MOVK preserves unwritten lanes
- [x] Parser accepts canonical `movz`/`movk` forms and rejects bad shifts, oversized immediates, and register shift operands
- [x] Encoder round-trips MOVZ/MOVK at every legal shift; rejects shift=8 and shift=24