### PR TITLE
Add AArch64 bit-field instructions (UBFX/SBFX/BFI/BFXIL/UBFIZ/SBFIZ)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ s11 is a superoptimizer written in Rust. It finds shorter or faster equivalent i
 
 **Key Features:**
 - ELF binary reading and disassembly using Capstone engine (auto-detects e_machine)
-- **AArch64** (27 instructions): MOV, ADD, SUB, AND, ORR, EOR, LSL, LSR, ASR, MUL, SDIV, UDIV, CMP, CMN, TST, CSEL, CSINC, CSINV, CSNEG, MADD, MSUB, MNEG, SMULH, UMULH, CCMP, CCMN — full pipeline including stochastic/symbolic/hybrid/LLM search
+- **AArch64** (33 instructions): MOV, ADD, SUB, AND, ORR, EOR, LSL, LSR, ASR, MUL, SDIV, UDIV, CMP, CMN, TST, CSEL, CSINC, CSINV, CSNEG, MADD, MSUB, MNEG, SMULH, UMULH, CCMP, CCMN, UBFX, SBFX, BFI, BFXIL, UBFIZ, SBFIZ — full pipeline including stochastic/symbolic/hybrid/LLM search
 - **x86-64 + x86-32** (14 variants, 7 mnemonics): MOV, ADD, SUB, AND, OR, XOR, CMP (each with reg/imm forms) — enumerative search only in v1
 - SMT-based equivalence checking using Z3 (width-parameterised for x86-32 vs x86-64)
 - Multi-threaded parallel search with worker coordination

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -1237,6 +1237,55 @@ impl AArch64Assembler {
                     }
                 }
             }
+            // Bit-field manipulation aliases (UBFX/SBFX/BFI/BFXIL/UBFIZ/SBFIZ).
+            Instruction::Ubfx { rd, rn, lsb, width } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                let lsb_imm = *lsb as u32;
+                let width_imm = *width as u32;
+                dynasm!(ops ; .arch aarch64 ; ubfx X(rd_reg), X(rn_reg), lsb_imm, width_imm);
+                Ok(())
+            }
+            Instruction::Sbfx { rd, rn, lsb, width } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                let lsb_imm = *lsb as u32;
+                let width_imm = *width as u32;
+                dynasm!(ops ; .arch aarch64 ; sbfx X(rd_reg), X(rn_reg), lsb_imm, width_imm);
+                Ok(())
+            }
+            Instruction::Bfi { rd, rn, lsb, width } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                let lsb_imm = *lsb as u32;
+                let width_imm = *width as u32;
+                dynasm!(ops ; .arch aarch64 ; bfi X(rd_reg), X(rn_reg), lsb_imm, width_imm);
+                Ok(())
+            }
+            Instruction::Bfxil { rd, rn, lsb, width } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                let lsb_imm = *lsb as u32;
+                let width_imm = *width as u32;
+                dynasm!(ops ; .arch aarch64 ; bfxil X(rd_reg), X(rn_reg), lsb_imm, width_imm);
+                Ok(())
+            }
+            Instruction::Ubfiz { rd, rn, lsb, width } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                let lsb_imm = *lsb as u32;
+                let width_imm = *width as u32;
+                dynasm!(ops ; .arch aarch64 ; ubfiz X(rd_reg), X(rn_reg), lsb_imm, width_imm);
+                Ok(())
+            }
+            Instruction::Sbfiz { rd, rn, lsb, width } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                let lsb_imm = *lsb as u32;
+                let width_imm = *width as u32;
+                dynasm!(ops ; .arch aarch64 ; sbfiz X(rd_reg), X(rn_reg), lsb_imm, width_imm);
+                Ok(())
+            }
         }
     }
 }
@@ -1719,6 +1768,137 @@ mod tests {
             .assemble_instructions(&instructions)
             .expect("CCMN immediate form should encode");
         disassemble_and_verify(&bytes, "ccmn", &["x4", "#7", "#4", "ge"]);
+    }
+
+    #[test]
+    fn test_ubfx_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Ubfx {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 8,
+            width: 16,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("UBFX encoding should succeed");
+        disassemble_and_verify(&bytes, "ubfx", &["x0", "x1", "#8", "#0x10"]);
+    }
+
+    #[test]
+    fn test_ubfx_full_width_correctness() {
+        // UBFX X0, X1, #0, #64 — the maximally wide field. Exercises the
+        // boundary of the (lsb+width <= 64) constraint.
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Ubfx {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 0,
+            width: 64,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("UBFX (full width) encoding should succeed");
+        // UBFX with (lsb=0, width=64) is canonically `mov x0, x1` in Capstone's
+        // alias decoder, since immr=0/imms=63 with the UBFM bit pattern
+        // matches the LSR-by-0 form. Roundtrip pinned to "mov" is acceptable.
+        // Verify just that encoding succeeded; semantic equivalence is
+        // covered by the concrete + SMT tests.
+        assert_eq!(bytes.len(), 4, "UBFX must encode to exactly 4 bytes");
+    }
+
+    #[test]
+    fn test_sbfiz_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Sbfiz {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 4,
+            width: 8,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("SBFIZ encoding should succeed");
+        disassemble_and_verify(&bytes, "sbfiz", &["x0", "x1", "#4", "#8"]);
+    }
+
+    #[test]
+    fn test_ubfiz_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Ubfiz {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 4,
+            width: 8,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("UBFIZ encoding should succeed");
+        disassemble_and_verify(&bytes, "ubfiz", &["x0", "x1", "#4", "#8"]);
+    }
+
+    #[test]
+    fn test_bfxil_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Bfxil {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 8,
+            width: 8,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("BFXIL encoding should succeed");
+        disassemble_and_verify(&bytes, "bfxil", &["x0", "x1", "#8", "#8"]);
+    }
+
+    #[test]
+    fn test_bfi_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Bfi {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 4,
+            width: 8,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("BFI encoding should succeed");
+        disassemble_and_verify(&bytes, "bfi", &["x0", "x1", "#4", "#8"]);
+    }
+
+    #[test]
+    fn test_sbfx_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Sbfx {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 8,
+            width: 16,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("SBFX encoding should succeed");
+        disassemble_and_verify(&bytes, "sbfx", &["x0", "x1", "#8", "#0x10"]);
+    }
+
+    #[test]
+    fn test_ubfx_high_lsb_correctness() {
+        // (lsb=32, width=8) — high-half extract that doesn't collide with the
+        // LSR alias. Under UBFM, LSR is the form where imms == 63
+        // (i.e., lsb+width == 64); any (lsb, width) with lsb+width < 64
+        // disassembles as UBFX.
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Ubfx {
+            rd: Register::X2,
+            rn: Register::X3,
+            lsb: 32,
+            width: 8,
+        }];
+        let bytes = assembler
+            .assemble_instructions(&instructions)
+            .expect("UBFX (high lsb) encoding should succeed");
+        disassemble_and_verify(&bytes, "ubfx", &["x2", "x3", "#0x20", "#8"]);
     }
 
     #[test]

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -315,6 +315,46 @@ pub enum Instruction {
         rd: Register,
         rn: Register,
     },
+    // Bit-field manipulation (64-bit, aliases of UBFM/SBFM/BFM per ARM ARM C6.2).
+    // `lsb` is the bit position of the least-significant bit of the field in the
+    // source; `width` is the field width. Constraint: lsb ∈ [0..=63],
+    // width ∈ [1..=64-lsb]. Enforced in `is_encodable_aarch64`.
+    Ubfx {
+        rd: Register,
+        rn: Register,
+        lsb: u8,
+        width: u8,
+    },
+    Sbfx {
+        rd: Register,
+        rn: Register,
+        lsb: u8,
+        width: u8,
+    },
+    Bfi {
+        rd: Register,
+        rn: Register,
+        lsb: u8,
+        width: u8,
+    },
+    Bfxil {
+        rd: Register,
+        rn: Register,
+        lsb: u8,
+        width: u8,
+    },
+    Ubfiz {
+        rd: Register,
+        rn: Register,
+        lsb: u8,
+        width: u8,
+    },
+    Sbfiz {
+        rd: Register,
+        rn: Register,
+        lsb: u8,
+        width: u8,
+    },
 }
 
 impl Instruction {
@@ -370,7 +410,13 @@ impl Instruction {
             | Instruction::Sxth { rd, .. }
             | Instruction::Sxtw { rd, .. }
             | Instruction::Uxtb { rd, .. }
-            | Instruction::Uxth { rd, .. } => Some(*rd),
+            | Instruction::Uxth { rd, .. }
+            | Instruction::Ubfx { rd, .. }
+            | Instruction::Sbfx { rd, .. }
+            | Instruction::Bfi { rd, .. }
+            | Instruction::Bfxil { rd, .. }
+            | Instruction::Ubfiz { rd, .. }
+            | Instruction::Sbfiz { rd, .. } => Some(*rd),
             // Comparison instructions only set flags, no destination register
             Instruction::Cmp { .. }
             | Instruction::Cmn { .. }
@@ -624,6 +670,20 @@ impl Instruction {
             | Instruction::Sxtw { rd, rn }
             | Instruction::Uxtb { rd, rn }
             | Instruction::Uxth { rd, rn } => *rd != Register::SP && *rn != Register::SP,
+            // Bit-field aliases of UBFM/SBFM/BFM. Constraint: lsb ∈ [0..=63],
+            // width ∈ [1..=64-lsb]. SP rejected in rd and rn.
+            Instruction::Ubfx { rd, rn, lsb, width }
+            | Instruction::Sbfx { rd, rn, lsb, width }
+            | Instruction::Bfi { rd, rn, lsb, width }
+            | Instruction::Bfxil { rd, rn, lsb, width }
+            | Instruction::Ubfiz { rd, rn, lsb, width }
+            | Instruction::Sbfiz { rd, rn, lsb, width } => {
+                *rd != Register::SP
+                    && *rn != Register::SP
+                    && *lsb <= 63
+                    && *width >= 1
+                    && (*lsb as u16 + *width as u16) <= 64
+            }
         }
     }
 
@@ -738,6 +798,15 @@ impl Instruction {
             | Instruction::Sxtw { rn, .. }
             | Instruction::Uxtb { rn, .. }
             | Instruction::Uxth { rn, .. } => vec![*rn],
+            // Bit-field extracts: only `rn` is read.
+            Instruction::Ubfx { rn, .. }
+            | Instruction::Sbfx { rn, .. }
+            | Instruction::Ubfiz { rn, .. }
+            | Instruction::Sbfiz { rn, .. } => vec![*rn],
+            // BFI / BFXIL preserve unmodified bits of `rd`, so they also read `rd`.
+            Instruction::Bfi { rd, rn, .. } | Instruction::Bfxil { rd, rn, .. } => {
+                vec![*rd, *rn]
+            }
         }
     }
 }
