### PR TITLE
Add multiply-accumulate AArch64 instructions (MADD, MSUB, MNEG, SMULH, UMULH)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ s11 is a superoptimizer written in Rust. It finds shorter or faster equivalent i
 
 **Key Features:**
 - ELF binary reading and disassembly using Capstone engine (auto-detects e_machine)
-- **AArch64** (20 instructions): MOV, ADD, SUB, AND, ORR, EOR, LSL, LSR, ASR, MUL, SDIV, UDIV, CMP, CMN, TST, CSEL, CSINC, CSINV, CSNEG — full pipeline including stochastic/symbolic/hybrid/LLM search
+- **AArch64** (25 instructions): MOV, ADD, SUB, AND, ORR, EOR, LSL, LSR, ASR, MUL, SDIV, UDIV, CMP, CMN, TST, CSEL, CSINC, CSINV, CSNEG, MADD, MSUB, MNEG, SMULH, UMULH — full pipeline including stochastic/symbolic/hybrid/LLM search
 - **x86-64 + x86-32** (14 variants, 7 mnemonics): MOV, ADD, SUB, AND, OR, XOR, CMP (each with reg/imm forms) — enumerative search only in v1
 - SMT-based equivalence checking using Z3 (width-parameterised for x86-32 vs x86-64)
 - Multi-threaded parallel search with worker coordination

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -315,6 +315,63 @@ impl AArch64Assembler {
                 );
                 Ok(())
             }
+            Instruction::Madd { rd, rn, rm, ra } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                let rm_reg = register_to_dynasm(*rm)?;
+                let ra_reg = register_to_dynasm(*ra)?;
+
+                dynasm!(ops
+                    ; .arch aarch64
+                    ; madd X(rd_reg), X(rn_reg), X(rm_reg), X(ra_reg)
+                );
+                Ok(())
+            }
+            Instruction::Msub { rd, rn, rm, ra } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                let rm_reg = register_to_dynasm(*rm)?;
+                let ra_reg = register_to_dynasm(*ra)?;
+
+                dynasm!(ops
+                    ; .arch aarch64
+                    ; msub X(rd_reg), X(rn_reg), X(rm_reg), X(ra_reg)
+                );
+                Ok(())
+            }
+            Instruction::Mneg { rd, rn, rm } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                let rm_reg = register_to_dynasm(*rm)?;
+
+                dynasm!(ops
+                    ; .arch aarch64
+                    ; mneg X(rd_reg), X(rn_reg), X(rm_reg)
+                );
+                Ok(())
+            }
+            Instruction::Smulh { rd, rn, rm } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                let rm_reg = register_to_dynasm(*rm)?;
+
+                dynasm!(ops
+                    ; .arch aarch64
+                    ; smulh X(rd_reg), X(rn_reg), X(rm_reg)
+                );
+                Ok(())
+            }
+            Instruction::Umulh { rd, rn, rm } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                let rm_reg = register_to_dynasm(*rm)?;
+
+                dynasm!(ops
+                    ; .arch aarch64
+                    ; umulh X(rd_reg), X(rn_reg), X(rm_reg)
+                );
+                Ok(())
+            }
             Instruction::Cmp { rn, rm } => {
                 let rn_reg = register_to_dynasm(*rn)?;
 
@@ -1096,6 +1153,78 @@ mod tests {
             .assemble_instructions(&instructions)
             .expect("CSNEG encoding should succeed");
         disassemble_and_verify(&bytes, "csneg", &["x20", "x21", "x22", "ge"]);
+    }
+
+    #[test]
+    fn test_madd_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Madd {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+            ra: Register::X3,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("MADD encoding should succeed");
+        disassemble_and_verify(&bytes, "madd", &["x0", "x1", "x2", "x3"]);
+    }
+
+    #[test]
+    fn test_msub_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Msub {
+            rd: Register::X4,
+            rn: Register::X5,
+            rm: Register::X6,
+            ra: Register::X7,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("MSUB encoding should succeed");
+        disassemble_and_verify(&bytes, "msub", &["x4", "x5", "x6", "x7"]);
+    }
+
+    #[test]
+    fn test_mneg_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Mneg {
+            rd: Register::X10,
+            rn: Register::X11,
+            rm: Register::X12,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("MNEG encoding should succeed");
+        disassemble_and_verify(&bytes, "mneg", &["x10", "x11", "x12"]);
+    }
+
+    #[test]
+    fn test_smulh_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Smulh {
+            rd: Register::X13,
+            rn: Register::X14,
+            rm: Register::X15,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("SMULH encoding should succeed");
+        disassemble_and_verify(&bytes, "smulh", &["x13", "x14", "x15"]);
+    }
+
+    #[test]
+    fn test_umulh_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Umulh {
+            rd: Register::X16,
+            rn: Register::X17,
+            rm: Register::X18,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("UMULH encoding should succeed");
+        disassemble_and_verify(&bytes, "umulh", &["x16", "x17", "x18"]);
     }
 
     #[test]

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -1286,5 +1286,57 @@ mod tests {
         assert!(!madd.modifies_flags());
         assert!(!madd.reads_flags());
         assert!(madd.is_encodable_aarch64());
+
+        let msub = Instruction::Msub {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+            ra: Register::X3,
+        };
+        assert_eq!(msub.to_string(), "msub x0, x1, x2, x3");
+        assert_eq!(msub.destination(), Some(Register::X0));
+        assert_eq!(
+            msub.source_registers(),
+            vec![Register::X1, Register::X2, Register::X3]
+        );
+        assert!(!msub.modifies_flags());
+        assert!(!msub.reads_flags());
+        assert!(msub.is_encodable_aarch64());
+
+        let mneg = Instruction::Mneg {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+        };
+        assert_eq!(mneg.to_string(), "mneg x0, x1, x2");
+        assert_eq!(mneg.destination(), Some(Register::X0));
+        assert_eq!(mneg.source_registers(), vec![Register::X1, Register::X2]);
+        assert!(!mneg.modifies_flags());
+        assert!(!mneg.reads_flags());
+        assert!(mneg.is_encodable_aarch64());
+
+        let smulh = Instruction::Smulh {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+        };
+        assert_eq!(smulh.to_string(), "smulh x0, x1, x2");
+        assert_eq!(smulh.destination(), Some(Register::X0));
+        assert_eq!(smulh.source_registers(), vec![Register::X1, Register::X2]);
+        assert!(!smulh.modifies_flags());
+        assert!(!smulh.reads_flags());
+        assert!(smulh.is_encodable_aarch64());
+
+        let umulh = Instruction::Umulh {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+        };
+        assert_eq!(umulh.to_string(), "umulh x0, x1, x2");
+        assert_eq!(umulh.destination(), Some(Register::X0));
+        assert_eq!(umulh.source_registers(), vec![Register::X1, Register::X2]);
+        assert!(!umulh.modifies_flags());
+        assert!(!umulh.reads_flags());
+        assert!(umulh.is_encodable_aarch64());
     }
 }

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -86,6 +86,35 @@ pub enum Instruction {
         rm: Register,
     },
 
