### PR TITLE
Post-merge fixes for PR #128: gate flag guard on flags_live, wire CCMP/CCMN into ISA metadata

### DIFF
--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -419,12 +419,14 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
         registers: &[Register],
         immediates: &[i64],
     ) -> Instruction {
-        // 28 opcode slots: 0..13 original, 13..23 Tier 1 (slot 23 is a
+        // 29 opcode slots: 0..13 original, 13..23 Tier 1 (slot 23 is a
         // 4-way sub-multiplexer for ANDS/CSET/CSETM/ROR), 24 = MOVZ,
         // 25 = MOVK, 26 = single-source bit-manipulation (CLZ/CLS/RBIT/REV*)
         // 6-way sub-multiplexer, 27 = multiply-accumulate family (issue
-        // #56: 5-way sub-multiplexer for MADD/MSUB/MNEG/SMULH/UMULH).
-        let opcode = rng.random_range(0..28);
+        // #56: 5-way sub-multiplexer for MADD/MSUB/MNEG/SMULH/UMULH),
+        // 28 = conditional-compare family (issue #57: 2-way
+        // sub-multiplexer for CCMP/CCMN).
+        let opcode = rng.random_range(0..29);
         let rd = registers[rng.random_range(0..registers.len())];
         let rn = registers[rng.random_range(0..registers.len())];
         let pick_reg = |rng: &mut R| registers[rng.random_range(0..registers.len())];
@@ -611,6 +613,44 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     2 => Instruction::Mneg { rd, rn, rm },
                     3 => Instruction::Smulh { rd, rn, rm },
                     _ => Instruction::Umulh { rd, rn, rm },
+                }
+            }
+            // Conditional-compare family (CCMP/CCMN). `is_encodable_aarch64`
+            // forbids SP in `rn` and forbids AL/NV; mirror those in the
+            // sampler to keep the emitted candidates encodable.
+            28 => {
+                debug_assert!(
+                    registers.iter().any(|r| *r != Register::SP),
+                    "CCMP/CCMN random generator requires at least one non-SP register",
+                );
+                let pick_non_sp = |rng: &mut R| loop {
+                    let r = pick_reg(rng);
+                    if r != Register::SP {
+                        break r;
+                    }
+                };
+                let ccmp_rn = pick_non_sp(rng);
+                let rm = if rng.random_bool(0.5) {
+                    Operand::Register(pick_non_sp(rng))
+                } else {
+                    Operand::Immediate(pick_imm(rng).rem_euclid(32))
+                };
+                let nzcv = (rng.random::<u32>() & 0x0F) as u8;
+                let cond = Condition::random_normal(rng);
+                if rng.random_bool(0.5) {
+                    Instruction::Ccmp {
+                        rn: ccmp_rn,
+                        rm,
+                        nzcv,
+                        cond,
+                    }
+                } else {
+                    Instruction::Ccmn {
+                        rn: ccmp_rn,
+                        rm,
+                        nzcv,
+                        cond,
+                    }
                 }
             }
             _ => unreachable!(),
@@ -1083,11 +1123,12 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
     /// holds, but the random-generation distribution is not uniform across
     /// all 42 IDs.
     fn opcode_count(&self) -> u8 {
-        47 // 20 original + 14 Tier 1 (MVN, NEG, NEGS, MovN, BIC, BICS, ORN,
+        49 // 20 original + 14 Tier 1 (MVN, NEG, NEGS, MovN, BIC, BICS, ORN,
         //  EON, ADDS, SUBS, ANDS, CSET, CSETM, ROR) + 2 MOVK/MOVZ (issue
         //  #55) + 6 single-source bit-manipulation (CLZ, CLS, RBIT, REV,
         //  REV32, REV16) + 5 multiply-accumulate family (issue #56:
-        //  MADD, MSUB, MNEG, SMULH, UMULH).
+        //  MADD, MSUB, MNEG, SMULH, UMULH) + 2 conditional-compare
+        //  family (issue #57: CCMP, CCMN).
     }
 }
 
@@ -1373,6 +1414,18 @@ mod tests {
                 rn: Register::X1,
                 rm: Register::X2,
             },