@@ -835,6 +904,24 @@ impl fmt::Display for Instruction {
             Instruction::Sxtw { rd, rn } => write!(f, "sxtw {}, {}", rd, rn),
             Instruction::Uxtb { rd, rn } => write!(f, "uxtb {}, {}", rd, rn),
             Instruction::Uxth { rd, rn } => write!(f, "uxth {}, {}", rd, rn),
+            Instruction::Ubfx { rd, rn, lsb, width } => {
+                write!(f, "ubfx {}, {}, #{}, #{}", rd, rn, lsb, width)
+            }
+            Instruction::Sbfx { rd, rn, lsb, width } => {
+                write!(f, "sbfx {}, {}, #{}, #{}", rd, rn, lsb, width)
+            }
+            Instruction::Bfi { rd, rn, lsb, width } => {
+                write!(f, "bfi {}, {}, #{}, #{}", rd, rn, lsb, width)
+            }
+            Instruction::Bfxil { rd, rn, lsb, width } => {
+                write!(f, "bfxil {}, {}, #{}, #{}", rd, rn, lsb, width)
+            }
+            Instruction::Ubfiz { rd, rn, lsb, width } => {
+                write!(f, "ubfiz {}, {}, #{}, #{}", rd, rn, lsb, width)
+            }
+            Instruction::Sbfiz { rd, rn, lsb, width } => {
+                write!(f, "sbfiz {}, {}, #{}, #{}", rd, rn, lsb, width)
+            }
         }
     }
 }
@@ -870,6 +957,17 @@ mod tests {
             rm: Operand::Register(Register::X0),
         };
         assert_eq!(format!("{}", eor), "eor x0, x0, x0");
+    }
+
+    #[test]
+    fn test_ubfx_display() {
+        let ubfx = Instruction::Ubfx {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 5,
+            width: 10,
+        };
+        assert_eq!(format!("{}", ubfx), "ubfx x0, x1, #5, #10");
     }
 
     #[test]
@@ -1295,6 +1393,91 @@ mod tests {
             Instruction::Rev {
                 rd: Register::X0,
                 rn: Register::XZR
+            }
+            .is_encodable_aarch64()
+        );
+    }
+
+    #[test]
+    fn test_is_encodable_bitfield() {
+        // Valid combinations.
+        for (lsb, width) in [(0u8, 1u8), (0, 64), (5, 10), (32, 16), (63, 1)] {
+            let instr = Instruction::Ubfx {
+                rd: Register::X0,
+                rn: Register::X1,
+                lsb,
+                width,
+            };
+            assert!(
+                instr.is_encodable_aarch64(),
+                "valid (lsb={}, width={}) must be encodable",
+                lsb,
+                width
+            );
+        }
+
+        // SP rejection in rd.
+        assert!(
+            !Instruction::Ubfx {
+                rd: Register::SP,
+                rn: Register::X1,
+                lsb: 0,
+                width: 8,
+            }
+            .is_encodable_aarch64()
+        );
+
+        // SP rejection in rn.
+        assert!(
+            !Instruction::Sbfx {
+                rd: Register::X0,
+                rn: Register::SP,
+                lsb: 0,
+                width: 8,
+            }
+            .is_encodable_aarch64()
+        );
+
+        // XZR is OK.
+        assert!(
+            Instruction::Ubfx {
+                rd: Register::XZR,
+                rn: Register::X1,
+                lsb: 0,
+                width: 8,
+            }
+            .is_encodable_aarch64()
+        );
+
+        // width=0 rejected.
+        assert!(
+            !Instruction::Bfi {
+                rd: Register::X0,
+                rn: Register::X1,
+                lsb: 0,
+                width: 0,
+            }
+            .is_encodable_aarch64()
+        );
+
+        // lsb+width > 64 rejected.
+        assert!(
+            !Instruction::Bfxil {
+                rd: Register::X0,
+                rn: Register::X1,
+                lsb: 60,
+                width: 10,
+            }
+            .is_encodable_aarch64()
+        );
+
+        // The (lsb=63, width=1) boundary stays valid: lsb<=63 and lsb+width==64.
+        assert!(
+            Instruction::Ubfiz {
+                rd: Register::X0,
+                rn: Register::X1,
+                lsb: 63,
+                width: 1,
             }
             .is_encodable_aarch64()
         );

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -489,14 +489,15 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
         registers: &[Register],
         immediates: &[i64],
     ) -> Instruction {
-        // 29 opcode slots: 0..13 original, 13..23 Tier 1 (slot 23 is a
+        // 30 opcode slots: 0..13 original, 13..23 Tier 1 (slot 23 is a
         // 4-way sub-multiplexer for ANDS/CSET/CSETM/ROR), 24 = MOVZ,
         // 25 = MOVK, 26 = single-source bit-manipulation (CLZ/CLS/RBIT/REV*)
         // 6-way sub-multiplexer, 27 = multiply-accumulate family (issue
         // #56: 5-way sub-multiplexer for MADD/MSUB/MNEG/SMULH/UMULH),
         // 28 = conditional-compare family (issue #57: 2-way
-        // sub-multiplexer for CCMP/CCMN).
-        let opcode = rng.random_range(0..29);
+        // sub-multiplexer for CCMP/CCMN), 29 = bit-field aliases (issue
+        // #61: 6-way sub-multiplexer for UBFX/SBFX/BFI/BFXIL/UBFIZ/SBFIZ).
+        let opcode = rng.random_range(0..30);
         let rd = registers[rng.random_range(0..registers.len())];
         let rn = registers[rng.random_range(0..registers.len())];
         let pick_reg = |rng: &mut R| registers[rng.random_range(0..registers.len())];
@@ -728,6 +729,68 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                         nzcv,
                         cond,
                     }
+                }
+            }
+            // Bit-field aliases (issue #61: UBFX/SBFX/BFI/BFXIL/UBFIZ/SBFIZ).
+            // SP is illegal in both rd and rn; we pre-filter rather than retry
+            // so the release build has no infinite-spin path on a degenerate
+            // `[SP]`-only pool — that case falls back to the multiply-accumulate
+            // family (which tolerates any register). The 2D constraint
+            // `lsb + width <= 64` is enforced by sampling width AFTER lsb so
+            // width is bounded by `64 - lsb`.
+            29 => {
+                let non_sp: Vec<Register> = registers
+                    .iter()
+                    .copied()
+                    .filter(|r| *r != Register::SP)
+                    .collect();
+                if non_sp.is_empty() {
+                    let rm = pick_reg(rng);
+                    return Instruction::Mneg { rd, rn, rm };
+                }
+                let pick_non_sp = |rng: &mut R| non_sp[rng.random_range(0..non_sp.len())];
+                let bf_rd = pick_non_sp(rng);
+                let bf_rn = pick_non_sp(rng);
+                let lsb = (rng.random::<u32>() & 0x3F) as u8;
+                let max_w = 64 - lsb as u32;
+                let width = ((rng.random::<u32>() % max_w) + 1) as u8;
+                match rng.random_range(0..6) {
+                    0 => Instruction::Ubfx {
+                        rd: bf_rd,
+                        rn: bf_rn,
+                        lsb,
+                        width,
+                    },
+                    1 => Instruction::Sbfx {
+                        rd: bf_rd,
+                        rn: bf_rn,
+                        lsb,
+                        width,
+                    },
+                    2 => Instruction::Bfi {
+                        rd: bf_rd,
+                        rn: bf_rn,
+                        lsb,
+                        width,
+                    },
+                    3 => Instruction::Bfxil {
+                        rd: bf_rd,
+                        rn: bf_rn,
+                        lsb,
+                        width,
+                    },
+                    4 => Instruction::Ubfiz {
+                        rd: bf_rd,
+                        rn: bf_rn,
+                        lsb,
+                        width,
+                    },
+                    _ => Instruction::Sbfiz {
+                        rd: bf_rd,
+                        rn: bf_rn,
+                        lsb,
+                        width,
+                    },
                 }
             }
             _ => unreachable!(),

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -164,6 +164,12 @@ impl InstructionType for Instruction {
             Instruction::Sxtw { .. } => 51,
             Instruction::Uxtb { .. } => 52,
             Instruction::Uxth { .. } => 53,
+            Instruction::Ubfx { .. } => 49,
+            Instruction::Sbfx { .. } => 50,
+            Instruction::Bfi { .. } => 51,
+            Instruction::Bfxil { .. } => 52,
+            Instruction::Ubfiz { .. } => 53,
+            Instruction::Sbfiz { .. } => 54,
         }
     }
 
