### PR TITLE
Add bit-count and bit-reverse AArch64 instructions (#58)

### DIFF
--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -414,6 +414,42 @@ impl AArch64Assembler {
                 dynasm!(ops ; .arch aarch64 ; mvn X(rd_reg), X(rm_reg));
                 Ok(())
             }
+            Instruction::Clz { rd, rn } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                dynasm!(ops ; .arch aarch64 ; clz X(rd_reg), X(rn_reg));
+                Ok(())
+            }
+            Instruction::Cls { rd, rn } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                dynasm!(ops ; .arch aarch64 ; cls X(rd_reg), X(rn_reg));
+                Ok(())
+            }
+            Instruction::Rbit { rd, rn } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                dynasm!(ops ; .arch aarch64 ; rbit X(rd_reg), X(rn_reg));
+                Ok(())
+            }
+            Instruction::Rev { rd, rn } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                dynasm!(ops ; .arch aarch64 ; rev X(rd_reg), X(rn_reg));
+                Ok(())
+            }
+            Instruction::Rev32 { rd, rn } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                dynasm!(ops ; .arch aarch64 ; rev32 X(rd_reg), X(rn_reg));
+                Ok(())
+            }
+            Instruction::Rev16 { rd, rn } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                dynasm!(ops ; .arch aarch64 ; rev16 X(rd_reg), X(rn_reg));
+                Ok(())
+            }
             Instruction::Neg { rd, rm } => {
                 let rd_reg = register_to_dynasm(*rd)?;
                 let rm_reg = register_to_dynasm(*rm)?;
@@ -1733,5 +1769,62 @@ mod tests {
         }
         assert!(register_to_dynasm(Register::SP).is_err());
         assert_eq!(register_to_dynasm_xsp(Register::SP).unwrap(), 31);
+    }
+
+    #[test]
+    fn test_bit_manipulation_encoders_roundtrip() {
+        let cases: &[(Instruction, &str)] = &[
+            (
+                Instruction::Clz {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                },
+                "clz",
+            ),
+            (
+                Instruction::Cls {
+                    rd: Register::X2,
+                    rn: Register::X3,
+                },
+                "cls",
+            ),
+            (
+                Instruction::Rbit {
+                    rd: Register::X4,
+                    rn: Register::X5,
+                },
+                "rbit",
+            ),
+            (
+                Instruction::Rev {
+                    rd: Register::X6,
+                    rn: Register::X7,
+                },
+                "rev",
+            ),
+            (
+                Instruction::Rev32 {
+                    rd: Register::X8,
+                    rn: Register::X9,
+                },
+                "rev32",
+            ),
+            (
+                Instruction::Rev16 {
+                    rd: Register::X10,
+                    rn: Register::X11,
+                },
+                "rev16",
+            ),
+        ];
+        for (instr, mnemonic) in cases {
+            let mut assembler = AArch64Assembler::new();
+            let bytes = assembler
+                .assemble_instructions(std::slice::from_ref(instr))
+                .unwrap_or_else(|e| panic!("{} encoding should succeed: {}", mnemonic, e));
+            let rd = instr.destination().unwrap().to_string();
+            let rn = instr.source_registers()[0].to_string();
+            disassemble_and_verify(&bytes, mnemonic, &[&rd, &rn]);
+        }
     }
 }

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -418,13 +418,16 @@ impl Instruction {
                 Operand::Immediate(amt) => *amt >= 0 && *amt <= 63,
             },
 
-            // Single-source bit-manipulation: always encodable (register-only).
-            Instruction::Clz { .. }
-            | Instruction::Cls { .. }
-            | Instruction::Rbit { .. }
-            | Instruction::Rev { .. }
-            | Instruction::Rev32 { .. }
-            | Instruction::Rev16 { .. } => true,
+            // Single-source bit-manipulation: register-only, Xn class (no SP).
+            // AArch64 reg-31 in this slot is XZR, so SP must be rejected before
+            // any caller (SMT, equivalence, LLM) reasons about the candidate.
+            // XZR remains encodable.
+            Instruction::Clz { rd, rn }
+            | Instruction::Cls { rd, rn }
+            | Instruction::Rbit { rd, rn }
+            | Instruction::Rev { rd, rn }
+            | Instruction::Rev32 { rd, rn }
+            | Instruction::Rev16 { rd, rn } => *rd != Register::SP && *rn != Register::SP,
         }
     }
 
@@ -794,6 +797,59 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Immediate(0)
+            }
+            .is_encodable_aarch64()
+        );
+    }
+
+    #[test]
+    fn test_is_encodable_bit_manip_rejects_sp() {
+        // Xn class — SP must be rejected on both rd and rn. XZR is valid.
+        for instr in [
+            Instruction::Clz {
+                rd: Register::SP,
+                rn: Register::X1,
+            },
+            Instruction::Cls {
+                rd: Register::X0,
+                rn: Register::SP,
+            },
+            Instruction::Rbit {
+                rd: Register::SP,
+                rn: Register::SP,
+            },
+            Instruction::Rev {
+                rd: Register::SP,
+                rn: Register::X1,
+            },
+            Instruction::Rev32 {
+                rd: Register::X0,
+                rn: Register::SP,
+            },
+            Instruction::Rev16 {
+                rd: Register::SP,
+                rn: Register::X1,
+            },
+        ] {
+            assert!(
+                !instr.is_encodable_aarch64(),
+                "SP must be rejected: {}",
+                instr
+            );
+        }
+
+        // XZR is part of the Xn class and stays encodable.
+        assert!(
+            Instruction::Clz {
+                rd: Register::XZR,
+                rn: Register::X1
+            }
+            .is_encodable_aarch64()
+        );
+        assert!(
+            Instruction::Rev {
+                rd: Register::X0,
+                rn: Register::XZR
             }
             .is_encodable_aarch64()
         );

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -218,6 +218,32 @@ pub enum Instruction {
         rn: Register,
         shift: Operand,
     },
+
+    // Single-source bit-manipulation (always register-only, {rd, rn})
+    Clz {
+        rd: Register,
+        rn: Register,
+    },
+    Cls {
+        rd: Register,
+        rn: Register,
+    },
+    Rbit {
+        rd: Register,
+        rn: Register,
+    },
+    Rev {
+        rd: Register,
+        rn: Register,
+    },
+    Rev32 {
+        rd: Register,
+        rn: Register,
+    },
+    Rev16 {
+        rd: Register,
+        rn: Register,
+    },
 }
 
 impl Instruction {
@@ -257,7 +283,13 @@ impl Instruction {
             | Instruction::Ands { rd, .. }
             | Instruction::Cset { rd, .. }
             | Instruction::Csetm { rd, .. }
-            | Instruction::Ror { rd, .. } => Some(*rd),
+            | Instruction::Ror { rd, .. }
+            | Instruction::Clz { rd, .. }
+            | Instruction::Cls { rd, .. }
+            | Instruction::Rbit { rd, .. }
+            | Instruction::Rev { rd, .. }
+            | Instruction::Rev32 { rd, .. }
+            | Instruction::Rev16 { rd, .. } => Some(*rd),
             // Comparison instructions only set flags, no destination register
             Instruction::Cmp { .. } | Instruction::Cmn { .. } | Instruction::Tst { .. } => None,
         }
@@ -385,6 +417,14 @@ impl Instruction {
                 Operand::Register(_) => true,
                 Operand::Immediate(amt) => *amt >= 0 && *amt <= 63,
             },
+
+            // Single-source bit-manipulation: always encodable (register-only).
+            Instruction::Clz { .. }
+            | Instruction::Cls { .. }
+            | Instruction::Rbit { .. }
+            | Instruction::Rev { .. }
+            | Instruction::Rev32 { .. }
+            | Instruction::Rev16 { .. } => true,
         }
     }
 