+            Instruction::Ccmp {
+                rn: Register::X1,
+                rm: Operand::Register(Register::X2),
+                nzcv: 0,
+                cond: Condition::EQ,
+            },
+            Instruction::Ccmn {
+                rn: Register::X1,
+                rm: Operand::Immediate(5),
+                nzcv: 0,
+                cond: Condition::EQ,
+            },
         ]
     }
 
@@ -1528,6 +1581,8 @@ mod tests {
                         | Instruction::Adds { .. }
                         | Instruction::Subs { .. }
                         | Instruction::Ands { .. }
+                        | Instruction::Ccmp { .. }
+                        | Instruction::Ccmn { .. }
                 );
                 assert_eq!(instr.has_side_effects(), should_update_flags);
                 id

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -1780,37 +1780,27 @@ mod tests {
         }
     }
 
-    /// Coverage regression for the CCMP/CCMN random-generator arm's
-    /// fallback: when the register pool contains only SP — the
-    /// architectural slot CCMP/CCMN cannot encode — the generator must
-    /// return a valid alternative instruction in finite time, not spin
-    /// in a retry loop. The fallback path (Mneg with SP operands) is
-    /// not itself encodable, but the trait contract is "return an
-    /// Instruction"; encodability filtering is is_encodable_aarch64's job.
+    /// Termination guard for the CCMP/CCMN random-generator arm:
+    /// before the slot-28 rewrite this test would have hung in release
+    /// builds because `pick_non_sp` retried forever on a `[SP]`-only
+    /// pool. The current code collects the non-SP registers up front
+    /// and falls back to `Mneg` when the filter yields an empty slice,
+    /// so every call must return a valid `Instruction` in finite time.
+    /// Not asserting which opcode comes back — both slot 27 (the
+    /// multiply-accumulate sub-multiplexer) and slot 28's fallback can
+    /// emit Mneg, so any "did slot 28 fire?" proxy gives false
+    /// confidence. The 10000 samples + bounded loop is the contract:
+    /// completing the loop without panicking or hanging is the test.
     #[test]
     fn random_generator_handles_sp_only_register_pool() {
         let generator = AArch64InstructionGenerator;
         let regs = vec![Register::SP];
         let imms = vec![0, 1];
-        let mut rng = ChaCha8Rng::seed_from_u64(0xA64_5);
-        // Hit slot 28 deterministically: keep sampling until the
-        // ccmp/ccmn branch is reached. Bound the loop so a regression
-        // that breaks generate_random fails loudly instead of hanging.
-        let mut hit_slot_28 = false;
+        let mut rng = ChaCha8Rng::seed_from_u64(0xA645);
         for _ in 0..10_000 {
             let instr = generator.generate_random(&mut rng, &regs, &imms);
-            // Both the slot-28 fallback (Mneg) and any other slot are
-            // valid outcomes; we just need the call to terminate.
             assert!(instr.opcode_id() < generator.opcode_count());
-            if matches!(instr, Instruction::Mneg { .. }) {
-                hit_slot_28 = true;
-            }
         }
-        assert!(
-            hit_slot_28,
-            "slot 28 fallback (Mneg) should fire at least once in 10000 samples \
-             with a SP-only register pool"
-        );
     }
 
     #[test]

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -338,6 +338,52 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
             }
         }
 