@@ -222,6 +228,12 @@ impl InstructionType for Instruction {
             Instruction::Sxtw { .. } => "sxtw",
             Instruction::Uxtb { .. } => "uxtb",
             Instruction::Uxth { .. } => "uxth",
+            Instruction::Ubfx { .. } => "ubfx",
+            Instruction::Sbfx { .. } => "sbfx",
+            Instruction::Bfi { .. } => "bfi",
+            Instruction::Bfxil { .. } => "bfxil",
+            Instruction::Ubfiz { .. } => "ubfiz",
+            Instruction::Sbfiz { .. } => "sbfiz",
         }
     }
 
@@ -855,6 +867,42 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     Instruction::Sxtw { rn, .. } => Instruction::Sxtw { rd: new_rd, rn },
                     Instruction::Uxtb { rn, .. } => Instruction::Uxtb { rd: new_rd, rn },
                     Instruction::Uxth { rn, .. } => Instruction::Uxth { rd: new_rd, rn },
+                    Instruction::Ubfx { rn, lsb, width, .. } => Instruction::Ubfx {
+                        rd: new_rd,
+                        rn,
+                        lsb,
+                        width,
+                    },
+                    Instruction::Sbfx { rn, lsb, width, .. } => Instruction::Sbfx {
+                        rd: new_rd,
+                        rn,
+                        lsb,
+                        width,
+                    },
+                    Instruction::Bfi { rn, lsb, width, .. } => Instruction::Bfi {
+                        rd: new_rd,
+                        rn,
+                        lsb,
+                        width,
+                    },
+                    Instruction::Bfxil { rn, lsb, width, .. } => Instruction::Bfxil {
+                        rd: new_rd,
+                        rn,
+                        lsb,
+                        width,
+                    },
+                    Instruction::Ubfiz { rn, lsb, width, .. } => Instruction::Ubfiz {
+                        rd: new_rd,
+                        rn,
+                        lsb,
+                        width,
+                    },
+                    Instruction::Sbfiz { rn, lsb, width, .. } => Instruction::Sbfiz {
+                        rd: new_rd,
+                        rn,
+                        lsb,
+                        width,
+                    },
                 }
             }
             2 => {
@@ -1197,6 +1245,42 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     Instruction::Uxth { rd, .. } => Instruction::Uxth {
                         rd,
                         rn: registers[rng.random_range(0..registers.len())],
+                    },
+                    Instruction::Ubfx { rd, lsb, width, .. } => Instruction::Ubfx {
+                        rd,
+                        rn: registers[rng.random_range(0..registers.len())],
+                        lsb,
+                        width,
+                    },
+                    Instruction::Sbfx { rd, lsb, width, .. } => Instruction::Sbfx {
+                        rd,
+                        rn: registers[rng.random_range(0..registers.len())],
+                        lsb,
+                        width,
+                    },
+                    Instruction::Bfi { rd, lsb, width, .. } => Instruction::Bfi {
+                        rd,
+                        rn: registers[rng.random_range(0..registers.len())],
+                        lsb,
+                        width,
+                    },
+                    Instruction::Bfxil { rd, lsb, width, .. } => Instruction::Bfxil {
+                        rd,
+                        rn: registers[rng.random_range(0..registers.len())],
+                        lsb,
+                        width,
+                    },
+                    Instruction::Ubfiz { rd, lsb, width, .. } => Instruction::Ubfiz {
+                        rd,
+                        rn: registers[rng.random_range(0..registers.len())],
+                        lsb,
+                        width,
+                    },
+                    Instruction::Sbfiz { rd, lsb, width, .. } => Instruction::Sbfiz {
+                        rd,
+                        rn: registers[rng.random_range(0..registers.len())],
+                        lsb,
+                        width,
                     },
                 }
             }

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -1290,20 +1290,21 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
 
     /// Total number of distinct opcode *families* (the upper bound on
     /// `opcode_id()`). Not the same as `generate_random`'s slot count —
-    /// `generate_random` samples 29 top-level slots and folds ANDS, CSET,
-    /// CSETM, and ROR into a sub-multiplexer on slot 23, the six single-
-    /// source bit-manipulation ops into a sub-multiplexer on slot 26, the
-    /// five multiply-accumulate ops into one on slot 27, and the two
-    /// conditional-compare ops into one on slot 28 — keeping the slot
-    /// table small. So `opcode_id < opcode_count` always holds, but the
-    /// random-generation distribution is not uniform across all 49 IDs.
+    /// `generate_random` samples 29 top-level slots and folds several
+    /// families into sub-multiplexers (e.g. CLZ/CLS/RBIT/REV*/REV16 on
+    /// slot 26, the five multiply-accumulate ops on slot 27, the two
+    /// conditional-compare ops on slot 28, and the six bit-field aliases
+    /// on slot 29) — keeping the slot table small. So
+    /// `opcode_id < opcode_count` always holds, but the random-generation
+    /// distribution is not uniform across all 55 IDs.
     fn opcode_count(&self) -> u8 {
-        49 // 20 original + 14 Tier 1 (MVN, NEG, NEGS, MovN, BIC, BICS, ORN,
+        55 // 20 original + 14 Tier 1 (MVN, NEG, NEGS, MovN, BIC, BICS, ORN,
         //  EON, ADDS, SUBS, ANDS, CSET, CSETM, ROR) + 2 MOVK/MOVZ (issue
         //  #55) + 6 single-source bit-manipulation (CLZ, CLS, RBIT, REV,
         //  REV32, REV16) + 5 multiply-accumulate family (issue #56:
-        //  MADD, MSUB, MNEG, SMULH, UMULH) + 2 conditional-compare
-        //  family (issue #57: CCMP, CCMN).
+        //  MADD, MSUB, MNEG, SMULH, UMULH) + 2 conditional-compare family
+        //  (issue #57: CCMP, CCMN) + 6 bit-field aliases (UBFX, SBFX, BFI,
+        //  BFXIL, UBFIZ, SBFIZ, issue #61).
     }
 }
 
@@ -1604,6 +1605,42 @@ mod tests {
                 rm: Operand::Immediate(5),
                 nzcv: 0,
                 cond: Condition::EQ,
+            },
+            Instruction::Ubfx {
+                rd: Register::X0,
+                rn: Register::X1,
+                lsb: 8,
+                width: 16,
+            },
+            Instruction::Sbfx {
+                rd: Register::X0,
+                rn: Register::X1,
+                lsb: 8,
+                width: 16,
+            },
+            Instruction::Bfi {
+                rd: Register::X0,
+                rn: Register::X1,
+                lsb: 4,
+                width: 8,
+            },
+            Instruction::Bfxil {
+                rd: Register::X0,
+                rn: Register::X1,
+                lsb: 4,
+                width: 8,
+            },
+            Instruction::Ubfiz {
+                rd: Register::X0,
+                rn: Register::X1,
+                lsb: 4,
+                width: 8,
+            },
+            Instruction::Sbfiz {
+                rd: Register::X0,
+                rn: Register::X1,
+                lsb: 4,
+                width: 8,
             },
         ]
     }

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -480,6 +480,37 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
             }
         }
 
+        // Bit-field aliases (issue #61: UBFX/SBFX/BFI/BFXIL/UBFIZ/SBFIZ).
+        // Sparse (lsb, width) sampling to keep the enumerative budget bounded.
+        // Filter SP from both rd and rn (matches is_encodable_aarch64). 2D
+        // constraint lsb + width <= 64 enforced via the if-guard. Mirrors the
+        // sampling tables in `src/search/candidate.rs::generate_all_instructions`.
+        const BITFIELD_LSB_SAMPLES: [u8; 5] = [0, 1, 16, 32, 63];
+        const BITFIELD_WIDTH_SAMPLES: [u8; 6] = [1, 4, 8, 16, 32, 64];
+        for &rd in registers {
+            if rd == Register::SP {
+                continue;
+            }
+            for &rn in registers {
+                if rn == Register::SP {
+                    continue;
+                }
+                for &lsb in &BITFIELD_LSB_SAMPLES {
+                    for &width in &BITFIELD_WIDTH_SAMPLES {
+                        if (lsb as u16 + width as u16) > 64 {
+                            continue;
+                        }
+                        instructions.push(Instruction::Ubfx { rd, rn, lsb, width });
+                        instructions.push(Instruction::Sbfx { rd, rn, lsb, width });
+                        instructions.push(Instruction::Bfi { rd, rn, lsb, width });
+                        instructions.push(Instruction::Bfxil { rd, rn, lsb, width });
+                        instructions.push(Instruction::Ubfiz { rd, rn, lsb, width });
+                        instructions.push(Instruction::Sbfiz { rd, rn, lsb, width });
+                    }
+                }
+            }
+        }
+
         instructions
     }
 
@@ -1353,7 +1384,7 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
 
     /// Total number of distinct opcode *families* (the upper bound on
     /// `opcode_id()`). Not the same as `generate_random`'s slot count —
