### PR TITLE
Add CCMP/CCMN AArch64 instructions and model NZCV in SMT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ s11 is a superoptimizer written in Rust. It finds shorter or faster equivalent i
 
 **Key Features:**
 - ELF binary reading and disassembly using Capstone engine (auto-detects e_machine)
-- **AArch64** (25 instructions): MOV, ADD, SUB, AND, ORR, EOR, LSL, LSR, ASR, MUL, SDIV, UDIV, CMP, CMN, TST, CSEL, CSINC, CSINV, CSNEG, MADD, MSUB, MNEG, SMULH, UMULH — full pipeline including stochastic/symbolic/hybrid/LLM search
+- **AArch64** (27 instructions): MOV, ADD, SUB, AND, ORR, EOR, LSL, LSR, ASR, MUL, SDIV, UDIV, CMP, CMN, TST, CSEL, CSINC, CSINV, CSNEG, MADD, MSUB, MNEG, SMULH, UMULH, CCMP, CCMN — full pipeline including stochastic/symbolic/hybrid/LLM search
 - **x86-64 + x86-32** (14 variants, 7 mnemonics): MOV, ADD, SUB, AND, OR, XOR, CMP (each with reg/imm forms) — enumerative search only in v1
 - SMT-based equivalence checking using Z3 (width-parameterised for x86-32 vs x86-64)
 - Multi-threaded parallel search with worker coordination

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -201,7 +201,6 @@ macro_rules! emit_ccmp_imm {
     }};
 }
 
-
 pub struct AArch64Assembler;
 
 impl AArch64Assembler {
@@ -707,9 +706,7 @@ impl AArch64Assembler {
                         emit_ccmp_imm!(ops, ccmp, rn_reg, *imm, *nzcv, *cond);
                     }
                     Operand::ShiftedRegister { .. } => {
-                        return Err(
-                            "CCMP does not support shifted-register operand".to_string()
-                        );
+                        return Err("CCMP does not support shifted-register operand".to_string());
                     }
                 }
                 Ok(())
@@ -731,9 +728,7 @@ impl AArch64Assembler {
                         emit_ccmp_imm!(ops, ccmn, rn_reg, *imm, *nzcv, *cond);
                     }
                     Operand::ShiftedRegister { .. } => {
-                        return Err(
-                            "CCMN does not support shifted-register operand".to_string()
-                        );
+                        return Err("CCMN does not support shifted-register operand".to_string());
                     }
                 }
                 Ok(())

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -144,10 +144,11 @@ macro_rules! emit_shifted_reg_2op_logical {
     }};
 }
 
-/// CCMP/CCMN reg form: `ccmp Xn, Xm, #nzcv, cond`. The condition suffix and
-/// the `#nzcv` literal must be compile-time, so we expand 14 condition × use
-/// `$nzcv` as a u32-cast expression at emit time. AL and NV are forbidden by
-/// `is_encodable_aarch64` and excluded from the macro arms.
+/// CCMP/CCMN reg form: `ccmp Xn, Xm, #nzcv, cond`. The condition suffix
+/// must be a compile-time literal for dynasm-rs, so we expand 14 condition
+/// arms; `$nzcv` is bound to a `u32`-cast value once at the top so the
+/// dynasm `#` literal slot accepts it at emit time. AL and NV are forbidden
+/// by `is_encodable_aarch64` and excluded from the macro arms.
 macro_rules! emit_ccmp_reg {
     ($ops:expr, $mnem:ident, $rn:expr, $rm:expr, $nzcv:expr, $cond:expr) => {{
         let n = $nzcv as u32;
@@ -1494,6 +1495,21 @@ mod tests {
             .assemble_instructions(&instructions)
             .expect("CCMN register form should encode");
         disassemble_and_verify(&bytes, "ccmn", &["x0", "x1", "#0xf", "lt"]);
+    }
+
+    #[test]
+    fn test_ccmn_imm_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Ccmn {
+            rn: Register::X4,
+            rm: Operand::Immediate(7),
+            nzcv: 4,
+            cond: Condition::GE,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("CCMN immediate form should encode");
+        disassemble_and_verify(&bytes, "ccmn", &["x4", "#7", "#4", "ge"]);
     }
 
     #[test]

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -144,6 +144,63 @@ macro_rules! emit_shifted_reg_2op_logical {
     }};
 }
 
+/// CCMP/CCMN reg form: `ccmp Xn, Xm, #nzcv, cond`. The condition suffix and
+/// the `#nzcv` literal must be compile-time, so we expand 14 condition × use
+/// `$nzcv` as a u32-cast expression at emit time. AL and NV are forbidden by
+/// `is_encodable_aarch64` and excluded from the macro arms.
+macro_rules! emit_ccmp_reg {
+    ($ops:expr, $mnem:ident, $rn:expr, $rm:expr, $nzcv:expr, $cond:expr) => {{
+        let n = $nzcv as u32;
+        match $cond {
+            Condition::EQ => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), X($rm), #n, eq),
+            Condition::NE => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), X($rm), #n, ne),
+            Condition::CS => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), X($rm), #n, cs),
+            Condition::CC => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), X($rm), #n, cc),
+            Condition::MI => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), X($rm), #n, mi),
+            Condition::PL => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), X($rm), #n, pl),
+            Condition::VS => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), X($rm), #n, vs),
+            Condition::VC => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), X($rm), #n, vc),
+            Condition::HI => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), X($rm), #n, hi),
+            Condition::LS => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), X($rm), #n, ls),
+            Condition::GE => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), X($rm), #n, ge),
+            Condition::LT => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), X($rm), #n, lt),
+            Condition::GT => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), X($rm), #n, gt),
+            Condition::LE => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), X($rm), #n, le),
+            Condition::AL | Condition::NV => {
+                return Err("CCMP/CCMN forbid AL/NV per ARM ARM C6.2.36".to_string());
+            }
+        }
+    }};
+}
+
+/// CCMP/CCMN immediate form: `ccmp Xn, #imm5, #nzcv, cond`.
+macro_rules! emit_ccmp_imm {
+    ($ops:expr, $mnem:ident, $rn:expr, $imm5:expr, $nzcv:expr, $cond:expr) => {{
+        let i = $imm5 as u32;
+        let n = $nzcv as u32;
+        match $cond {
+            Condition::EQ => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), #i, #n, eq),
+            Condition::NE => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), #i, #n, ne),
+            Condition::CS => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), #i, #n, cs),
+            Condition::CC => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), #i, #n, cc),
+            Condition::MI => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), #i, #n, mi),
+            Condition::PL => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), #i, #n, pl),
+            Condition::VS => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), #i, #n, vs),
+            Condition::VC => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), #i, #n, vc),
+            Condition::HI => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), #i, #n, hi),
+            Condition::LS => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), #i, #n, ls),
+            Condition::GE => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), #i, #n, ge),
+            Condition::LT => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), #i, #n, lt),
+            Condition::GT => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), #i, #n, gt),
+            Condition::LE => dynasm!($ops ; .arch aarch64 ; $mnem X($rn), #i, #n, le),
+            Condition::AL | Condition::NV => {
+                return Err("CCMP/CCMN forbid AL/NV per ARM ARM C6.2.36".to_string());
+            }
+        }
+    }};
+}
+
+
 pub struct AArch64Assembler;
 
 impl AArch64Assembler {
@@ -630,6 +687,54 @@ impl AArch64Assembler {
                 let rn_reg = register_to_dynasm(*rn)?;
                 let rm_reg = register_to_dynasm(*rm)?;
                 emit_csel!(ops, csneg, rd_reg, rn_reg, rm_reg, *cond);
+                Ok(())
+            }
+            Instruction::Ccmp { rn, rm, nzcv, cond } => {
+                if *nzcv > 15 {
+                    return Err(format!("CCMP nzcv {} out of range (0..=15)", nzcv));
+                }
+                let rn_reg = register_to_dynasm(*rn)?;
+                match rm {
+                    Operand::Register(rm_reg) => {
+                        let rm_idx = register_to_dynasm(*rm_reg)?;
+                        emit_ccmp_reg!(ops, ccmp, rn_reg, rm_idx, *nzcv, *cond);
+                    }
+                    Operand::Immediate(imm) => {
+                        if *imm < 0 || *imm > 31 {
+                            return Err(format!("CCMP imm5 {} out of range (0..=31)", imm));
+                        }
+                        emit_ccmp_imm!(ops, ccmp, rn_reg, *imm, *nzcv, *cond);
+                    }
+                    Operand::ShiftedRegister { .. } => {
+                        return Err(
+                            "CCMP does not support shifted-register operand".to_string()
+                        );
+                    }
+                }
+                Ok(())
+            }
+            Instruction::Ccmn { rn, rm, nzcv, cond } => {
+                if *nzcv > 15 {
+                    return Err(format!("CCMN nzcv {} out of range (0..=15)", nzcv));
+                }
+                let rn_reg = register_to_dynasm(*rn)?;
+                match rm {
+                    Operand::Register(rm_reg) => {
+                        let rm_idx = register_to_dynasm(*rm_reg)?;
+                        emit_ccmp_reg!(ops, ccmn, rn_reg, rm_idx, *nzcv, *cond);
+                    }
+                    Operand::Immediate(imm) => {
+                        if *imm < 0 || *imm > 31 {
+                            return Err(format!("CCMN imm5 {} out of range (0..=31)", imm));
+                        }
+                        emit_ccmp_imm!(ops, ccmn, rn_reg, *imm, *nzcv, *cond);
+                    }
+                    Operand::ShiftedRegister { .. } => {
+                        return Err(
+                            "CCMN does not support shifted-register operand".to_string()
+                        );
+                    }
+                }
                 Ok(())
             }
             Instruction::Mvn { rd, rm } => {
@@ -1344,6 +1449,51 @@ mod tests {
             .assemble_instructions(&instructions)
             .expect("CSNEG encoding should succeed");
         disassemble_and_verify(&bytes, "csneg", &["x20", "x21", "x22", "ge"]);
+    }
+
+    #[test]
+    fn test_ccmp_reg_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Ccmp {
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+            nzcv: 5,
+            cond: Condition::EQ,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("CCMP register form should encode");
+        disassemble_and_verify(&bytes, "ccmp", &["x1", "x2", "#5", "eq"]);
+    }
+
+    #[test]
+    fn test_ccmp_imm_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Ccmp {
+            rn: Register::X3,
+            rm: Operand::Immediate(15),
+            nzcv: 0,
+            cond: Condition::NE,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("CCMP immediate form should encode");
+        disassemble_and_verify(&bytes, "ccmp", &["x3", "#0xf", "#0", "ne"]);
+    }
+
+    #[test]
+    fn test_ccmn_reg_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Ccmn {
+            rn: Register::X0,
+            rm: Operand::Register(Register::X1),
+            nzcv: 15,
+            cond: Condition::LT,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("CCMN register form should encode");
+        disassemble_and_verify(&bytes, "ccmn", &["x0", "x1", "#0xf", "lt"]);
     }
 
     #[test]

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -155,6 +155,23 @@ pub enum Instruction {
         cond: Condition,
     },
 
+    // Conditional compare (subtract): if `cond` holds, set NZCV from
+    // `rn - operand(rm)`; otherwise set NZCV to the 4-bit `nzcv` literal
+    // (bit3=N, bit2=Z, bit1=C, bit0=V). Reads and writes NZCV.
+    Ccmp {
+        rn: Register,
+        rm: Operand,
+        nzcv: u8,
+        cond: Condition,
+    },
+    // Conditional compare negative (add): same as Ccmp with `rn + operand(rm)`.
+    Ccmn {
+        rn: Register,
+        rm: Operand,
+        nzcv: u8,
+        cond: Condition,
+    },
+
     // Bitwise NOT (alias of ORN with XZR)
     Mvn {
         rd: Register,
@@ -325,7 +342,11 @@ impl Instruction {
             | Instruction::Rev32 { rd, .. }
             | Instruction::Rev16 { rd, .. } => Some(*rd),
             // Comparison instructions only set flags, no destination register
-            Instruction::Cmp { .. } | Instruction::Cmn { .. } | Instruction::Tst { .. } => None,
+            Instruction::Cmp { .. }
+            | Instruction::Cmn { .. }
+            | Instruction::Tst { .. }
+            | Instruction::Ccmp { .. }
+            | Instruction::Ccmn { .. } => None,
         }
     }
 
@@ -346,6 +367,8 @@ impl Instruction {
                 | Instruction::Adds { .. }
                 | Instruction::Subs { .. }
                 | Instruction::Ands { .. }
+                | Instruction::Ccmp { .. }
+                | Instruction::Ccmn { .. }
         )
     }
 
@@ -360,6 +383,8 @@ impl Instruction {
                 | Instruction::Csneg { .. }
                 | Instruction::Cset { .. }
                 | Instruction::Csetm { .. }
+                | Instruction::Ccmp { .. }
+                | Instruction::Ccmn { .. }
         )
     }
 
@@ -490,6 +515,29 @@ impl Instruction {
                 !matches!(cond, Condition::AL | Condition::NV)
             }
 
+            // CCMP / CCMN: reject AL/NV (ARM ARM C6.2.36); reject SP in `rn`
+            // (Xn slot, not XSP); the `rm` immediate is a 5-bit unsigned literal
+            // (0..=31); `nzcv` is a 4-bit unsigned literal (0..=15). The
+            // shifted-register form is not encoded in this IR — CCMP's
+            // architectural register form is a plain Xm without shift, so we
+            // reject `Operand::ShiftedRegister` here.
+            Instruction::Ccmp { rn, rm, nzcv, cond } | Instruction::Ccmn { rn, rm, nzcv, cond } => {
+                if matches!(cond, Condition::AL | Condition::NV) {
+                    return false;
+                }
+                if *rn == Register::SP {
+                    return false;
+                }
+                if *nzcv > 15 {
+                    return false;
+                }
+                match rm {
+                    Operand::Register(reg) => *reg != Register::SP,
+                    Operand::Immediate(imm) => (0..=31).contains(imm),
+                    Operand::ShiftedRegister { .. } => false,
+                }
+            }
+
             // ROR: shift amount 0..=63 (same as LSL/LSR/ASR). ShiftedRegister
             // in the shift slot is rejected (semantically nonsense; same as
             // LSL/LSR/ASR above).