+    // Multiply-accumulate (rd = ra ± rn*rm) and high-half multiplies
+    Madd {
+        rd: Register,
+        rn: Register,
+        rm: Register,
+        ra: Register,
+    },
+    Msub {
+        rd: Register,
+        rn: Register,
+        rm: Register,
+        ra: Register,
+    },
+    Mneg {
+        rd: Register,
+        rn: Register,
+        rm: Register,
+    },
+    Smulh {
+        rd: Register,
+        rn: Register,
+        rm: Register,
+    },
+    Umulh {
+        rd: Register,
+        rn: Register,
+        rm: Register,
+    },
+
     // Comparison (set NZCV flags, no destination register)
     Cmp {
         rn: Register,
@@ -264,6 +293,11 @@ impl Instruction {
             | Instruction::Mul { rd, .. }
             | Instruction::Sdiv { rd, .. }
             | Instruction::Udiv { rd, .. }
+            | Instruction::Madd { rd, .. }
+            | Instruction::Msub { rd, .. }
+            | Instruction::Mneg { rd, .. }
+            | Instruction::Smulh { rd, .. }
+            | Instruction::Umulh { rd, .. }
             | Instruction::Csel { rd, .. }
             | Instruction::Csinc { rd, .. }
             | Instruction::Csinv { rd, .. }
@@ -368,6 +402,13 @@ impl Instruction {
             // MUL/SDIV/UDIV: always register operands, always encodable
             Instruction::Mul { .. } | Instruction::Sdiv { .. } | Instruction::Udiv { .. } => true,
 
+            // Multiply-accumulate family: always register operands, always encodable
+            Instruction::Madd { .. }
+            | Instruction::Msub { .. }
+            | Instruction::Mneg { .. }
+            | Instruction::Smulh { .. }
+            | Instruction::Umulh { .. } => true,
+
             // CMP/CMN immediate: 12-bit unsigned range
             Instruction::Cmp { rm, .. } | Instruction::Cmn { rm, .. } => match rm {
                 Operand::Register(_) => true,
@@ -460,6 +501,12 @@ impl Instruction {
             Instruction::Mul { rn, rm, .. }
             | Instruction::Sdiv { rn, rm, .. }
             | Instruction::Udiv { rn, rm, .. } => vec![*rn, *rm],
+            Instruction::Madd { rn, rm, ra, .. } | Instruction::Msub { rn, rm, ra, .. } => {
+                vec![*rn, *rm, *ra]
+            }
+            Instruction::Mneg { rn, rm, .. }
+            | Instruction::Smulh { rn, rm, .. }
+            | Instruction::Umulh { rn, rm, .. } => vec![*rn, *rm],
             // Comparison instructions read rn and rm (if register)
             Instruction::Cmp { rn, rm }
             | Instruction::Cmn { rn, rm }
@@ -534,6 +581,15 @@ impl fmt::Display for Instruction {
             Instruction::Mul { rd, rn, rm } => write!(f, "mul {}, {}, {}", rd, rn, rm),
             Instruction::Sdiv { rd, rn, rm } => write!(f, "sdiv {}, {}, {}", rd, rn, rm),
             Instruction::Udiv { rd, rn, rm } => write!(f, "udiv {}, {}, {}", rd, rn, rm),
+            Instruction::Madd { rd, rn, rm, ra } => {
+                write!(f, "madd {}, {}, {}, {}", rd, rn, rm, ra)
+            }
+            Instruction::Msub { rd, rn, rm, ra } => {
+                write!(f, "msub {}, {}, {}, {}", rd, rn, rm, ra)
+            }
+            Instruction::Mneg { rd, rn, rm } => write!(f, "mneg {}, {}, {}", rd, rn, rm),
+            Instruction::Smulh { rd, rn, rm } => write!(f, "smulh {}, {}, {}", rd, rn, rm),
+            Instruction::Umulh { rd, rn, rm } => write!(f, "umulh {}, {}, {}", rd, rn, rm),
             // Comparison instructions
             Instruction::Cmp { rn, rm } => write!(f, "cmp {}, {}", rn, rm),
             Instruction::Cmn { rn, rm } => write!(f, "cmn {}, {}", rn, rm),
@@ -1032,6 +1088,33 @@ mod tests {
                 rn: Register::X1,
                 rm: Register::X2,
             },
+            Instruction::Madd {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Register::X2,
+                ra: Register::X3,
+            },
+            Instruction::Msub {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Register::X2,
+                ra: Register::X3,
+            },
+            Instruction::Mneg {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Register::X2,
+            },
+            Instruction::Smulh {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Register::X2,
+            },
+            Instruction::Umulh {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Register::X2,
+            },
             Instruction::Cmp {
                 rn: Register::X1,
                 rm: Operand::Immediate(1),
@@ -1187,5 +1270,21 @@ mod tests {
         assert_eq!(adds.source_registers(), vec![Register::X1, Register::X2]);
         assert!(adds.modifies_flags());
         assert!(!adds.reads_flags());
+
+        let madd = Instruction::Madd {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+            ra: Register::X3,
+        };
+        assert_eq!(madd.to_string(), "madd x0, x1, x2, x3");
+        assert_eq!(madd.destination(), Some(Register::X0));
+        assert_eq!(
+            madd.source_registers(),
+            vec![Register::X1, Register::X2, Register::X3]
+        );
+        assert!(!madd.modifies_flags());
+        assert!(!madd.reads_flags());
+        assert!(madd.is_encodable_aarch64());
     }
 }

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -145,6 +145,11 @@ impl InstructionType for Instruction {
             Instruction::Rev { .. } => 39,
             Instruction::Rev32 { .. } => 40,
             Instruction::Rev16 { .. } => 41,
+            Instruction::Madd { .. } => 42,
+            Instruction::Msub { .. } => 43,
+            Instruction::Mneg { .. } => 44,
+            Instruction::Smulh { .. } => 45,
+            Instruction::Umulh { .. } => 46,
         }
     }
 
@@ -191,6 +196,11 @@ impl InstructionType for Instruction {
             Instruction::Rev { .. } => "rev",
             Instruction::Rev32 { .. } => "rev32",
             Instruction::Rev16 { .. } => "rev16",
+            Instruction::Madd { .. } => "madd",
+            Instruction::Msub { .. } => "msub",
+            Instruction::Mneg { .. } => "mneg",
+            Instruction::Smulh { .. } => "smulh",
+            Instruction::Umulh { .. } => "umulh",
         }
     }
 
@@ -302,6 +312,23 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
             }
         }
 
+        // Multiply-accumulate family. MADD/MSUB add a 4th register slot,
+        // so candidate count grows by |registers|^4 per variant
+        // (e.g. 8^4 = 4096 per arm). MNEG/SMULH/UMULH are 3-operand like MUL.
+        for &rd in registers {
+            for &rn in registers {
+                for &rm in registers {
+                    instructions.push(Instruction::Mneg { rd, rn, rm });
+                    instructions.push(Instruction::Smulh { rd, rn, rm });
+                    instructions.push(Instruction::Umulh { rd, rn, rm });
+                    for &ra in registers {
+                        instructions.push(Instruction::Madd { rd, rn, rm, ra });
+                        instructions.push(Instruction::Msub { rd, rn, rm, ra });
+                    }
+                }
+            }
+        }
+
         // Tier 1 inverted-logical / flag-setting binary ops (register form).
         for &rd in registers {
             for &rn in registers {
@@ -383,11 +410,12 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
         registers: &[Register],
         immediates: &[i64],
     ) -> Instruction {
-        // 27 opcode slots: 0..13 original, 13..23 Tier 1 (slot 23 is a
+        // 28 opcode slots: 0..13 original, 13..23 Tier 1 (slot 23 is a
         // 4-way sub-multiplexer for ANDS/CSET/CSETM/ROR), 24 = MOVZ,
         // 25 = MOVK, 26 = single-source bit-manipulation (CLZ/CLS/RBIT/REV*)
-        // 6-way sub-multiplexer.
-        let opcode = rng.random_range(0..27);
+        // 6-way sub-multiplexer, 27 = multiply-accumulate family (issue
+        // #56: 5-way sub-multiplexer for MADD/MSUB/MNEG/SMULH/UMULH).
+        let opcode = rng.random_range(0..28);
         let rd = registers[rng.random_range(0..registers.len())];
         let rn = registers[rng.random_range(0..registers.len())];
         let pick_reg = |rng: &mut R| registers[rng.random_range(0..registers.len())];
@@ -559,6 +587,23 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     _ => Instruction::Rev16 { rd, rn },
                 }
             }
+            // Multiply-accumulate family.
+            27 => {
+                let rm = pick_reg(rng);
+                match rng.random_range(0..5) {
+                    0 => {
+                        let ra = pick_reg(rng);
+                        Instruction::Madd { rd, rn, rm, ra }
+                    }
+                    1 => {
+                        let ra = pick_reg(rng);
+                        Instruction::Msub { rd, rn, rm, ra }
+                    }
+                    2 => Instruction::Mneg { rd, rn, rm },
+                    3 => Instruction::Smulh { rd, rn, rm },
+                    _ => Instruction::Umulh { rd, rn, rm },
+                }
+            }
             _ => unreachable!(),
         }
     }