-    /// `generate_random` samples 29 top-level slots and folds several
+    /// `generate_random` samples 30 top-level slots and folds several
     /// families into sub-multiplexers (e.g. CLZ/CLS/RBIT/REV*/REV16 on
     /// slot 26, the five multiply-accumulate ops on slot 27, the two
     /// conditional-compare ops on slot 28, and the six bit-field aliases

--- a/src/main.rs
+++ b/src/main.rs
@@ -1941,12 +1941,19 @@ mod cli_helper_tests {
             ("sxtb", "x0, w1"),
             ("sxth", "x0, w1"),
             ("sxtw", "x0, w1"),
+            // Issue #61: bit-field aliases of UBFM/SBFM/BFM.
+            ("ubfx", "x0, x1, #8, #16"),
+            ("sbfx", "x0, x1, #8, #16"),
+            ("bfi", "x0, x1, #4, #8"),
+            ("bfxil", "x0, x1, #8, #8"),
+            ("ubfiz", "x0, x1, #4, #8"),
+            ("sbfiz", "x0, x1, #4, #8"),
         ];
 
         // Tripwire: bump in lockstep when adding/removing rows. Catches
         // accidental row deletion and forces a re-read when adding a parser
         // mnemonic without a matching test row.
-        assert_eq!(cases.len(), 61);
+        assert_eq!(cases.len(), 67);
 
         for (mnem, ops) in cases {
             match convert_capstone_op(mnem, ops) {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -977,6 +977,37 @@ fn parse_ccmn(operands: &[&str]) -> Result<Instruction, String> {
     })
 }
 
+/// Parse a bit-field-manipulation instruction operand list:
+/// `rd, rn, #lsb, #width`. Used by UBFX/SBFX/BFI/BFXIL/UBFIZ/SBFIZ.
+fn parse_bfm_like(operands: &[&str], mnem: &str) -> Result<(Register, Register, u8, u8), String> {
+    if operands.len() != 4 {
+        return Err(format!(
+            "{} requires 4 operands, got {}",
+            mnem,
+            operands.len()
+        ));
+    }
+    let rd = parse_register(operands[0])?;
+    let rn = parse_register(operands[1])?;
+    let lsb_raw = parse_immediate(operands[2])?;
+    if !(0..=63).contains(&lsb_raw) {
+        return Err(format!("{} lsb {} out of range (0..=63)", mnem, lsb_raw));
+    }
+    let width_raw = parse_immediate(operands[3])?;
+    if !(1..=64).contains(&width_raw) {
+        return Err(format!(
+            "{} width {} out of range (1..=64)",
+            mnem, width_raw
+        ));
+    }
+    let lsb = lsb_raw as u8;
+    let width = width_raw as u8;
+    if (lsb as u16 + width as u16) > 64 {
+        return Err(format!("{} lsb {} + width {} exceeds 64", mnem, lsb, width));
+    }
+    Ok((rd, rn, lsb, width))
+}
+
 fn parse_ccmp_like(
     operands: &[&str],
     mnem: &str,
@@ -1118,6 +1149,24 @@ pub fn parse_line(line: &str) -> Result<LineResult, ParseLineError> {
         "tst" => parse_tst(&operands).map_err(ParseLineError::Other)?,
         "ccmp" => parse_ccmp(&operands).map_err(ParseLineError::Other)?,
         "ccmn" => parse_ccmn(&operands).map_err(ParseLineError::Other)?,
+        "ubfx" => parse_bfm_like(&operands, "ubfx")
+            .map(|(rd, rn, lsb, width)| Instruction::Ubfx { rd, rn, lsb, width })
+            .map_err(ParseLineError::Other)?,
+        "sbfx" => parse_bfm_like(&operands, "sbfx")
+            .map(|(rd, rn, lsb, width)| Instruction::Sbfx { rd, rn, lsb, width })
+            .map_err(ParseLineError::Other)?,
+        "bfi" => parse_bfm_like(&operands, "bfi")
+            .map(|(rd, rn, lsb, width)| Instruction::Bfi { rd, rn, lsb, width })
+            .map_err(ParseLineError::Other)?,
+        "bfxil" => parse_bfm_like(&operands, "bfxil")
+            .map(|(rd, rn, lsb, width)| Instruction::Bfxil { rd, rn, lsb, width })
+            .map_err(ParseLineError::Other)?,
+        "ubfiz" => parse_bfm_like(&operands, "ubfiz")
+            .map(|(rd, rn, lsb, width)| Instruction::Ubfiz { rd, rn, lsb, width })
+            .map_err(ParseLineError::Other)?,
+        "sbfiz" => parse_bfm_like(&operands, "sbfiz")
+            .map(|(rd, rn, lsb, width)| Instruction::Sbfiz { rd, rn, lsb, width })
+            .map_err(ParseLineError::Other)?,
         "csel" => parse_csel(&operands).map_err(ParseLineError::Other)?,
         "csinc" => parse_csinc(&operands).map_err(ParseLineError::Other)?,
         "csinv" => parse_csinv(&operands).map_err(ParseLineError::Other)?,
@@ -1675,6 +1724,43 @@ mod tests {
         let line = "ccmp x1, #32, #0, eq";
         let result = parse_line(line);
         assert!(result.is_err(), "imm5 > 31 must be rejected");
+    }
+
+    #[test]
+    fn parse_ubfx_roundtrip() {
+        let parsed = match parse_line("ubfx x0, x1, #5, #10").unwrap() {
+            LineResult::Instruction(instr) => instr,
+            LineResult::Skip => panic!("unexpected skip"),
+        };
+        assert_eq!(
+            parsed,
+            Instruction::Ubfx {
+                rd: Register::X0,
+                rn: Register::X1,
+                lsb: 5,
+                width: 10,
+            }
+        );
+        assert_eq!(format!("{}", parsed), "ubfx x0, x1, #5, #10");
+    }
+
+    #[test]
+    fn parse_ubfx_rejects_out_of_range_lsb() {
+        let result = parse_line("ubfx x0, x1, #64, #1");
+        assert!(result.is_err(), "lsb >= 64 must be rejected");
+    }
+
+    #[test]
+    fn parse_ubfx_rejects_zero_width() {
+        let result = parse_line("ubfx x0, x1, #0, #0");
+        assert!(result.is_err(), "width == 0 must be rejected");
+    }
+
+    #[test]
+    fn parse_ubfx_rejects_overlap() {
+        // lsb + width > 64
+        let result = parse_line("ubfx x0, x1, #60, #10");
+        assert!(result.is_err(), "lsb + width > 64 must be rejected");
     }
 
     #[test]

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -337,6 +337,36 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
         }
     }
 
+    // Bit-field manipulation (UBFX/SBFX/BFI/BFXIL/UBFIZ/SBFIZ): sparse
+    // (lsb, width) samples to keep the enumerative budget bounded. With
+    // 31 non-SP registers × 31 rn × ~24 valid (lsb,width) pairs × 6 variants
+    // ≈ 138k additional candidates, comparable to the CCMP/CCMN budget.
+    const BITFIELD_LSB_SAMPLES: [u8; 5] = [0, 1, 16, 32, 63];
+    const BITFIELD_WIDTH_SAMPLES: [u8; 6] = [1, 4, 8, 16, 32, 64];
+    for &rd in registers {
+        if rd == Register::SP {
+            continue;
+        }
+        for &rn in registers {
+            if rn == Register::SP {
+                continue;
+            }
+            for &lsb in &BITFIELD_LSB_SAMPLES {
+                for &width in &BITFIELD_WIDTH_SAMPLES {
+                    if (lsb as u16 + width as u16) > 64 {
+                        continue;
+                    }
+                    instrs.push(Instruction::Ubfx { rd, rn, lsb, width });
+                    instrs.push(Instruction::Sbfx { rd, rn, lsb, width });
+                    instrs.push(Instruction::Bfi { rd, rn, lsb, width });
+                    instrs.push(Instruction::Bfxil { rd, rn, lsb, width });
+                    instrs.push(Instruction::Ubfiz { rd, rn, lsb, width });
+                    instrs.push(Instruction::Sbfiz { rd, rn, lsb, width });
+                }
+            }
+        }
+    }
+
     instrs
 }
 