@@ -464,6 +504,13 @@ impl Instruction {
                 }
                 regs
             }
+            // Single-source bit-manipulation: rn is the only source.
+            Instruction::Clz { rn, .. }
+            | Instruction::Cls { rn, .. }
+            | Instruction::Rbit { rn, .. }
+            | Instruction::Rev { rn, .. }
+            | Instruction::Rev32 { rn, .. }
+            | Instruction::Rev16 { rn, .. } => vec![*rn],
         }
     }
 }
@@ -535,6 +582,12 @@ impl fmt::Display for Instruction {
             Instruction::Cset { rd, cond } => write!(f, "cset {}, {}", rd, cond),
             Instruction::Csetm { rd, cond } => write!(f, "csetm {}, {}", rd, cond),
             Instruction::Ror { rd, rn, shift } => write!(f, "ror {}, {}, {}", rd, rn, shift),
+            Instruction::Clz { rd, rn } => write!(f, "clz {}, {}", rd, rn),
+            Instruction::Cls { rd, rn } => write!(f, "cls {}, {}", rd, rn),
+            Instruction::Rbit { rd, rn } => write!(f, "rbit {}, {}", rd, rn),
+            Instruction::Rev { rd, rn } => write!(f, "rev {}, {}", rd, rn),
+            Instruction::Rev32 { rd, rn } => write!(f, "rev32 {}, {}", rd, rn),
+            Instruction::Rev16 { rd, rn } => write!(f, "rev16 {}, {}", rd, rn),
         }
     }
 }

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -139,6 +139,12 @@ impl InstructionType for Instruction {
             Instruction::Ror { .. } => 33,
             Instruction::MovZ { .. } => 34,
             Instruction::MovK { .. } => 35,
+            Instruction::Clz { .. } => 36,
+            Instruction::Cls { .. } => 37,
+            Instruction::Rbit { .. } => 38,
+            Instruction::Rev { .. } => 39,
+            Instruction::Rev32 { .. } => 40,
+            Instruction::Rev16 { .. } => 41,
         }
     }
 
@@ -179,6 +185,12 @@ impl InstructionType for Instruction {
             Instruction::Ror { .. } => "ror",
             Instruction::MovZ { .. } => "movz",
             Instruction::MovK { .. } => "movk",
+            Instruction::Clz { .. } => "clz",
+            Instruction::Cls { .. } => "cls",
+            Instruction::Rbit { .. } => "rbit",
+            Instruction::Rev { .. } => "rev",
+            Instruction::Rev32 { .. } => "rev32",
+            Instruction::Rev16 { .. } => "rev16",
         }
     }
 
@@ -333,6 +345,16 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                 instructions.push(Instruction::Negs { rd, rm });
             }
 
+            // Single-source bit-manipulation: CLZ / CLS / RBIT / REV / REV32 / REV16.
+            for &rn in registers {
+                instructions.push(Instruction::Clz { rd, rn });
+                instructions.push(Instruction::Cls { rd, rn });
+                instructions.push(Instruction::Rbit { rd, rn });
+                instructions.push(Instruction::Rev { rd, rn });
+                instructions.push(Instruction::Rev32 { rd, rn });
+                instructions.push(Instruction::Rev16 { rd, rn });
+            }
+
             // MOVN / MOVZ / MOVK: small representative imm × {0,16,32,48}
             // shift table. The same parsimony rationale as MOVN applies for
             // MOVZ/MOVK — the full u16 × 4-shift space would balloon
@@ -361,10 +383,11 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
         registers: &[Register],
         immediates: &[i64],
     ) -> Instruction {
-        // 26 opcode slots: 0..13 original, 13..23 Tier 1 (slot 23 is a
+        // 27 opcode slots: 0..13 original, 13..23 Tier 1 (slot 23 is a
         // 4-way sub-multiplexer for ANDS/CSET/CSETM/ROR), 24 = MOVZ,
-        // 25 = MOVK.
-        let opcode = rng.random_range(0..26);
+        // 25 = MOVK, 26 = single-source bit-manipulation (CLZ/CLS/RBIT/REV*)
+        // 6-way sub-multiplexer.
+        let opcode = rng.random_range(0..27);
         let rd = registers[rng.random_range(0..registers.len())];
         let rn = registers[rng.random_range(0..registers.len())];
         let pick_reg = |rng: &mut R| registers[rng.random_range(0..registers.len())];
@@ -524,6 +547,18 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     shift: shifts[rng.random_range(0..shifts.len())],
                 }
             }