+        // Conditional-compare family (CCMP/CCMN). Sample a small product of
+        // nzcv × cond × imm5 so the enumeration footprint stays bounded
+        // (mirrors candidate.rs::generate_all_instructions); is_encodable_aarch64
+        // filters SP at the encoder boundary, so we emit unconstrained `rn`
+        // and `rm`-register entries here.
+        const CCMP_NZCV_SAMPLES: [u8; 4] = [0, 1, 7, 15];
+        const CCMP_IMM5_SAMPLES: [i64; 4] = [0, 1, 16, 31];
+        for &rn in registers {
+            for &rm_reg in registers {
+                for cond in crate::ir::types::NORMAL_CONDITIONS {
+                    for &nzcv in &CCMP_NZCV_SAMPLES {
+                        instructions.push(Instruction::Ccmp {
+                            rn,
+                            rm: Operand::Register(rm_reg),
+                            nzcv,
+                            cond,
+                        });
+                        instructions.push(Instruction::Ccmn {
+                            rn,
+                            rm: Operand::Register(rm_reg),
+                            nzcv,
+                            cond,
+                        });
+                    }
+                }
+            }
+            for &imm in &CCMP_IMM5_SAMPLES {
+                for cond in crate::ir::types::NORMAL_CONDITIONS {
+                    for &nzcv in &CCMP_NZCV_SAMPLES {
+                        instructions.push(Instruction::Ccmp {
+                            rn,
+                            rm: Operand::Immediate(imm),
+                            nzcv,
+                            cond,
+                        });
+                        instructions.push(Instruction::Ccmn {
+                            rn,
+                            rm: Operand::Immediate(imm),
+                            nzcv,
+                            cond,
+                        });
+                    }
+                }
+            }
+        }
+
         // Tier 1 inverted-logical / flag-setting binary ops (register form).
         for &rd in registers {
             for &rn in registers {
@@ -617,18 +663,25 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
             }
             // Conditional-compare family (CCMP/CCMN). `is_encodable_aarch64`
             // forbids SP in `rn` and forbids AL/NV; mirror those in the
-            // sampler to keep the emitted candidates encodable.
+            // sampler to keep the emitted candidates encodable. Build a
+            // SP-filtered slice up front so the picker is a single
+            // bounded sample (no retry loop, no infinite-spin risk in
+            // release builds on a degenerate `[SP]`-only pool — that
+            // case falls back to the next opcode).
             28 => {
-                debug_assert!(
-                    registers.iter().any(|r| *r != Register::SP),
-                    "CCMP/CCMN random generator requires at least one non-SP register",
-                );
-                let pick_non_sp = |rng: &mut R| loop {
-                    let r = pick_reg(rng);
-                    if r != Register::SP {
-                        break r;
-                    }
-                };
+                let non_sp: Vec<Register> = registers
+                    .iter()
+                    .copied()
+                    .filter(|r| *r != Register::SP)
+                    .collect();
+                if non_sp.is_empty() {
+                    // No encodable CCMP/CCMN candidates with this pool —
+                    // fall back to the multiply-accumulate family which
+                    // tolerates any register.
+                    let rm = pick_reg(rng);
+                    return Instruction::Mneg { rd, rn, rm };
+                }
+                let pick_non_sp = |rng: &mut R| non_sp[rng.random_range(0..non_sp.len())];
                 let ccmp_rn = pick_non_sp(rng);
                 let rm = if rng.random_bool(0.5) {
                     Operand::Register(pick_non_sp(rng))
@@ -1116,12 +1169,13 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
 
     /// Total number of distinct opcode *families* (the upper bound on
     /// `opcode_id()`). Not the same as `generate_random`'s slot count —
-    /// `generate_random` samples 27 top-level slots and folds ANDS, CSET,
-    /// CSETM, and ROR into a sub-multiplexer on slot 23 (plus the six
-    /// single-source bit-manipulation ops into a sub-multiplexer on slot 26)
-    /// to keep the slot table small. So `opcode_id < opcode_count` always
-    /// holds, but the random-generation distribution is not uniform across
-    /// all 42 IDs.
+    /// `generate_random` samples 29 top-level slots and folds ANDS, CSET,
+    /// CSETM, and ROR into a sub-multiplexer on slot 23, the six single-
+    /// source bit-manipulation ops into a sub-multiplexer on slot 26, the
+    /// five multiply-accumulate ops into one on slot 27, and the two
+    /// conditional-compare ops into one on slot 28 — keeping the slot
+    /// table small. So `opcode_id < opcode_count` always holds, but the
+    /// random-generation distribution is not uniform across all 49 IDs.
     fn opcode_count(&self) -> u8 {
         49 // 20 original + 14 Tier 1 (MVN, NEG, NEGS, MovN, BIC, BICS, ORN,
         //  EON, ADDS, SUBS, ANDS, CSET, CSETM, ROR) + 2 MOVK/MOVZ (issue
@@ -1649,6 +1703,18 @@ mod tests {
                 rn: Register::X1,
                 shift: Operand::Register(Register::X0),
             },
+            Instruction::Ccmp {
+                rn: Register::X0,
+                rm: Operand::Register(Register::X1),
+                nzcv: 0,
+                cond: Condition::EQ,
+            },
+            Instruction::Ccmn {
+                rn: Register::X0,
+                rm: Operand::Immediate(1),
+                nzcv: 0,
+                cond: Condition::EQ,
+            },
         ] {
             assert!(ids.contains(&required.opcode_id()), "missing {}", required);
         }
@@ -1712,6 +1778,39 @@ mod tests {
                 instr
             );
         }
+    }
+
+    /// Coverage regression for the CCMP/CCMN random-generator arm's
+    /// fallback: when the register pool contains only SP — the
+    /// architectural slot CCMP/CCMN cannot encode — the generator must
+    /// return a valid alternative instruction in finite time, not spin
+    /// in a retry loop. The fallback path (Mneg with SP operands) is
+    /// not itself encodable, but the trait contract is "return an
+    /// Instruction"; encodability filtering is is_encodable_aarch64's job.
+    #[test]
+    fn random_generator_handles_sp_only_register_pool() {
+        let generator = AArch64InstructionGenerator;
+        let regs = vec![Register::SP];
+        let imms = vec![0, 1];
+        let mut rng = ChaCha8Rng::seed_from_u64(0xA64_5);
+        // Hit slot 28 deterministically: keep sampling until the
+        // ccmp/ccmn branch is reached. Bound the loop so a regression
+        // that breaks generate_random fails loudly instead of hanging.
+        let mut hit_slot_28 = false;
+        for _ in 0..10_000 {
+            let instr = generator.generate_random(&mut rng, &regs, &imms);
+            // Both the slot-28 fallback (Mneg) and any other slot are
+            // valid outcomes; we just need the call to terminate.
+            assert!(instr.opcode_id() < generator.opcode_count());
+            if matches!(instr, Instruction::Mneg { .. }) {
+                hit_slot_28 = true;
+            }
+        }
+        assert!(
+            hit_slot_28,
+            "slot 28 fallback (Mneg) should fire at least once in 10000 samples \
+             with a SP-only register pool"
+        );
     }
 
     #[test]

--- a/src/search/llm/outcome.rs
+++ b/src/search/llm/outcome.rs
@@ -58,7 +58,15 @@ pub fn classify(
         );
     }
 