@@ -356,7 +386,7 @@ pub fn generate_random_instruction<R: rand::RngExt>(
     let rd = registers[rng.random_range(0..registers.len())];
     let pick_reg = |rng: &mut R| registers[rng.random_range(0..registers.len())];
 
-    match rng.random_range(0..30) {
+    match rng.random_range(0..31) {
         0 => {
             let imm = if immediates.is_empty() {
                 0
@@ -551,6 +581,65 @@ pub fn generate_random_instruction<R: rand::RngExt>(
                 Instruction::Ccmn { rn, rm, nzcv, cond }
             }
         }
+        // Bit-field manipulation (UBFX/SBFX/BFI/BFXIL/UBFIZ/SBFIZ).
+        // SP rejected in rd and rn (matches `generate_all_instructions` and
+        // `is_encodable_aarch64`); 2D constraint on (lsb, width) enforced by
+        // sampling width AFTER lsb so width is bounded by `64-lsb`.
+        28 => {
+            debug_assert!(
+                registers.iter().any(|r| *r != Register::SP),
+                "bit-field random generator requires at least one non-SP register",
+            );
+            let pick_non_sp = |rng: &mut R| loop {
+                let r = pick_reg(rng);
+                if r != Register::SP {
+                    break r;
+                }
+            };
+            let rd_local = pick_non_sp(rng);
+            let rn = pick_non_sp(rng);
+            let lsb = (rng.random::<u32>() & 0x3F) as u8;
+            let max_w = 64 - lsb as u32;
+            let width = ((rng.random::<u32>() % max_w) + 1) as u8;
+            match rng.random_range(0..6) {
+                0 => Instruction::Ubfx {
+                    rd: rd_local,
+                    rn,
+                    lsb,
+                    width,
+                },
+                1 => Instruction::Sbfx {
+                    rd: rd_local,
+                    rn,
+                    lsb,
+                    width,
+                },
+                2 => Instruction::Bfi {
+                    rd: rd_local,
+                    rn,
+                    lsb,
+                    width,
+                },
+                3 => Instruction::Bfxil {
+                    rd: rd_local,
+                    rn,
+                    lsb,
+                    width,
+                },
+                4 => Instruction::Ubfiz {
+                    rd: rd_local,
+                    rn,
+                    lsb,
+                    width,
+                },
+                _ => Instruction::Sbfiz {
+                    rd: rd_local,
+                    rn,
+                    lsb,
+                    width,
+                },
+            }
+        }
         // Multiply-accumulate family: MADD/MSUB (4-operand) and MNEG/SMULH/UMULH (3-operand).
         _ => {
             let rn = pick_reg(rng);
@@ -670,6 +759,12 @@ pub fn opcode_id(instr: &Instruction) -> u8 {
         Instruction::Sxtw { .. } => 51,
         Instruction::Uxtb { .. } => 52,
         Instruction::Uxth { .. } => 53,
+        Instruction::Ubfx { .. } => 49,
+        Instruction::Sbfx { .. } => 50,
+        Instruction::Bfi { .. } => 51,
+        Instruction::Bfxil { .. } => 52,
+        Instruction::Ubfiz { .. } => 53,
+        Instruction::Sbfiz { .. } => 54,
     }
 }
 
@@ -867,6 +962,41 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_random_instruction_emits_bitfield_eventually() {
+        let mut rng = rand::rng();
+        let regs = default_registers();
+        let imms = default_immediates();
+
+        // Random generator picks among many cases; over 5000 trials it must
+        // produce at least one bit-field instruction. Also: every random
+        // bit-field must be encodable.
+        let mut seen_bitfield = false;
+        for _ in 0..5000 {
+            let instr = generate_random_instruction(&mut rng, &regs, &imms);
+            if matches!(
+                &instr,
+                Instruction::Ubfx { .. }
+                    | Instruction::Sbfx { .. }
+                    | Instruction::Bfi { .. }
+                    | Instruction::Bfxil { .. }
+                    | Instruction::Ubfiz { .. }
+                    | Instruction::Sbfiz { .. }
+            ) {
+                seen_bitfield = true;
+                assert!(
+                    instr.is_encodable_aarch64(),
+                    "random bit-field must be encodable: {}",
+                    instr
+                );
+            }
+        }
+        assert!(
+            seen_bitfield,
+            "random generator must emit at least one bit-field instruction in 5000 trials"
+        );
+    }
+
+    #[test]
     fn test_generate_random_sequence() {
         let mut rng = rand::rng();
         let regs = default_registers();
@@ -932,6 +1062,110 @@ mod tests {
         let ids: Vec<_> = instrs.iter().map(opcode_id).collect();
         let unique: std::collections::HashSet<_> = ids.iter().collect();
         assert_eq!(ids.len(), unique.len());
+    }
+
+    /// Sync test: opcode_id in candidate.rs must agree with
+    /// AArch64InstructionInfo::opcode_id in isa/aarch64.rs for every bitfield
+    /// variant. Catches drift between the two definitions.
+    #[test]
+    fn test_bitfield_opcode_id_matches_isa_backend() {
+        use crate::isa::InstructionType;
+        let instrs = vec![
+            Instruction::Ubfx {
+                rd: Register::X0,
+                rn: Register::X1,
+                lsb: 0,
+                width: 1,
+            },
+            Instruction::Sbfx {
+                rd: Register::X0,
+                rn: Register::X1,
+                lsb: 0,
+                width: 1,
+            },
+            Instruction::Bfi {
+                rd: Register::X0,
+                rn: Register::X1,
+                lsb: 0,
+                width: 1,
+            },
+            Instruction::Bfxil {
+                rd: Register::X0,
+                rn: Register::X1,
+                lsb: 0,
+                width: 1,
+            },
+            Instruction::Ubfiz {
+                rd: Register::X0,
+                rn: Register::X1,
+                lsb: 0,
+                width: 1,
+            },
+            Instruction::Sbfiz {
+                rd: Register::X0,
+                rn: Register::X1,
+                lsb: 0,
+                width: 1,
+            },
+        ];
+        for instr in &instrs {
+            assert_eq!(
+                opcode_id(instr),
+                instr.opcode_id(),
+                "opcode_id drift for {}",
+                instr
+            );
+        }
+    }
+
+    #[test]
+    fn test_generate_all_instructions_includes_bitfield() {
+        let registers = vec![Register::X0, Register::X1];
+        let immediates = vec![0];
+        let all = generate_all_instructions(&registers, &immediates);
+        assert!(
+            all.iter().any(|i| matches!(i, Instruction::Ubfx { .. })),
+            "enumerative output must contain at least one Ubfx"
+        );
+        assert!(
+            all.iter().any(|i| matches!(i, Instruction::Sbfx { .. })),
+            "enumerative output must contain at least one Sbfx"
+        );
+        assert!(
+            all.iter().any(|i| matches!(i, Instruction::Bfi { .. })),
+            "enumerative output must contain at least one Bfi"
+        );
+        assert!(
+            all.iter().any(|i| matches!(i, Instruction::Bfxil { .. })),
+            "enumerative output must contain at least one Bfxil"
+        );
+        assert!(
+            all.iter().any(|i| matches!(i, Instruction::Ubfiz { .. })),
+            "enumerative output must contain at least one Ubfiz"
+        );
+        assert!(
+            all.iter().any(|i| matches!(i, Instruction::Sbfiz { .. })),
+            "enumerative output must contain at least one Sbfiz"
+        );
+
+        // Every generated bitfield instruction must satisfy is_encodable_aarch64.
+        for instr in all.iter().filter(|i| {
+            matches!(
+                i,
+                Instruction::Ubfx { .. }
+                    | Instruction::Sbfx { .. }
+                    | Instruction::Bfi { .. }
+                    | Instruction::Bfxil { .. }
+                    | Instruction::Ubfiz { .. }
+                    | Instruction::Sbfiz { .. }
+            )
+        }) {
+            assert!(
+                instr.is_encodable_aarch64(),
+                "enumerative produced un-encodable: {}",
+                instr
+            );
+        }
     }
 
     #[test]

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -351,6 +351,33 @@ impl Mutator {
                     _ => *shift = self.random_shift_operand(rng),
                 }
             }
+            // Bit-field manipulation: 4-way operand mutation (rd, rn, lsb, width)
+            // with 2D clamping so the (lsb + width <= 64) constraint is always
+            // preserved. When mutating lsb, clamp width if necessary.
+            Instruction::Ubfx { rd, rn, lsb, width }
+            | Instruction::Sbfx { rd, rn, lsb, width }
+            | Instruction::Bfi { rd, rn, lsb, width }
+            | Instruction::Bfxil { rd, rn, lsb, width }
+            | Instruction::Ubfiz { rd, rn, lsb, width }
+            | Instruction::Sbfiz { rd, rn, lsb, width } => {
+                match rng.random_range(0..4) {
+                    0 => *rd = self.random_register(rng),
+                    1 => *rn = self.random_register(rng),
+                    2 => {
+                        // Mutate width: bound by current lsb so the pair stays valid.
+                        let max_w = (64 - *lsb).max(1);
+                        *width = ((rng.random::<u32>() % max_w as u32) + 1) as u8;
+                    }
+                    _ => {
+                        // Mutate lsb; clamp width down if the new lsb would
+                        // overflow the (lsb + width <= 64) constraint.
+                        *lsb = (rng.random::<u32>() & 0x3F) as u8;
+                        if (*lsb as u16 + *width as u16) > 64 {
+                            *width = 64 - *lsb;
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -754,6 +781,59 @@ impl Mutator {
                 0 => Instruction::Smulh { rd, rn, rm },
                 _ => Instruction::Umulh { rd, rn, rm },
             },
+            // Bit-field manipulation: 6-peer cluster. Each variant has 5
+            // peers + self-identity. Note: swapping between extract (UBFX/SBFX)
+            // and insert (BFI/BFXIL/UBFIZ/SBFIZ) variants changes whether rd
+            // is read; MCMC tolerates this because invalid proposals fail
+            // equivalence checking and are rejected by the acceptance step.
+            Instruction::Ubfx { rd, rn, lsb, width } => match rng.random_range(0..6) {
+                0 => Instruction::Sbfx { rd, rn, lsb, width },
+                1 => Instruction::Bfi { rd, rn, lsb, width },
+                2 => Instruction::Bfxil { rd, rn, lsb, width },
+                3 => Instruction::Ubfiz { rd, rn, lsb, width },
+                4 => Instruction::Sbfiz { rd, rn, lsb, width },
+                _ => Instruction::Ubfx { rd, rn, lsb, width },
+            },
+            Instruction::Sbfx { rd, rn, lsb, width } => match rng.random_range(0..6) {
+                0 => Instruction::Ubfx { rd, rn, lsb, width },
+                1 => Instruction::Bfi { rd, rn, lsb, width },
+                2 => Instruction::Bfxil { rd, rn, lsb, width },
+                3 => Instruction::Ubfiz { rd, rn, lsb, width },
+                4 => Instruction::Sbfiz { rd, rn, lsb, width },
+                _ => Instruction::Sbfx { rd, rn, lsb, width },
+            },
+            Instruction::Bfi { rd, rn, lsb, width } => match rng.random_range(0..6) {
+                0 => Instruction::Ubfx { rd, rn, lsb, width },
+                1 => Instruction::Sbfx { rd, rn, lsb, width },
+                2 => Instruction::Bfxil { rd, rn, lsb, width },
+                3 => Instruction::Ubfiz { rd, rn, lsb, width },
+                4 => Instruction::Sbfiz { rd, rn, lsb, width },
+                _ => Instruction::Bfi { rd, rn, lsb, width },
+            },
+            Instruction::Bfxil { rd, rn, lsb, width } => match rng.random_range(0..6) {
+                0 => Instruction::Ubfx { rd, rn, lsb, width },
+                1 => Instruction::Sbfx { rd, rn, lsb, width },
+                2 => Instruction::Bfi { rd, rn, lsb, width },
+                3 => Instruction::Ubfiz { rd, rn, lsb, width },
+                4 => Instruction::Sbfiz { rd, rn, lsb, width },
+                _ => Instruction::Bfxil { rd, rn, lsb, width },
+            },
+            Instruction::Ubfiz { rd, rn, lsb, width } => match rng.random_range(0..6) {
+                0 => Instruction::Ubfx { rd, rn, lsb, width },
+                1 => Instruction::Sbfx { rd, rn, lsb, width },
+                2 => Instruction::Bfi { rd, rn, lsb, width },
+                3 => Instruction::Bfxil { rd, rn, lsb, width },
+                4 => Instruction::Sbfiz { rd, rn, lsb, width },
+                _ => Instruction::Ubfiz { rd, rn, lsb, width },
+            },
+            Instruction::Sbfiz { rd, rn, lsb, width } => match rng.random_range(0..6) {
+                0 => Instruction::Ubfx { rd, rn, lsb, width },
+                1 => Instruction::Sbfx { rd, rn, lsb, width },
+                2 => Instruction::Bfi { rd, rn, lsb, width },
+                3 => Instruction::Bfxil { rd, rn, lsb, width },
+                4 => Instruction::Ubfiz { rd, rn, lsb, width },
+                _ => Instruction::Sbfiz { rd, rn, lsb, width },
+            },
         };
     }
 
@@ -1108,6 +1188,75 @@ mod tests {
         }
 
         assert!(changed_to_different_opcode);
+    }
+
+    #[test]
+    fn test_bitfield_operand_mutation_changes_fields_and_stays_encodable() {
+        let mutator = default_mutator();
+        let mut rng = rand::rng();
+
+        let original = Instruction::Ubfx {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 8,
+            width: 16,
+        };
+        let mut changed = false;
+        for _ in 0..200 {
+            let mut seq = vec![original];
+            mutator.mutate_operand(&mut rng, &mut seq);
+            assert!(
+                seq[0].is_encodable_aarch64(),
+                "mutated bit-field instruction must remain encodable: {}",
+                seq[0]
+            );
+            if seq[0] != original {
+                changed = true;
+            }
+        }
+        assert!(
+            changed,
+            "operand mutation must produce a different bit-field instruction within 200 trials"
+        );
+    }
+
+    #[test]
+    fn test_bitfield_opcode_mutation_swaps_to_peer() {
+        let mutator = default_mutator();
+        let mut rng = rand::rng();
+
+        let original = Instruction::Ubfx {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 8,
+            width: 16,
+        };
+        let mut swapped_to_peer = false;
+        for _ in 0..200 {
+            let mut seq = vec![original];
+            mutator.mutate_opcode(&mut rng, &mut seq);
+            assert!(
+                seq[0].is_encodable_aarch64(),
+                "opcode mutation must produce encodable bit-field: {}",
+                seq[0]
+            );
+            // A peer is any of the other 5 bit-field variants.
+            if matches!(
+                seq[0],
+                Instruction::Sbfx { .. }
+                    | Instruction::Bfi { .. }
+                    | Instruction::Bfxil { .. }
+                    | Instruction::Ubfiz { .. }
+                    | Instruction::Sbfiz { .. }
+            ) {
+                swapped_to_peer = true;
+                break;
+            }
+        }
+        assert!(
+            swapped_to_peer,
+            "opcode mutation must reach a peer bit-field variant within 200 trials"
+        );
     }
 
     #[test]

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -427,6 +427,83 @@ pub fn apply_instruction_concrete(
             let value = state.get_register(*rn).as_u64();
             state.set_register(*rd, ConcreteValue::new(value & 0xFFFF));
         }
+        // UBFX rd, rn, #lsb, #width: extract bits [lsb+width-1:lsb] of rn,
+        // zero-extend the result into rd. width=64 must use u64::MAX as the
+        // low-bits mask to avoid the `1u64 << 64` UB.
+        Instruction::Ubfx { rd, rn, lsb, width } => {
+            let value = state.get_register(*rn).as_u64();
+            let low_mask = if *width == 64 {
+                u64::MAX
+            } else {
+                (1u64 << *width) - 1
+            };
+            let extracted = (value >> *lsb) & low_mask;
+            state.set_register(*rd, ConcreteValue::new(extracted));
+        }
+        // SBFX rd, rn, #lsb, #width: extract bits [lsb+width-1:lsb] of rn,
+        // sign-extend the result into rd. width=64 is the no-op identity.
+        Instruction::Sbfx { rd, rn, lsb, width } => {
+            let value = state.get_register(*rn).as_u64();
+            // Shift left then arithmetic-right by the same amount, computed on
+            // i64, to sign-extend the field MSB across the upper bits.
+            let shift_left = 64 - (*lsb + *width) as u32;
+            let intermediate = (value << shift_left) as i64;
+            // Right shift by (64 - width) sign-extends from bit (width-1).
+            let result = (intermediate >> (64 - *width as u32)) as u64;
+            state.set_register(*rd, ConcreteValue::new(result));
+        }
+        // BFI rd, rn, #lsb, #width: insert low `width` bits of rn at position
+        // lsb of rd, preserving the other bits of rd.
+        Instruction::Bfi { rd, rn, lsb, width } => {
+            let dest = state.get_register(*rd).as_u64();
+            let src = state.get_register(*rn).as_u64();
+            let low_mask = if *width == 64 {
+                u64::MAX
+            } else {
+                (1u64 << *width) - 1
+            };
+            let shifted_mask = low_mask << *lsb;
+            let inserted = (src & low_mask) << *lsb;
+            let result = (dest & !shifted_mask) | inserted;
+            state.set_register(*rd, ConcreteValue::new(result));
+        }
+        // BFXIL rd, rn, #lsb, #width: extract bits [lsb+width-1:lsb] of rn,
+        // place at [width-1:0] of rd, preserve rd[63:width].
+        Instruction::Bfxil { rd, rn, lsb, width } => {
+            let dest = state.get_register(*rd).as_u64();
+            let src = state.get_register(*rn).as_u64();
+            let low_mask = if *width == 64 {
+                u64::MAX
+            } else {
+                (1u64 << *width) - 1
+            };
+            let extracted = (src >> *lsb) & low_mask;
+            let result = (dest & !low_mask) | extracted;
+            state.set_register(*rd, ConcreteValue::new(result));
+        }
+        // UBFIZ rd, rn, #lsb, #width: take low `width` bits of rn, zero-extend
+        // to 64, shift left by lsb → rd (other bits zero).
+        Instruction::Ubfiz { rd, rn, lsb, width } => {
+            let value = state.get_register(*rn).as_u64();
+            let low_mask = if *width == 64 {
+                u64::MAX
+            } else {
+                (1u64 << *width) - 1
+            };
+            let inserted = (value & low_mask) << *lsb;
+            state.set_register(*rd, ConcreteValue::new(inserted));
+        }
+        // SBFIZ rd, rn, #lsb, #width: low `width` bits of rn, sign-extended
+        // across bits [63:width], then shifted left by lsb → rd.
+        Instruction::Sbfiz { rd, rn, lsb, width } => {
+            let value = state.get_register(*rn).as_u64();
+            // Sign-extend the low `width` bits to 64.
+            let shift_left = 64 - *width as u32;
+            let sign_extended = ((value << shift_left) as i64 >> shift_left) as u64;
+            // Then shift left by lsb.
+            let result = sign_extended << *lsb;
+            state.set_register(*rd, ConcreteValue::new(result));
+        }
     }
     state
 }
@@ -2018,5 +2095,188 @@ mod tests {
             },
         );
         assert_eq!(after.get_register(Register::X0).as_u64(), 0xFF);
+    }
+
+    #[test]
+    fn test_ubfx_extracts_zero_extended_field() {
+        // UBFX X0, X1, #8, #16: take bits [23:8] of X1, zero-extend into X0.
+        let state = state_with(vec![(Register::X1, 0xDEAD_BEEF_CAFE_0123)]);
+        let instr = Instruction::Ubfx {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 8,
+            width: 16,
+        };
+        let after = apply_instruction_concrete(state, &instr);
+        // bits [23:8] of 0xDEAD_BEEF_CAFE_0123 = 0xFE01
+        assert_eq!(after.get_register(Register::X0).as_u64(), 0xFE01);
+    }
+
+    #[test]
+    fn test_ubfx_full_width_is_identity() {
+        // UBFX X0, X1, #0, #64 — extracts the whole word. Exercises the
+        // `1u64 << 64` UB guard documented in the plan.
+        let state = state_with(vec![(Register::X1, 0xFFFF_0000_5555_AAAA)]);
+        let instr = Instruction::Ubfx {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 0,
+            width: 64,
+        };
+        let after = apply_instruction_concrete(state, &instr);
+        assert_eq!(
+            after.get_register(Register::X0).as_u64(),
+            0xFFFF_0000_5555_AAAA
+        );
+    }
+
+    #[test]
+    fn test_sbfx_sign_extends_negative_field() {
+        // SBFX X0, X1, #4, #8: extract bits [11:4] of X1 (= 0xF0) and
+        // sign-extend. The MSB of the field is 1, so the upper 56 bits of X0
+        // become all-ones.
+        let state = state_with(vec![(Register::X1, 0xF00)]);
+        let instr = Instruction::Sbfx {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 4,
+            width: 8,
+        };
+        let after = apply_instruction_concrete(state, &instr);
+        // 0xF0 sign-extended from 8 bits = 0xFFFF_FFFF_FFFF_FFF0
+        assert_eq!(
+            after.get_register(Register::X0).as_u64(),
+            0xFFFF_FFFF_FFFF_FFF0
+        );
+    }
+
+    #[test]
+    fn test_sbfx_positive_field_no_extension() {
+        // SBFX with MSB of the extracted field = 0: result equals UBFX.
+        let state = state_with(vec![(Register::X1, 0x7F00)]);
+        let instr = Instruction::Sbfx {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 8,
+            width: 8,
+        };
+        let after = apply_instruction_concrete(state, &instr);
+        assert_eq!(after.get_register(Register::X0).as_u64(), 0x7F);
+    }
+
+    #[test]
+    fn test_sbfiz_sign_extends_field_above_lsb_plus_width() {
+        // SBFIZ X0, X1, #4, #8: low 8 bits of X1 = 0xAB (MSB set),
+        // sign-extend across bits [63:12], shift left by 4, zero bits [3:0].
+        let state = state_with(vec![(Register::X1, 0xAB)]);
+        let instr = Instruction::Sbfiz {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 4,
+            width: 8,
+        };
+        let after = apply_instruction_concrete(state, &instr);
+        // 0xAB sign-extended from 8 bits → 0xFFFF_FFFF_FFFF_FFAB
+        // <<4 → 0xFFFF_FFFF_FFFF_FAB0
+        assert_eq!(
+            after.get_register(Register::X0).as_u64(),
+            0xFFFF_FFFF_FFFF_FAB0
+        );
+    }
+
+    #[test]
+    fn test_sbfiz_positive_field() {
+        // MSB of field clear → result equals UBFIZ.
+        let state = state_with(vec![(Register::X1, 0x7F)]);
+        let instr = Instruction::Sbfiz {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 4,
+            width: 8,
+        };
+        let after = apply_instruction_concrete(state, &instr);
+        // 0x7F << 4 = 0x7F0; no sign extension.
+        assert_eq!(after.get_register(Register::X0).as_u64(), 0x7F0);
+    }
+
+    #[test]
+    fn test_ubfiz_zero_extends_field_shifted_into_position() {
+        // UBFIZ X0, X1, #4, #8: take low 8 bits of X1 (= 0xAB),
+        // shift left by 4, zero the rest. Existing X0 contents are discarded.
+        let state = state_with(vec![
+            (Register::X0, 0xFFFF_FFFF_FFFF_FFFF), // discarded
+            (Register::X1, 0x0000_0000_0000_00AB),
+        ]);
+        let instr = Instruction::Ubfiz {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 4,
+            width: 8,
+        };
+        let after = apply_instruction_concrete(state, &instr);
+        // 0xAB << 4 = 0xAB0; everything else zero.
+        assert_eq!(after.get_register(Register::X0).as_u64(), 0xAB0);
+    }
+
+    #[test]
+    fn test_bfxil_extracts_then_inserts_low() {
+        // BFXIL X0, X1, #8, #8: take bits [15:8] of X1 → 0xAB,
+        // place at bits [7:0] of X0, preserving X0's upper bits.
+        let state = state_with(vec![
+            (Register::X0, 0xFFFF_FFFF_FFFF_FFFF),
+            (Register::X1, 0x0000_0000_0000_AB00),
+        ]);
+        let instr = Instruction::Bfxil {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 8,
+            width: 8,
+        };
+        let after = apply_instruction_concrete(state, &instr);
+        // X0 upper 56 bits preserved (all ones), low 8 bits = 0xAB
+        assert_eq!(
+            after.get_register(Register::X0).as_u64(),
+            0xFFFF_FFFF_FFFF_FFAB
+        );
+    }
+
+    #[test]
+    fn test_bfi_preserves_other_bits_of_rd() {
+        // BFI X0, X1, #4, #8: insert low 8 bits of X1 at position 4 of X0,
+        // leaving the other bits of X0 unchanged.
+        let state = state_with(vec![
+            (Register::X0, 0xFFFF_FFFF_FFFF_0FFF),
+            (Register::X1, 0x000A_BEEF_DEAD_BEAA), // low 8 bits = 0xAA
+        ]);
+        let instr = Instruction::Bfi {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 4,
+            width: 8,
+        };
+        let after = apply_instruction_concrete(state, &instr);
+        // Bits [11:4] become 0xAA (from rn low 8 bits); other bits of X0 preserved.
+        // Original X0 = 0xFFFF_FFFF_FFFF_0FFF
+        //   bits [11:4] = 0xFF (within the 0x0FFF nibble pattern)
+        // After insert:
+        //   bits [11:4] = 0xAA → result = 0xFFFF_FFFF_FFFF_0AAF
+        assert_eq!(
+            after.get_register(Register::X0).as_u64(),
+            0xFFFF_FFFF_FFFF_0AAF
+        );
+    }
+
+    #[test]
+    fn test_ubfx_high_lsb_boundary() {
+        // UBFX X0, X1, #63, #1 — extracts the topmost bit.
+        let state = state_with(vec![(Register::X1, 0x8000_0000_0000_0000)]);
+        let instr = Instruction::Ubfx {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 63,
+            width: 1,
+        };
+        let after = apply_instruction_concrete(state, &instr);
+        assert_eq!(after.get_register(Register::X0).as_u64(), 1);
     }
 }

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -446,7 +446,10 @@ pub fn apply_instruction_concrete(
             let value = state.get_register(*rn).as_u64();
             // Shift left then arithmetic-right by the same amount, computed on
             // i64, to sign-extend the field MSB across the upper bits.
-            let shift_left = 64 - (*lsb + *width) as u32;
+            // Widen lsb/width to u32 before the sum so we never narrowly wrap
+            // through u8 when the caller passes unvalidated immediates
+            // (validated paths are bounded by is_encodable_aarch64).
+            let shift_left = 64 - ((*lsb as u32) + (*width as u32));
             let intermediate = (value << shift_left) as i64;
             // Right shift by (64 - width) sign-extends from bit (width-1).
             let result = (intermediate >> (64 - *width as u32)) as u64;

--- a/src/semantics/cost.rs
+++ b/src/semantics/cost.rs
@@ -68,6 +68,7 @@ fn instruction_latency(instr: &Instruction) -> u64 {
         // Rotate right
         Instruction::Ror { .. } => 1,
         // Single-source bit-manipulation (CLZ/CLS/RBIT/REV*): single-cycle ALU.
+        // Extends to SXT*/UXT* extended-register instructions (issue #60).
         Instruction::Clz { .. }
         | Instruction::Cls { .. }
         | Instruction::Rbit { .. }
@@ -79,6 +80,13 @@ fn instruction_latency(instr: &Instruction) -> u64 {
         | Instruction::Sxtw { .. }
         | Instruction::Uxtb { .. }
         | Instruction::Uxth { .. } => 1,
+        // Bit-field manipulation (UBFX/SBFX/BFI/BFXIL/UBFIZ/SBFIZ): single-cycle ALU.
+        Instruction::Ubfx { .. }
+        | Instruction::Sbfx { .. }
+        | Instruction::Bfi { .. }
+        | Instruction::Bfxil { .. }
+        | Instruction::Ubfiz { .. }
+        | Instruction::Sbfiz { .. } => 1,
     }
 }
 

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -1808,4 +1808,97 @@ mod tests {
             EquivalenceResult::Equivalent
         );
     }