@@ -559,6 +607,16 @@ impl Instruction {
                     Operand::Register(r) => regs.push(*r),
                     Operand::ShiftedRegister { reg, .. } => regs.push(*reg),
                     Operand::Immediate(_) => {}
+                }
+                regs
+            }
+            // CCMP / CCMN read rn and rm (if register). They also read NZCV
+            // (via `cond`), but the live-out machinery models flag liveness
+            // separately via `reads_flags` and `modifies_flags`.
+            Instruction::Ccmp { rn, rm, .. } | Instruction::Ccmn { rn, rm, .. } => {
+                let mut regs = vec![*rn];
+                if let Operand::Register(r) = rm {
+                    regs.push(*r);
                 }
                 regs
             }
@@ -651,6 +709,12 @@ impl fmt::Display for Instruction {
             }
             Instruction::Csneg { rd, rn, rm, cond } => {
                 write!(f, "csneg {}, {}, {}, {}", rd, rn, rm, cond)
+            }
+            Instruction::Ccmp { rn, rm, nzcv, cond } => {
+                write!(f, "ccmp {}, {}, #{}, {}", rn, rm, nzcv, cond)
+            }
+            Instruction::Ccmn { rn, rm, nzcv, cond } => {
+                write!(f, "ccmn {}, {}, #{}, {}", rn, rm, nzcv, cond)
             }
             Instruction::Mvn { rd, rm } => write!(f, "mvn {}, {}", rd, rm),
             Instruction::Neg { rd, rm } => write!(f, "neg {}, {}", rd, rm),

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -155,6 +155,8 @@ impl InstructionType for Instruction {
             Instruction::Mneg { .. } => 44,
             Instruction::Smulh { .. } => 45,
             Instruction::Umulh { .. } => 46,
+            Instruction::Ccmp { .. } => 47,
+            Instruction::Ccmn { .. } => 48,
         }
     }
 
@@ -206,6 +208,8 @@ impl InstructionType for Instruction {
             Instruction::Mneg { .. } => "mneg",
             Instruction::Smulh { .. } => "smulh",
             Instruction::Umulh { .. } => "umulh",
+            Instruction::Ccmp { .. } => "ccmp",
+            Instruction::Ccmn { .. } => "ccmn",
         }
     }
 
@@ -673,9 +677,11 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     Instruction::Smulh { rn, rm, .. } => Instruction::Smulh { rd: new_rd, rn, rm },
                     Instruction::Umulh { rn, rm, .. } => Instruction::Umulh { rd: new_rd, rn, rm },
                     // Comparison instructions have no destination - generate random instead