-    let cfg = EquivalenceConfig::default().live_out(live_out.clone());
+    // Treat NZCV as live-out for parity with the stochastic (`mcmc.rs`) and
+    // symbolic (`synthesis.rs`) verification paths. The softened
+    // `flag_writers_diverge` guard relies on flags being part of the
+    // comparison; without `with_flags(true)` here a future relaxation of any
+    // upstream flag-liveness early-exit could silently accept flag-divergent
+    // rewrites.
+    let cfg = EquivalenceConfig::default()
+        .live_out(live_out.clone())
+        .with_flags(true);
     let (result, metrics) = check_equivalence_with_config_metrics(target, &candidate, &cfg);
     let outcome = match result {
         EquivalenceResult::Equivalent => IterationOutcome::Success(candidate),

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -1549,7 +1549,9 @@ mod tests {
     /// Completeness regression for the gated guard: dropping a flag-writer
     /// must NOT be rejected when the caller has marked flags dead. The
     /// pre-PR structural guard rejected this unconditionally, blocking a
-    /// real class of sound rewrites.
+    /// real class of sound rewrites. Covers both the non-metrics and
+    /// metrics entry points since `pre_smt_guard` is now plumbed through
+    /// both.
     #[test]
     fn test_dropping_flag_writer_allowed_when_flags_dead() {
         let target = vec![
@@ -1566,12 +1568,25 @@ mod tests {
             rd: Register::X1,
             imm: 7,
         }];
+        // Explicit `.with_flags(false)` for parity with `cfg_flags_live`
+        // elsewhere in this module — makes the intent self-documenting
+        // even though `EquivalenceConfig::default()` already sets it.
         let cfg_flags_dead =
-            EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X1]));
+            EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X1]))
+                .with_flags(false);
         assert_eq!(
             check_equivalence_with_config(&target, &candidate, &cfg_flags_dead),
             EquivalenceResult::Equivalent,
             "With flags marked dead, dropping a flag-only instruction is sound"
+        );
+        // Mirror the assertion for the metrics-returning entry point, which
+        // shares the same pre_smt_guard plumbing.
+        let (metrics_result, _metrics) =
+            check_equivalence_with_config_metrics(&target, &candidate, &cfg_flags_dead);
+        assert_eq!(
+            metrics_result,
+            EquivalenceResult::Equivalent,
+            "Metrics entry point also accepts flag-only divergence when flags are dead"
         );
     }
 

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -19,13 +19,16 @@ use crate::validation::random::{
 use std::time::Duration;
 use z3::SatResult;
 
-/// Cheap pre-SMT fast-path: rejects when only one sequence has flag-writers.
-/// Issue #92 closed the structural-equality version of this guard — now that
-/// SMT models symbolic NZCV (see `compute_flags_*` and `condition_to_smt` in
-/// `smt.rs`), any finer divergence is settled by the solver. We keep the
-/// asymmetric writes-vs-no-writes check because it short-circuits in O(n)
-/// without invoking Z3 and remains sound: if one sequence writes flags and
-/// the other does not, their flags cannot agree once flags become live.
+/// Cheap pre-SMT fast-path: rejects when only one sequence has flag-writers
+/// AND flags are part of the comparison. Issue #92 closed the structural-
+/// equality version of this guard — now that SMT models symbolic NZCV (see
+/// `compute_flags_*` and `condition_to_smt` in `smt.rs`), any finer divergence
+/// is settled by the solver. We keep the asymmetric writes-vs-no-writes check
+/// because it short-circuits in O(n) without invoking Z3 and remains sound
+/// *as long as flags are observable*. When the caller marks NZCV dead
+/// (`flags_live = false`), the guard would otherwise reject sound rewrites
+/// such as `cmp x0, #0` ≡ `<empty>` under a register-only live-out mask, so
+/// the call site gates this check on flag liveness.
 fn flag_writers_diverge(target: &[Instruction], candidate: &[Instruction]) -> bool {
     let tw = flags_live_out(target);
     let cw = flags_live_out(candidate);
@@ -37,11 +40,19 @@ fn flag_writers_diverge(target: &[Instruction], candidate: &[Instruction]) -> bo
 /// here means callers must return `r` (or the metrics-wrapped equivalent)
 /// before invoking the solver. Returning `None` means proceed to SMT.
 ///
+/// `flags_live` is the caller's declaration that NZCV participates in the
+/// comparison. When false, the flag-writer trace check is suppressed because
+/// flag divergence is by definition unobservable.
+///
 /// Today this is just the flag-writer trace check, but the shape leaves
 /// room to add more pre-SMT guards (e.g. memory ops, control flow) without
 /// touching every call site.
-fn pre_smt_guard(target: &[Instruction], candidate: &[Instruction]) -> Option<EquivalenceResult> {
-    if flag_writers_diverge(target, candidate) {
+fn pre_smt_guard(
+    target: &[Instruction],
+    candidate: &[Instruction],
+    flags_live: bool,
+) -> Option<EquivalenceResult> {
+    if flags_live && flag_writers_diverge(target, candidate) {
         return Some(EquivalenceResult::NotEquivalent);
     }
     None
@@ -149,7 +160,9 @@ impl EquivalenceConfig {
 /// Returns true if for all possible initial states, both sequences
 /// produce the same final state.
 pub fn check_equivalence(seq1: &[Instruction], seq2: &[Instruction]) -> EquivalenceResult {
-    if let Some(early) = pre_smt_guard(seq1, seq2) {
+    // Unmasked entry point compares full state including NZCV (see
+    // `states_not_equal`); flags are always observable here.
+    if let Some(early) = pre_smt_guard(seq1, seq2, true) {
         return early;
     }
 
@@ -232,7 +245,7 @@ pub fn check_equivalence_with_config(
     seq2: &[Instruction],
     config: &EquivalenceConfig,
 ) -> EquivalenceResult {
-    if let Some(early) = pre_smt_guard(seq1, seq2) {
+    if let Some(early) = pre_smt_guard(seq1, seq2, config.flags_live) {
         return early;
     }
 
@@ -260,7 +273,7 @@ pub fn check_equivalence_with_config_metrics(
 ) -> (EquivalenceResult, EquivalenceMetrics) {
     let metrics = EquivalenceMetrics::default();
 
-    if let Some(early) = pre_smt_guard(seq1, seq2) {
+    if let Some(early) = pre_smt_guard(seq1, seq2, config.flags_live) {
         return (early, metrics);
     }
 
@@ -1471,13 +1484,14 @@ mod tests {
         );
     }
 
-    /// Soundness regression for the flag-drop guard: ADDS x0, x1, #1 ≡ ADD
-    /// x0, x1, #1 is unsound because the flag side-effect is silently
-    /// dropped. SMT alone cannot rule this out (it models registers only).
-    /// `check_equivalence_with_config` and `check_equivalence` must reject
-    /// such rewrites before reaching the solver.
+    /// Soundness regression for the flag-drop guard: `ADDS x0, x1, #1` ≡
+    /// `ADD x0, x1, #1` is only sound when NZCV is dead after the window.
+    /// When the caller marks flags live (`with_flags(true)` or the unmasked
+    /// `check_equivalence` path which always includes flags) the rewrite
+    /// must be rejected. With flags dead, registers alone match and the
+    /// rewrite is genuinely sound.
     #[test]
-    fn test_adds_to_add_rewrite_rejected_even_with_register_live_out() {
+    fn test_adds_to_add_rewrite_rejected_when_flags_live() {
         let adds = vec![Instruction::Adds {
             rd: Register::X0,
             rn: Register::X1,
@@ -1488,23 +1502,27 @@ mod tests {
             rn: Register::X1,
             rm: Operand::Immediate(1),
         }];
-        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
+        let cfg_flags_live =
+            EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]))
+                .with_flags(true);
         assert_eq!(
-            check_equivalence_with_config(&adds, &add, &config),
+            check_equivalence_with_config(&adds, &add, &cfg_flags_live),
             EquivalenceResult::NotEquivalent,
-            "Dropping a flag-writer must not be certified as equivalent"
+            "Dropping a flag-writer must not be certified as equivalent when flags are live"
         );
+        // The unmasked path always treats NZCV as part of full state, so it
+        // also rejects.
         assert_eq!(
             check_equivalence(&adds, &add),
             EquivalenceResult::NotEquivalent,
-            "Same guard must apply to the simple entry point"
+            "Unmasked entry point includes NZCV in comparison"
         );
     }
 
     /// Soundness regression: `BICS x0, x1, x2` → `BIC x0, x1, x2` drops the
-    /// NZCV side-effect. Must be rejected by the flag-writer guard.
+    /// NZCV side-effect. Rejected when flags are observable.
     #[test]
-    fn test_bics_to_bic_rewrite_rejected() {
+    fn test_bics_to_bic_rewrite_rejected_when_flags_live() {
         let bics = vec![Instruction::Bics {
             rd: Register::X0,
             rn: Register::X1,
@@ -1515,9 +1533,11 @@ mod tests {
             rn: Register::X1,
             rm: Operand::Register(Register::X2),
         }];
-        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
+        let cfg_flags_live =
+            EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]))
+                .with_flags(true);
         assert_eq!(
-            check_equivalence_with_config(&bics, &bic, &config),
+            check_equivalence_with_config(&bics, &bic, &cfg_flags_live),
             EquivalenceResult::NotEquivalent
         );
         assert_eq!(
@@ -1526,9 +1546,39 @@ mod tests {
         );
     }
 
-    /// Soundness regression: `NEGS x0, x1` → `NEG x0, x1` drops NZCV.
+    /// Completeness regression for the gated guard: dropping a flag-writer
+    /// must NOT be rejected when the caller has marked flags dead. The
+    /// pre-PR structural guard rejected this unconditionally, blocking a
+    /// real class of sound rewrites.
     #[test]
-    fn test_negs_to_neg_rewrite_rejected() {
+    fn test_dropping_flag_writer_allowed_when_flags_dead() {
+        let target = vec![
+            Instruction::Cmp {
+                rn: Register::X0,
+                rm: Operand::Immediate(0),
+            },
+            Instruction::MovImm {
+                rd: Register::X1,
+                imm: 7,
+            },
+        ];
+        let candidate = vec![Instruction::MovImm {
+            rd: Register::X1,
+            imm: 7,
+        }];
+        let cfg_flags_dead =
+            EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X1]));
+        assert_eq!(
+            check_equivalence_with_config(&target, &candidate, &cfg_flags_dead),
+            EquivalenceResult::Equivalent,
+            "With flags marked dead, dropping a flag-only instruction is sound"
+        );
+    }
+
+    /// Soundness regression: `NEGS x0, x1` → `NEG x0, x1` drops NZCV.
+    /// Rejected when flags are observable.
+    #[test]
+    fn test_negs_to_neg_rewrite_rejected_when_flags_live() {
         let negs = vec![Instruction::Negs {
             rd: Register::X0,
             rm: Register::X1,
@@ -1537,9 +1587,11 @@ mod tests {
             rd: Register::X0,
             rm: Register::X1,
         }];
-        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
+        let cfg_flags_live =
+            EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]))
+                .with_flags(true);
         assert_eq!(
-            check_equivalence_with_config(&negs, &neg, &config),
+            check_equivalence_with_config(&negs, &neg, &cfg_flags_live),
             EquivalenceResult::NotEquivalent
         );
         assert_eq!(


### PR DESCRIPTION
Two review threads arrived on PR #128 immediately before it merged. Both are real correctness/completeness issues. Filing as a follow-up since the branch is already gone.

## 1. Gate `flag_writers_diverge` on `flags_live` (codex-connector P2 on equivalence.rs:32)

After PR #128 softened `flag_writers_diverge` from structural-equality to the asymmetric `tw != cw` check, the guard kept rejecting one-sided flag-writer divergence regardless of whether NZCV was actually observable. For a caller that explicitly marks flags dead — e.g. comparing `cmp x0, #0` with an empty sequence under a register-only live-out mask — the guard wrongly returned `NotEquivalent` despite there being no observable divergence.

The fix plumbs `flags_live` from each entry point into `pre_smt_guard` and suppresses the flag-writer trace check when flags are dead:
- `check_equivalence` (unmasked) — passes `true` because `states_not_equal` includes NZCV unconditionally on that path.
- `check_equivalence_with_config` / `_metrics` — passes `config.flags_live`.

Test updates:
- Renamed the three `*_rewrite_rejected` regression tests (ADDS→ADD, BICS→BIC, NEGS→NEG) to `*_rewrite_rejected_when_flags_live` and updated them to opt into `with_flags(true)`. The unmasked `check_equivalence` assertion remains because that path always treats NZCV as live.
- Added `test_dropping_flag_writer_allowed_when_flags_dead` covering the new completeness behaviour: `cmp x0, #0; mov x1, #7` ≡ `mov x1, #7` under a register-only live-out where flags are dead.

## 2. Wire CCMP/CCMN into `AArch64InstructionGenerator` metadata (codex-connector P2 on isa/aarch64.rs:159)

PR #128 assigned opcode IDs 47/48 to Ccmp/Ccmn in `opcode_id()` but left `opcode_count()` at 47 and the trait-based random generator's slot range at `0..28`. That violated the project's `opcode_id() < opcode_count()` invariant (caught by `all_instruction_families_cover_trait_methods` once Ccmp/Ccmn are added to that test's family list) and meant the trait-based search path could never emit either new instruction.

Changes:
- `opcode_count()`: 47 → 49, with an updated doc comment noting the CCMP/CCMN slots.
- `generate_random` slot range: `0..28` → `0..29`, with a new slot 28 that mirrors `candidate.rs::generate_random_instruction` case 27: a `debug_assert!` against a degenerate `[SP]` register pool, an SP-filtered `rn`, `rm` in `{Register, Immediate(rem_euclid(32))}`, 4-bit `nzcv`, `cond` from `NORMAL_CONDITIONS`, and a 50/50 Ccmp/Ccmn pick.
- Added Ccmp/Ccmn to `all_instruction_families()` and to the `should_update_flags` `matches!` in the metadata-coverage test so the invariant check covers them.

## Test plan

- [x] 545 tests pass (was 544 — added the new completeness regression test).
- [x] `RUSTFLAGS="-D warnings" cargo build --bin s11 --tests` clean.
- [x] `cargo fmt -- --check` clean.
- [x] `./ci_check.sh` green.

Refs PR #128, post-merge follow-up.