+
+    /// Acceptance criterion #2 from issue #61:
+    /// SMT proves `BFI rd,rn,#lsb,#width` ≡ {
+    ///   AND tmp_field, rn, #low_mask;       // isolate low `width` bits of rn
+    ///   LSL tmp_shift, tmp_field, #lsb;     // shift them into position
+    ///   AND tmp_clear, rd, #!shifted_mask;  // clear destination window in rd
+    ///   ORR rd, tmp_clear, tmp_shift;       // merge
+    /// }
+    /// The issue's wording was "AND clear; AND mask; ORR" — this is the
+    /// formal expansion. Verified for one representative (lsb, width).
+    #[test]
+    fn test_bfi_equivalent_to_and_and_or() {
+        let lsb = 4u8;
+        let width = 8u8;
+        let low_mask = (1i64 << width) - 1;
+        let shifted_mask = low_mask << lsb;
+        let clear_mask = !shifted_mask;
+
+        let bfi = vec![Instruction::Bfi {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb,
+            width,
+        }];
+
+        let expanded = vec![
+            // tmp_field (X2) = rn & low_mask
+            Instruction::And {
+                rd: Register::X2,
+                rn: Register::X1,
+                rm: Operand::Immediate(low_mask),
+            },
+            // tmp_shift (X2) = tmp_field << lsb
+            Instruction::Lsl {
+                rd: Register::X2,
+                rn: Register::X2,
+                shift: Operand::Immediate(lsb as i64),
+            },
+            // tmp_clear (X3) = rd & !shifted_mask
+            Instruction::And {
+                rd: Register::X3,
+                rn: Register::X0,
+                rm: Operand::Immediate(clear_mask),
+            },
+            // rd = tmp_clear | tmp_shift
+            Instruction::Orr {
+                rd: Register::X0,
+                rn: Register::X3,
+                rm: Operand::Register(Register::X2),
+            },
+        ];
+
+        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
+        assert_eq!(
+            check_equivalence_with_config(&bfi, &expanded, &config),
+            EquivalenceResult::Equivalent
+        );
+    }
+
+    /// Acceptance criterion #1 from issue #61:
+    /// SMT proves `UBFX rd,rn,#lsb,#width` ≡ `LSR t,rn,#lsb; AND rd,t,#((1<<width)-1)`.
+    #[test]
+    fn test_ubfx_equivalent_to_lsr_and_mask() {
+        let lsb = 8i64;
+        let width = 16u8;
+        let mask = (1i64 << width) - 1;
+
+        let ubfx = vec![Instruction::Ubfx {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: lsb as u8,
+            width,
+        }];
+
+        let lsr_and = vec![
+            Instruction::Lsr {
+                rd: Register::X2,
+                rn: Register::X1,
+                shift: Operand::Immediate(lsb),
+            },
+            Instruction::And {
+                rd: Register::X0,
+                rn: Register::X2,
+                rm: Operand::Immediate(mask),
+            },
+        ];
+
+        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
+        assert_eq!(
+            check_equivalence_with_config(&ubfx, &lsr_and, &config),
+            EquivalenceResult::Equivalent
+        );
+    }
 }

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -734,6 +734,97 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let result = value.extract(15, 0).zero_ext(48);
             state.set_register(*rd, result);
         }