@@ -607,6 +652,21 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     Instruction::Mul { rn, rm, .. } => Instruction::Mul { rd: new_rd, rn, rm },
                     Instruction::Sdiv { rn, rm, .. } => Instruction::Sdiv { rd: new_rd, rn, rm },
                     Instruction::Udiv { rn, rm, .. } => Instruction::Udiv { rd: new_rd, rn, rm },
+                    Instruction::Madd { rn, rm, ra, .. } => Instruction::Madd {
+                        rd: new_rd,
+                        rn,
+                        rm,
+                        ra,
+                    },
+                    Instruction::Msub { rn, rm, ra, .. } => Instruction::Msub {
+                        rd: new_rd,
+                        rn,
+                        rm,
+                        ra,
+                    },
+                    Instruction::Mneg { rn, rm, .. } => Instruction::Mneg { rd: new_rd, rn, rm },
+                    Instruction::Smulh { rn, rm, .. } => Instruction::Smulh { rd: new_rd, rn, rm },
+                    Instruction::Umulh { rn, rm, .. } => Instruction::Umulh { rd: new_rd, rn, rm },
                     // Comparison instructions have no destination - generate random instead
                     Instruction::Cmp { .. } | Instruction::Cmn { .. } | Instruction::Tst { .. } => {
                         self.generate_random(rng, registers, immediates)
@@ -746,6 +806,58 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     Instruction::Udiv { rd, rn, .. } => {
                         let new_rm = registers[rng.random_range(0..registers.len())];
                         Instruction::Udiv { rd, rn, rm: new_rm }
+                    }
+                    Instruction::Madd { rd, rn, rm, ra } => {
+                        // Pick one of {rm, ra} to substitute (rd handled by
+                        // strategy 1; rn by the broader source-mutation path).
+                        if rng.random_bool(0.5) {
+                            let new_rm = registers[rng.random_range(0..registers.len())];
+                            Instruction::Madd {
+                                rd,
+                                rn,
+                                rm: new_rm,
+                                ra,
+                            }
+                        } else {
+                            let new_ra = registers[rng.random_range(0..registers.len())];
+                            Instruction::Madd {
+                                rd,
+                                rn,
+                                rm,
+                                ra: new_ra,
+                            }
+                        }
+                    }
+                    Instruction::Msub { rd, rn, rm, ra } => {
+                        if rng.random_bool(0.5) {
+                            let new_rm = registers[rng.random_range(0..registers.len())];
+                            Instruction::Msub {
+                                rd,
+                                rn,
+                                rm: new_rm,
+                                ra,
+                            }
+                        } else {
+                            let new_ra = registers[rng.random_range(0..registers.len())];
+                            Instruction::Msub {
+                                rd,
+                                rn,
+                                rm,
+                                ra: new_ra,
+                            }
+                        }
+                    }
+                    Instruction::Mneg { rd, rn, .. } => {
+                        let new_rm = registers[rng.random_range(0..registers.len())];
+                        Instruction::Mneg { rd, rn, rm: new_rm }
+                    }
+                    Instruction::Smulh { rd, rn, .. } => {
+                        let new_rm = registers[rng.random_range(0..registers.len())];
+                        Instruction::Smulh { rd, rn, rm: new_rm }
+                    }
+                    Instruction::Umulh { rd, rn, .. } => {
+                        let new_rm = registers[rng.random_range(0..registers.len())];
+                        Instruction::Umulh { rd, rn, rm: new_rm }
                     }
                     // Comparison instructions - change operand
                     Instruction::Cmp { rn, rm } => {
@@ -939,10 +1051,11 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
     /// holds, but the random-generation distribution is not uniform across
     /// all 42 IDs.
     fn opcode_count(&self) -> u8 {
-        42 // 20 original + 14 Tier 1 (MVN, NEG, NEGS, MovN, BIC, BICS, ORN,
+        47 // 20 original + 14 Tier 1 (MVN, NEG, NEGS, MovN, BIC, BICS, ORN,
         //  EON, ADDS, SUBS, ANDS, CSET, CSETM, ROR) + 2 MOVK/MOVZ (issue
         //  #55) + 6 single-source bit-manipulation (CLZ, CLS, RBIT, REV,
-        //  REV32, REV16).
+        //  REV32, REV16) + 5 multiply-accumulate family (issue #56:
+        //  MADD, MSUB, MNEG, SMULH, UMULH).
     }
 }
 
@@ -1200,6 +1313,33 @@ mod tests {
             Instruction::Rev16 {
                 rd: Register::X0,
                 rn: Register::X1,
+            },
+            Instruction::Madd {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Register::X2,
+                ra: Register::X3,
+            },
+            Instruction::Msub {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Register::X2,
+                ra: Register::X3,
+            },
+            Instruction::Mneg {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Register::X2,
+            },
+            Instruction::Smulh {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Register::X2,
+            },
+            Instruction::Umulh {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Register::X2,
             },
         ]
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -598,6 +598,73 @@ fn parse_mul(operands: &[&str]) -> Result<Instruction, String> {
     Ok(Instruction::Mul { rd, rn, rm })
 }
 
+/// Parse MADD instruction (4 register operands: rd, rn, rm, ra)
+fn parse_madd(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() != 4 {
+        return Err(format!("madd requires 4 operands, got {}", operands.len()));
+    }
+
+    let rd = parse_register(operands[0])?;
+    let rn = parse_register(operands[1])?;
+    let rm = parse_register(operands[2])?;
+    let ra = parse_register(operands[3])?;
+
+    Ok(Instruction::Madd { rd, rn, rm, ra })
+}
+
+/// Parse MSUB instruction (4 register operands: rd, rn, rm, ra)
+fn parse_msub(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() != 4 {
+        return Err(format!("msub requires 4 operands, got {}", operands.len()));
+    }
+
+    let rd = parse_register(operands[0])?;
+    let rn = parse_register(operands[1])?;
+    let rm = parse_register(operands[2])?;
+    let ra = parse_register(operands[3])?;
+
+    Ok(Instruction::Msub { rd, rn, rm, ra })
+}
+
+/// Parse MNEG instruction (3 register operands: rd, rn, rm)
+fn parse_mneg(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() != 3 {
+        return Err(format!("mneg requires 3 operands, got {}", operands.len()));
+    }
+
+    let rd = parse_register(operands[0])?;
+    let rn = parse_register(operands[1])?;
+    let rm = parse_register(operands[2])?;
+
+    Ok(Instruction::Mneg { rd, rn, rm })
+}
+
+/// Parse SMULH instruction (3 register operands: rd, rn, rm)
+fn parse_smulh(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() != 3 {
+        return Err(format!("smulh requires 3 operands, got {}", operands.len()));
+    }
+
+    let rd = parse_register(operands[0])?;
+    let rn = parse_register(operands[1])?;
+    let rm = parse_register(operands[2])?;
+
+    Ok(Instruction::Smulh { rd, rn, rm })
+}
+
+/// Parse UMULH instruction (3 register operands: rd, rn, rm)
+fn parse_umulh(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() != 3 {
+        return Err(format!("umulh requires 3 operands, got {}", operands.len()));
+    }
+
+    let rd = parse_register(operands[0])?;
+    let rn = parse_register(operands[1])?;
+    let rm = parse_register(operands[2])?;
+
+    Ok(Instruction::Umulh { rd, rn, rm })
+}
+
 /// Parse SDIV instruction
 fn parse_sdiv(operands: &[&str]) -> Result<Instruction, String> {
     if operands.len() != 3 {
@@ -763,6 +830,11 @@ pub fn parse_line(line: &str) -> Result<LineResult, ParseLineError> {
         "lsr" => parse_lsr(&operands).map_err(ParseLineError::Other)?,
         "asr" => parse_asr(&operands).map_err(ParseLineError::Other)?,
         "mul" => parse_mul(&operands).map_err(ParseLineError::Other)?,
+        "madd" => parse_madd(&operands).map_err(ParseLineError::Other)?,
+        "msub" => parse_msub(&operands).map_err(ParseLineError::Other)?,
+        "mneg" => parse_mneg(&operands).map_err(ParseLineError::Other)?,
+        "smulh" => parse_smulh(&operands).map_err(ParseLineError::Other)?,
+        "umulh" => parse_umulh(&operands).map_err(ParseLineError::Other)?,
         "sdiv" => parse_sdiv(&operands).map_err(ParseLineError::Other)?,
         "udiv" => parse_udiv(&operands).map_err(ParseLineError::Other)?,
         "cmp" => parse_cmp(&operands).map_err(ParseLineError::Other)?,
@@ -1198,6 +1270,11 @@ mod tests {
             ("lsr x0, x1, x2", "lsr x0, x1, x2"),
             ("asr x0, x1, #8", "asr x0, x1, #8"),
             ("mul x0, x1, x2", "mul x0, x1, x2"),
+            ("madd x0, x1, x2, x3", "madd x0, x1, x2, x3"),
+            ("msub x0, x1, x2, x3", "msub x0, x1, x2, x3"),
+            ("mneg x0, x1, x2", "mneg x0, x1, x2"),
+            ("smulh x0, x1, x2", "smulh x0, x1, x2"),
+            ("umulh x0, x1, x2", "umulh x0, x1, x2"),
             ("sdiv x0, x1, x2", "sdiv x0, x1, x2"),
             ("udiv x0, x1, x2", "udiv x0, x1, x2"),
             ("cmp x1, #5", "cmp x1, #5"),
@@ -1228,8 +1305,9 @@ mod tests {
         for mnemonic in [
             "mov", "mvn", "neg", "negs", "bic", "bics", "orn", "eon", "adds", "subs", "ands",
             "cset", "csetm", "ror", "movn", "movz", "movk", "add", "sub", "and", "orr", "eor",
-            "lsl", "lsr", "asr", "mul", "sdiv", "udiv", "cmp", "cmn", "tst", "csel", "csinc",
-            "csinv", "csneg", "clz", "cls", "rbit", "rev", "rev32", "rev16",
+            "lsl", "lsr", "asr", "mul", "madd", "msub", "mneg", "smulh", "umulh", "sdiv", "udiv",
+            "cmp", "cmn", "tst", "csel", "csinc", "csinv", "csneg", "clz", "cls", "rbit", "rev",
+            "rev32", "rev16",
         ] {
             assert!(
                 matches!(parse_line(mnemonic), Err(ParseLineError::Other(_))),

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -147,6 +147,20 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
             instrs.push(Instruction::Rev16 { rd, rn });
         }
 
+        // Multiply-accumulate family. MADD/MSUB take a 4th register slot
+        // (`ra`); MNEG/SMULH/UMULH are 3-operand register-only.
+        for &rn in registers {
+            for &rm in registers {
+                instrs.push(Instruction::Mneg { rd, rn, rm });
+                instrs.push(Instruction::Smulh { rd, rn, rm });
+                instrs.push(Instruction::Umulh { rd, rn, rm });
+                for &ra in registers {
+                    instrs.push(Instruction::Madd { rd, rn, rm, ra });
+                    instrs.push(Instruction::Msub { rd, rn, rm, ra });
+                }
+            }
+        }
+
         // MOVN / MOVZ / MOVK: small representative imm set × four legal shift
         // positions. Keep this small — the full u16 × 4-shift space would
         // balloon the candidate count. The same parsimony rationale applies
@@ -188,7 +202,7 @@ pub fn generate_random_instruction<R: rand::RngExt>(
     let rd = registers[rng.random_range(0..registers.len())];
     let pick_reg = |rng: &mut R| registers[rng.random_range(0..registers.len())];
 
-    match rng.random_range(0..27) {
+    match rng.random_range(0..28) {
         0 => {
             let imm = if immediates.is_empty() {
                 0
@@ -330,7 +344,7 @@ pub fn generate_random_instruction<R: rand::RngExt>(
             Instruction::MovK { rd, imm, shift }
         }
         // Single-source bit-manipulation: CLZ / CLS / RBIT / REV / REV32 / REV16.
-        _ => {
+        26 => {
             let rn = pick_reg(rng);
             match rng.random_range(0..6) {
                 0 => Instruction::Clz { rd, rn },
@@ -339,6 +353,24 @@ pub fn generate_random_instruction<R: rand::RngExt>(
                 3 => Instruction::Rev { rd, rn },
                 4 => Instruction::Rev32 { rd, rn },
                 _ => Instruction::Rev16 { rd, rn },
+            }
+        }
+        // Multiply-accumulate family: MADD/MSUB (4-operand) and MNEG/SMULH/UMULH (3-operand).
+        _ => {
+            let rn = pick_reg(rng);
+            let rm = pick_reg(rng);
+            match rng.random_range(0..5) {
+                0 => {
+                    let ra = pick_reg(rng);
+                    Instruction::Madd { rd, rn, rm, ra }
+                }
+                1 => {
+                    let ra = pick_reg(rng);
+                    Instruction::Msub { rd, rn, rm, ra }
+                }
+                2 => Instruction::Mneg { rd, rn, rm },
+                3 => Instruction::Smulh { rd, rn, rm },
+                _ => Instruction::Umulh { rd, rn, rm },
             }
         }
     }

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -430,6 +430,11 @@ pub fn opcode_id(instr: &Instruction) -> u8 {
         Instruction::Rev { .. } => 39,
         Instruction::Rev32 { .. } => 40,
         Instruction::Rev16 { .. } => 41,
+        Instruction::Madd { .. } => 42,
+        Instruction::Msub { .. } => 43,
+        Instruction::Mneg { .. } => 44,
+        Instruction::Smulh { .. } => 45,
+        Instruction::Umulh { .. } => 46,
     }
 }
 

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -152,6 +152,27 @@ impl Mutator {
                     _ => *rm = self.random_register(rng),
                 }
             }
+            // Multiply-accumulate: 4 register slots so 4-way pick.
+            Instruction::Madd { rd, rn, rm, ra } | Instruction::Msub { rd, rn, rm, ra } => {
+                let choice = rng.random_range(0..4);
+                match choice {
+                    0 => *rd = self.random_register(rng),
+                    1 => *rn = self.random_register(rng),
+                    2 => *rm = self.random_register(rng),
+                    _ => *ra = self.random_register(rng),
+                }
+            }
+            // MNEG / SMULH / UMULH: 3 register slots like MUL.
+            Instruction::Mneg { rd, rn, rm }
+            | Instruction::Smulh { rd, rn, rm }
+            | Instruction::Umulh { rd, rn, rm } => {
+                let choice = rng.random_range(0..3);
+                match choice {
+                    0 => *rd = self.random_register(rng),
+                    1 => *rn = self.random_register(rng),
+                    _ => *rm = self.random_register(rng),
+                }
+            }
             // Comparison instructions (no destination)
             Instruction::Cmp { rn, rm } | Instruction::Cmn { rn, rm } => {
                 if rng.random_bool(0.5) {
@@ -593,6 +614,27 @@ impl Mutator {
                 1 => Instruction::Lsr { rd, rn, shift },
                 2 => Instruction::Asr { rd, rn, shift },
                 _ => Instruction::Ror { rd, rn, shift },
+            },
+            // Multiply-accumulate cluster — widens as SMULH/UMULH land.
+            Instruction::Madd { rd, rn, rm, ra } => match rng.random_range(0..3) {
+                0 => Instruction::Msub { rd, rn, rm, ra },
+                1 => Instruction::Mneg { rd, rn, rm },
+                _ => Instruction::Madd { rd, rn, rm, ra },
+            },
+            Instruction::Msub { rd, rn, rm, ra } => match rng.random_range(0..3) {
+                0 => Instruction::Madd { rd, rn, rm, ra },
+                1 => Instruction::Mneg { rd, rn, rm },
+                _ => Instruction::Msub { rd, rn, rm, ra },
+            },
+            Instruction::Mneg { rd, rn, rm } => Instruction::Mneg { rd, rn, rm },
+            // High-half multiply cluster (signed ↔ unsigned).
+            Instruction::Smulh { rd, rn, rm } => match rng.random_range(0..2) {
+                0 => Instruction::Umulh { rd, rn, rm },
+                _ => Instruction::Smulh { rd, rn, rm },
+            },
+            Instruction::Umulh { rd, rn, rm } => match rng.random_range(0..2) {
+                0 => Instruction::Smulh { rd, rn, rm },
+                _ => Instruction::Umulh { rd, rn, rm },
             },
         };
     }

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -368,9 +368,10 @@ impl Mutator {
                 1 => Instruction::Lsr { rd, rn, shift },
                 _ => Instruction::Asr { rd, rn, shift },
             },
-            Instruction::Mul { rd, rn, rm } => match rng.random_range(0..3) {
+            Instruction::Mul { rd, rn, rm } => match rng.random_range(0..4) {
                 0 => Instruction::Sdiv { rd, rn, rm },
                 1 => Instruction::Udiv { rd, rn, rm },
+                2 => Instruction::Mneg { rd, rn, rm },
                 _ => Instruction::Mul { rd, rn, rm },
             },
             Instruction::Sdiv { rd, rn, rm } => match rng.random_range(0..3) {
@@ -626,7 +627,13 @@ impl Mutator {
                 1 => Instruction::Mneg { rd, rn, rm },
                 _ => Instruction::Msub { rd, rn, rm, ra },
             },
-            Instruction::Mneg { rd, rn, rm } => Instruction::Mneg { rd, rn, rm },
+            // MNEG ↔ MUL is the sign-flip bridge (MNEG = -(rn*rm), MUL = rn*rm).
+            // MNEG also already receives reverse edges from MADD/MSUB above
+            // (which collapse `ra` when they convert).
+            Instruction::Mneg { rd, rn, rm } => match rng.random_range(0..2) {
+                0 => Instruction::Mul { rd, rn, rm },
+                _ => Instruction::Mneg { rd, rn, rm },
+            },
             // High-half multiply cluster (signed ↔ unsigned).
             Instruction::Smulh { rd, rn, rm } => match rng.random_range(0..2) {
                 0 => Instruction::Umulh { rd, rn, rm },

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -96,6 +96,41 @@ pub fn apply_instruction_concrete(
             let result = lhs.checked_div(rhs).unwrap_or(0); // Division by zero returns 0 in AArch64
             state.set_register(*rd, ConcreteValue::new(result));
         }
+        Instruction::Madd { rd, rn, rm, ra } => {
+            let a = state.get_register(*rn).as_u64();
+            let b = state.get_register(*rm).as_u64();
+            let c = state.get_register(*ra).as_u64();
+            let result = c.wrapping_add(a.wrapping_mul(b));
+            state.set_register(*rd, ConcreteValue::new(result));
+        }
+        Instruction::Msub { rd, rn, rm, ra } => {
+            let a = state.get_register(*rn).as_u64();
+            let b = state.get_register(*rm).as_u64();
+            let c = state.get_register(*ra).as_u64();
+            let result = c.wrapping_sub(a.wrapping_mul(b));
+            state.set_register(*rd, ConcreteValue::new(result));
+        }
+        Instruction::Mneg { rd, rn, rm } => {
+            let a = state.get_register(*rn).as_u64();
+            let b = state.get_register(*rm).as_u64();
+            let result = 0u64.wrapping_sub(a.wrapping_mul(b));
+            state.set_register(*rd, ConcreteValue::new(result));
+        }
+        Instruction::Smulh { rd, rn, rm } => {
+            let a = state.get_register(*rn).as_i64() as i128;
+            let b = state.get_register(*rm).as_i64() as i128;
+            // wrapping_mul for i128 is sufficient: a×b fits in 128 bits when
+            // |a|,|b| ≤ i64::MAX, except for i64::MIN×i64::MIN which still
+            // fits in i128 since i64::MIN as i128 is -2^63.
+            let result = (a.wrapping_mul(b) >> 64) as i64;
+            state.set_register(*rd, ConcreteValue::from_i64(result));
+        }
+        Instruction::Umulh { rd, rn, rm } => {
+            let a = state.get_register(*rn).as_u64() as u128;
+            let b = state.get_register(*rm).as_u64() as u128;
+            let result = ((a * b) >> 64) as u64;
+            state.set_register(*rd, ConcreteValue::new(result));
+        }
         // CMP: Compare (subtract and set flags, discard result)
         Instruction::Cmp { rn, rm } => {
             let lhs = state.get_register(*rn).as_u64();
@@ -730,6 +765,90 @@ mod tests {
             new_state.get_register(Register::X0).as_u64(),
             u64::MAX.wrapping_mul(2)
         );
+    }
+
+    /// Issue #56 acceptance: UMULH must match Rust's u128 high-half product
+    /// across edge cases (boundaries, identity, max×max).
+    #[test]
+    fn test_umulh_matches_rust_u128() {
+        let cases: [(u64, u64); 16] = [
+            (0, 0),
+            (0, 12345),
+            (1, u64::MAX),
+            (u64::MAX, u64::MAX),
+            (u64::MAX, 1),
+            (u64::MAX, 2),
+            (1 << 32, 1 << 32),
+            (1 << 32, (1 << 32) - 1),
+            (0xDEAD_BEEF, 0x1234_5678),
+            (0xFFFF_FFFF_FFFF_FFFE, 2),
+            (0x8000_0000_0000_0000, 0x8000_0000_0000_0000),
+            (0xAAAA_AAAA_AAAA_AAAA, 0x5555_5555_5555_5555),
+            (0xCAFE_F00D, 0xBABE_BEEF),
+            ((1u64 << 63) - 1, (1u64 << 63) - 1),
+            (u64::MAX - 1, u64::MAX - 1),
+            (0xFFFF_FFFF, 0xFFFF_FFFF),
+        ];
+
+        for (a, b) in cases {
+            let state = state_with(vec![(Register::X1, a), (Register::X2, b)]);
+            let instr = Instruction::Umulh {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Register::X2,
+            };
+            let new_state = apply_instruction_concrete(state, &instr);
+            let expected = (((a as u128) * (b as u128)) >> 64) as u64;
+            assert_eq!(
+                new_state.get_register(Register::X0).as_u64(),
+                expected,
+                "umulh(0x{:x}, 0x{:x})",
+                a,
+                b
+            );
+        }
+    }
+
+    /// Issue #56 acceptance: SMULH must match Rust's i128 high-half product
+    /// across edge cases (signed boundaries, zero, identity, MIN×-1).
+    #[test]
+    fn test_smulh_matches_rust_i128() {
+        let cases: [(i64, i64); 16] = [
+            (0, 0),
+            (0, 12345),
+            (1, i64::MAX),
+            (-1, i64::MIN),
+            (i64::MAX, i64::MAX),
+            (i64::MIN, i64::MIN),
+            (i64::MIN, -1),
+            (i64::MIN, 1),
+            (i64::MAX, -1),
+            (123456789, -987654321),
+            (-1, -1),
+            (2, i64::MAX),
+            (-2, i64::MIN),
+            (1 << 32, 1 << 32),
+            (-(1 << 32), 1 << 32),
+            (0xDEAD_BEEF, 0x1234_5678),
+        ];
+
+        for (a, b) in cases {
+            let state = state_with(vec![(Register::X1, a as u64), (Register::X2, b as u64)]);
+            let instr = Instruction::Smulh {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Register::X2,
+            };
+            let new_state = apply_instruction_concrete(state, &instr);
+            let expected = ((a as i128).wrapping_mul(b as i128) >> 64) as i64;
+            assert_eq!(
+                new_state.get_register(Register::X0).as_i64(),
+                expected,
+                "smulh(0x{:x}, 0x{:x})",
+                a,
+                b
+            );
+        }
     }
 
     #[test]

--- a/src/semantics/cost.rs
+++ b/src/semantics/cost.rs
@@ -34,6 +34,10 @@ fn instruction_latency(instr: &Instruction) -> u64 {
         Instruction::Lsl { .. } | Instruction::Lsr { .. } | Instruction::Asr { .. } => 1,
         // Multiply has higher latency than simple ALU ops
         Instruction::Mul { .. } => 3,
+        // Multiply-accumulate fuses with the multiply pipeline
+        Instruction::Madd { .. } | Instruction::Msub { .. } | Instruction::Mneg { .. } => 3,
+        // High-half multiply: one extra cycle vs MUL on Cortex-A72/A76.
+        Instruction::Smulh { .. } | Instruction::Umulh { .. } => 4,
         // Division has the highest latency
         Instruction::Sdiv { .. } | Instruction::Udiv { .. } => 12,
         // Comparison instructions (just set flags)

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -1321,4 +1321,89 @@ mod tests {
         let s2 = s1.clone();
         assert_eq!(check_equivalence(&s1, &s2), EquivalenceResult::Equivalent);
     }
+
+    /// Issue #56 acceptance: `MUL t,a,b; NEG r,t` ≡ `MNEG r,a,b`
+    /// (MNEG is `rd = -(rn*rm)`, the alias of `MSUB rd,rn,rm,XZR`).
+    #[test]
+    fn test_mneg_equivalent_to_neg_mul() {
+        let seq1 = vec![
+            Instruction::Mul {
+                rd: Register::X3,
+                rn: Register::X1,
+                rm: Register::X2,
+            },
+            Instruction::Neg {
+                rd: Register::X0,
+                rm: Register::X3,
+            },
+        ];
+        let seq2 = vec![Instruction::Mneg {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+        }];
+        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
+        assert_eq!(
+            check_equivalence_with_config(&seq1, &seq2, &config),
+            EquivalenceResult::Equivalent
+        );
+    }
+
+    /// Issue #56 acceptance: `MUL t,a,b; SUB r,c,t` ≡ `MSUB r,a,b,c`
+    /// when only `r` is live-out.
+    #[test]
+    fn test_msub_equivalent_to_sub_mul() {
+        let seq1 = vec![
+            Instruction::Mul {
+                rd: Register::X3,
+                rn: Register::X1,
+                rm: Register::X2,
+            },
+            Instruction::Sub {
+                rd: Register::X0,
+                rn: Register::X4,
+                rm: Operand::Register(Register::X3),
+            },
+        ];
+        let seq2 = vec![Instruction::Msub {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+            ra: Register::X4,
+        }];
+        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
+        assert_eq!(
+            check_equivalence_with_config(&seq1, &seq2, &config),
+            EquivalenceResult::Equivalent
+        );
+    }
+
+    /// Issue #56 acceptance: `MUL t,a,b; ADD r,c,t` ≡ `MADD r,a,b,c`
+    /// when only `r` is live-out (the temporary `t` is dead).
+    #[test]
+    fn test_madd_equivalent_to_mul_then_add() {
+        let seq1 = vec![
+            Instruction::Mul {
+                rd: Register::X3,
+                rn: Register::X1,
+                rm: Register::X2,
+            },
+            Instruction::Add {
+                rd: Register::X0,
+                rn: Register::X4,
+                rm: Operand::Register(Register::X3),
+            },
+        ];
+        let seq2 = vec![Instruction::Madd {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+            ra: Register::X4,
+        }];
+        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
+        assert_eq!(
+            check_equivalence_with_config(&seq1, &seq2, &config),
+            EquivalenceResult::Equivalent
+        );
+    }
 }

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -251,6 +251,37 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let result = is_zero.ite(&zero, &div_result);
             state.set_register(*rd, result);
         }
+        Instruction::Madd { rd, rn, rm, ra } => {
+            let a = state.get_register(*rn).clone();
+            let b = state.get_register(*rm).clone();
+            let c = state.get_register(*ra).clone();
+            state.set_register(*rd, c.bvadd(&a.bvmul(&b)));
+        }
+        Instruction::Msub { rd, rn, rm, ra } => {
+            let a = state.get_register(*rn).clone();
+            let b = state.get_register(*rm).clone();
+            let c = state.get_register(*ra).clone();
+            state.set_register(*rd, c.bvsub(&a.bvmul(&b)));
+        }
+        Instruction::Mneg { rd, rn, rm } => {
+            let a = state.get_register(*rn).clone();
+            let b = state.get_register(*rm).clone();
+            state.set_register(*rd, a.bvmul(&b).bvneg());
+        }
+        Instruction::Smulh { rd, rn, rm } => {
+            // 64-bit sign-extend to 128, multiply, extract upper 64 bits.
+            let a = state.get_register(*rn).sign_ext(64);
+            let b = state.get_register(*rm).sign_ext(64);
+            let prod = a.bvmul(&b);
+            state.set_register(*rd, prod.extract(127, 64));
+        }
+        Instruction::Umulh { rd, rn, rm } => {
+            // 64-bit zero-extend to 128, multiply, extract upper 64 bits.
+            let a = state.get_register(*rn).zero_ext(64);
+            let b = state.get_register(*rm).zero_ext(64);
+            let prod = a.bvmul(&b);
+            state.set_register(*rd, prod.extract(127, 64));
+        }
         // Comparison instructions set flags but don't modify registers
         // For now, we don't model flags in SMT - these are no-ops for register state
         Instruction::Cmp { .. } | Instruction::Cmn { .. } | Instruction::Tst { .. } => {


### PR DESCRIPTION
## Summary

Closes #56. Adds the AArch64 multiply-accumulate family — five new instructions wired end-to-end through IR, semantics (concrete + Z3 SMT), cost model, encoder, parser, candidate generation, and stochastic mutation.

- `MADD rd, rn, rm, ra` — `rd = ra + rn*rm`
- `MSUB rd, rn, rm, ra` — `rd = ra - rn*rm`
- `MNEG rd, rn, rm` — `rd = -(rn*rm)` (kept as a distinct IR variant, matching the MVN/NEG/NEGS precedent)
- `SMULH rd, rn, rm` — signed high 64 bits of 64×64 product
- `UMULH rd, rn, rm` — unsigned high 64 bits of 64×64 product

SMULH/UMULH lower to `sign_ext(64) / zero_ext(64) → bvmul → extract(127, 64)` in Z3.

Latency model: MADD/MSUB/MNEG = 3 (fuses with the multiply pipeline, same as MUL); SMULH/UMULH = 4 (one extra cycle on Cortex-A72/A76).

## Test plan

- [x] `cargo test` — 488 unit tests pass (was 477; +11 new tests)
- [x] `./ci_check.sh` — all CI checks pass (fmt, build, unit tests, test binaries, full suite)
- [x] Issue #56 acceptance: SMT proves `MUL+ADD ≡ MADD` (`test_madd_equivalent_to_mul_then_add`)
- [x] Issue #56 acceptance: SMT proves `MNEG ≡ Neg(Mul)` (`test_mneg_equivalent_to_neg_mul`)
- [x] Issue #56 acceptance: SMULH/UMULH match Rust `i128`/`u128` across 16 fixed seeds inc. `i64::MIN×i64::MIN`, `i64::MIN×-1`, `u64::MAX×u64::MAX`, identity, and zero (`test_smulh_matches_rust_i128`, `test_umulh_matches_rust_u128`)
- [x] Bonus: SMT proves `MUL+SUB ≡ MSUB` (`test_msub_equivalent_to_sub_mul`)
- [x] Encoder round-trips via Capstone for all 5 mnemonics
- [x] Parser positive coverage (round-trip) and negative coverage (arity errors) for all 5 mnemonics