+            // Single-source bit-manipulation: CLZ / CLS / RBIT / REV / REV32 / REV16.
+            26 => {
+                let rn = pick_reg(rng);
+                match rng.random_range(0..6) {
+                    0 => Instruction::Clz { rd, rn },
+                    1 => Instruction::Cls { rd, rn },
+                    2 => Instruction::Rbit { rd, rn },
+                    3 => Instruction::Rev { rd, rn },
+                    4 => Instruction::Rev32 { rd, rn },
+                    _ => Instruction::Rev16 { rd, rn },
+                }
+            }
             _ => unreachable!(),
         }
     }
@@ -633,6 +668,12 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                         rn,
                         shift,
                     },
+                    Instruction::Clz { rn, .. } => Instruction::Clz { rd: new_rd, rn },
+                    Instruction::Cls { rn, .. } => Instruction::Cls { rd: new_rd, rn },
+                    Instruction::Rbit { rn, .. } => Instruction::Rbit { rd: new_rd, rn },
+                    Instruction::Rev { rn, .. } => Instruction::Rev { rd: new_rd, rn },
+                    Instruction::Rev32 { rn, .. } => Instruction::Rev32 { rd: new_rd, rn },
+                    Instruction::Rev16 { rn, .. } => Instruction::Rev16 { rd: new_rd, rn },
                 }
             }
             2 => {
@@ -859,6 +900,30 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                             shift: new_shift,
                         }
                     }
+                    Instruction::Clz { rd, .. } => Instruction::Clz {
+                        rd,
+                        rn: registers[rng.random_range(0..registers.len())],
+                    },
+                    Instruction::Cls { rd, .. } => Instruction::Cls {
+                        rd,
+                        rn: registers[rng.random_range(0..registers.len())],
+                    },
+                    Instruction::Rbit { rd, .. } => Instruction::Rbit {
+                        rd,
+                        rn: registers[rng.random_range(0..registers.len())],
+                    },
+                    Instruction::Rev { rd, .. } => Instruction::Rev {
+                        rd,
+                        rn: registers[rng.random_range(0..registers.len())],
+                    },
+                    Instruction::Rev32 { rd, .. } => Instruction::Rev32 {
+                        rd,
+                        rn: registers[rng.random_range(0..registers.len())],
+                    },
+                    Instruction::Rev16 { rd, .. } => Instruction::Rev16 {
+                        rd,
+                        rn: registers[rng.random_range(0..registers.len())],
+                    },
                 }
             }
             _ => unreachable!(),
@@ -867,14 +932,17 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
 
     /// Total number of distinct opcode *families* (the upper bound on
     /// `opcode_id()`). Not the same as `generate_random`'s slot count —
-    /// `generate_random` samples 26 top-level slots and folds ANDS, CSET,
-    /// CSETM, and ROR into a sub-multiplexer on slot 23 to keep the slot
-    /// table small. So `opcode_id < opcode_count` always holds, but the
-    /// random-generation distribution is not uniform across all 36 IDs.
+    /// `generate_random` samples 27 top-level slots and folds ANDS, CSET,
+    /// CSETM, and ROR into a sub-multiplexer on slot 23 (plus the six
+    /// single-source bit-manipulation ops into a sub-multiplexer on slot 26)
+    /// to keep the slot table small. So `opcode_id < opcode_count` always
+    /// holds, but the random-generation distribution is not uniform across
+    /// all 42 IDs.
     fn opcode_count(&self) -> u8 {
-        36 // 20 original + 14 Tier 1 (MVN, NEG, NEGS, MovN, BIC, BICS, ORN, EON,
-        //                          ADDS, SUBS, ANDS, CSET, CSETM, ROR)
-        //                          + 2 MOVK/MOVZ (issue #55).
+        42 // 20 original + 14 Tier 1 (MVN, NEG, NEGS, MovN, BIC, BICS, ORN,
+        //  EON, ADDS, SUBS, ANDS, CSET, CSETM, ROR) + 2 MOVK/MOVZ (issue
+        //  #55) + 6 single-source bit-manipulation (CLZ, CLS, RBIT, REV,
+        //  REV32, REV16).
     }
 }
 
@@ -1108,6 +1176,30 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 shift: Operand::Immediate(8),
+            },
+            Instruction::Clz {
+                rd: Register::X0,
+                rn: Register::X1,
+            },
+            Instruction::Cls {
+                rd: Register::X0,
+                rn: Register::X1,
+            },
+            Instruction::Rbit {
+                rd: Register::X0,
+                rn: Register::X1,
+            },
+            Instruction::Rev {
+                rd: Register::X0,
+                rn: Register::X1,
+            },
+            Instruction::Rev32 {
+                rd: Register::X0,
+                rn: Register::X1,
+            },
+            Instruction::Rev16 {
+                rd: Register::X0,
+                rn: Register::X1,
             },
         ]
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -263,6 +263,23 @@ fn parse_mvn(operands: &[&str]) -> Result<Instruction, String> {
     Ok(Instruction::Mvn { rd, rm })
 }
 