-                    Instruction::Cmp { .. } | Instruction::Cmn { .. } | Instruction::Tst { .. } => {
-                        self.generate_random(rng, registers, immediates)
-                    }
+                    Instruction::Cmp { .. }
+                    | Instruction::Cmn { .. }
+                    | Instruction::Tst { .. }
+                    | Instruction::Ccmp { .. }
+                    | Instruction::Ccmn { .. } => self.generate_random(rng, registers, immediates),
                     // Conditional select instructions
                     Instruction::Csel { rn, rm, cond, .. } => Instruction::Csel {
                         rd: new_rd,
@@ -877,6 +883,27 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                         let new_rm =
                             Operand::Register(registers[rng.random_range(0..registers.len())]);
                         Instruction::Tst { rn, rm: new_rm }
+                    }
+                    // CCMP / CCMN: pick a new rm (register or imm5). The
+                    // dedicated mutate_operand path in
+                    // `search/stochastic/mutation.rs` covers nzcv and cond.
+                    Instruction::Ccmp { rn, rm, nzcv, cond } => {
+                        let new_rm = mutate_operand(rng, rm, registers, immediates);
+                        Instruction::Ccmp {
+                            rn,
+                            rm: new_rm,
+                            nzcv,
+                            cond,
+                        }
+                    }
+                    Instruction::Ccmn { rn, rm, nzcv, cond } => {
+                        let new_rm = mutate_operand(rng, rm, registers, immediates);
+                        Instruction::Ccmn {
+                            rn,
+                            rm: new_rm,
+                            nzcv,
+                            cond,
+                        }
                     }
                     // Conditional select - change operands
                     Instruction::Csel { rd, rn, cond, .. } => {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -768,6 +768,52 @@ fn parse_tst(operands: &[&str]) -> Result<Instruction, String> {
     Ok(Instruction::Tst { rn, rm })
 }
 
+/// Parse CCMP instruction: `ccmp Xn, <Xm | #imm5>, #nzcv, cond`.
+fn parse_ccmp(operands: &[&str]) -> Result<Instruction, String> {
+    parse_ccmp_like(operands, "ccmp").map(|(rn, rm, nzcv, cond)| Instruction::Ccmp {
+        rn,
+        rm,
+        nzcv,
+        cond,
+    })
+}
+
+/// Parse CCMN instruction: `ccmn Xn, <Xm | #imm5>, #nzcv, cond`.
+fn parse_ccmn(operands: &[&str]) -> Result<Instruction, String> {
+    parse_ccmp_like(operands, "ccmn").map(|(rn, rm, nzcv, cond)| Instruction::Ccmn {
+        rn,
+        rm,
+        nzcv,
+        cond,
+    })
+}
+
+fn parse_ccmp_like(
+    operands: &[&str],
+    mnem: &str,
+) -> Result<(Register, Operand, u8, Condition), String> {
+    if operands.len() != 4 {
+        return Err(format!(
+            "{} requires 4 operands, got {}",
+            mnem,
+            operands.len()
+        ));
+    }
+    let rn = parse_register(operands[0])?;
+    let rm = parse_operand(operands[1])?;
+    if let Operand::Immediate(imm) = rm {
+        if !(0..=31).contains(&imm) {
+            return Err(format!("{} imm5 {} out of range (0..=31)", mnem, imm));
+        }
+    }
+    let nzcv_raw = parse_immediate(operands[2])?;
+    if !(0..=15).contains(&nzcv_raw) {
+        return Err(format!("{} nzcv {} out of range (0..=15)", mnem, nzcv_raw));
+    }
+    let cond = parse_condition(operands[3])?;
+    Ok((rn, rm, nzcv_raw as u8, cond))
+}
+
 /// Parse CSEL instruction
 fn parse_csel(operands: &[&str]) -> Result<Instruction, String> {
     if operands.len() != 4 {
@@ -881,6 +927,8 @@ pub fn parse_line(line: &str) -> Result<LineResult, ParseLineError> {
         "cmp" => parse_cmp(&operands).map_err(ParseLineError::Other)?,
         "cmn" => parse_cmn(&operands).map_err(ParseLineError::Other)?,
         "tst" => parse_tst(&operands).map_err(ParseLineError::Other)?,
+        "ccmp" => parse_ccmp(&operands).map_err(ParseLineError::Other)?,
+        "ccmn" => parse_ccmn(&operands).map_err(ParseLineError::Other)?,
         "csel" => parse_csel(&operands).map_err(ParseLineError::Other)?,
         "csinc" => parse_csinc(&operands).map_err(ParseLineError::Other)?,
         "csinv" => parse_csinv(&operands).map_err(ParseLineError::Other)?,
@@ -1398,6 +1446,20 @@ mod tests {
     }
 
     #[test]
+    fn parse_ccmp_rejects_out_of_range_nzcv() {
+        let line = "ccmp x1, x2, #16, eq";
+        let result = parse_line(line);
+        assert!(result.is_err(), "nzcv > 15 must be rejected");
+    }
+
+    #[test]
+    fn parse_ccmp_rejects_out_of_range_imm5() {
+        let line = "ccmp x1, #32, #0, eq";
+        let result = parse_line(line);
+        assert!(result.is_err(), "imm5 > 31 must be rejected");
+    }
+
+    #[test]
     fn parse_line_covers_all_core_mnemonics() {
         let cases = [
             ("sub x0, x1, #3", "sub x0, x1, #3"),
@@ -1418,6 +1480,9 @@ mod tests {
             ("cmp x1, #5", "cmp x1, #5"),
             ("cmn x1, x2", "cmn x1, x2"),
             ("tst x1, x2", "tst x1, x2"),
+            ("ccmp x1, x2, #5, eq", "ccmp x1, x2, #5, eq"),
+            ("ccmp x1, #15, #3, ne", "ccmp x1, #15, #3, ne"),
+            ("ccmn x1, x2, #0, lt", "ccmn x1, x2, #0, lt"),
             ("csinc x0, x1, x2, ne", "csinc x0, x1, x2, ne"),
             ("csinv x0, x1, x2, lt", "csinv x0, x1, x2, lt"),
             ("csneg x0, x1, x2, ge", "csneg x0, x1, x2, ge"),

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -448,9 +448,22 @@ pub fn generate_random_instruction<R: rand::RngExt>(
         // clamped/coerced to a valid 5-bit immediate if it lands on the
         // immediate side. nzcv is a 4-bit literal; cond from NORMAL_CONDITIONS.
         27 => {
-            let rn = pick_reg(rng);
-            let rm_raw = random_operand(rng, registers, immediates);
-            let rm = match rm_raw {
+            // CCMP/CCMN forbid SP in `rn` and in the register form of `rm`
+            // (encoded in the Xn slot, not XSP). `generate_all_instructions`
+            // filters SP at enumeration time; mirror that here so the
+            // mutator does not bleed avoidable is_encodable_aarch64
+            // rejections.
+            let pick_non_sp = |rng: &mut R| loop {
+                let r = pick_reg(rng);
+                if r != Register::SP {
+                    break r;
+                }
+            };
+            let rn = pick_non_sp(rng);
+            let rm = match random_operand(rng, registers, immediates) {
+                Operand::Register(r) if r == Register::SP => {
+                    Operand::Register(pick_non_sp(rng))
+                }
                 Operand::Register(r) => Operand::Register(r),
                 Operand::Immediate(v) => Operand::Immediate(v.rem_euclid(32)),
                 // random_operand only returns Register/Immediate, but the

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -452,7 +452,13 @@ pub fn generate_random_instruction<R: rand::RngExt>(
             // (encoded in the Xn slot, not XSP). `generate_all_instructions`
             // filters SP at enumeration time; mirror that here so the
             // mutator does not bleed avoidable is_encodable_aarch64
-            // rejections.
+            // rejections. The debug_assert guards against a degenerate
+            // `registers = [SP]` caller, which would otherwise spin
+            // forever in the retry loop below.
+            debug_assert!(
+                registers.iter().any(|r| *r != Register::SP),
+                "CCMP/CCMN random generator requires at least one non-SP register",
+            );
             let pick_non_sp = |rng: &mut R| loop {
                 let r = pick_reg(rng);
                 if r != Register::SP {

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -461,9 +461,7 @@ pub fn generate_random_instruction<R: rand::RngExt>(
             };
             let rn = pick_non_sp(rng);
             let rm = match random_operand(rng, registers, immediates) {
-                Operand::Register(r) if r == Register::SP => {
-                    Operand::Register(pick_non_sp(rng))
-                }
+                Operand::Register(r) if r == Register::SP => Operand::Register(pick_non_sp(rng)),
                 Operand::Register(r) => Operand::Register(r),
                 Operand::Immediate(v) => Operand::Immediate(v.rem_euclid(32)),
                 // random_operand only returns Register/Immediate, but the

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -220,6 +220,57 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
         }
     }
 
+    // CCMP / CCMN: nested loops over register pairs × NORMAL_CONDITIONS ×
+    // a representative nzcv subset × {register, imm5} for `rm`. Keep the
+    // nzcv and imm5 samples bounded so the combined space stays around
+    // ~120k candidates total — already inside the enumerative budget.
+    const CCMP_NZCV_SAMPLES: [u8; 4] = [0, 1, 7, 15];
+    const CCMP_IMM5_SAMPLES: [i64; 4] = [0, 1, 16, 31];
+    for &rn in registers {
+        if rn == Register::SP {
+            continue;
+        }
+        for &rm_reg in registers {
+            if rm_reg == Register::SP {
+                continue;
+            }
+            for cond in crate::ir::types::NORMAL_CONDITIONS {
+                for &nzcv in &CCMP_NZCV_SAMPLES {
+                    instrs.push(Instruction::Ccmp {
+                        rn,
+                        rm: Operand::Register(rm_reg),
+                        nzcv,
+                        cond,
+                    });
+                    instrs.push(Instruction::Ccmn {
+                        rn,
+                        rm: Operand::Register(rm_reg),
+                        nzcv,
+                        cond,
+                    });
+                }
+            }
+        }
+        for &imm in &CCMP_IMM5_SAMPLES {
+            for cond in crate::ir::types::NORMAL_CONDITIONS {
+                for &nzcv in &CCMP_NZCV_SAMPLES {
+                    instrs.push(Instruction::Ccmp {
+                        rn,
+                        rm: Operand::Immediate(imm),
+                        nzcv,
+                        cond,
+                    });
+                    instrs.push(Instruction::Ccmn {
+                        rn,
+                        rm: Operand::Immediate(imm),
+                        nzcv,
+                        cond,
+                    });
+                }
+            }
+        }
+    }
+
     instrs
 }
 
@@ -239,7 +290,7 @@ pub fn generate_random_instruction<R: rand::RngExt>(
     let rd = registers[rng.random_range(0..registers.len())];
     let pick_reg = |rng: &mut R| registers[rng.random_range(0..registers.len())];
 
-    match rng.random_range(0..28) {
+    match rng.random_range(0..30) {
         0 => {
             let imm = if immediates.is_empty() {
                 0
@@ -392,6 +443,29 @@ pub fn generate_random_instruction<R: rand::RngExt>(
                 _ => Instruction::Rev16 { rd, rn },
             }
         }
+        // CCMP / CCMN: conditional compare. The dispatch picks Ccmp or Ccmn
+        // uniformly; the rm operand is sampled via random_operand and then
+        // clamped/coerced to a valid 5-bit immediate if it lands on the
+        // immediate side. nzcv is a 4-bit literal; cond from NORMAL_CONDITIONS.
+        27 => {
+            let rn = pick_reg(rng);
+            let rm_raw = random_operand(rng, registers, immediates);
+            let rm = match rm_raw {
+                Operand::Register(r) => Operand::Register(r),
+                Operand::Immediate(v) => Operand::Immediate(v.rem_euclid(32)),
+                // random_operand only returns Register/Immediate, but the
+                // compiler can't prove that — drop ShiftedRegister to a plain
+                // register (CCMP rejects shifted form anyway).
+                Operand::ShiftedRegister { reg, .. } => Operand::Register(reg),
+            };
+            let nzcv = (rng.random::<u32>() & 0x0F) as u8;
+            let cond = crate::ir::types::Condition::random_normal(rng);
+            if rng.random_bool(0.5) {
+                Instruction::Ccmp { rn, rm, nzcv, cond }
+            } else {
+                Instruction::Ccmn { rn, rm, nzcv, cond }
+            }
+        }
         // Multiply-accumulate family: MADD/MSUB (4-operand) and MNEG/SMULH/UMULH (3-operand).
         _ => {
             let rn = pick_reg(rng);
@@ -504,6 +578,8 @@ pub fn opcode_id(instr: &Instruction) -> u8 {
         Instruction::Mneg { .. } => 44,
         Instruction::Smulh { .. } => 45,
         Instruction::Umulh { .. } => 46,
+        Instruction::Ccmp { .. } => 47,
+        Instruction::Ccmn { .. } => 48,
     }
 }
 

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -203,9 +203,15 @@ impl SearchAlgorithm for StochasticSearch {
                 // Verify with SMT solver
                 self.statistics.smt_queries += 1;
 
+                // Treat NZCV as live-out so the solver cannot certify a
+                // flag-divergent rewrite (e.g. ADD;CMP vs ADDS). The
+                // softened pre-SMT guard relies on flags being part of the
+                // comparison; without `with_flags(true)` here the search
+                // could accept rewrites that disturb post-window NZCV.
                 let equiv_config = EquivalenceConfig::with_live_out(live_out.clone())
                     .random_tests(0) // Already tested
-                    .timeout(std::time::Duration::from_secs(5));
+                    .timeout(std::time::Duration::from_secs(5))
+                    .with_flags(true);
 
                 match check_equivalence_with_config(target, &proposal, &equiv_config) {
                     EquivalenceResult::Equivalent => {

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -179,7 +179,12 @@ impl SearchAlgorithm for StochasticSearch {
             let mut passes_tests = true;
             for (input, target_output) in all_inputs.iter().zip(target_outputs.iter()) {
                 let proposal_output = apply_sequence_concrete(input.clone(), &proposal);
-                if !states_equal_for_live_out(&proposal_output, target_output, live_out_registers) {
+                if !states_equal_for_live_out(
+                    &proposal_output,
+                    target_output,
+                    live_out_registers,
+                    false,
+                ) {
                     passes_tests = false;
                     break;
                 }
@@ -275,7 +280,7 @@ pub fn evaluate_with_tests(
 
     for (input, target_output) in test_inputs.iter().zip(target_outputs.iter()) {
         let proposal_output = apply_sequence_concrete(input.clone(), proposal);
-        if !states_equal_for_live_out(&proposal_output, target_output, live_out) {
+        if !states_equal_for_live_out(&proposal_output, target_output, live_out, false) {
             passes_all = false;
             break;
         }

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -236,6 +236,10 @@ impl Mutator {
                         *rm = match self.random_operand(rng) {
                             Operand::Register(r) => Operand::Register(r),
                             Operand::Immediate(v) => Operand::Immediate(v.rem_euclid(32)),
+                            // CCMP/CCMN reject shifted-register operands;
+                            // collapse to a plain register (consistent with
+                            // candidate::generate_random_instruction case 27).
+                            Operand::ShiftedRegister { reg, .. } => Operand::Register(reg),
                         };
                     }
                     2 => *nzcv = (rng.random::<u32>() & 0x0F) as u8,

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -224,6 +224,16 @@ impl Mutator {
                     }
                 }
             }
+            // CCMP / CCMN: rn (register), rm (operand), nzcv (0..=15), cond.
+            // Uniform pick among the four mutable fields.
+            Instruction::Ccmp { rn, rm, nzcv, cond } | Instruction::Ccmn { rn, rm, nzcv, cond } => {
+                match rng.random_range(0..4) {
+                    0 => *rn = self.random_register(rng),
+                    1 => *rm = self.random_operand(rng),
+                    2 => *nzcv = (rng.random::<u32>() & 0x0F) as u8,
+                    _ => *cond = Condition::random_normal(rng),
+                }
+            }
             // Conditional select instructions
             Instruction::Csel { rd, rn, rm, .. }
             | Instruction::Csinc { rd, rn, rm, .. }
@@ -468,6 +478,9 @@ impl Mutator {
                 },
                 _ => Instruction::Tst { rn, rm },
             },
+            // CCMP ↔ CCMN swap (both share (rn, rm, nzcv, cond)).
+            Instruction::Ccmp { rn, rm, nzcv, cond } => Instruction::Ccmn { rn, rm, nzcv, cond },
+            Instruction::Ccmn { rn, rm, nzcv, cond } => Instruction::Ccmp { rn, rm, nzcv, cond },
             // Conditional select instructions can mutate between each other
             Instruction::Csel { rd, rn, rm, cond } => match rng.random_range(0..4) {
                 0 => Instruction::Csinc { rd, rn, rm, cond },

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -225,11 +225,19 @@ impl Mutator {
                 }
             }
             // CCMP / CCMN: rn (register), rm (operand), nzcv (0..=15), cond.
-            // Uniform pick among the four mutable fields.
+            // Uniform pick among the four mutable fields. Immediate `rm`
+            // operands are clamped to imm5 via rem_euclid(32) to match the
+            // candidate generator (candidate.rs::generate_random_instruction)
+            // and avoid avoidable is_encodable_aarch64 rejection churn.
             Instruction::Ccmp { rn, rm, nzcv, cond } | Instruction::Ccmn { rn, rm, nzcv, cond } => {
                 match rng.random_range(0..4) {
                     0 => *rn = self.random_register(rng),
-                    1 => *rm = self.random_operand(rng),
+                    1 => {
+                        *rm = match self.random_operand(rng) {
+                            Operand::Register(r) => Operand::Register(r),
+                            Operand::Immediate(v) => Operand::Immediate(v.rem_euclid(32)),
+                        };
+                    }
                     2 => *nzcv = (rng.random::<u32>() & 0x0F) as u8,
                     _ => *cond = Condition::random_normal(rng),
                 }

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -235,9 +235,13 @@ impl SymbolicSearch {
             .solver_timeout
             .unwrap_or(Duration::from_secs(5));
 
+        // Treat NZCV as live-out so the solver cannot certify a
+        // flag-divergent rewrite (see the equivalent note in
+        // `mcmc.rs::run_search`).
         let equiv_config = EquivalenceConfig::with_live_out(live_out.clone())
             .random_tests(5) // Quick pre-filter with tests
-            .timeout(timeout);
+            .timeout(timeout)
+            .with_flags(true);
 
         self.statistics.smt_queries += 1;
 

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -169,6 +169,31 @@ pub fn apply_instruction_concrete(
             };
             state.set_flags(flags);
         }
+        // CCMP: conditional compare (subtract). If `cond` holds at runtime,
+        // set NZCV from `rn - operand(rm)` exactly like CMP; otherwise force
+        // NZCV to the 4-bit immediate.
+        Instruction::Ccmp { rn, rm, nzcv, cond } => {
+            let flags = if evaluate_condition(&state, *cond) {
+                let lhs = state.get_register(*rn).as_u64();
+                let rhs = eval_operand(&state, rm).as_u64();
+                ConditionFlags::from_sub(lhs, rhs, lhs.wrapping_sub(rhs))
+            } else {
+                unpack_nzcv(*nzcv)
+            };
+            state.set_flags(flags);
+        }
+        // CCMN: conditional compare negative (add). Same as CCMP but with
+        // addition for the true branch.
+        Instruction::Ccmn { rn, rm, nzcv, cond } => {
+            let flags = if evaluate_condition(&state, *cond) {
+                let lhs = state.get_register(*rn).as_u64();
+                let rhs = eval_operand(&state, rm).as_u64();
+                ConditionFlags::from_add(lhs, rhs, lhs.wrapping_add(rhs))
+            } else {
+                unpack_nzcv(*nzcv)
+            };
+            state.set_flags(flags);
+        }
         // CSEL: Conditional select
         Instruction::Csel { rd, rn, rm, cond } => {
             let cond_true = evaluate_condition(&state, *cond);
@@ -367,6 +392,18 @@ pub fn apply_instruction_concrete(
 }
 
 /// Evaluate a condition code against the current flags
+/// Unpack a 4-bit NZCV literal (CCMP/CCMN false-branch flag value) into the
+/// `ConditionFlags` struct. Layout per ARM ARM: bit3 = N, bit2 = Z, bit1 = C,
+/// bit0 = V.
+fn unpack_nzcv(byte: u8) -> ConditionFlags {
+    ConditionFlags {
+        n: (byte >> 3) & 1 == 1,
+        z: (byte >> 2) & 1 == 1,
+        c: (byte >> 1) & 1 == 1,
+        v: byte & 1 == 1,
+    }
+}
+
 fn evaluate_condition(state: &ConcreteMachineState, cond: Condition) -> bool {
     let flags = state.get_flags();
     match cond {
@@ -400,31 +437,54 @@ pub fn apply_sequence_concrete(
     state
 }
 
-/// Check if two concrete states are equal for the specified live-out registers
+/// Check if two concrete states are equal for the specified live-out registers,
+/// optionally including the NZCV condition flags.
 pub fn states_equal_for_live_out(
     state1: &ConcreteMachineState,
     state2: &ConcreteMachineState,
     live_out: &LiveOutRegisters,
+    flags_live: bool,
 ) -> bool {
     for reg in live_out.iter() {
         if state1.get_register(*reg) != state2.get_register(*reg) {
             return false;
         }
     }
+    if flags_live && state1.get_flags() != state2.get_flags() {
+        return false;
+    }
     true
 }
 
-/// Find the first differing register between two states for live-out registers
+/// Find the first differing register between two states for live-out registers.
+/// Flag divergence (when `flags_live` is set) is reported via the `XZR`
+/// sentinel since the function signature is register-typed.
 pub fn find_first_difference(
     state1: &ConcreteMachineState,
     state2: &ConcreteMachineState,
     live_out: &LiveOutRegisters,
+    flags_live: bool,
 ) -> Option<(Register, ConcreteValue, ConcreteValue)> {
     for reg in live_out.iter() {
         let v1 = state1.get_register(*reg);
         let v2 = state2.get_register(*reg);
         if v1 != v2 {
             return Some((*reg, v1, v2));
+        }
+    }
+    if flags_live {
+        let f1 = state1.get_flags();
+        let f2 = state2.get_flags();
+        if f1 != f2 {
+            // Pack each flag set into a ConcreteValue so the return type stays
+            // (Register, ConcreteValue, ConcreteValue). Layout: N<<3 | Z<<2 | C<<1 | V.
+            // The XZR register slot signals "this difference is a flag, not a register."
+            let pack = |f: crate::semantics::state::ConditionFlags| -> ConcreteValue {
+                ConcreteValue(
+                    ((f.n as u64) << 3) | ((f.z as u64) << 2) | ((f.c as u64) << 1) | (f.v as u64),
+                )
+            };
+            return Some((Register::XZR, pack(f1), pack(f2)));
         }
     }
     None
@@ -768,7 +828,9 @@ mod tests {
         let state2 = state_with(vec![(Register::X0, 42), (Register::X1, 999)]);
 
         let live_out = LiveOutRegisters::from_registers(vec![Register::X0]);
-        assert!(states_equal_for_live_out(&state1, &state2, &live_out));
+        assert!(states_equal_for_live_out(
+            &state1, &state2, &live_out, false
+        ));
     }
 
     #[test]
@@ -777,7 +839,9 @@ mod tests {
         let state2 = state_with(vec![(Register::X0, 43)]);
 
         let live_out = LiveOutRegisters::from_registers(vec![Register::X0]);
-        assert!(!states_equal_for_live_out(&state1, &state2, &live_out));
+        assert!(!states_equal_for_live_out(
+            &state1, &state2, &live_out, false
+        ));
     }
 
     #[test]
@@ -786,7 +850,7 @@ mod tests {
         let state2 = state_with(vec![(Register::X0, 42), (Register::X1, 200)]);
 
         let live_out = LiveOutRegisters::from_registers(vec![Register::X0, Register::X1]);
-        let diff = find_first_difference(&state1, &state2, &live_out);
+        let diff = find_first_difference(&state1, &state2, &live_out, false);
         assert!(diff.is_some());
         let (reg, v1, v2) = diff.unwrap();
         assert_eq!(reg, Register::X1);
@@ -800,7 +864,7 @@ mod tests {
         let state2 = state_with(vec![(Register::X0, 42)]);
 
         let live_out = LiveOutRegisters::from_registers(vec![Register::X0]);
-        let diff = find_first_difference(&state1, &state2, &live_out);
+        let diff = find_first_difference(&state1, &state2, &live_out, false);
         assert!(diff.is_none());
     }
 
@@ -822,7 +886,9 @@ mod tests {
         let state2 = apply_sequence_concrete(state, &seq2);
 
         let live_out = LiveOutRegisters::from_registers(vec![Register::X0]);
-        assert!(states_equal_for_live_out(&state1, &state2, &live_out));
+        assert!(states_equal_for_live_out(
+            &state1, &state2, &live_out, false
+        ));
     }
 
     #[test]
@@ -1696,5 +1762,121 @@ mod tests {
                 input
             );
         }
+    }
+
+    #[test]
+    fn test_unpack_nzcv_bit_packing() {
+        // bit3 = N, bit2 = Z, bit1 = C, bit0 = V.
+        assert_eq!(
+            unpack_nzcv(0b1010),
+            ConditionFlags {
+                n: true,
+                z: false,
+                c: true,
+                v: false
+            }
+        );
+        assert_eq!(unpack_nzcv(0), ConditionFlags::default());
+        assert_eq!(
+            unpack_nzcv(0b1111),
+            ConditionFlags {
+                n: true,
+                z: true,
+                c: true,
+                v: true
+            }
+        );
+    }
+
+    #[test]
+    fn test_ccmp_true_branch_matches_cmp() {
+        // Pre-condition: Z=1 (so EQ holds). CCMP X1, X2, #0, EQ must then
+        // behave like CMP X1, X2.
+        let mut state = state_with(vec![(Register::X1, 7), (Register::X2, 3)]);
+        state.set_flags(ConditionFlags {
+            n: false,
+            z: true,
+            c: false,
+            v: false,
+        });
+        let ccmp = Instruction::Ccmp {
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+            nzcv: 0,
+            cond: Condition::EQ,
+        };
+        let after = apply_instruction_concrete(state.clone(), &ccmp);
+        let cmp = Instruction::Cmp {
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        };
+        let after_cmp = apply_instruction_concrete(state, &cmp);
+        assert_eq!(after.get_flags(), after_cmp.get_flags());
+    }
+
+    #[test]
+    fn test_ccmp_false_branch_uses_nzcv_literal() {
+        // Pre-condition: Z=0 (so EQ does NOT hold). CCMP must install the
+        // 4-bit nzcv immediate as the new flag set.
+        let mut state = state_with(vec![(Register::X1, 7), (Register::X2, 3)]);
+        state.set_flags(ConditionFlags {
+            n: false,
+            z: false,
+            c: false,
+            v: false,
+        });
+        let ccmp = Instruction::Ccmp {
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+            nzcv: 0b1010, // N=1, Z=0, C=1, V=0
+            cond: Condition::EQ,
+        };
+        let after = apply_instruction_concrete(state, &ccmp);
+        assert_eq!(
+            after.get_flags(),
+            ConditionFlags {
+                n: true,
+                z: false,
+                c: true,
+                v: false
+            }
+        );
+    }
+
+    #[test]
+    fn test_ccmn_true_branch_matches_cmn() {
+        let mut state = state_with(vec![(Register::X1, 5), (Register::X2, 0)]);
+        state.set_flags(ConditionFlags {
+            n: false,
+            z: true,
+            c: false,
+            v: false,
+        });
+        let ccmn = Instruction::Ccmn {
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+            nzcv: 0,
+            cond: Condition::EQ,
+        };
+        let after = apply_instruction_concrete(state.clone(), &ccmn);
+        let cmn = Instruction::Cmn {
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        };
+        let after_cmn = apply_instruction_concrete(state, &cmn);
+        assert_eq!(after.get_flags(), after_cmn.get_flags());
+    }
+
+    #[test]
+    fn test_ccmp_immediate_rm() {
+        let state = state_with(vec![(Register::X1, 31)]);
+        let ccmp = Instruction::Ccmp {
+            rn: Register::X1,
+            rm: Operand::Immediate(31),
+            nzcv: 0,
+            cond: Condition::AL,
+        };
+        let after = apply_instruction_concrete(state, &ccmp);
+        assert!(after.get_flags().z);
     }
 }

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -1869,12 +1869,22 @@ mod tests {
 
     #[test]
     fn test_ccmp_immediate_rm() {
-        let state = state_with(vec![(Register::X1, 31)]);
+        // Pre-condition Z=1 so EQ holds. The true branch computes
+        // 31 - 31 = 0, so the resulting Z must again be 1. Use EQ (not AL,
+        // which is_encodable_aarch64 rejects for CCMP) to keep the test
+        // consistent with the encoder contract.
+        let mut state = state_with(vec![(Register::X1, 31)]);
+        state.set_flags(ConditionFlags {
+            n: false,
+            z: true,
+            c: false,
+            v: false,
+        });
         let ccmp = Instruction::Ccmp {
             rn: Register::X1,
             rm: Operand::Immediate(31),
             nzcv: 0,
-            cond: Condition::AL,
+            cond: Condition::EQ,
         };
         let after = apply_instruction_concrete(state, &ccmp);
         assert!(after.get_flags().z);

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -1868,6 +1868,22 @@ mod tests {
     }
 
     #[test]
+    fn test_csinc_nv_selects_rn_concrete() {
+        // Concrete-interpreter pair for the SMT test
+        // `test_csel_nv_evaluates_as_always_true`. NV per ARM ARM still
+        // satisfies condition_holds = true; CSINC must select rn, not rm+1.
+        let state = state_with(vec![(Register::X1, 7), (Register::X2, 2)]);
+        let csinc = Instruction::Csinc {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+            cond: Condition::NV,
+        };
+        let after = apply_instruction_concrete(state, &csinc);
+        assert_eq!(after.get_register(Register::X0).as_u64(), 7);
+    }
+
+    #[test]
     fn test_ccmp_immediate_rm() {
         // Pre-condition Z=1 so EQ holds. The true branch computes
         // 31 - 31 = 0, so the resulting Z must again be 1. Use EQ (not AL,

--- a/src/semantics/cost.rs
+++ b/src/semantics/cost.rs
@@ -42,6 +42,8 @@ fn instruction_latency(instr: &Instruction) -> u64 {
         Instruction::Sdiv { .. } | Instruction::Udiv { .. } => 12,
         // Comparison instructions (just set flags)
         Instruction::Cmp { .. } | Instruction::Cmn { .. } | Instruction::Tst { .. } => 1,
+        // Conditional comparisons (read NZCV, write NZCV)
+        Instruction::Ccmp { .. } | Instruction::Ccmn { .. } => 1,
         // Conditional selects
         Instruction::Csel { .. }
         | Instruction::Csinc { .. }

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -19,42 +19,17 @@ use crate::validation::random::{
 use std::time::Duration;
 use z3::SatResult;
 
-/// Soundness guard: SMT does not model NZCV, so any rewrite that disturbs
-/// the flag-writing trace cannot be proved equivalent — a downstream
-/// conditional branch (or CSEL chain) would observe different flags.
-/// Equivalent in registers ≠ equivalent in flags.
-///
-/// This guard fires when the sub-sequence of flag-writing instructions in
-/// `target` differs in any way from the sub-sequence in `candidate` — drop,
-/// swap, reorder, or replace-with-different-flag-writer all count. The
-/// comparison is `Instruction`-level structural equality, so a `CMP x2, #0`
-/// in target vs `ADDS x0, x1, #1` in candidate (both modify NZCV but with
-/// different operands and different flag-setting rules) is correctly
-/// rejected — see the regression tests below.
-///
-/// Conservative on purpose: some valid rewrites that happen to produce
-/// identical final NZCV from different flag-writers will be wrongly
-/// rejected here. A symmetric incompleteness also remains — when both
-/// sequences contain the same structural flag-writer but with different
-/// upstream operands feeding it (e.g. `mov x1,#0; cmp x1,#0` vs
-/// `mov x1,#5; cmp x1,#0`), the guard does not detect the divergence.
-/// Closing either gap requires full NZCV modelling in SMT, tracked as
-/// issue #92.
+/// Cheap pre-SMT fast-path: rejects when only one sequence has flag-writers.
+/// Issue #92 closed the structural-equality version of this guard — now that
+/// SMT models symbolic NZCV (see `compute_flags_*` and `condition_to_smt` in
+/// `smt.rs`), any finer divergence is settled by the solver. We keep the
+/// asymmetric writes-vs-no-writes check because it short-circuits in O(n)
+/// without invoking Z3 and remains sound: if one sequence writes flags and
+/// the other does not, their flags cannot agree once flags become live.
 fn flag_writers_diverge(target: &[Instruction], candidate: &[Instruction]) -> bool {
-    // Fast paths: most rewrites involve no flag writers at all.
     let tw = flags_live_out(target);
     let cw = flags_live_out(candidate);
-    if !tw && !cw {
-        return false;
-    }
-    if tw != cw {
-        return true; // target writes flags, candidate doesn't (or vice versa)
-    }
-    let target_flag_writers: Vec<&Instruction> =
-        target.iter().filter(|i| i.modifies_flags()).collect();
-    let candidate_flag_writers: Vec<&Instruction> =
-        candidate.iter().filter(|i| i.modifies_flags()).collect();
-    target_flag_writers != candidate_flag_writers
+    tw != cw
 }
 
 /// Combined pre-SMT soundness guard. Single source of truth for the
@@ -96,6 +71,9 @@ pub struct EquivalenceConfig {
     pub smt_timeout: Option<Duration>,
     /// Skip SMT verification (fast path only)
     pub fast_only: bool,
+    /// Treat NZCV as live-out (include flag equality in both fast-path and
+    /// SMT comparisons).
+    pub flags_live: bool,
 }
 
 impl Default for EquivalenceConfig {
@@ -105,6 +83,7 @@ impl Default for EquivalenceConfig {
             random_test_count: 10,
             smt_timeout: Some(Duration::from_secs(30)),
             fast_only: false,
+            flags_live: false,
         }
     }
 }
@@ -153,6 +132,14 @@ impl EquivalenceConfig {
     /// Builder method to enable fast-only mode
     pub fn set_fast_only(mut self, fast_only: bool) -> Self {
         self.fast_only = fast_only;
+        self
+    }
+
+    /// Builder method to mark NZCV as live-out — flag inequality then
+    /// participates in both the fast-path concrete comparison and the SMT
+    /// formula. Mirrors `X86LiveOutMask::with_flags(true)` on the x86 side.
+    pub fn with_flags(mut self, flags_live: bool) -> Self {
+        self.flags_live = flags_live;
         self
     }
 }
@@ -217,7 +204,7 @@ fn run_fast_path(
         let state1 = apply_sequence_concrete(input.clone(), seq1);
         let state2 = apply_sequence_concrete(input.clone(), seq2);
 
-        if !states_equal_for_live_out(&state1, &state2, live_out_registers) {
+        if !states_equal_for_live_out(&state1, &state2, live_out_registers, config.flags_live) {
             return Some(EquivalenceResult::NotEquivalentFast(input.clone()));
         }
     }
@@ -227,7 +214,7 @@ fn run_fast_path(
         let state1 = apply_sequence_concrete(input.clone(), seq1);
         let state2 = apply_sequence_concrete(input.clone(), seq2);
 
-        if !states_equal_for_live_out(&state1, &state2, live_out_registers) {
+        if !states_equal_for_live_out(&state1, &state2, live_out_registers, config.flags_live) {
             return Some(EquivalenceResult::NotEquivalentFast(input.clone()));
         }
     }
@@ -318,6 +305,7 @@ fn build_smt_solver(
         &final_state1,
         &final_state2,
         config.live_out.registers(),
+        config.flags_live,
     ));
     solver
 }
@@ -399,7 +387,9 @@ pub fn find_counterexample_concrete(
         let state1 = apply_sequence_concrete(input.clone(), seq1);
         let state2 = apply_sequence_concrete(input.clone(), seq2);
 
-        if let Some(diff) = find_first_difference(&state1, &state2, live_out_registers) {
+        if let Some(diff) =
+            find_first_difference(&state1, &state2, live_out_registers, config.flags_live)
+        {
             return Some(diff);
         }
     }
@@ -409,7 +399,9 @@ pub fn find_counterexample_concrete(
         let state1 = apply_sequence_concrete(input.clone(), seq1);
         let state2 = apply_sequence_concrete(input.clone(), seq2);
 
-        if let Some(diff) = find_first_difference(&state1, &state2, live_out_registers) {
+        if let Some(diff) =
+            find_first_difference(&state1, &state2, live_out_registers, config.flags_live)
+        {
             return Some(diff);
         }
     }
@@ -712,6 +704,223 @@ mod tests {
         assert!(
             discovered.is_some(),
             "enumerative search must discover `ADD X0, X1, X2, LSL #3` as equivalent to LSL+ADD"
+        );
+    }
+
+    #[test]
+    fn issue_57_acceptance_ccmp_branchless_equiv_to_cmp_csel() {
+        // The issue 57 acceptance criterion: SMT proves a CCMP-based
+        // branchless `(a==b) && (a<c)` ≡ the multi-instruction CMP+CSET
+        // form, with the result deposited in X3.
+        //
+        // CCMP form (3 instructions):
+        //   CMP x0, x1            ; flags from x0 - x1
+        //   CCMP x0, x2, #0, EQ   ; if EQ: flags = x0 - x2; else flags = 0
+        //   CSET x3, LT
+        //
+        // Multi-instruction form (5 instructions):
+        //   CMP x0, x1
+        //   CSET xtmp, EQ         ; (x0 == x1)
+        //   CMP x0, x2
+        //   CSET x3, LT           ; (x0 < x2 signed)
+        //   AND x3, x3, xtmp
+        let target = vec![
+            Instruction::Cmp {
+                rn: Register::X0,
+                rm: Operand::Register(Register::X1),
+            },
+            Instruction::Ccmp {
+                rn: Register::X0,
+                rm: Operand::Register(Register::X2),
+                nzcv: 0,
+                cond: crate::ir::types::Condition::EQ,
+            },
+            Instruction::Cset {
+                rd: Register::X3,
+                cond: crate::ir::types::Condition::LT,
+            },
+        ];
+        let candidate = vec![
+            Instruction::Cmp {
+                rn: Register::X0,
+                rm: Operand::Register(Register::X1),
+            },
+            Instruction::Cset {
+                rd: Register::X4,
+                cond: crate::ir::types::Condition::EQ,
+            },
+            Instruction::Cmp {
+                rn: Register::X0,
+                rm: Operand::Register(Register::X2),
+            },
+            Instruction::Cset {
+                rd: Register::X3,
+                cond: crate::ir::types::Condition::LT,
+            },
+            Instruction::And {
+                rd: Register::X3,
+                rn: Register::X3,
+                rm: Operand::Register(Register::X4),
+            },
+        ];
+        let cfg =
+            EquivalenceConfig::default().live_out(LiveOut::from_registers(vec![Register::X3]));
+        assert_eq!(
+            check_equivalence_with_config(&target, &candidate, &cfg),
+            EquivalenceResult::Equivalent,
+            "Issue 57 acceptance: CCMP branchless ≡ CMP+CSET multi-instruction form"
+        );
+    }
+
+    #[test]
+    fn cmp_then_csel_is_flag_dependent() {
+        // CMP x1, x2; CSEL x0, x3, x4, eq writes x0 = (x1==x2 ? x3 : x4),
+        // which is not equivalent to MOV x0, x3 in general. With both
+        // sequences as their own target, equivalence should hold.
+        let cmp_csel = vec![
+            Instruction::Cmp {
+                rn: Register::X1,
+                rm: Operand::Register(Register::X2),
+            },
+            Instruction::Csel {
+                rd: Register::X0,
+                rn: Register::X3,
+                rm: Register::X4,
+                cond: crate::ir::types::Condition::EQ,
+            },
+        ];
+        let mov_only = vec![Instruction::MovReg {
+            rd: Register::X0,
+            rn: Register::X3,
+        }];
+        let cfg =
+            EquivalenceConfig::default().live_out(LiveOut::from_registers(vec![Register::X0]));
+        assert_ne!(
+            check_equivalence_with_config(&cmp_csel, &mov_only, &cfg),
+            EquivalenceResult::Equivalent,
+            "CMP+CSEL outcome depends on x1==x2; cannot collapse to MOV"
+        );
+        // Self-equivalence: a sequence equals itself.
+        assert_eq!(
+            check_equivalence_with_config(&cmp_csel, &cmp_csel, &cfg),
+            EquivalenceResult::Equivalent
+        );
+    }
+
+    #[test]
+    fn csinc_wraps_on_max_input() {
+        // CSINC x0, x1, x2, EQ with EQ=false sets x0 = x2 + 1 (wrapping).
+        // Build a target with x2 forced to u64::MAX and EQ forced false;
+        // candidate `MOV x0, #0` matches by 2's-complement wraparound.
+        let target = vec![
+            // Force EQ false: CMP x1, x1+1 always sets Z=0 — easier path:
+            // pin x2 to u64::MAX via MOVN (which writes !((imm)<<shift)),
+            // and use MovN with imm=0 to get all-ones (0xFFFF_FFFF_FFFF_FFFF).
+            Instruction::MovN {
+                rd: Register::X2,
+                imm: 0,
+                shift: 0,
+            },
+            Instruction::Cmp {
+                rn: Register::X1,
+                rm: Operand::Immediate(1),
+            },
+            // After CMP x1, #1 the condition NE is data-dependent on x1.
+            // Use unconditional fall-through by picking CSINC with NV
+            // (always-false on AArch64, treated as `never`).
+            Instruction::Csinc {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Register::X2,
+                cond: crate::ir::types::Condition::NV,
+            },
+        ];
+        let candidate = vec![
+            Instruction::MovN {
+                rd: Register::X2,
+                imm: 0,
+                shift: 0,
+            },
+            Instruction::Cmp {
+                rn: Register::X1,
+                rm: Operand::Immediate(1),
+            },
+            Instruction::MovImm {
+                rd: Register::X0,
+                imm: 0,
+            },
+        ];
+        let cfg =
+            EquivalenceConfig::default().live_out(LiveOut::from_registers(vec![Register::X0]));
+        assert_eq!(
+            check_equivalence_with_config(&target, &candidate, &cfg),
+            EquivalenceResult::Equivalent,
+            "CSINC with rm = u64::MAX must wrap to 0"
+        );
+    }
+
+    #[test]
+    fn cmp_equivalent_to_subs_xzr_with_flags_live() {
+        // CMP x1, x2 and SUBS XZR, x1, x2 leave registers unchanged and
+        // write identical NZCV. With flags as live-out, SMT must prove
+        // equivalence — but only if the pre-SMT guard does not reject
+        // them as having "different flag-writers" by structural equality.
+        let seq_cmp = vec![Instruction::Cmp {
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        }];
+        let seq_subs = vec![Instruction::Subs {
+            rd: Register::XZR,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        }];
+        let cfg = EquivalenceConfig::default().with_flags(true);
+        assert_eq!(
+            check_equivalence_with_config(&seq_cmp, &seq_subs, &cfg),
+            EquivalenceResult::Equivalent
+        );
+    }
+
+    #[test]
+    fn issue_92_regression_mismatched_upstream_flags() {
+        // Issue #92: two sequences with structurally identical flag-writers
+        // but feeding them different upstream values produce different NZCV.
+        // With flags live, SMT must reject the rewrite. The fast-path will
+        // also catch it on random inputs (the constants -7 != +7).
+        let target = vec![
+            Instruction::MovImm {
+                rd: Register::X1,
+                imm: 0,
+            },
+            Instruction::Cmp {
+                rn: Register::X1,
+                rm: Operand::Immediate(0),
+            },
+            Instruction::MovImm {
+                rd: Register::X0,
+                imm: 7,
+            },
+        ];
+        let candidate = vec![
+            Instruction::MovImm {
+                rd: Register::X1,
+                imm: 5,
+            },
+            Instruction::Cmp {
+                rn: Register::X1,
+                rm: Operand::Immediate(0),
+            },
+            Instruction::MovImm {
+                rd: Register::X0,
+                imm: 7,
+            },
+        ];
+        let cfg = EquivalenceConfig::default()
+            .live_out(LiveOut::from_registers(vec![Register::X0]))
+            .with_flags(true);
+        assert_ne!(
+            check_equivalence_with_config(&target, &candidate, &cfg),
+            EquivalenceResult::Equivalent
         );
     }
 
@@ -1330,16 +1539,14 @@ mod tests {
         );
     }
 
-    /// Soundness regression for the strengthened flag-writer guard:
     /// `ADD x0, x1, #1; CMP x2, #0` (writes flags from `CMP x2, #0`) vs
     /// `ADDS x0, x1, #1` (writes flags from `ADDS x0, x1, #1`). Both
-    /// sequences write X0 to x1+1 and both have a flag-writer, so the SMT
-    /// register check would pass and the old "any writer present" guard
-    /// would also pass — but the post-sequence NZCV differs. The
-    /// strengthened guard rejects on structural flag-writer-sequence
-    /// inequality.
+    /// sequences write X0 to x1+1 and both have a flag-writer, so the
+    /// pre-SMT guard now lets SMT settle it. With flags live-out the
+    /// solver sees the NZCV divergence; with flags dead the rewrite is
+    /// genuinely sound (registers alone match).
     #[test]
-    fn test_swapped_flag_writer_rewrite_rejected() {
+    fn test_swapped_flag_writer_rewrite_rejected_when_flags_live() {
         let target = vec![
             Instruction::Add {
                 rd: Register::X0,
@@ -1356,12 +1563,16 @@ mod tests {
             rn: Register::X1,
             rm: Operand::Immediate(1),
         }];
-        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
-        assert_eq!(
-            check_equivalence_with_config(&target, &candidate, &config),
-            EquivalenceResult::NotEquivalent,
-            "Replacing one flag-writer with a different flag-writer changes NZCV"
+        let cfg_flags_live =
+            EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]))
+                .with_flags(true);
+        assert_ne!(
+            check_equivalence_with_config(&target, &candidate, &cfg_flags_live),
+            EquivalenceResult::Equivalent,
+            "When NZCV is live, the two flag-writers produce different flags"
         );
+        // Same with the no-config entry point, which now includes flags in
+        // the unmasked full-state comparison.
         assert_eq!(
             check_equivalence(&target, &candidate),
             EquivalenceResult::NotEquivalent

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -810,12 +810,14 @@ mod tests {
     #[test]
     fn csinc_wraps_on_max_input() {
         // CSINC x0, x1, x2, EQ with EQ=false sets x0 = x2 + 1 (wrapping).
-        // Build a target with x2 forced to u64::MAX and EQ forced false;
-        // candidate `MOV x0, #0` matches by 2's-complement wraparound.
+        // Pin x1 = 0 and x2 = u64::MAX, then CMP x1, #1 leaves Z=0 so the
+        // EQ predicate is false in both interpreters. CSINC's false branch
+        // then writes x2 + 1 = 0 (wrap), matching the MovImm #0 candidate.
         let target = vec![
-            // Force EQ false: CMP x1, x1+1 always sets Z=0 — easier path:
-            // pin x2 to u64::MAX via MOVN (which writes !((imm)<<shift)),
-            // and use MovN with imm=0 to get all-ones (0xFFFF_FFFF_FFFF_FFFF).
+            Instruction::MovImm {
+                rd: Register::X1,
+                imm: 0,
+            },
             Instruction::MovN {
                 rd: Register::X2,
                 imm: 0,
@@ -825,17 +827,18 @@ mod tests {
                 rn: Register::X1,
                 rm: Operand::Immediate(1),
             },
-            // After CMP x1, #1 the condition NE is data-dependent on x1.
-            // Use unconditional fall-through by picking CSINC with NV
-            // (always-false on AArch64, treated as `never`).
             Instruction::Csinc {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Register::X2,
-                cond: crate::ir::types::Condition::NV,
+                cond: crate::ir::types::Condition::EQ,
             },
         ];
         let candidate = vec![
+            Instruction::MovImm {
+                rd: Register::X1,
+                imm: 0,
+            },
             Instruction::MovN {
                 rd: Register::X2,
                 imm: 0,

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -763,6 +763,12 @@ mod tests {
                 rm: Operand::Register(Register::X4),
             },
         ];
+        // Deliberately omit `.with_flags(true)`: the two forms produce
+        // intentionally different post-window NZCV (the candidate has two
+        // CMPs vs the target's one CMP + CCMP), so the proof only holds
+        // when X3 is the sole observable. Search callers that need flag
+        // preservation set `with_flags(true)` themselves — see
+        // `mcmc.rs` / `synthesis.rs`.
         let cfg =
             EquivalenceConfig::default().live_out(LiveOut::from_registers(vec![Register::X3]));
         assert_eq!(

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -282,7 +282,6 @@ pub fn compute_flags_logical(result: &BV) -> Nzcv {
 pub fn condition_to_smt(cond: crate::ir::types::Condition, n: &BV, z: &BV, c: &BV, v: &BV) -> BV {
     use crate::ir::types::Condition;
     let one = bv_one();
-    let zero = bv_zero();
     let not_n = n.bvxor(&one);
     let not_z = z.bvxor(&one);
     let not_c = c.bvxor(&one);

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -5,20 +5,9 @@
 use crate::ir::{Instruction, Operand, Register};
 use crate::semantics::live_out::LiveOutRegisters;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use z3::ast::BV;
 use z3::{Params, Solver};
-
-/// Monotonic counter used to generate unique names for fresh symbolic values
-/// produced when modelling instructions whose result depends on state we do
-/// not symbolically track (currently: the CSEL family, which reads NZCV).
-static FRESH_BV_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-fn fresh_bv(prefix: &str) -> BV {
-    let id = FRESH_BV_COUNTER.fetch_add(1, Ordering::Relaxed);
-    BV::new_const(format!("{}_{}", prefix, id), 64)
-}
 
 /// Reverse the byte order of a 64-bit BV by concatenating its 8 byte slices
 /// with byte 0 placed in the most-significant position.
@@ -133,6 +122,11 @@ pub fn create_solver_with_config(cfg: &SolverConfig) -> Solver {
 pub struct MachineState {
     /// Register values as 64-bit bitvectors
     pub registers: HashMap<Register, BV>,
+    /// NZCV condition flags as 1-bit bitvectors
+    pub n: BV,
+    pub z: BV,
+    pub c: BV,
+    pub v: BV,
 }
 
 impl MachineState {
@@ -154,7 +148,18 @@ impl MachineState {
         // SP is also symbolic
         registers.insert(Register::SP, BV::new_const(format!("{}_sp", prefix), 64));
 
-        MachineState { registers }
+        let n = BV::new_const(format!("{}_n", prefix), 1);
+        let z = BV::new_const(format!("{}_z", prefix), 1);
+        let c = BV::new_const(format!("{}_c", prefix), 1);
+        let v = BV::new_const(format!("{}_v", prefix), 1);
+
+        MachineState {
+            registers,
+            n,
+            z,
+            c,
+            v,
+        }
     }
 
     /// Get the value of a register
@@ -168,6 +173,19 @@ impl MachineState {
         if reg != Register::XZR {
             self.registers.insert(reg, value);
         }
+    }
+
+    /// Read the four NZCV flag bitvectors.
+    pub fn get_flags(&self) -> (&BV, &BV, &BV, &BV) {
+        (&self.n, &self.z, &self.c, &self.v)
+    }
+
+    /// Replace all four NZCV flag bitvectors at once.
+    pub fn set_flags(&mut self, n: BV, z: BV, c: BV, v: BV) {
+        self.n = n;
+        self.z = z;
+        self.c = c;
+        self.v = v;
     }
 
     /// Evaluate an operand to get its value
@@ -186,6 +204,110 @@ impl MachineState {
                 }
             }
         }
+    }
+}
+
+/// Symbolic NZCV flag tuple `(N, Z, C, V)` produced by flag-computing helpers.
+type Nzcv = (BV, BV, BV, BV);
+
+fn bv_one() -> BV {
+    BV::from_u64(1, 1)
+}
+
+fn bv_zero() -> BV {
+    BV::from_u64(0, 1)
+}
+
+/// Compute symbolic NZCV for the subtraction `lhs - rhs`. Mirrors
+/// `ConditionFlags::from_sub` in `state.rs` bit-for-bit.
+pub fn compute_flags_sub(lhs: &BV, rhs: &BV) -> Nzcv {
+    let result = lhs.bvsub(rhs);
+    let zero64 = BV::from_u64(0, 64);
+    let n = result.extract(63, 63);
+    let z = result.eq(&zero64).ite(&bv_one(), &bv_zero());
+    let c = lhs.bvuge(rhs).ite(&bv_one(), &bv_zero());
+    // Signed overflow on subtraction: (lhs and rhs differ in sign) AND
+    // (lhs and result differ in sign).
+    let lhs_sign = lhs.extract(63, 63);
+    let rhs_sign = rhs.extract(63, 63);
+    let res_sign = result.extract(63, 63);
+    let v = lhs_sign.bvxor(&rhs_sign).bvand(&lhs_sign.bvxor(&res_sign));
+    (n, z, c, v)
+}
+
+/// Compute symbolic NZCV for the addition `lhs + rhs`. Mirrors
+/// `ConditionFlags::from_add` in `state.rs`.
+pub fn compute_flags_add(lhs: &BV, rhs: &BV) -> Nzcv {
+    let result = lhs.bvadd(rhs);
+    let zero64 = BV::from_u64(0, 64);
+    let n = result.extract(63, 63);
+    let z = result.eq(&zero64).ite(&bv_one(), &bv_zero());
+    // Carry on add: result < lhs (unsigned).
+    let c = result.bvult(lhs).ite(&bv_one(), &bv_zero());
+    // Signed overflow on add: (lhs and rhs share sign) AND (lhs and result
+    // differ in sign).
+    let lhs_sign = lhs.extract(63, 63);
+    let rhs_sign = rhs.extract(63, 63);
+    let res_sign = result.extract(63, 63);
+    let one_bit = bv_one();
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&one_bit); // 1 when signs match
+    let signs_flip = lhs_sign.bvxor(&res_sign); // 1 when lhs and result differ
+    let v = signs_match.bvand(&signs_flip);
+    (n, z, c, v)
+}
+
+/// Convert a 4-bit NZCV literal to four 1-bit BV constants.
+/// Layout per ARM ARM: bit3 = N, bit2 = Z, bit1 = C, bit0 = V.
+pub fn nzcv_to_bvs(byte: u8) -> Nzcv {
+    (
+        BV::from_u64(((byte >> 3) & 1) as u64, 1),
+        BV::from_u64(((byte >> 2) & 1) as u64, 1),
+        BV::from_u64(((byte >> 1) & 1) as u64, 1),
+        BV::from_u64((byte & 1) as u64, 1),
+    )
+}
+
+/// Compute symbolic NZCV for a logical (AND/ORR/EOR/TST) result. C and V are
+/// always cleared per the AArch64 ARM.
+pub fn compute_flags_logical(result: &BV) -> Nzcv {
+    let zero64 = BV::from_u64(0, 64);
+    let n = result.extract(63, 63);
+    let z = result.eq(&zero64).ite(&bv_one(), &bv_zero());
+    (n, z, bv_zero(), bv_zero())
+}
+
+/// Translate a `Condition` code into a 1-bit symbolic predicate over the
+/// supplied NZCV flag BVs. Mirrors `ConditionFlags::evaluate` in `state.rs`
+/// and `evaluate_condition` in `concrete.rs` for all 16 condition codes.
+pub fn condition_to_smt(cond: crate::ir::types::Condition, n: &BV, z: &BV, c: &BV, v: &BV) -> BV {
+    use crate::ir::types::Condition;
+    let one = bv_one();
+    let zero = bv_zero();
+    let not_n = n.bvxor(&one);
+    let not_z = z.bvxor(&one);
+    let not_c = c.bvxor(&one);
+    let not_v = v.bvxor(&one);
+    let n_eq_v = n.bvxor(v).bvxor(&one); // 1 iff N == V
+
+    match cond {
+        Condition::EQ => z.clone(),
+        Condition::NE => not_z,
+        Condition::CS => c.clone(),
+        Condition::CC => not_c,
+        Condition::MI => n.clone(),
+        Condition::PL => not_n,
+        Condition::VS => v.clone(),
+        Condition::VC => not_v,
+        Condition::HI => c.bvand(&not_z),
+        Condition::LS => not_c.bvor(z),
+        Condition::GE => n_eq_v.clone(),
+        Condition::LT => n_eq_v.bvxor(&one), // N != V
+        Condition::GT => not_z.bvand(&n_eq_v),
+        Condition::LE => z.bvor(&n_eq_v.bvxor(&one)),
+        Condition::AL => one,
+        // NV is reserved in AArch64 and treated as "never" by
+        // `ConditionFlags::evaluate`; mirror that here.
+        Condition::NV => zero,
     }
 }
 
@@ -309,22 +431,86 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let prod = a.bvmul(&b);
             state.set_register(*rd, prod.extract(127, 64));
         }
-        // Comparison instructions set flags but don't modify registers
-        // For now, we don't model flags in SMT - these are no-ops for register state
-        Instruction::Cmp { .. } | Instruction::Cmn { .. } | Instruction::Tst { .. } => {
-            // These only affect flags, which we don't model symbolically yet
-            // No register state changes
+        // Comparison instructions set flags and don't modify registers.
+        Instruction::Cmp { rn, rm } => {
+            let lhs = state.get_register(*rn).clone();
+            let rhs = state.eval_operand(rm);
+            let (n, z, c, v) = compute_flags_sub(&lhs, &rhs);
+            state.set_flags(n, z, c, v);
         }
-        // CSEL family depends on NZCV, which we don't model symbolically.
-        // Emit a fresh, unconstrained BV per use site so the solver can never
-        // prove equivalence across the conditional select. Sound (cannot
-        // wrongly accept) but uninformative (cannot prove valid rewrites that
-        // span CSEL chains). Flag-aware modelling is deferred.
-        Instruction::Csel { rd, .. }
-        | Instruction::Csinc { rd, .. }
-        | Instruction::Csinv { rd, .. }
-        | Instruction::Csneg { rd, .. } => {
-            state.set_register(*rd, fresh_bv("csel_result"));
+        Instruction::Cmn { rn, rm } => {
+            let lhs = state.get_register(*rn).clone();
+            let rhs = state.eval_operand(rm);
+            let (n, z, c, v) = compute_flags_add(&lhs, &rhs);
+            state.set_flags(n, z, c, v);
+        }
+        Instruction::Tst { rn, rm } => {
+            let lhs = state.get_register(*rn).clone();
+            let rhs = state.eval_operand(rm);
+            let result = lhs.bvand(&rhs);
+            let (n, z, c, v) = compute_flags_logical(&result);
+            state.set_flags(n, z, c, v);
+        }
+        // CCMP / CCMN: ITE between freshly-computed sub/add NZCV (true branch)
+        // and the unpacked 4-bit immediate (false branch), gated on the
+        // current symbolic NZCV-derived predicate.
+        Instruction::Ccmp { rn, rm, nzcv, cond } => {
+            let lhs = state.get_register(*rn).clone();
+            let rhs = state.eval_operand(rm);
+            let (n_t, z_t, c_t, v_t) = compute_flags_sub(&lhs, &rhs);
+            let pred =
+                condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
+            let (n_f, z_f, c_f, v_f) = nzcv_to_bvs(*nzcv);
+            state.set_flags(
+                pred.ite(&n_t, &n_f),
+                pred.ite(&z_t, &z_f),
+                pred.ite(&c_t, &c_f),
+                pred.ite(&v_t, &v_f),
+            );
+        }
+        Instruction::Ccmn { rn, rm, nzcv, cond } => {
+            let lhs = state.get_register(*rn).clone();
+            let rhs = state.eval_operand(rm);
+            let (n_t, z_t, c_t, v_t) = compute_flags_add(&lhs, &rhs);
+            let pred =
+                condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
+            let (n_f, z_f, c_f, v_f) = nzcv_to_bvs(*nzcv);
+            state.set_flags(
+                pred.ite(&n_t, &n_f),
+                pred.ite(&z_t, &z_f),
+                pred.ite(&c_t, &c_f),
+                pred.ite(&v_t, &v_f),
+            );
+        }
+        // CSEL family: rd = cond ? rn : f(rm), encoded as an SMT ITE over the
+        // 1-bit predicate produced by condition_to_smt.
+        Instruction::Csel { rd, rn, rm, cond } => {
+            let rn_v = state.get_register(*rn).clone();
+            let rm_v = state.get_register(*rm).clone();
+            let pred =
+                condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
+            state.set_register(*rd, pred.ite(&rn_v, &rm_v));
+        }
+        Instruction::Csinc { rd, rn, rm, cond } => {
+            let rn_v = state.get_register(*rn).clone();
+            let rm_plus_one = state.get_register(*rm).bvadd(&BV::from_u64(1, 64));
+            let pred =
+                condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
+            state.set_register(*rd, pred.ite(&rn_v, &rm_plus_one));
+        }
+        Instruction::Csinv { rd, rn, rm, cond } => {
+            let rn_v = state.get_register(*rn).clone();
+            let rm_not = state.get_register(*rm).bvnot();
+            let pred =
+                condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
+            state.set_register(*rd, pred.ite(&rn_v, &rm_not));
+        }
+        Instruction::Csneg { rd, rn, rm, cond } => {
+            let rn_v = state.get_register(*rn).clone();
+            let rm_neg = state.get_register(*rm).bvneg();
+            let pred =
+                condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
+            state.set_register(*rd, pred.ite(&rn_v, &rm_neg));
         }
         Instruction::Mvn { rd, rm } => {
             let value = state.get_register(*rm).bvnot();
@@ -334,12 +520,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let value = state.get_register(*rm).bvneg();
             state.set_register(*rd, value);
         }
-        // NEGS writes rd just like NEG; flag side-effects are not modelled
-        // symbolically (matches CMP/CMN/TST). Soundness barrier: callers must
-        // refuse to drop flag-writers when flags are live-out.
+        // NEGS = SUBS rd, XZR, rm — write rd and the resulting NZCV.
         Instruction::Negs { rd, rm } => {
-            let value = state.get_register(*rm).bvneg();
+            let rhs = state.get_register(*rm).clone();
+            let zero = BV::from_u64(0, 64);
+            let value = zero.bvsub(&rhs);
+            let (n, z, c, v) = compute_flags_sub(&zero, &rhs);
             state.set_register(*rd, value);
+            state.set_flags(n, z, c, v);
         }
         Instruction::MovN { rd, imm, shift } => {
             let value = !((*imm as u64) << (*shift as u32));
@@ -359,15 +547,21 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let result = prev.bvand(&mask).bvor(&new_chunk);
             state.set_register(*rd, result);
         }
-        // BIC: rd = rn & !rm. BICS shares the SMT body — the flag effect is
-        // not modelled (matches CMP/CMN/TST and ADDS/SUBS/ANDS). The
-        // soundness barrier lives in `equivalence::flag_writers_diverge`,
-        // which refuses any rewrite that drops a flag-writer the target had.
-        Instruction::Bic { rd, rn, rm } | Instruction::Bics { rd, rn, rm } => {
+        // BIC: rd = rn & !rm (no flag side-effect).
+        Instruction::Bic { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.eval_operand(rm);
             let result = lhs.bvand(rhs.bvnot());
             state.set_register(*rd, result);
+        }
+        // BICS: same data path as BIC plus logical-NZCV computation.
+        Instruction::Bics { rd, rn, rm } => {
+            let lhs = state.get_register(*rn).clone();
+            let rhs = state.eval_operand(rm);
+            let result = lhs.bvand(rhs.bvnot());
+            let (n, z, c, v) = compute_flags_logical(&result);
+            state.set_register(*rd, result);
+            state.set_flags(n, z, c, v);
         }
         Instruction::Orn { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
@@ -381,29 +575,44 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let result = lhs.bvxor(rhs.bvnot());
             state.set_register(*rd, result);
         }
-        // Flag-setting arith/logical: rd is modelled symbolically (same as
-        // ADD/SUB/AND); flag side-effects are NOT modelled (matches CMP/CMN/TST).
-        // Soundness barrier: callers must refuse to drop flag-writers when
-        // flags are live-out (see `flags_live_out` and `modifies_flags`).
+        // Flag-setting arithmetic/logical instructions: write rd AND set the
+        // four NZCV flag BVs via the appropriate compute_flags helper.
         Instruction::Adds { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.eval_operand(rm);
+            let (n, z, c, v) = compute_flags_add(&lhs, &rhs);
             state.set_register(*rd, lhs.bvadd(&rhs));
+            state.set_flags(n, z, c, v);
         }
         Instruction::Subs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.eval_operand(rm);
+            let (n, z, c, v) = compute_flags_sub(&lhs, &rhs);
             state.set_register(*rd, lhs.bvsub(&rhs));
+            state.set_flags(n, z, c, v);
         }
         Instruction::Ands { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.eval_operand(rm);
-            state.set_register(*rd, lhs.bvand(&rhs));
+            let result = lhs.bvand(&rhs);
+            let (n, z, c, v) = compute_flags_logical(&result);
+            state.set_register(*rd, result);
+            state.set_flags(n, z, c, v);
         }
-        // CSET / CSETM: depend on NZCV, which we don't model symbolically.
-        // Emit a fresh symbolic value per use (matches CSEL family policy).
-        Instruction::Cset { rd, .. } | Instruction::Csetm { rd, .. } => {
-            state.set_register(*rd, fresh_bv("cset_result"));
+        // CSET / CSETM: rd = cond ? 1 : 0 (or all-ones for CSETM).
+        Instruction::Cset { rd, cond } => {
+            let pred =
+                condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
+            let one64 = BV::from_u64(1, 64);
+            let zero64 = BV::from_u64(0, 64);
+            state.set_register(*rd, pred.ite(&one64, &zero64));
+        }
+        Instruction::Csetm { rd, cond } => {
+            let pred =
+                condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
+            let ones = BV::from_u64(u64::MAX, 64);
+            let zero64 = BV::from_u64(0, 64);
+            state.set_register(*rd, pred.ite(&ones, &zero64));
         }
         // ROR: composed via bv_ror_64 (see helper at top of file for the
         // edge-case discussion at n == 0).
@@ -488,7 +697,17 @@ pub fn apply_sequence(mut state: MachineState, instructions: &[Instruction]) -> 
     state
 }
 
-/// Check if two machine states are not equal (for any register values)
+fn flags_not_equal(state1: &MachineState, state2: &MachineState) -> z3::ast::Bool {
+    z3::ast::Bool::or(&[
+        &state1.n.eq(&state2.n).not(),
+        &state1.z.eq(&state2.z).not(),
+        &state1.c.eq(&state2.c).not(),
+        &state1.v.eq(&state2.v).not(),
+    ])
+}
+
+/// Check if two machine states are not equal (full state: every register plus
+/// the four NZCV flags). Used by the unmasked `check_equivalence` entry point.
 pub fn states_not_equal(state1: &MachineState, state2: &MachineState) -> z3::ast::Bool {
     let mut not_equal = z3::ast::Bool::from_bool(false);
 
@@ -508,14 +727,17 @@ pub fn states_not_equal(state1: &MachineState, state2: &MachineState) -> z3::ast
     let sp_not_equal = sp1.eq(sp2).not();
     not_equal = z3::ast::Bool::or(&[&not_equal, &sp_not_equal]);
 
-    not_equal
+    // And the NZCV flag bits.
+    z3::ast::Bool::or(&[&not_equal, &flags_not_equal(state1, state2)])
 }
 
-/// Check if two machine states are not equal for the specified live-out registers
+/// Check if two machine states are not equal for the specified live-out
+/// registers, optionally including the NZCV flag bits.
 pub fn states_not_equal_for_live_out(
     state1: &MachineState,
     state2: &MachineState,
     live_out: &LiveOutRegisters,
+    flags_live: bool,
 ) -> z3::ast::Bool {
     let mut not_equal = z3::ast::Bool::from_bool(false);
 
@@ -524,6 +746,10 @@ pub fn states_not_equal_for_live_out(
         let val2 = state2.get_register(*reg);
         let reg_not_equal = val1.eq(val2).not();
         not_equal = z3::ast::Bool::or(&[&not_equal, &reg_not_equal]);
+    }
+
+    if flags_live {
+        not_equal = z3::ast::Bool::or(&[&not_equal, &flags_not_equal(state1, state2)]);
     }
 
     not_equal
@@ -855,5 +1081,505 @@ mod tests {
             SatResult::Unsat,
             "CLZ; MOV #63; SUB pattern must produce floor_log2(x1) for nonzero x1"
         );
+    }
+
+    #[test]
+    fn test_symbolic_state_has_independent_nzcv_flags() {
+        // After new_symbolic, each NZCV flag is its own 1-bit symbolic BV.
+        // Two independent states must be free to disagree on every flag bit
+        // simultaneously — i.e. the conjunction (n1!=n2 ∧ z1!=z2 ∧ c1!=c2 ∧ v1!=v2)
+        // must be satisfiable. This proves the four flags are distinct
+        // symbolic constants, not aliased to the same name or to register BVs.
+        let s1 = MachineState::new_symbolic("a");
+        let s2 = MachineState::new_symbolic("b");
+        let (n1, z1, c1, v1) = s1.get_flags();
+        let (n2, z2, c2, v2) = s2.get_flags();
+
+        let solver = Solver::new();
+        solver.assert(&n1.eq(n2).not());
+        solver.assert(&z1.eq(z2).not());
+        solver.assert(&c1.eq(c2).not());
+        solver.assert(&v1.eq(v2).not());
+        assert_eq!(solver.check(), SatResult::Sat);
+    }
+
+    fn assert_state_flags_equal_bvs(state: &MachineState, expected: &Nzcv, ctx: &str) {
+        let solver = Solver::new();
+        let (n_e, z_e, c_e, v_e) = expected;
+        let neq = z3::ast::Bool::or(&[
+            &state.n.eq(n_e).not(),
+            &state.z.eq(z_e).not(),
+            &state.c.eq(c_e).not(),
+            &state.v.eq(v_e).not(),
+        ]);
+        solver.assert(&neq);
+        assert_eq!(solver.check(), SatResult::Unsat, "{}", ctx);
+    }
+
+    #[test]
+    fn test_cmp_sets_symbolic_flags() {
+        // Applying CMP X0, X1 must leave the four flag BVs in agreement with
+        // compute_flags_sub(X0, X1) — a property check across all symbolic
+        // input values.
+        let state = MachineState::new_symbolic("pre");
+        let x0 = state.get_register(Register::X0).clone();
+        let x1 = state.get_register(Register::X1).clone();
+        let expected = compute_flags_sub(&x0, &x1);
+        let after = apply_instruction(
+            state,
+            &Instruction::Cmp {
+                rn: Register::X0,
+                rm: Operand::Register(Register::X1),
+            },
+        );
+        assert_state_flags_equal_bvs(&after, &expected, "CMP x0, x1");
+    }
+
+    fn force_flags(state: &mut MachineState, n: u64, z: u64, c: u64, v: u64) {
+        state.set_flags(
+            BV::from_u64(n, 1),
+            BV::from_u64(z, 1),
+            BV::from_u64(c, 1),
+            BV::from_u64(v, 1),
+        );
+    }
+
+    fn assert_register_eq(state: &MachineState, reg: Register, expected: &BV, ctx: &str) {
+        let solver = Solver::new();
+        solver.assert(&state.get_register(reg).eq(expected).not());
+        assert_eq!(solver.check(), SatResult::Unsat, "{}", ctx);
+    }
+
+    #[test]
+    fn test_states_not_equal_detects_flag_divergence() {
+        // Build two symbolic states whose registers are pin-locked equal
+        // and whose flags are forced to differ. states_not_equal must be
+        // satisfiable in this configuration — proving that flag inequality
+        // is part of full-state equivalence.
+        let mut s1 = MachineState::new_symbolic("a");
+        let mut s2 = MachineState::new_symbolic("b");
+        // Force each register and SP to the same concrete value across
+        // both states so register equality holds trivially.
+        for i in 0..=30 {
+            if let Some(reg) = Register::from_index(i) {
+                let v = BV::from_u64(0, 64);
+                s1.set_register(reg, v.clone());
+                s2.set_register(reg, v);
+            }
+        }
+        s1.set_register(Register::SP, BV::from_u64(0, 64));
+        s2.set_register(Register::SP, BV::from_u64(0, 64));
+        // Force flags: s1 has Z=1, s2 has Z=0. Registers are identical.
+        force_flags(&mut s1, 0, 1, 0, 0);
+        force_flags(&mut s2, 0, 0, 0, 0);
+
+        let solver = Solver::new();
+        solver.assert(&states_not_equal(&s1, &s2));
+        assert_eq!(solver.check(), SatResult::Sat);
+    }
+
+    #[test]
+    fn test_csel_family_uses_symbolic_flag_ite() {
+        // For each CS-family variant, pin the NZCV flags concretely so that
+        // EQ is true (Z=1) or false (Z=0) and assert rd takes the spec-defined
+        // branch in each case.
+        let rn_val = BV::from_u64(7, 64);
+        let rm_val = BV::from_u64(2, 64);
+
+        let setup = |cond_true: bool| {
+            let mut s = MachineState::new_symbolic("pre");
+            s.set_register(Register::X1, rn_val.clone());
+            s.set_register(Register::X2, rm_val.clone());
+            force_flags(&mut s, 0, cond_true as u64, 0, 0);
+            s
+        };
+
+        // CSEL: x0 = z==1 ? x1 : x2
+        for &cond_true in &[true, false] {
+            let s = setup(cond_true);
+            let after = apply_instruction(
+                s,
+                &Instruction::Csel {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Register::X2,
+                    cond: crate::ir::types::Condition::EQ,
+                },
+            );
+            let expected = if cond_true { &rn_val } else { &rm_val };
+            assert_register_eq(&after, Register::X0, expected, "CSEL EQ branch");
+        }
+
+        // CSINC: x0 = z==1 ? x1 : (x2 + 1)
+        let s = setup(false);
+        let after = apply_instruction(
+            s,
+            &Instruction::Csinc {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Register::X2,
+                cond: crate::ir::types::Condition::EQ,
+            },
+        );
+        assert_register_eq(
+            &after,
+            Register::X0,
+            &BV::from_u64(3, 64),
+            "CSINC EQ-false branch is rm+1",
+        );
+
+        // CSINV: x0 = z==1 ? x1 : ~x2
+        let s = setup(false);
+        let after = apply_instruction(
+            s,
+            &Instruction::Csinv {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Register::X2,
+                cond: crate::ir::types::Condition::EQ,
+            },
+        );
+        assert_register_eq(
+            &after,
+            Register::X0,
+            &BV::from_u64(!2u64, 64),
+            "CSINV EQ-false branch is ~rm",
+        );
+
+        // CSNEG: x0 = z==1 ? x1 : -x2
+        let s = setup(false);
+        let after = apply_instruction(
+            s,
+            &Instruction::Csneg {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Register::X2,
+                cond: crate::ir::types::Condition::EQ,
+            },
+        );
+        assert_register_eq(
+            &after,
+            Register::X0,
+            &BV::from_u64((-2i64) as u64, 64),
+            "CSNEG EQ-false branch is -rm",
+        );
+
+        // CSET: x0 = z==1 ? 1 : 0
+        for &cond_true in &[true, false] {
+            let s = setup(cond_true);
+            let after = apply_instruction(
+                s,
+                &Instruction::Cset {
+                    rd: Register::X0,
+                    cond: crate::ir::types::Condition::EQ,
+                },
+            );
+            let expected = BV::from_u64(cond_true as u64, 64);
+            assert_register_eq(&after, Register::X0, &expected, "CSET EQ");
+        }
+
+        // CSETM: x0 = z==1 ? -1 : 0
+        for &cond_true in &[true, false] {
+            let s = setup(cond_true);
+            let after = apply_instruction(
+                s,
+                &Instruction::Csetm {
+                    rd: Register::X0,
+                    cond: crate::ir::types::Condition::EQ,
+                },
+            );
+            let expected = BV::from_u64(if cond_true { u64::MAX } else { 0 }, 64);
+            assert_register_eq(&after, Register::X0, &expected, "CSETM EQ");
+        }
+    }
+
+    #[test]
+    fn test_ccmp_true_branch_matches_compute_flags_sub() {
+        // Force the predicate to true (Z=1, cond=EQ) so the true branch
+        // applies: state flags must equal compute_flags_sub(x1, x2).
+        let mut state = MachineState::new_symbolic("pre");
+        force_flags(&mut state, 0, 1, 0, 0);
+        let x1 = state.get_register(Register::X1).clone();
+        let x2 = state.get_register(Register::X2).clone();
+        let expected = compute_flags_sub(&x1, &x2);
+        let after = apply_instruction(
+            state,
+            &Instruction::Ccmp {
+                rn: Register::X1,
+                rm: Operand::Register(Register::X2),
+                nzcv: 0b1010,
+                cond: crate::ir::types::Condition::EQ,
+            },
+        );
+        assert_state_flags_equal_bvs(&after, &expected, "CCMP EQ-true matches CMP");
+    }
+
+    #[test]
+    fn test_ccmp_false_branch_uses_nzcv_literal_smt() {
+        // Force the predicate to false (Z=0, cond=EQ) so the false branch
+        // applies: state flags must equal the 4-bit nzcv literal.
+        let mut state = MachineState::new_symbolic("pre");
+        force_flags(&mut state, 0, 0, 0, 0);
+        let expected = nzcv_to_bvs(0b1010);
+        let after = apply_instruction(
+            state,
+            &Instruction::Ccmp {
+                rn: Register::X1,
+                rm: Operand::Register(Register::X2),
+                nzcv: 0b1010,
+                cond: crate::ir::types::Condition::EQ,
+            },
+        );
+        assert_state_flags_equal_bvs(&after, &expected, "CCMP EQ-false uses nzcv literal");
+    }
+
+    #[test]
+    fn test_ccmn_true_branch_matches_compute_flags_add() {
+        let mut state = MachineState::new_symbolic("pre");
+        force_flags(&mut state, 0, 1, 0, 0);
+        let x1 = state.get_register(Register::X1).clone();
+        let x2 = state.get_register(Register::X2).clone();
+        let expected = compute_flags_add(&x1, &x2);
+        let after = apply_instruction(
+            state,
+            &Instruction::Ccmn {
+                rn: Register::X1,
+                rm: Operand::Register(Register::X2),
+                nzcv: 0,
+                cond: crate::ir::types::Condition::EQ,
+            },
+        );
+        assert_state_flags_equal_bvs(&after, &expected, "CCMN EQ-true matches CMN");
+    }
+
+    #[test]
+    fn test_flag_writers_set_symbolic_flags() {
+        // Apply each flag-writing instruction over symbolic x0/x1 and prove
+        // its final NZCV agrees with the helper that mirrors concrete
+        // semantics. Covers every variant of modifies_flags() except CMP
+        // (already verified in test_cmp_sets_symbolic_flags).
+        let pre = MachineState::new_symbolic("pre");
+        let x0 = pre.get_register(Register::X0).clone();
+        let x1 = pre.get_register(Register::X1).clone();
+        let rm_reg = Operand::Register(Register::X1);
+
+        let cases: Vec<(Instruction, Nzcv, &'static str)> = vec![
+            (
+                Instruction::Cmn {
+                    rn: Register::X0,
+                    rm: rm_reg.clone(),
+                },
+                compute_flags_add(&x0, &x1),
+                "CMN x0, x1",
+            ),
+            (
+                Instruction::Tst {
+                    rn: Register::X0,
+                    rm: rm_reg.clone(),
+                },
+                compute_flags_logical(&x0.bvand(&x1)),
+                "TST x0, x1",
+            ),
+            (
+                Instruction::Adds {
+                    rd: Register::X2,
+                    rn: Register::X0,
+                    rm: rm_reg.clone(),
+                },
+                compute_flags_add(&x0, &x1),
+                "ADDS x2, x0, x1",
+            ),
+            (
+                Instruction::Subs {
+                    rd: Register::X2,
+                    rn: Register::X0,
+                    rm: rm_reg.clone(),
+                },
+                compute_flags_sub(&x0, &x1),
+                "SUBS x2, x0, x1",
+            ),
+            (
+                Instruction::Ands {
+                    rd: Register::X2,
+                    rn: Register::X0,
+                    rm: rm_reg.clone(),
+                },
+                compute_flags_logical(&x0.bvand(&x1)),
+                "ANDS x2, x0, x1",
+            ),
+            (
+                Instruction::Negs {
+                    rd: Register::X2,
+                    rm: Register::X1,
+                },
+                compute_flags_sub(&BV::from_u64(0, 64), &x1),
+                "NEGS x2, x1",
+            ),
+            (
+                Instruction::Bics {
+                    rd: Register::X2,
+                    rn: Register::X0,
+                    rm: rm_reg.clone(),
+                },
+                compute_flags_logical(&x0.bvand(&x1.bvnot())),
+                "BICS x2, x0, x1",
+            ),
+        ];
+
+        for (instr, expected, ctx) in cases {
+            let after = apply_instruction(pre.clone(), &instr);
+            assert_state_flags_equal_bvs(&after, &expected, ctx);
+        }
+    }
+
+    fn assert_flags_match(
+        actual: Nzcv,
+        expected: crate::semantics::state::ConditionFlags,
+        ctx: &str,
+    ) {
+        let (n, z, c, v) = actual;
+        let solver = Solver::new();
+        let exp_n = BV::from_u64(expected.n as u64, 1);
+        let exp_z = BV::from_u64(expected.z as u64, 1);
+        let exp_c = BV::from_u64(expected.c as u64, 1);
+        let exp_v = BV::from_u64(expected.v as u64, 1);
+        let neq = z3::ast::Bool::or(&[
+            &n.eq(&exp_n).not(),
+            &z.eq(&exp_z).not(),
+            &c.eq(&exp_c).not(),
+            &v.eq(&exp_v).not(),
+        ]);
+        solver.assert(&neq);
+        assert_eq!(solver.check(), SatResult::Unsat, "{}", ctx);
+    }
+
+    #[test]
+    fn test_compute_flags_sub_matches_concrete() {
+        use crate::semantics::state::ConditionFlags;
+        let cases: &[(u64, u64)] = &[
+            (5, 3),                // positive non-zero result, C set, no overflow
+            (3, 3),                // zero result
+            (0, 1),                // borrow / N set
+            (i64::MIN as u64, 1),  // signed overflow
+            (i64::MAX as u64, !0), // signed overflow other direction
+        ];
+        for &(a, b) in cases {
+            let lhs = BV::from_u64(a, 64);
+            let rhs = BV::from_u64(b, 64);
+            let expected = ConditionFlags::from_sub(a, b, a.wrapping_sub(b));
+            assert_flags_match(
+                compute_flags_sub(&lhs, &rhs),
+                expected,
+                &format!("compute_flags_sub({a}, {b}) vs ConditionFlags::from_sub"),
+            );
+        }
+    }
+
+    #[test]
+    fn test_compute_flags_add_matches_concrete() {
+        use crate::semantics::state::ConditionFlags;
+        let cases: &[(u64, u64)] = &[
+            (5, 3),
+            (0, 0),
+            (u64::MAX, 1),        // unsigned wrap → C set
+            (i64::MAX as u64, 1), // signed overflow
+            (i64::MIN as u64, i64::MIN as u64),
+        ];
+        for &(a, b) in cases {
+            let lhs = BV::from_u64(a, 64);
+            let rhs = BV::from_u64(b, 64);
+            let expected = ConditionFlags::from_add(a, b, a.wrapping_add(b));
+            assert_flags_match(
+                compute_flags_add(&lhs, &rhs),
+                expected,
+                &format!("compute_flags_add({a}, {b}) vs ConditionFlags::from_add"),
+            );
+        }
+    }
+
+    #[test]
+    fn test_compute_flags_logical_matches_concrete() {
+        use crate::semantics::state::ConditionFlags;
+        let cases: &[u64] = &[0, 1, !0, 1 << 63, 0x5555_5555_5555_5555];
+        for &r in cases {
+            let result = BV::from_u64(r, 64);
+            let expected = ConditionFlags::from_logical(r);
+            assert_flags_match(
+                compute_flags_logical(&result),
+                expected,
+                &format!("compute_flags_logical({r}) vs ConditionFlags::from_logical"),
+            );
+        }
+    }
+
+    #[test]
+    fn test_condition_to_smt_matches_concrete() {
+        use crate::ir::types::Condition;
+        use crate::semantics::state::ConditionFlags;
+        let conds = [
+            Condition::EQ,
+            Condition::NE,
+            Condition::CS,
+            Condition::CC,
+            Condition::MI,
+            Condition::PL,
+            Condition::VS,
+            Condition::VC,
+            Condition::HI,
+            Condition::LS,
+            Condition::GE,
+            Condition::LT,
+            Condition::GT,
+            Condition::LE,
+            Condition::AL,
+            Condition::NV,
+        ];
+        for nb in 0..16u8 {
+            let n = (nb >> 3) & 1 == 1;
+            let z = (nb >> 2) & 1 == 1;
+            let c = (nb >> 1) & 1 == 1;
+            let v = nb & 1 == 1;
+            let flags = ConditionFlags { n, z, c, v };
+            let n_bv = BV::from_u64(n as u64, 1);
+            let z_bv = BV::from_u64(z as u64, 1);
+            let c_bv = BV::from_u64(c as u64, 1);
+            let v_bv = BV::from_u64(v as u64, 1);
+            for &cond in &conds {
+                let expected = flags.evaluate(cond);
+                let smt = condition_to_smt(cond, &n_bv, &z_bv, &c_bv, &v_bv);
+                let solver = Solver::new();
+                let expected_bv = BV::from_u64(expected as u64, 1);
+                solver.assert(&smt.eq(&expected_bv).not());
+                assert_eq!(
+                    solver.check(),
+                    SatResult::Unsat,
+                    "condition_to_smt({:?}) disagrees with concrete at flags={:?}",
+                    cond,
+                    flags,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_set_flags_round_trip() {
+        // set_flags writes; get_flags reads back the exact BVs.
+        let mut s = MachineState::new_symbolic("rt");
+        let n_in = BV::from_u64(1, 1);
+        let z_in = BV::from_u64(0, 1);
+        let c_in = BV::from_u64(1, 1);
+        let v_in = BV::from_u64(0, 1);
+        s.set_flags(n_in.clone(), z_in.clone(), c_in.clone(), v_in.clone());
+        let (n_out, z_out, c_out, v_out) = s.get_flags();
+
+        let solver = Solver::new();
+        let neq = z3::ast::Bool::or(&[
+            &n_out.eq(&n_in).not(),
+            &z_out.eq(&z_in).not(),
+            &c_out.eq(&c_in).not(),
+            &v_out.eq(&v_in).not(),
+        ]);
+        solver.assert(&neq);
+        assert_eq!(solver.check(), SatResult::Unsat);
     }
 }

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -304,10 +304,13 @@ pub fn condition_to_smt(cond: crate::ir::types::Condition, n: &BV, z: &BV, c: &B
         Condition::LT => n_eq_v.bvxor(&one), // N != V
         Condition::GT => not_z.bvand(&n_eq_v),
         Condition::LE => z.bvor(&n_eq_v.bvxor(&one)),
-        Condition::AL => one,
-        // NV is reserved in AArch64 and treated as "never" by
-        // `ConditionFlags::evaluate`; mirror that here.
-        Condition::NV => zero,
+        Condition::AL => one.clone(),
+        // NV (0b1111) is reserved but per ARM ARM still satisfies
+        // condition_holds = true — equivalent to AL. Concrete execution
+        // selects rn for `csel/csinc/csinv/csneg ..., nv`; SMT must agree
+        // or the equivalence checker can certify unsound rewrites for any
+        // CSEL-family instruction encoded with the NV suffix.
+        Condition::NV => one,
     }
 }
 
@@ -1176,6 +1179,38 @@ mod tests {
         let solver = Solver::new();
         solver.assert(&states_not_equal(&s1, &s2));
         assert_eq!(solver.check(), SatResult::Sat);
+    }
+
+    #[test]
+    fn test_csel_nv_evaluates_as_always_true() {
+        // Regression for the soundness gap caught by review on PR #128:
+        // `condition_holds(NV)` is true per ARM ARM (NV is the reserved
+        // encoding, not a real "never"). is_encodable_aarch64 permits NV
+        // for the CSEL family, so the SMT predicate must agree with the
+        // concrete interpreter (which already returns true for NV).
+        //
+        // `CSINC x0, x1, x2, NV` must select rn=x1 in both interpreters.
+        let mut state = MachineState::new_symbolic("pre");
+        // Force flags to a state where ConditionFlags::evaluate would
+        // disagree if NV were treated as false somewhere.
+        force_flags(&mut state, 0, 0, 0, 0);
+        state.set_register(Register::X1, BV::from_u64(7, 64));
+        state.set_register(Register::X2, BV::from_u64(2, 64));
+        let after = apply_instruction(
+            state,
+            &Instruction::Csinc {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Register::X2,
+                cond: crate::ir::types::Condition::NV,
+            },
+        );
+        assert_register_eq(
+            &after,
+            Register::X0,
+            &BV::from_u64(7, 64),
+            "CSINC NV must select rn (always-true predicate)",
+        );
     }
 
     #[test]

--- a/src/semantics/state.rs
+++ b/src/semantics/state.rs
@@ -81,7 +81,10 @@ impl ConditionFlags {
             Condition::GT => !self.z && (self.n == self.v), // Z==0 && N==V (signed >)
             Condition::LE => self.z || (self.n != self.v),  // Z==1 || N!=V (signed <=)
             Condition::AL => true,                          // Always
-            Condition::NV => false,                         // Never (reserved, treat as false)
+            // NV (0b1111) is reserved in AArch64; per ARM ARM the encoding
+            // still satisfies "condition holds = true" (it does NOT mean
+            // "never"). Concrete and SMT both treat it as always-true.
+            Condition::NV => true,
         }
     }
 }
@@ -510,7 +513,9 @@ mod tests {
         assert!(!flags.evaluate(Condition::GT));
         assert!(flags.evaluate(Condition::LE));
         assert!(flags.evaluate(Condition::AL));
-        assert!(!flags.evaluate(Condition::NV));
+        // NV is reserved but ARM ARM specifies condition_holds = true, so it
+        // is equivalent to AL — never the opposite of AL.
+        assert!(flags.evaluate(Condition::NV));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements issue #57 (CCMP / CCMN conditional compares) bundled with the principled fix for issue #92 (full NZCV modelling in SMT) that the acceptance criterion requires. Adds 2 instructions; total AArch64 ISA coverage now 27.

## Phase 1 — Symbolic NZCV in SMT (closes #92)

The SMT layer treated NZCV as unmodelled (CMP/CMN/TST as no-ops, CSEL family as `fresh_bv`). The acceptance criterion of #57 requires SMT proofs that span flag-dependent rewrites, so the SMT lowering is upgraded to a full flag-aware model:

- `MachineState` carries four 1-bit BV flag fields; `new_symbolic` seeds them as named symbolic constants.
- New pure helpers `compute_flags_sub`, `compute_flags_add`, `compute_flags_logical`, and `condition_to_smt` mirror `state.rs::ConditionFlags` exactly (verified via 16-flag × 14-condition round-trip).
- CMP, CMN, TST, ADDS, SUBS, ANDS, NEGS, BICS now write symbolic NZCV alongside their register effects. BIC and BICS are split so the unified pre-existing arm doesn't write flags for BIC.
- CSEL / CSINC / CSINV / CSNEG / CSET / CSETM use a real symbolic-flag ITE (no more `fresh_bv`).
- `states_not_equal` includes flag inequality unconditionally; `states_not_equal_for_live_out` gains a `flags_live` parameter. `EquivalenceConfig::with_flags(true)` is the user-facing opt-in, mirroring `X86LiveOutMask::with_flags`.
- `flag_writers_diverge` softened from structural-equality to the cheap writes-vs-no-writes asymmetric check. The principled cases the structural guard could not catch (issue #92 example: identical CMP fed by different upstream MOVs) are now caught by SMT itself.

## Phase 2 — CCMP / CCMN

- IR variants `Ccmp` / `Ccmn { rn, rm: Operand, nzcv: u8, cond: Condition }`.
- Accessor arms in `destination`, `modifies_flags`, `reads_flags`, `source_registers`, `Display`, and `is_encodable_aarch64`. The encodability check rejects SP in `rn`, AL/NV in `cond`, `nzcv > 15`, and `imm5 > 31`.
- Concrete semantics with `unpack_nzcv(byte) -> ConditionFlags` using the ARM ARM layout (bit3=N, bit2=Z, bit1=C, bit0=V).
- SMT semantics with `nzcv_to_bvs(byte) -> (BV,BV,BV,BV)` and a 4-way ITE; the predicate reads the *current* symbolic NZCV before writing the new value.
- Parser `parse_ccmp` / `parse_ccmn` (4 operands: register, register-or-#imm5, #nzcv, cond) with range validation, factored through `parse_ccmp_like`.
- Assembler: `emit_ccmp_reg!` and `emit_ccmp_imm!` 14-arm macros (AL/NV refused at the macro). dynasm-rs 5.0 supports both mnemonics natively — confirmed via Capstone round-trip.
- Search wiring: enumerative generator (~120k candidates with bounded `nzcv ∈ {0,1,7,15}` and `imm5 ∈ {0,1,16,31}` samples), random generator (cases 27/28 of 30, ~3.4% probability each), stochastic `mutate_operand` (4-way uniform pick on rn/rm/nzcv/cond) and `mutate_opcode` (CCMP ↔ CCMN swap).
- Cost model: 1 cycle. New opcode IDs 47 / 48.
- `CLAUDE.md` instruction count 25 → 27.

## Phase 3 — Acceptance test (closes #57)

`issue_57_acceptance_ccmp_branchless_equiv_to_cmp_csel` proves via SMT that

    CMP x0, x1
    CCMP x0, x2, #0, EQ
    CSET x3, LT

is equivalent to the 5-instruction CMP+CSET form for `(x0 == x1) && (x0 < x2)` with X3 as the live-out result.

## Test plan

- [x] Unit tests: 516 pass (was 490 pre-change). Includes:
  - Phase 1: state shape, helper round-trips, flag-writer property checks, CSEL-family ITE, issue #92 regression, structural-guard softening regression, CSINC wrap-add.
  - Phase 2: concrete CCMP/CCMN both branches, `unpack_nzcv` bit layout, SMT CCMP/CCMN both branches, Capstone round-trips for reg + imm forms of both mnemonics, parser display round-trip + range rejection.
  - Phase 3: SMT acceptance proof.
- [x] `./ci_check.sh` green (fmt, build, unit tests, test-binary builds, AArch64 integration tests).
- [ ] Local `just coverage` patch coverage check (optional).

Closes #57.
Closes #92.