+        // UBFX rd, rn, #lsb, #width: extract bits [lsb+width-1:lsb] of rn,
+        // zero-extend the result into rd.
+        Instruction::Ubfx { rd, rn, lsb, width } => {
+            let value = state.get_register(*rn).clone();
+            let hi = (*lsb as u32) + (*width as u32) - 1;
+            let lo = *lsb as u32;
+            let extracted = value.extract(hi, lo);
+            // zero_extend by (64 - width); width=64 is a no-op.
+            let result = if *width == 64 {
+                extracted
+            } else {
+                extracted.zero_ext(64 - *width as u32)
+            };
+            state.set_register(*rd, result);
+        }
+        // SBFX rd, rn, #lsb, #width: extract bits [lsb+width-1:lsb] of rn,
+        // sign-extend into rd.
+        Instruction::Sbfx { rd, rn, lsb, width } => {
+            let value = state.get_register(*rn).clone();
+            let hi = (*lsb as u32) + (*width as u32) - 1;
+            let lo = *lsb as u32;
+            let extracted = value.extract(hi, lo);
+            let result = if *width == 64 {
+                extracted
+            } else {
+                extracted.sign_ext(64 - *width as u32)
+            };
+            state.set_register(*rd, result);
+        }
+        // BFI rd, rn, #lsb, #width: insert low `width` bits of rn at position
+        // lsb of rd, preserving the other bits of rd.
+        Instruction::Bfi { rd, rn, lsb, width } => {
+            let dest = state.get_register(*rd).clone();
+            let src = state.get_register(*rn).clone();
+            let low_mask_const = if *width == 64 {
+                u64::MAX
+            } else {
+                (1u64 << *width) - 1
+            };
+            let shifted_mask_const = low_mask_const << *lsb;
+            let low_mask = BV::from_u64(low_mask_const, 64);
+            let clear_mask = BV::from_u64(!shifted_mask_const, 64);
+            let shift = BV::from_u64(*lsb as u64, 64);
+            let inserted = src.bvand(&low_mask).bvshl(&shift);
+            let cleared = dest.bvand(&clear_mask);
+            state.set_register(*rd, cleared.bvor(&inserted));
+        }
+        // BFXIL rd, rn, #lsb, #width: extract bits [lsb+width-1:lsb] of rn,
+        // place at [width-1:0] of rd preserving rd[63:width].
+        Instruction::Bfxil { rd, rn, lsb, width } => {
+            let dest = state.get_register(*rd).clone();
+            let src = state.get_register(*rn).clone();
+            let low_mask_const = if *width == 64 {
+                u64::MAX
+            } else {
+                (1u64 << *width) - 1
+            };
+            let low_mask = BV::from_u64(low_mask_const, 64);
+            let clear_mask = BV::from_u64(!low_mask_const, 64);
+            let shift = BV::from_u64(*lsb as u64, 64);
+            // (rn >> lsb) & low_mask
+            let extracted = src.bvlshr(&shift).bvand(&low_mask);
+            let cleared = dest.bvand(&clear_mask);
+            state.set_register(*rd, cleared.bvor(&extracted));
+        }
+        // UBFIZ rd, rn, #lsb, #width: low `width` bits of rn, zero-extend,
+        // shift left by lsb → rd (other bits zero).
+        Instruction::Ubfiz { rd, rn, lsb, width } => {
+            let value = state.get_register(*rn).clone();
+            let field = value.extract(*width as u32 - 1, 0);
+            let widened = if *width == 64 {
+                field
+            } else {
+                field.zero_ext(64 - *width as u32)
+            };
+            let shift = BV::from_u64(*lsb as u64, 64);
+            state.set_register(*rd, widened.bvshl(&shift));
+        }
+        // SBFIZ rd, rn, #lsb, #width: low `width` bits of rn, sign-extended
+        // to 64, then shifted left by lsb → rd.
+        Instruction::Sbfiz { rd, rn, lsb, width } => {
+            let value = state.get_register(*rn).clone();
+            let field = value.extract(*width as u32 - 1, 0);
+            let widened = if *width == 64 {
+                field
+            } else {
+                field.sign_ext(64 - *width as u32)
+            };
+            let shift = BV::from_u64(*lsb as u64, 64);
+            state.set_register(*rd, widened.bvshl(&shift));
+        }
     }
     state
 }