+/// Parse a single-source bit-manipulation instruction (CLZ/CLS/RBIT/REV/REV32/REV16).
+fn parse_unary_rd_rn<F>(mnemonic: &str, operands: &[&str], build: F) -> Result<Instruction, String>
+where
+    F: FnOnce(Register, Register) -> Instruction,
+{
+    if operands.len() != 2 {
+        return Err(format!(
+            "{} requires 2 operands, got {}",
+            mnemonic,
+            operands.len()
+        ));
+    }
+    let rd = parse_register(operands[0])?;
+    let rn = parse_register(operands[1])?;
+    Ok(build(rd, rn))
+}
+
 /// Parse NEG instruction
 fn parse_neg(operands: &[&str]) -> Result<Instruction, String> {
     if operands.len() != 2 {
@@ -771,6 +788,18 @@ pub fn parse_line(line: &str) -> Result<LineResult, ParseLineError> {
         "cset" => parse_cset(&operands).map_err(ParseLineError::Other)?,
         "csetm" => parse_csetm(&operands).map_err(ParseLineError::Other)?,
         "ror" => parse_ror(&operands).map_err(ParseLineError::Other)?,
+        "clz" => parse_unary_rd_rn("clz", &operands, |rd, rn| Instruction::Clz { rd, rn })
+            .map_err(ParseLineError::Other)?,
+        "cls" => parse_unary_rd_rn("cls", &operands, |rd, rn| Instruction::Cls { rd, rn })
+            .map_err(ParseLineError::Other)?,
+        "rbit" => parse_unary_rd_rn("rbit", &operands, |rd, rn| Instruction::Rbit { rd, rn })
+            .map_err(ParseLineError::Other)?,
+        "rev" => parse_unary_rd_rn("rev", &operands, |rd, rn| Instruction::Rev { rd, rn })
+            .map_err(ParseLineError::Other)?,
+        "rev32" => parse_unary_rd_rn("rev32", &operands, |rd, rn| Instruction::Rev32 { rd, rn })
+            .map_err(ParseLineError::Other)?,
+        "rev16" => parse_unary_rd_rn("rev16", &operands, |rd, rn| Instruction::Rev16 { rd, rn })
+            .map_err(ParseLineError::Other)?,
         _ => return Err(ParseLineError::UnknownInstruction(opcode)),
     };
 
@@ -1194,7 +1223,7 @@ mod tests {
             "mov", "mvn", "neg", "negs", "bic", "bics", "orn", "eon", "adds", "subs", "ands",
             "cset", "csetm", "ror", "movn", "movz", "movk", "add", "sub", "and", "orr", "eor",
             "lsl", "lsr", "asr", "mul", "sdiv", "udiv", "cmp", "cmn", "tst", "csel", "csinc",
-            "csinv", "csneg",
+            "csinv", "csneg", "clz", "cls", "rbit", "rev", "rev32", "rev16",
         ] {
             assert!(
                 matches!(parse_line(mnemonic), Err(ParseLineError::Other(_))),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1206,6 +1206,12 @@ mod tests {
             ("csinc x0, x1, x2, ne", "csinc x0, x1, x2, ne"),
             ("csinv x0, x1, x2, lt", "csinv x0, x1, x2, lt"),
             ("csneg x0, x1, x2, ge", "csneg x0, x1, x2, ge"),
+            ("clz x0, x1", "clz x0, x1"),
+            ("cls x0, x1", "cls x0, x1"),
+            ("rbit x0, x1", "rbit x0, x1"),
+            ("rev x0, x1", "rev x0, x1"),
+            ("rev32 x0, x1", "rev32 x0, x1"),
+            ("rev16 x0, x1", "rev16 x0, x1"),
         ];
 
         for (line, display) in cases {

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -137,6 +137,16 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
             instrs.push(Instruction::Negs { rd, rm });
         }
 
+        // Single-source bit-manipulation: CLZ / CLS / RBIT / REV / REV32 / REV16.
+        for &rn in registers {
+            instrs.push(Instruction::Clz { rd, rn });
+            instrs.push(Instruction::Cls { rd, rn });
+            instrs.push(Instruction::Rbit { rd, rn });
+            instrs.push(Instruction::Rev { rd, rn });
+            instrs.push(Instruction::Rev32 { rd, rn });
+            instrs.push(Instruction::Rev16 { rd, rn });
+        }
+
         // MOVN / MOVZ / MOVK: small representative imm set × four legal shift
         // positions. Keep this small — the full u16 × 4-shift space would
         // balloon the candidate count. The same parsimony rationale applies
@@ -178,7 +188,7 @@ pub fn generate_random_instruction<R: rand::RngExt>(
     let rd = registers[rng.random_range(0..registers.len())];
     let pick_reg = |rng: &mut R| registers[rng.random_range(0..registers.len())];
 
-    match rng.random_range(0..26) {
+    match rng.random_range(0..27) {
         0 => {
             let imm = if immediates.is_empty() {
                 0
@@ -313,11 +323,23 @@ pub fn generate_random_instruction<R: rand::RngExt>(
             let shift = shifts[rng.random_range(0..shifts.len())];
             Instruction::MovZ { rd, imm, shift }
         }
-        _ => {
+        25 => {
             let imm = (rng.random::<u32>() & 0xFFFF) as u16;
             let shifts = MOVW_LEGAL_SHIFTS;
             let shift = shifts[rng.random_range(0..shifts.len())];
             Instruction::MovK { rd, imm, shift }
+        }
+        // Single-source bit-manipulation: CLZ / CLS / RBIT / REV / REV32 / REV16.
+        _ => {
+            let rn = pick_reg(rng);
+            match rng.random_range(0..6) {
+                0 => Instruction::Clz { rd, rn },
+                1 => Instruction::Cls { rd, rn },
+                2 => Instruction::Rbit { rd, rn },
+                3 => Instruction::Rev { rd, rn },
+                4 => Instruction::Rev32 { rd, rn },
+                _ => Instruction::Rev16 { rd, rn },
+            }
         }
     }
 }
@@ -402,6 +424,12 @@ pub fn opcode_id(instr: &Instruction) -> u8 {
         Instruction::Ror { .. } => 33,
         Instruction::MovZ { .. } => 34,
         Instruction::MovK { .. } => 35,
+        Instruction::Clz { .. } => 36,
+        Instruction::Cls { .. } => 37,
+        Instruction::Rbit { .. } => 38,
+        Instruction::Rev { .. } => 39,
+        Instruction::Rev32 { .. } => 40,
+        Instruction::Rev16 { .. } => 41,
     }
 }
 

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -189,6 +189,19 @@ impl Mutator {
                     *rm = self.random_register(rng);
                 }
             }
+            // Single-source bit-manipulation: CLZ, CLS, RBIT, REV, REV32, REV16.
+            Instruction::Clz { rd, rn }
+            | Instruction::Cls { rd, rn }
+            | Instruction::Rbit { rd, rn }
+            | Instruction::Rev { rd, rn }
+            | Instruction::Rev32 { rd, rn }
+            | Instruction::Rev16 { rd, rn } => {
+                if rng.random_bool(0.5) {
+                    *rd = self.random_register(rng);
+                } else {
+                    *rn = self.random_register(rng);
+                }
+            }
             // MOVN / MOVZ / MOVK: mutate rd, imm, or shift. MOVK reads rd, so
             // mutating rd here additionally changes the upper-lanes source —
             // that's intentional and matches the other dest-mutating arms.
@@ -405,6 +418,55 @@ impl Mutator {
                 0 => Instruction::Mvn { rd, rm },
                 1 => Instruction::Neg { rd, rm },
                 _ => Instruction::Negs { rd, rm },
+            },
+            // Single-source bit-manipulation: 6-way peer cluster.
+            Instruction::Clz { rd, rn } => match rng.random_range(0..6) {
+                0 => Instruction::Cls { rd, rn },
+                1 => Instruction::Rbit { rd, rn },
+                2 => Instruction::Rev { rd, rn },
+                3 => Instruction::Rev32 { rd, rn },
+                4 => Instruction::Rev16 { rd, rn },
+                _ => Instruction::Clz { rd, rn },
+            },
+            Instruction::Cls { rd, rn } => match rng.random_range(0..6) {
+                0 => Instruction::Clz { rd, rn },
+                1 => Instruction::Rbit { rd, rn },
+                2 => Instruction::Rev { rd, rn },
+                3 => Instruction::Rev32 { rd, rn },
+                4 => Instruction::Rev16 { rd, rn },
+                _ => Instruction::Cls { rd, rn },
+            },
+            Instruction::Rbit { rd, rn } => match rng.random_range(0..6) {
+                0 => Instruction::Clz { rd, rn },
+                1 => Instruction::Cls { rd, rn },
+                2 => Instruction::Rev { rd, rn },
+                3 => Instruction::Rev32 { rd, rn },
+                4 => Instruction::Rev16 { rd, rn },
+                _ => Instruction::Rbit { rd, rn },
+            },
+            Instruction::Rev { rd, rn } => match rng.random_range(0..6) {
+                0 => Instruction::Clz { rd, rn },
+                1 => Instruction::Cls { rd, rn },
+                2 => Instruction::Rbit { rd, rn },
+                3 => Instruction::Rev32 { rd, rn },
+                4 => Instruction::Rev16 { rd, rn },
+                _ => Instruction::Rev { rd, rn },
+            },
+            Instruction::Rev32 { rd, rn } => match rng.random_range(0..6) {
+                0 => Instruction::Clz { rd, rn },
+                1 => Instruction::Cls { rd, rn },
+                2 => Instruction::Rbit { rd, rn },
+                3 => Instruction::Rev { rd, rn },
+                4 => Instruction::Rev16 { rd, rn },
+                _ => Instruction::Rev32 { rd, rn },
+            },
+            Instruction::Rev16 { rd, rn } => match rng.random_range(0..6) {
+                0 => Instruction::Clz { rd, rn },
+                1 => Instruction::Cls { rd, rn },
+                2 => Instruction::Rbit { rd, rn },
+                3 => Instruction::Rev { rd, rn },
+                4 => Instruction::Rev32 { rd, rn },
+                _ => Instruction::Rev16 { rd, rn },
             },
             // Move-wide cluster: MOVN ↔ MOVZ ↔ MOVK (all share rd/imm/shift),
             // plus a single MovImm bridge anchored at MOVZ.

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -276,6 +276,44 @@ pub fn apply_instruction_concrete(
             let amount = (eval_operand(&state, shift).as_u64() & 63) as u32;
             state.set_register(*rd, ConcreteValue::new(value.rotate_right(amount)));
         }
+        // CLZ: count leading zero bits (returns 64 for input 0).
+        Instruction::Clz { rd, rn } => {
+            let value = state.get_register(*rn).as_u64();
+            state.set_register(*rd, ConcreteValue::new(value.leading_zeros() as u64));
+        }
+        // CLS: count leading bits that match the sign bit, excluding the sign
+        // bit itself. Equivalent to `clz(x ^ (x asr 63)) - 1`; for input 0 or
+        // all-ones the result is 63.
+        Instruction::Cls { rd, rn } => {
+            let value = state.get_register(*rn).as_u64();
+            let folded = value ^ ((value as i64 >> 63) as u64);
+            let result = (folded.leading_zeros() as u64).saturating_sub(1);
+            state.set_register(*rd, ConcreteValue::new(result));
+        }
+        // RBIT: reverse the bit order of the 64-bit value.
+        Instruction::Rbit { rd, rn } => {
+            let value = state.get_register(*rn).as_u64();
+            state.set_register(*rd, ConcreteValue::new(value.reverse_bits()));
+        }
+        // REV: reverse the byte order of the 64-bit value.
+        Instruction::Rev { rd, rn } => {
+            let value = state.get_register(*rn).as_u64();
+            state.set_register(*rd, ConcreteValue::new(value.swap_bytes()));
+        }
+        // REV32: byte-reverse within each 32-bit half (independently).
+        Instruction::Rev32 { rd, rn } => {
+            let value = state.get_register(*rn).as_u64();
+            let lo = (value as u32).swap_bytes() as u64;
+            let hi = ((value >> 32) as u32).swap_bytes() as u64;
+            state.set_register(*rd, ConcreteValue::new(lo | (hi << 32)));
+        }
+        // REV16: byte-reverse within each 16-bit half (four halves).
+        Instruction::Rev16 { rd, rn } => {
+            let value = state.get_register(*rn).as_u64();
+            let result =
+                ((value & 0xFF00_FF00_FF00_FF00) >> 8) | ((value & 0x00FF_00FF_00FF_00FF) << 8);
+            state.set_register(*rd, ConcreteValue::new(result));
+        }
     }
     state
 }
@@ -1246,6 +1284,208 @@ mod tests {
                 "MVN({:#x}) should be {:#x}",
                 input,
                 expected
+            );
+        }
+    }
+
+    fn apply_unary(instr: Instruction, input: u64) -> u64 {
+        let state = state_with(vec![(Register::X1, input)]);
+        apply_instruction_concrete(state, &instr)
+            .get_register(Register::X0)
+            .as_u64()
+    }
+
+    #[test]
+    fn test_clz_matches_leading_zeros() {
+        let cases: &[u64] = &[
+            0,
+            1,
+            2,
+            0xFF,
+            0x8000_0000,
+            0x8000_0000_0000_0000,
+            u64::MAX,
+            0xDEAD_BEEF_DEAD_BEEF,
+        ];
+        for &input in cases {
+            let got = apply_unary(
+                Instruction::Clz {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                },
+                input,
+            );
+            assert_eq!(
+                got,
+                input.leading_zeros() as u64,
+                "CLZ({:#x}) mismatch",
+                input
+            );
+        }
+    }
+
+    #[test]
+    fn test_cls_matches_arm_spec() {
+        // AArch64 CLS: count of consecutive bits matching the sign bit *after*
+        // the sign bit. Spec values from the Arm reference for 64-bit form.
+        let cases: &[(u64, u64)] = &[
+            (0, 63),
+            (u64::MAX, 63),
+            (1, 62),
+            (0x8000_0000_0000_0000, 0),
+            (0x7FFF_FFFF_FFFF_FFFF, 0),
+            (0xC000_0000_0000_0000, 1),
+            (0x3FFF_FFFF_FFFF_FFFF, 1),
+        ];
+        for &(input, expected) in cases {
+            let got = apply_unary(
+                Instruction::Cls {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                },
+                input,
+            );
+            assert_eq!(got, expected, "CLS({:#x}) should be {}", input, expected);
+        }
+    }
+
+    #[test]
+    fn test_rbit_matches_reverse_bits() {
+        let cases: &[u64] = &[
+            0,
+            1,
+            0x8000_0000_0000_0000,
+            u64::MAX,
+            0xAAAA_AAAA_AAAA_AAAA,
+            0xDEAD_BEEF_CAFE_BABE,
+        ];
+        for &input in cases {
+            let got = apply_unary(
+                Instruction::Rbit {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                },
+                input,
+            );
+            assert_eq!(
+                got,
+                input.reverse_bits(),
+                "RBIT({:#x}) should match u64::reverse_bits",
+                input
+            );
+        }
+    }
+
+    #[test]
+    fn test_rev_matches_swap_bytes() {
+        let cases: &[u64] = &[0, u64::MAX, 0x0102_0304_0506_0708, 0xDEAD_BEEF_CAFE_BABE];
+        for &input in cases {
+            let got = apply_unary(
+                Instruction::Rev {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                },
+                input,
+            );
+            assert_eq!(
+                got,
+                input.swap_bytes(),
+                "REV({:#x}) should match u64::swap_bytes",
+                input
+            );
+        }
+    }
+
+    #[test]
+    fn test_rev32_byte_reverses_each_word() {
+        let cases: &[(u64, u64)] = &[
+            (0x0102_0304_0506_0708, 0x0403_0201_0807_0605),
+            (0, 0),
+            (u64::MAX, u64::MAX),
+            (0xDEAD_BEEF_CAFE_BABE, 0xEFBE_ADDE_BEBA_FECA),
+        ];
+        for &(input, expected) in cases {
+            let got = apply_unary(
+                Instruction::Rev32 {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                },
+                input,
+            );
+            assert_eq!(
+                got, expected,
+                "REV32({:#x}) should be {:#x}",
+                input, expected
+            );
+        }
+    }
+
+    #[test]
+    fn test_rev16_byte_reverses_each_halfword() {
+        let cases: &[(u64, u64)] = &[
+            (0x0102_0304_0506_0708, 0x0201_0403_0605_0807),
+            (0, 0),
+            (u64::MAX, u64::MAX),
+            (0xDEAD_BEEF_CAFE_BABE, 0xADDE_EFBE_FECA_BEBA),
+        ];
+        for &(input, expected) in cases {
+            let got = apply_unary(
+                Instruction::Rev16 {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                },
+                input,
+            );
+            assert_eq!(
+                got, expected,
+                "REV16({:#x}) should be {:#x}",
+                input, expected
+            );
+        }
+    }
+
+    #[test]
+    fn test_rev_is_involution() {
+        let input = 0xDEAD_BEEF_CAFE_BABE_u64;
+        let state = state_with(vec![(Register::X1, input)]);
+        let seq = [
+            Instruction::Rev {
+                rd: Register::X0,
+                rn: Register::X1,
+            },
+            Instruction::Rev {
+                rd: Register::X0,
+                rn: Register::X0,
+            },
+        ];
+        let final_state = apply_sequence_concrete(state, &seq);
+        assert_eq!(final_state.get_register(Register::X0).as_u64(), input);
+    }
+
+    #[test]
+    fn test_rbit_clz_equals_trailing_zeros() {
+        // For nonzero x, RBIT then CLZ returns the count of trailing zeros.
+        let cases: &[u64] = &[1, 2, 4, 0x80, 0x8000_0000_0000_0000, 0xDEAD_BEEF];
+        for &input in cases {
+            let state = state_with(vec![(Register::X1, input)]);
+            let seq = [
+                Instruction::Rbit {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                },
+                Instruction::Clz {
+                    rd: Register::X0,
+                    rn: Register::X0,
+                },
+            ];
+            let got = apply_sequence_concrete(state, &seq)
+                .get_register(Register::X0)
+                .as_u64();
+            assert_eq!(
+                got,
+                input.trailing_zeros() as u64,
+                "RBIT;CLZ({:#x}) should equal trailing_zeros",
+                input
             );
         }
     }

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -287,7 +287,10 @@ pub fn apply_instruction_concrete(
         Instruction::Cls { rd, rn } => {
             let value = state.get_register(*rn).as_u64();
             let folded = value ^ ((value as i64 >> 63) as u64);
-            let result = (folded.leading_zeros() as u64).saturating_sub(1);
+            // After the sign-fold `x ^ (x ASR 63)`, bit 63 of `folded` is
+            // always 0, so `leading_zeros(folded) >= 1` and the subtraction
+            // cannot underflow.
+            let result = folded.leading_zeros() as u64 - 1;
             state.set_register(*rd, ConcreteValue::new(result));
         }
         // RBIT: reverse the bit order of the 64-bit value.

--- a/src/semantics/cost.rs
+++ b/src/semantics/cost.rs
@@ -61,6 +61,13 @@ fn instruction_latency(instr: &Instruction) -> u64 {
         Instruction::Cset { .. } | Instruction::Csetm { .. } => 1,
         // Rotate right
         Instruction::Ror { .. } => 1,
+        // Single-source bit-manipulation (CLZ/CLS/RBIT/REV*): single-cycle ALU.
+        Instruction::Clz { .. }
+        | Instruction::Cls { .. }
+        | Instruction::Rbit { .. }
+        | Instruction::Rev { .. }
+        | Instruction::Rev32 { .. }
+        | Instruction::Rev16 { .. } => 1,
     }
 }
 

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -46,8 +46,12 @@ fn bv_reverse_bits_64(value: &BV) -> BV {
 
 /// Count leading zeros of a 64-bit BV using a nested ITE chain.
 /// Iterates bit positions from LSB upward; later iterations overwrite the
-/// result when their bit is set, so the final result reflects the
-/// most-significant set bit (or 64 if no bit is set).
+/// result when their bit is set, so the final result is the CLZ of the
+/// input — the number of leading zeros — derived from the highest-set-bit
+/// position found (or 64 if no bit is set).
+//
+// TODO(#112): replace this 64-deep ITE chain with an O(log n) binary-search
+// decomposition (top-32 / top-16 / … / top-1) to reduce Z3 formula depth.
 fn bv_clz_64(value: &BV) -> BV {
     let mut result = BV::from_u64(64, 64);
     let one_bit = BV::from_u64(1, 1);
@@ -369,9 +373,11 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
         }
         // CLS: count leading sign-bit replicas (excluding the sign bit).
         // Fold the sign bit out via `x XOR (x ASR 63)` so the answer reduces
-        // to `clz(folded) - 1`. For all-sign inputs (0 or -1) folded is zero,
-        // clz is 64, and the result clamps to 63 via bvsub (no underflow at
-        // 64-bit width).
+        // to `clz(folded) - 1`. Bit 63 of `folded` is always 0 (a positive
+        // sign cancels its own top bit; a negative sign inverts it to 0),
+        // so `bv_clz_64(folded) ∈ [1, 64]` and the subtraction lands in
+        // `[0, 63]` — `bvsub` never wraps. For all-sign inputs (0 or -1)
+        // folded is zero, clz is 64, and the result is 63.
         Instruction::Cls { rd, rn } => {
             let value = state.get_register(*rn).clone();
             let asr = value.bvashr(&BV::from_u64(63, 64));

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -20,6 +20,46 @@ fn fresh_bv(prefix: &str) -> BV {
     BV::new_const(format!("{}_{}", prefix, id), 64)
 }
 
+/// Reverse the byte order of a 64-bit BV by concatenating its 8 byte slices
+/// with byte 0 placed in the most-significant position.
+fn bv_swap_bytes_64(value: &BV) -> BV {
+    // Place byte 0 (originally at bits [7:0]) at the new top, byte 7
+    // (originally at bits [63:56]) at the new bottom.
+    let mut result = value.extract(7, 0);
+    for i in 1..8u32 {
+        let lo = i * 8;
+        let hi = lo + 7;
+        result = result.concat(&value.extract(hi, lo));
+    }
+    result
+}
+
+/// Reverse the bit order of a 64-bit BV via 64 single-bit extracts.
+fn bv_reverse_bits_64(value: &BV) -> BV {
+    // Bit 0 of `value` becomes the new MSB; bit 63 becomes the new LSB.
+    let mut result = value.extract(0, 0);
+    for i in 1..64u32 {
+        result = result.concat(&value.extract(i, i));
+    }
+    result
+}
+
+/// Count leading zeros of a 64-bit BV using a nested ITE chain.
+/// Iterates bit positions from LSB upward; later iterations overwrite the
+/// result when their bit is set, so the final result reflects the
+/// most-significant set bit (or 64 if no bit is set).
+fn bv_clz_64(value: &BV) -> BV {
+    let mut result = BV::from_u64(64, 64);
+    let one_bit = BV::from_u64(1, 1);
+    for pos in 0..64u32 {
+        let bit = value.extract(pos, pos);
+        let is_set = bit.eq(&one_bit);
+        let clz_if_top = BV::from_u64(63 - pos as u64, 64);
+        result = is_set.ite(&clz_if_top, &result);
+    }
+    result
+}
+
 /// Configuration for the SMT solver
 #[derive(Debug, Clone)]
 pub struct SolverConfig {
@@ -322,6 +362,68 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let hi = value.bvshl(&complement);
             state.set_register(*rd, lo.bvor(&hi));
         }
+        // CLZ: count leading zero bits; returns 64 when the value is zero.
+        Instruction::Clz { rd, rn } => {
+            let value = state.get_register(*rn).clone();
+            state.set_register(*rd, bv_clz_64(&value));
+        }
+        // CLS: count leading sign-bit replicas (excluding the sign bit).
+        // Fold the sign bit out via `x XOR (x ASR 63)` so the answer reduces
+        // to `clz(folded) - 1`. For all-sign inputs (0 or -1) folded is zero,
+        // clz is 64, and the result clamps to 63 via bvsub (no underflow at
+        // 64-bit width).
+        Instruction::Cls { rd, rn } => {
+            let value = state.get_register(*rn).clone();
+            let asr = value.bvashr(&BV::from_u64(63, 64));
+            let folded = value.bvxor(&asr);
+            let clz = bv_clz_64(&folded);
+            let result = clz.bvsub(&BV::from_u64(1, 64));
+            state.set_register(*rd, result);
+        }
+        // RBIT: reverse the 64 bits.
+        Instruction::Rbit { rd, rn } => {
+            let value = state.get_register(*rn).clone();
+            state.set_register(*rd, bv_reverse_bits_64(&value));
+        }
+        // REV: byte-reverse the 64-bit value.
+        Instruction::Rev { rd, rn } => {
+            let value = state.get_register(*rn).clone();
+            state.set_register(*rd, bv_swap_bytes_64(&value));
+        }
+        // REV32: byte-reverse within each 32-bit half independently.
+        Instruction::Rev32 { rd, rn } => {
+            let value = state.get_register(*rn).clone();
+            let lo = value.extract(31, 0);
+            let hi = value.extract(63, 32);
+            // Each half byte-reversed: concat its 4 byte slices with the
+            // original LSB byte at the new MSB position.
+            let rev_half = |h: &BV| -> BV {
+                let mut acc = h.extract(7, 0);
+                for i in 1..4u32 {
+                    let l = i * 8;
+                    acc = acc.concat(&h.extract(l + 7, l));
+                }
+                acc
+            };
+            let result = rev_half(&hi).concat(&rev_half(&lo));
+            state.set_register(*rd, result);
+        }
+        // REV16: byte-reverse within each 16-bit half (four halves).
+        Instruction::Rev16 { rd, rn } => {
+            let value = state.get_register(*rn).clone();
+            // For each of the 4 half-words, swap its high and low byte.
+            let swap_half = |start: u32| -> BV {
+                value
+                    .extract(start + 7, start)
+                    .concat(&value.extract(start + 15, start + 8))
+            };
+            let h3 = swap_half(48);
+            let h2 = swap_half(32);
+            let h1 = swap_half(16);
+            let h0 = swap_half(0);
+            let result = h3.concat(&h2).concat(&h1).concat(&h0);
+            state.set_register(*rd, result);
+        }
     }
     state
 }
@@ -501,6 +603,122 @@ mod tests {
             solver.check(),
             SatResult::Sat,
             "CSEL must not be proved equivalent to MOV — SMT model is unsound"
+        );
+    }
+
+    fn assert_involution(op: fn(Register, Register) -> Instruction, label: &str) {
+        let initial = MachineState::new_symbolic("pre");
+        let initial_x1 = initial.get_register(Register::X1).clone();
+        let seq = vec![
+            op(Register::X0, Register::X1),
+            op(Register::X0, Register::X0),
+        ];
+        let final_state = apply_sequence(initial, &seq);
+        let final_x0 = final_state.get_register(Register::X0);
+
+        let solver = Solver::new();
+        solver.assert(&final_x0.eq(&initial_x1).not());
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "{} should be an involution: op(op(x)) must equal x",
+            label
+        );
+    }
+
+    #[test]
+    fn test_rev_smt_is_involution() {
+        assert_involution(|rd, rn| Instruction::Rev { rd, rn }, "REV");
+    }
+
+    #[test]
+    fn test_rbit_smt_is_involution() {
+        assert_involution(|rd, rn| Instruction::Rbit { rd, rn }, "RBIT");
+    }
+
+    #[test]
+    fn test_rev32_smt_is_involution() {
+        assert_involution(|rd, rn| Instruction::Rev32 { rd, rn }, "REV32");
+    }
+
+    #[test]
+    fn test_rev16_smt_is_involution() {
+        assert_involution(|rd, rn| Instruction::Rev16 { rd, rn }, "REV16");
+    }
+
+    #[test]
+    fn test_clz_of_one_is_63() {
+        // CLZ of an input known to equal 1 must be 63. Concrete constant
+        // rewrite: `MOV x1, #1; CLZ x0, x1` ≡ `MOV x0, #63`.
+        let initial = MachineState::new_symbolic("pre");
+        let seq = vec![
+            Instruction::MovImm {
+                rd: Register::X1,
+                imm: 1,
+            },
+            Instruction::Clz {
+                rd: Register::X0,
+                rn: Register::X1,
+            },
+        ];
+        let final_state = apply_sequence(initial, &seq);
+        let final_x0 = final_state.get_register(Register::X0);
+        let solver = Solver::new();
+        solver.assert(&final_x0.eq(&BV::from_u64(63, 64)).not());
+        assert_eq!(solver.check(), SatResult::Unsat, "CLZ(1) must be 63");
+    }
+
+    /// Floor-log2 acceptance test (issue #58): for nonzero `x1`, the sequence
+    /// `CLZ x0, x1; MOV x2, #63; SUB x0, x2, x0` produces the highest-set-bit
+    /// position. We characterise that position bitwise — the bit at the
+    /// resulting index is set, and no higher bit is set — and assert the
+    /// solver cannot find a counterexample. The "modulo zero-input edge case"
+    /// caveat from the issue is encoded as the `x1 != 0` precondition.
+    #[test]
+    fn test_clz_floor_log2_pattern() {
+        let initial = MachineState::new_symbolic("pre");
+        let initial_x1 = initial.get_register(Register::X1).clone();
+
+        let seq = vec![
+            Instruction::Clz {
+                rd: Register::X0,
+                rn: Register::X1,
+            },
+            Instruction::MovImm {
+                rd: Register::X2,
+                imm: 63,
+            },
+            Instruction::Sub {
+                rd: Register::X0,
+                rn: Register::X2,
+                rm: Operand::Register(Register::X0),
+            },
+        ];
+        let final_state = apply_sequence(initial, &seq);
+        let result = final_state.get_register(Register::X0).clone();
+
+        let zero = BV::from_u64(0, 64);
+        let one = BV::from_u64(1, 64);
+
+        // Bit at position `result` is set: (x1 >> result) & 1 == 1.
+        let bit_at_result = initial_x1.bvlshr(&result).bvand(&one).eq(&one);
+
+        // No higher bit set: x1 >> (result + 1) == 0. SMTLIB BV shifts wider
+        // than the bit-width yield zero, so result == 63 makes this vacuous.
+        let next = result.bvadd(&one);
+        let higher_zero = initial_x1.bvlshr(&next).eq(&zero);
+
+        let solver = Solver::new();
+        let nonzero = initial_x1.bvugt(&zero);
+        solver.assert(&nonzero);
+        // Look for a counterexample: nonzero x1 where the post-condition fails.
+        let violated = z3::ast::Bool::or(&[&bit_at_result.not(), &higher_zero.not()]);
+        solver.assert(&violated);
+
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "CLZ; MOV #63; SUB pattern must produce floor_log2(x1) for nonzero x1"
         );
     }
 }


### PR DESCRIPTION
## Summary

- New AArch64 IR variants: CLZ, CLS, RBIT, REV, REV32, REV16 (all `{rd, rn}`).
- Concrete semantics (`leading_zeros` / `reverse_bits` / `swap_bytes`) and Z3 SMT lowering (extract+concat permutations for REV/REV32/REV16/RBIT; 64-deep ITE chain for CLZ; CLS reduces to CLZ via the `x ^ (x ASR 63)` sign-fold).
- Wired through the cost model, dynasm encoder, GAS parser, enumerative and stochastic candidate generation, and the MCMC peer-mutation cluster.
- Always encodable (register-only), latency 1 each.

Fixes #58

## Test plan

- [x] `cargo fmt -- --check` — clean
- [x] `cargo build` — clean
- [x] `cargo test` — full suite passes (`./ci_check.sh`)
- [x] Concrete tests cross-check REV against `u64::swap_bytes`, RBIT against `u64::reverse_bits`, CLZ against `u64::leading_zeros`, and add CLS spec-vector tests
- [x] Encoder round-trip via Capstone for all 6 mnemonics
- [x] SMT involution proofs for REV / REV32 / REV16 / RBIT
- [x] SMT floor-log2 acceptance test: `CLZ x0, x1; MOV x2, #63; SUB x0, x2, x0` produces the highest-set-bit position for nonzero `x1` (the issue's `modulo zero-input edge case` example)