### PR DESCRIPTION
## Summary
- Adds the six 64-bit AArch64 bit-field aliases of UBFM/SBFM/BFM, end-to-end: IR + Display, dynasm encoder, parser, concrete + SMT semantics, cost model, is_encodable, enumerative + random candidate generation, and stochastic mutation cluster.
- `BFI` / `BFXIL` correctly report both `rd` and `rn` as source registers since they preserve unmodified bits of `rd` — distinct from the extract variants.
- 2D constraint `lsb + width <= 64` is enforced consistently in `is_encodable_aarch64`, parser, enumerative gen, random gen, and the mutation arm (which clamps `width` when `lsb` moves).
- Scope is 64-bit X-registers only; 32-bit W variants tracked separately (follow-up issue).

## Acceptance criteria (issue #61), both proved by SMT
- `UBFX rd,rn,#lsb,#width` ≡ `LSR t,rn,#lsb; AND rd,t,#((1<<width)-1)` — `test_ubfx_equivalent_to_lsr_and_mask`
- `BFI rd,rn,#lsb,#width` ≡ `AND/LSL/AND/ORR` expansion — `test_bfi_equivalent_to_and_and_or`
- Capstone roundtrip via existing `disassemble_and_verify` — `test_{ubfx,sbfx,bfi,bfxil,ubfiz,sbfiz}_correctness`

## Test plan
- [x] `./ci_check.sh` — fmt, build, unit tests, x86 test binaries, full suite (575 passing; +31 new since baseline 544).
- [x] `width = 64` boundary: `test_ubfx_full_width_is_identity` exercises the `1u64 << 64` UB guard.
- [x] `lsb = 63` upper boundary: `test_ubfx_high_lsb_boundary` (concrete) and `test_ubfx_high_lsb_correctness` (Capstone).
- [x] SP rejection in `rd` and `rn`: `test_is_encodable_bitfield`.
- [x] opcode_id drift guard between `candidate.rs` and `isa/aarch64.rs`: `test_bitfield_opcode_id_matches_isa_backend`.
- [x] Random generator must emit valid bit-field instructions: `test_generate_random_instruction_emits_bitfield_eventually` (5000 trials, every emission must pass `is_encodable_aarch64`).
- [x] Stochastic mutation produces a different, still-encodable bit-field within 200 trials, and reaches a peer variant via opcode mutation.

## Notes on alias collisions
Capstone's alias-decoder maps UBFX with `lsb + width == 64` (i.e., `imms == 63`) to `LSR` — they share the same UBFM bit pattern. The full-width correctness test only verifies encoding length; equivalence is covered by concrete + SMT.

Resolves #61.