### PR TITLE
Add extended-register operand and standalone sign/zero-extend instructions (#60)

### DIFF
--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -798,8 +798,15 @@ impl AArch64Assembler {
                 dynasm!(ops ; .arch aarch64 ; uxth W(rd_reg), W(rn_reg));
                 Ok(())
             }
-            // SXTH/SXTW encoder bodies land in follow-up slices.
-            Instruction::Sxth { .. } | Instruction::Sxtw { .. } => {
+            // SXTH Xd, Wn — alias of SBFM Xd, Xn, #0, #15. Issue #60.
+            Instruction::Sxth { rd, rn } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                dynasm!(ops ; .arch aarch64 ; sxth X(rd_reg), W(rn_reg));
+                Ok(())
+            }
+            // SXTW encoder body lands in the next slice.
+            Instruction::Sxtw { .. } => {
                 Err("standalone extend encoding not yet implemented".to_string())
             }
             Instruction::Neg { rd, rm } => {
@@ -2349,6 +2356,19 @@ mod tests {
             }])
             .expect("UXTB encoding should succeed");
         disassemble_and_verify(&bytes, "uxtb", &["w0", "w1"]);
+    }
+
+    /// Issue #60: SXTH sign-extends the low halfword of Wn into 64-bit Xd.
+    #[test]
+    fn test_sxth_encoder_round_trip() {
+        let mut assembler = AArch64Assembler::new();
+        let bytes = assembler
+            .assemble_instructions(&[Instruction::Sxth {
+                rd: Register::X0,
+                rn: Register::X1,
+            }])
+            .expect("SXTH encoding should succeed");
+        disassemble_and_verify(&bytes, "sxth", &["x0", "w1"]);
     }
 
     /// Issue #60: UXTH zero-extends the low halfword of Wn, so Capstone

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -805,9 +805,12 @@ impl AArch64Assembler {
                 dynasm!(ops ; .arch aarch64 ; sxth X(rd_reg), W(rn_reg));
                 Ok(())
             }
-            // SXTW encoder body lands in the next slice.
-            Instruction::Sxtw { .. } => {
-                Err("standalone extend encoding not yet implemented".to_string())
+            // SXTW Xd, Wn — alias of SBFM Xd, Xn, #0, #31. Issue #60.
+            Instruction::Sxtw { rd, rn } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                dynasm!(ops ; .arch aarch64 ; sxtw X(rd_reg), W(rn_reg));
+                Ok(())
             }
             Instruction::Neg { rd, rm } => {
                 let rd_reg = register_to_dynasm(*rd)?;
@@ -2356,6 +2359,19 @@ mod tests {
             }])
             .expect("UXTB encoding should succeed");
         disassemble_and_verify(&bytes, "uxtb", &["w0", "w1"]);
+    }
+
+    /// Issue #60: SXTW sign-extends the low word of Wn into 64-bit Xd.
+    #[test]
+    fn test_sxtw_encoder_round_trip() {
+        let mut assembler = AArch64Assembler::new();
+        let bytes = assembler
+            .assemble_instructions(&[Instruction::Sxtw {
+                rd: Register::X0,
+                rn: Register::X1,
+            }])
+            .expect("SXTW encoding should succeed");
+        disassemble_and_verify(&bytes, "sxtw", &["x0", "w1"]);
     }
 
     /// Issue #60: SXTH sign-extends the low halfword of Wn into 64-bit Xd.

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -775,12 +775,19 @@ impl AArch64Assembler {
                 dynasm!(ops ; .arch aarch64 ; rev16 X(rd_reg), X(rn_reg));
                 Ok(())
             }
-            // SXTB/SXTH/SXTW/UXTB/UXTH standalone extends. Issue #60.
-            // Encoder bodies land in a follow-up slice.
+            // UXTB Wd, Wn — alias of UBFM Wd, Wn, #0, #7. Issue #60.
+            // dynasm-rs emits the 32-bit (W) form; the upper 32 bits of Xd
+            // are zeroed by the AArch64 architectural rule for 32-bit ops.
+            Instruction::Uxtb { rd, rn } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                dynasm!(ops ; .arch aarch64 ; uxtb W(rd_reg), W(rn_reg));
+                Ok(())
+            }
+            // SXTB/SXTH/SXTW/UXTH encoder bodies land in follow-up slices.
             Instruction::Sxtb { .. }
             | Instruction::Sxth { .. }
             | Instruction::Sxtw { .. }
-            | Instruction::Uxtb { .. }
             | Instruction::Uxth { .. } => {
                 Err("standalone extend encoding not yet implemented".to_string())
             }
@@ -2316,6 +2323,21 @@ mod tests {
             let rn = instr.source_registers()[0].to_string();
             disassemble_and_verify(&bytes, mnemonic, &[&rd, &rn]);
         }
+    }
+
+    /// Issue #60: the standalone UXTB instruction round-trips through
+    /// Capstone as `uxtb w<rd>, w<rn>` (the architectural W-form per the
+    /// ARM ARM UBFM alias).
+    #[test]
+    fn test_uxtb_encoder_round_trip() {
+        let mut assembler = AArch64Assembler::new();
+        let bytes = assembler
+            .assemble_instructions(&[Instruction::Uxtb {
+                rd: Register::X0,
+                rn: Register::X1,
+            }])
+            .expect("UXTB encoding should succeed");
+        disassemble_and_verify(&bytes, "uxtb", &["w0", "w1"]);
     }
 
     /// Issue #59: shifted-register forms round-trip through Capstone with the

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -287,6 +287,7 @@ impl AArch64Assembler {
                             ops, add, rd_reg, rn_reg, rm_reg_num, kind, *amount
                         )
                     }
+                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
                 }
             }
             Instruction::Sub { rd, rn, rm } => {
@@ -319,6 +320,7 @@ impl AArch64Assembler {
                             ops, sub, rd_reg, rn_reg, rm_reg_num, kind, *amount
                         )
                     }
+                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
                 }
             }
             Instruction::And { rd, rn, rm } => {
@@ -345,6 +347,7 @@ impl AArch64Assembler {
                             ops, and, rd_reg, rn_reg, rm_reg_num, kind, *amount
                         )
                     }
+                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
                 }
             }
             Instruction::Orr { rd, rn, rm } => {
@@ -371,6 +374,7 @@ impl AArch64Assembler {
                             ops, orr, rd_reg, rn_reg, rm_reg_num, kind, *amount
                         )
                     }
+                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
                 }
             }
             Instruction::Eor { rd, rn, rm } => {
@@ -397,6 +401,7 @@ impl AArch64Assembler {
                             ops, eor, rd_reg, rn_reg, rm_reg_num, kind, *amount
                         )
                     }
+                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
                 }
             }
             Instruction::Lsl { rd, rn, shift } => {
@@ -430,6 +435,7 @@ impl AArch64Assembler {
                     Operand::ShiftedRegister { .. } => {
                         Err("LSL shift amount cannot be a ShiftedRegister".to_string())
                     }
+                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
                 }
             }
             Instruction::Lsr { rd, rn, shift } => {
@@ -461,6 +467,7 @@ impl AArch64Assembler {
                     Operand::ShiftedRegister { .. } => {
                         Err("LSR shift amount cannot be a ShiftedRegister".to_string())
                     }
+                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
                 }
             }
             Instruction::Asr { rd, rn, shift } => {
@@ -492,6 +499,7 @@ impl AArch64Assembler {
                     Operand::ShiftedRegister { .. } => {
                         Err("ASR shift amount cannot be a ShiftedRegister".to_string())
                     }
+                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
                 }
             }
             Instruction::Mul { rd, rn, rm } => {
@@ -610,6 +618,7 @@ impl AArch64Assembler {
                         let rm_reg_num = register_to_dynasm(*reg)?;
                         emit_shifted_reg_2op_arith!(ops, cmp, rn_reg, rm_reg_num, kind, *amount)
                     }
+                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
                 }
             }
             Instruction::Cmn { rn, rm } => {
@@ -638,6 +647,7 @@ impl AArch64Assembler {
                         let rm_reg_num = register_to_dynasm(*reg)?;
                         emit_shifted_reg_2op_arith!(ops, cmn, rn_reg, rm_reg_num, kind, *amount)
                     }
+                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
                 }
             }
             Instruction::Tst { rn, rm } => {
@@ -659,6 +669,7 @@ impl AArch64Assembler {
                         let rm_reg_num = register_to_dynasm(*reg)?;
                         emit_shifted_reg_2op_logical!(ops, tst, rn_reg, rm_reg_num, kind, *amount)
                     }
+                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
                 }
             }
             Instruction::Csel { rd, rn, rm, cond } => {
@@ -708,6 +719,7 @@ impl AArch64Assembler {
                     Operand::ShiftedRegister { .. } => {
                         return Err("CCMP does not support shifted-register operand".to_string());
                     }
+                    Operand::ExtendedRegister { .. } => { return Err("ExtendedRegister encoding not yet implemented".to_string()); }
                 }
                 Ok(())
             }
@@ -730,6 +742,7 @@ impl AArch64Assembler {
                     Operand::ShiftedRegister { .. } => {
                         return Err("CCMN does not support shifted-register operand".to_string());
                     }
+                    Operand::ExtendedRegister { .. } => { return Err("ExtendedRegister encoding not yet implemented".to_string()); }
                 }
                 Ok(())
             }
@@ -875,6 +888,7 @@ impl AArch64Assembler {
                     Operand::ShiftedRegister { .. } => {
                         Err("BIC shifted-register form not yet supported (issue #59 covers AND/ORR/EOR/TST only)".to_string())
                     }
+                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
                 }
             }
             Instruction::Bics { rd, rn, rm } => {
@@ -892,6 +906,7 @@ impl AArch64Assembler {
                     Operand::ShiftedRegister { .. } => {
                         Err("BICS shifted-register form not yet supported".to_string())
                     }
+                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
                 }
             }
             Instruction::Orn { rd, rn, rm } => {
@@ -909,6 +924,7 @@ impl AArch64Assembler {
                     Operand::ShiftedRegister { .. } => {
                         Err("ORN shifted-register form not yet supported".to_string())
                     }
+                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
                 }
             }
             Instruction::Eon { rd, rn, rm } => {
@@ -926,6 +942,7 @@ impl AArch64Assembler {
                     Operand::ShiftedRegister { .. } => {
                         Err("EON shifted-register form not yet supported".to_string())
                     }
+                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
                 }
             }
             Instruction::Adds { rd, rn, rm } => {
@@ -956,6 +973,7 @@ impl AArch64Assembler {
                     Operand::ShiftedRegister { .. } => {
                         Err("ADDS shifted-register form not yet supported (issue #59 covers ADD without flags)".to_string())
                     }
+                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
                 }
             }
             Instruction::Subs { rd, rn, rm } => {
@@ -983,6 +1001,7 @@ impl AArch64Assembler {
                     Operand::ShiftedRegister { .. } => {
                         Err("SUBS shifted-register form not yet supported".to_string())
                     }
+                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
                 }
             }
             Instruction::Ands { rd, rn, rm } => {
@@ -1000,6 +1019,7 @@ impl AArch64Assembler {
                     Operand::ShiftedRegister { .. } => {
                         Err("ANDS shifted-register form not yet supported".to_string())
                     }
+                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
                 }
             }
             // CSET / CSETM lower to CSINC/CSINV with XZR sources and inverted cond.
@@ -1058,6 +1078,7 @@ impl AArch64Assembler {
                     Operand::ShiftedRegister { .. } => {
                         Err("ROR shift amount cannot be a ShiftedRegister".to_string())
                     }
+                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
                 }
             }
         }

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -775,6 +775,15 @@ impl AArch64Assembler {
                 dynasm!(ops ; .arch aarch64 ; rev16 X(rd_reg), X(rn_reg));
                 Ok(())
             }
+            // SXTB/SXTH/SXTW/UXTB/UXTH standalone extends. Issue #60.
+            // Encoder bodies land in a follow-up slice.
+            Instruction::Sxtb { .. }
+            | Instruction::Sxth { .. }
+            | Instruction::Sxtw { .. }
+            | Instruction::Uxtb { .. }
+            | Instruction::Uxth { .. } => {
+                Err("standalone extend encoding not yet implemented".to_string())
+            }
             Instruction::Neg { rd, rm } => {
                 let rd_reg = register_to_dynasm(*rd)?;
                 let rm_reg = register_to_dynasm(*rm)?;

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -379,9 +379,17 @@ impl AArch64Assembler {
                         )
                     }
                     Operand::ExtendedRegister { reg, kind, shift } => {
+                        // Use the XSP-flavoured register encoders for rd/rn:
+                        // the extended-register encoding's Rd/Rn slot is
+                        // `Xn|SP`, and XZR (also reg 31) would otherwise
+                        // silently alias to SP. The encodability gate also
+                        // rejects XZR/SP for ExtendedRegister, so this is
+                        // belt-and-braces. Issue #60 (codex review on #144).
+                        let rd_xsp = register_to_dynasm_xsp(*rd)?;
+                        let rn_xsp = register_to_dynasm_xsp(*rn)?;
                         let rm_reg_num = register_to_dynasm(*reg)?;
                         emit_extended_reg_3op_arith!(
-                            ops, add, rd_reg, rn_reg, rm_reg_num, kind, *shift
+                            ops, add, rd_xsp, rn_xsp, rm_reg_num, kind, *shift
                         )
                     }
                 }
@@ -417,9 +425,13 @@ impl AArch64Assembler {
                         )
                     }
                     Operand::ExtendedRegister { reg, kind, shift } => {
+                        // See the ADD arm for why we re-fetch rd/rn via
+                        // register_to_dynasm_xsp. Issue #60.
+                        let rd_xsp = register_to_dynasm_xsp(*rd)?;
+                        let rn_xsp = register_to_dynasm_xsp(*rn)?;
                         let rm_reg_num = register_to_dynasm(*reg)?;
                         emit_extended_reg_3op_arith!(
-                            ops, sub, rd_reg, rn_reg, rm_reg_num, kind, *shift
+                            ops, sub, rd_xsp, rn_xsp, rm_reg_num, kind, *shift
                         )
                     }
                 }
@@ -732,8 +744,12 @@ impl AArch64Assembler {
                         emit_shifted_reg_2op_arith!(ops, cmp, rn_reg, rm_reg_num, kind, *amount)
                     }
                     Operand::ExtendedRegister { reg, kind, shift } => {
+                        // See the ADD ExtendedRegister arm — XSP-flavoured
+                        // rn encoder rejects XZR (which would alias to SP).
+                        // Issue #60 (codex review on #144).
+                        let rn_xsp = register_to_dynasm_xsp(*rn)?;
                         let rm_reg_num = register_to_dynasm(*reg)?;
-                        emit_extended_reg_2op_arith!(ops, cmp, rn_reg, rm_reg_num, kind, *shift)
+                        emit_extended_reg_2op_arith!(ops, cmp, rn_xsp, rm_reg_num, kind, *shift)
                     }
                 }
             }
@@ -764,8 +780,11 @@ impl AArch64Assembler {
                         emit_shifted_reg_2op_arith!(ops, cmn, rn_reg, rm_reg_num, kind, *amount)
                     }
                     Operand::ExtendedRegister { reg, kind, shift } => {
+                        // XSP-flavoured rn encoder rejects XZR. See ADD.
+                        // Issue #60 (codex review on #144).
+                        let rn_xsp = register_to_dynasm_xsp(*rn)?;
                         let rm_reg_num = register_to_dynasm(*reg)?;
-                        emit_extended_reg_2op_arith!(ops, cmn, rn_reg, rm_reg_num, kind, *shift)
+                        emit_extended_reg_2op_arith!(ops, cmn, rn_xsp, rm_reg_num, kind, *shift)
                     }
                 }
             }

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -784,9 +784,15 @@ impl AArch64Assembler {
                 dynasm!(ops ; .arch aarch64 ; uxtb W(rd_reg), W(rn_reg));
                 Ok(())
             }
-            // SXTB/SXTH/SXTW/UXTH encoder bodies land in follow-up slices.
-            Instruction::Sxtb { .. }
-            | Instruction::Sxth { .. }
+            // SXTB Xd, Wn — alias of SBFM Xd, Xn, #0, #7. Issue #60.
+            Instruction::Sxtb { rd, rn } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                dynasm!(ops ; .arch aarch64 ; sxtb X(rd_reg), W(rn_reg));
+                Ok(())
+            }
+            // SXTH/SXTW/UXTH encoder bodies land in follow-up slices.
+            Instruction::Sxth { .. }
             | Instruction::Sxtw { .. }
             | Instruction::Uxth { .. } => {
                 Err("standalone extend encoding not yet implemented".to_string())
@@ -2338,6 +2344,20 @@ mod tests {
             }])
             .expect("UXTB encoding should succeed");
         disassemble_and_verify(&bytes, "uxtb", &["w0", "w1"]);
+    }
+
+    /// Issue #60: SXTB sign-extends the low byte of Wn into the full 64-bit
+    /// Xd, so Capstone disassembles as `sxtb x<rd>, w<rn>`.
+    #[test]
+    fn test_sxtb_encoder_round_trip() {
+        let mut assembler = AArch64Assembler::new();
+        let bytes = assembler
+            .assemble_instructions(&[Instruction::Sxtb {
+                rd: Register::X0,
+                rn: Register::X1,
+            }])
+            .expect("SXTB encoding should succeed");
+        disassemble_and_verify(&bytes, "sxtb", &["x0", "w1"]);
     }
 
     /// Issue #59: shifted-register forms round-trip through Capstone with the

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -1,6 +1,6 @@
 pub mod x86;
 
-use crate::ir::types::{Condition, ShiftKind};
+use crate::ir::types::{Condition, ExtendKind, ShiftKind};
 use crate::ir::{Instruction, Operand, Register};
 use dynasmrt::{DynasmApi, dynasm};
 
@@ -139,6 +139,97 @@ macro_rules! emit_shifted_reg_2op_logical {
             ShiftKind::Ror => {
                 dynasm!($ops ; .arch aarch64 ; $mnem X(rn_n), X(rm_n), ROR amt_n);
                 Ok::<(), String>(())
+            }
+        }
+    }};
+}
+
+/// 3-operand extended-register form (ADD/SUB only — logical opcodes do not
+/// accept ExtendedRegister per ARM ARM). The Rd/Rn slot is `Xn|SP` (XSP in
+/// dynasm-rs); the Rm slot is W-form for byte/half/word extends and X-form
+/// for the 64-bit extends (UXTX/SXTX). Issue #60.
+macro_rules! emit_extended_reg_3op_arith {
+    ($ops:expr, $mnem:ident, $rd:expr, $rn:expr, $rm:expr, $kind:expr, $shift:expr) => {{
+        let rd_n: u8 = $rd;
+        let rn_n: u8 = $rn;
+        let rm_n: u8 = $rm;
+        let shift_n: u32 = ($shift) as u32;
+        match $kind {
+            ExtendKind::Uxtb => {
+                dynasm!($ops ; .arch aarch64 ; $mnem XSP(rd_n), XSP(rn_n), W(rm_n), UXTB shift_n);
+                Ok(())
+            }
+            ExtendKind::Uxth => {
+                dynasm!($ops ; .arch aarch64 ; $mnem XSP(rd_n), XSP(rn_n), W(rm_n), UXTH shift_n);
+                Ok(())
+            }
+            ExtendKind::Uxtw => {
+                dynasm!($ops ; .arch aarch64 ; $mnem XSP(rd_n), XSP(rn_n), W(rm_n), UXTW shift_n);
+                Ok(())
+            }
+            ExtendKind::Uxtx => {
+                dynasm!($ops ; .arch aarch64 ; $mnem XSP(rd_n), XSP(rn_n), X(rm_n), UXTX shift_n);
+                Ok(())
+            }
+            ExtendKind::Sxtb => {
+                dynasm!($ops ; .arch aarch64 ; $mnem XSP(rd_n), XSP(rn_n), W(rm_n), SXTB shift_n);
+                Ok(())
+            }
+            ExtendKind::Sxth => {
+                dynasm!($ops ; .arch aarch64 ; $mnem XSP(rd_n), XSP(rn_n), W(rm_n), SXTH shift_n);
+                Ok(())
+            }
+            ExtendKind::Sxtw => {
+                dynasm!($ops ; .arch aarch64 ; $mnem XSP(rd_n), XSP(rn_n), W(rm_n), SXTW shift_n);
+                Ok(())
+            }
+            ExtendKind::Sxtx => {
+                dynasm!($ops ; .arch aarch64 ; $mnem XSP(rd_n), XSP(rn_n), X(rm_n), SXTX shift_n);
+                Ok(())
+            }
+        }
+    }};
+}
+
+/// 2-operand extended-register form (CMP/CMN). The Rn slot is `Xn|SP` (XSP).
+/// Issue #60.
+macro_rules! emit_extended_reg_2op_arith {
+    ($ops:expr, $mnem:ident, $rn:expr, $rm:expr, $kind:expr, $shift:expr) => {{
+        let rn_n: u8 = $rn;
+        let rm_n: u8 = $rm;
+        let shift_n: u32 = ($shift) as u32;
+        match $kind {
+            ExtendKind::Uxtb => {
+                dynasm!($ops ; .arch aarch64 ; $mnem XSP(rn_n), W(rm_n), UXTB shift_n);
+                Ok(())
+            }
+            ExtendKind::Uxth => {
+                dynasm!($ops ; .arch aarch64 ; $mnem XSP(rn_n), W(rm_n), UXTH shift_n);
+                Ok(())
+            }
+            ExtendKind::Uxtw => {
+                dynasm!($ops ; .arch aarch64 ; $mnem XSP(rn_n), W(rm_n), UXTW shift_n);
+                Ok(())
+            }
+            ExtendKind::Uxtx => {
+                dynasm!($ops ; .arch aarch64 ; $mnem XSP(rn_n), X(rm_n), UXTX shift_n);
+                Ok(())
+            }
+            ExtendKind::Sxtb => {
+                dynasm!($ops ; .arch aarch64 ; $mnem XSP(rn_n), W(rm_n), SXTB shift_n);
+                Ok(())
+            }
+            ExtendKind::Sxth => {
+                dynasm!($ops ; .arch aarch64 ; $mnem XSP(rn_n), W(rm_n), SXTH shift_n);
+                Ok(())
+            }
+            ExtendKind::Sxtw => {
+                dynasm!($ops ; .arch aarch64 ; $mnem XSP(rn_n), W(rm_n), SXTW shift_n);
+                Ok(())
+            }
+            ExtendKind::Sxtx => {
+                dynasm!($ops ; .arch aarch64 ; $mnem XSP(rn_n), X(rm_n), SXTX shift_n);
+                Ok(())
             }
         }
     }};
@@ -287,7 +378,12 @@ impl AArch64Assembler {
                             ops, add, rd_reg, rn_reg, rm_reg_num, kind, *amount
                         )
                     }
-                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
+                    Operand::ExtendedRegister { reg, kind, shift } => {
+                        let rm_reg_num = register_to_dynasm(*reg)?;
+                        emit_extended_reg_3op_arith!(
+                            ops, add, rd_reg, rn_reg, rm_reg_num, kind, *shift
+                        )
+                    }
                 }
             }
             Instruction::Sub { rd, rn, rm } => {
@@ -320,7 +416,12 @@ impl AArch64Assembler {
                             ops, sub, rd_reg, rn_reg, rm_reg_num, kind, *amount
                         )
                     }
-                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
+                    Operand::ExtendedRegister { reg, kind, shift } => {
+                        let rm_reg_num = register_to_dynasm(*reg)?;
+                        emit_extended_reg_3op_arith!(
+                            ops, sub, rd_reg, rn_reg, rm_reg_num, kind, *shift
+                        )
+                    }
                 }
             }
             Instruction::And { rd, rn, rm } => {
@@ -618,7 +719,10 @@ impl AArch64Assembler {
                         let rm_reg_num = register_to_dynasm(*reg)?;
                         emit_shifted_reg_2op_arith!(ops, cmp, rn_reg, rm_reg_num, kind, *amount)
                     }
-                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
+                    Operand::ExtendedRegister { reg, kind, shift } => {
+                        let rm_reg_num = register_to_dynasm(*reg)?;
+                        emit_extended_reg_2op_arith!(ops, cmp, rn_reg, rm_reg_num, kind, *shift)
+                    }
                 }
             }
             Instruction::Cmn { rn, rm } => {
@@ -647,7 +751,10 @@ impl AArch64Assembler {
                         let rm_reg_num = register_to_dynasm(*reg)?;
                         emit_shifted_reg_2op_arith!(ops, cmn, rn_reg, rm_reg_num, kind, *amount)
                     }
-                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
+                    Operand::ExtendedRegister { reg, kind, shift } => {
+                        let rm_reg_num = register_to_dynasm(*reg)?;
+                        emit_extended_reg_2op_arith!(ops, cmn, rn_reg, rm_reg_num, kind, *shift)
+                    }
                 }
             }
             Instruction::Tst { rn, rm } => {
@@ -2380,6 +2487,74 @@ mod tests {
             }])
             .expect("UXTB encoding should succeed");
         disassemble_and_verify(&bytes, "uxtb", &["w0", "w1"]);
+    }
+
+    /// Issue #60: the ExtendedRegister operand form for ADD/SUB/CMP/CMN.
+    /// Capstone disassembles as `<mnem> <rd>, <rn>, <wm-or-xm>, <kind> #<shift>`.
+    #[test]
+    fn test_extended_register_encoder_round_trip() {
+        use crate::ir::ExtendKind;
+        let cases: Vec<(Instruction, &str, Vec<String>)> = vec![
+            (
+                Instruction::Add {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::ExtendedRegister {
+                        reg: Register::X2,
+                        kind: ExtendKind::Uxtb,
+                        shift: 2,
+                    },
+                },
+                "add",
+                vec!["x0".into(), "x1".into(), "w2".into(), "uxtb #2".into()],
+            ),
+            (
+                Instruction::Sub {
+                    rd: Register::X3,
+                    rn: Register::X4,
+                    rm: Operand::ExtendedRegister {
+                        reg: Register::X5,
+                        kind: ExtendKind::Sxth,
+                        shift: 1,
+                    },
+                },
+                "sub",
+                vec!["x3".into(), "x4".into(), "w5".into(), "sxth #1".into()],
+            ),
+            (
+                Instruction::Cmp {
+                    rn: Register::X6,
+                    rm: Operand::ExtendedRegister {
+                        reg: Register::X7,
+                        kind: ExtendKind::Uxtw,
+                        shift: 3,
+                    },
+                },
+                "cmp",
+                vec!["x6".into(), "w7".into(), "uxtw #3".into()],
+            ),
+            (
+                Instruction::Add {
+                    rd: Register::X8,
+                    rn: Register::X9,
+                    rm: Operand::ExtendedRegister {
+                        reg: Register::X10,
+                        kind: ExtendKind::Uxtx,
+                        shift: 4,
+                    },
+                },
+                "add",
+                vec!["x8".into(), "x9".into(), "x10".into(), "uxtx #4".into()],
+            ),
+        ];
+        for (instr, mnemonic, expected_fragments) in &cases {
+            let mut assembler = AArch64Assembler::new();
+            let bytes = assembler
+                .assemble_instructions(std::slice::from_ref(instr))
+                .unwrap_or_else(|e| panic!("{:?} encoding should succeed: {}", instr, e));
+            let frag_refs: Vec<&str> = expected_fragments.iter().map(|s| s.as_str()).collect();
+            disassemble_and_verify(&bytes, mnemonic, &frag_refs);
+        }
     }
 
     /// Issue #60: SXTW sign-extends the low word of Wn into 64-bit Xd.

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -791,10 +791,15 @@ impl AArch64Assembler {
                 dynasm!(ops ; .arch aarch64 ; sxtb X(rd_reg), W(rn_reg));
                 Ok(())
             }
-            // SXTH/SXTW/UXTH encoder bodies land in follow-up slices.
-            Instruction::Sxth { .. }
-            | Instruction::Sxtw { .. }
-            | Instruction::Uxth { .. } => {
+            // UXTH Wd, Wn — alias of UBFM Wd, Wn, #0, #15. Issue #60.
+            Instruction::Uxth { rd, rn } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                dynasm!(ops ; .arch aarch64 ; uxth W(rd_reg), W(rn_reg));
+                Ok(())
+            }
+            // SXTH/SXTW encoder bodies land in follow-up slices.
+            Instruction::Sxth { .. } | Instruction::Sxtw { .. } => {
                 Err("standalone extend encoding not yet implemented".to_string())
             }
             Instruction::Neg { rd, rm } => {
@@ -2344,6 +2349,20 @@ mod tests {
             }])
             .expect("UXTB encoding should succeed");
         disassemble_and_verify(&bytes, "uxtb", &["w0", "w1"]);
+    }
+
+    /// Issue #60: UXTH zero-extends the low halfword of Wn, so Capstone
+    /// disassembles as `uxth w<rd>, w<rn>` (32-bit form).
+    #[test]
+    fn test_uxth_encoder_round_trip() {
+        let mut assembler = AArch64Assembler::new();
+        let bytes = assembler
+            .assemble_instructions(&[Instruction::Uxth {
+                rd: Register::X0,
+                rn: Register::X1,
+            }])
+            .expect("UXTH encoding should succeed");
+        disassemble_and_verify(&bytes, "uxth", &["w0", "w1"]);
     }
 
     /// Issue #60: SXTB sign-extends the low byte of Wn into the full 64-bit

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -448,7 +448,9 @@ impl AArch64Assembler {
                             ops, and, rd_reg, rn_reg, rm_reg_num, kind, *amount
                         )
                     }
-                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
+                    Operand::ExtendedRegister { .. } => {
+                        Err("ExtendedRegister encoding not yet implemented".to_string())
+                    }
                 }
             }
             Instruction::Orr { rd, rn, rm } => {
@@ -475,7 +477,9 @@ impl AArch64Assembler {
                             ops, orr, rd_reg, rn_reg, rm_reg_num, kind, *amount
                         )
                     }
-                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
+                    Operand::ExtendedRegister { .. } => {
+                        Err("ExtendedRegister encoding not yet implemented".to_string())
+                    }
                 }
             }
             Instruction::Eor { rd, rn, rm } => {
@@ -502,7 +506,9 @@ impl AArch64Assembler {
                             ops, eor, rd_reg, rn_reg, rm_reg_num, kind, *amount
                         )
                     }
-                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
+                    Operand::ExtendedRegister { .. } => {
+                        Err("ExtendedRegister encoding not yet implemented".to_string())
+                    }
                 }
             }
             Instruction::Lsl { rd, rn, shift } => {
@@ -536,7 +542,9 @@ impl AArch64Assembler {
                     Operand::ShiftedRegister { .. } => {
                         Err("LSL shift amount cannot be a ShiftedRegister".to_string())
                     }
-                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
+                    Operand::ExtendedRegister { .. } => {
+                        Err("ExtendedRegister encoding not yet implemented".to_string())
+                    }
                 }
             }
             Instruction::Lsr { rd, rn, shift } => {
@@ -568,7 +576,9 @@ impl AArch64Assembler {
                     Operand::ShiftedRegister { .. } => {
                         Err("LSR shift amount cannot be a ShiftedRegister".to_string())
                     }
-                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
+                    Operand::ExtendedRegister { .. } => {
+                        Err("ExtendedRegister encoding not yet implemented".to_string())
+                    }
                 }
             }
             Instruction::Asr { rd, rn, shift } => {
@@ -600,7 +610,9 @@ impl AArch64Assembler {
                     Operand::ShiftedRegister { .. } => {
                         Err("ASR shift amount cannot be a ShiftedRegister".to_string())
                     }
-                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
+                    Operand::ExtendedRegister { .. } => {
+                        Err("ExtendedRegister encoding not yet implemented".to_string())
+                    }
                 }
             }
             Instruction::Mul { rd, rn, rm } => {
@@ -776,7 +788,9 @@ impl AArch64Assembler {
                         let rm_reg_num = register_to_dynasm(*reg)?;
                         emit_shifted_reg_2op_logical!(ops, tst, rn_reg, rm_reg_num, kind, *amount)
                     }
-                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
+                    Operand::ExtendedRegister { .. } => {
+                        Err("ExtendedRegister encoding not yet implemented".to_string())
+                    }
                 }
             }
             Instruction::Csel { rd, rn, rm, cond } => {
@@ -826,7 +840,9 @@ impl AArch64Assembler {
                     Operand::ShiftedRegister { .. } => {
                         return Err("CCMP does not support shifted-register operand".to_string());
                     }
-                    Operand::ExtendedRegister { .. } => { return Err("ExtendedRegister encoding not yet implemented".to_string()); }
+                    Operand::ExtendedRegister { .. } => {
+                        return Err("ExtendedRegister encoding not yet implemented".to_string());
+                    }
                 }
                 Ok(())
             }
@@ -849,7 +865,9 @@ impl AArch64Assembler {
                     Operand::ShiftedRegister { .. } => {
                         return Err("CCMN does not support shifted-register operand".to_string());
                     }
-                    Operand::ExtendedRegister { .. } => { return Err("ExtendedRegister encoding not yet implemented".to_string()); }
+                    Operand::ExtendedRegister { .. } => {
+                        return Err("ExtendedRegister encoding not yet implemented".to_string());
+                    }
                 }
                 Ok(())
             }
@@ -1013,7 +1031,9 @@ impl AArch64Assembler {
                     Operand::ShiftedRegister { .. } => {
                         Err("BICS shifted-register form not yet supported".to_string())
                     }
-                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
+                    Operand::ExtendedRegister { .. } => {
+                        Err("ExtendedRegister encoding not yet implemented".to_string())
+                    }
                 }
             }
             Instruction::Orn { rd, rn, rm } => {
@@ -1031,7 +1051,9 @@ impl AArch64Assembler {
                     Operand::ShiftedRegister { .. } => {
                         Err("ORN shifted-register form not yet supported".to_string())
                     }
-                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
+                    Operand::ExtendedRegister { .. } => {
+                        Err("ExtendedRegister encoding not yet implemented".to_string())
+                    }
                 }
             }
             Instruction::Eon { rd, rn, rm } => {
@@ -1049,7 +1071,9 @@ impl AArch64Assembler {
                     Operand::ShiftedRegister { .. } => {
                         Err("EON shifted-register form not yet supported".to_string())
                     }
-                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
+                    Operand::ExtendedRegister { .. } => {
+                        Err("ExtendedRegister encoding not yet implemented".to_string())
+                    }
                 }
             }
             Instruction::Adds { rd, rn, rm } => {
@@ -1108,7 +1132,9 @@ impl AArch64Assembler {
                     Operand::ShiftedRegister { .. } => {
                         Err("SUBS shifted-register form not yet supported".to_string())
                     }
-                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
+                    Operand::ExtendedRegister { .. } => {
+                        Err("ExtendedRegister encoding not yet implemented".to_string())
+                    }
                 }
             }
             Instruction::Ands { rd, rn, rm } => {
@@ -1126,7 +1152,9 @@ impl AArch64Assembler {
                     Operand::ShiftedRegister { .. } => {
                         Err("ANDS shifted-register form not yet supported".to_string())
                     }
-                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
+                    Operand::ExtendedRegister { .. } => {
+                        Err("ExtendedRegister encoding not yet implemented".to_string())
+                    }
                 }
             }
             // CSET / CSETM lower to CSINC/CSINV with XZR sources and inverted cond.
@@ -1185,7 +1213,9 @@ impl AArch64Assembler {
                     Operand::ShiftedRegister { .. } => {
                         Err("ROR shift amount cannot be a ShiftedRegister".to_string())
                     }
-                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
+                    Operand::ExtendedRegister { .. } => {
+                        Err("ExtendedRegister encoding not yet implemented".to_string())
+                    }
                 }
             }
         }

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -1694,4 +1694,44 @@ mod tests {
         assert!(!umulh.reads_flags());
         assert!(umulh.is_encodable_aarch64());
     }
+
+    #[test]
+    fn test_uxtb_metadata_and_encodability() {
+        // UXTB: register-only, single source, no flag effects, encodable on
+        // any X-register pair except SP. Issue #60.
+        let ok = Instruction::Uxtb {
+            rd: Register::X0,
+            rn: Register::X1,
+        };
+        assert_eq!(ok.to_string(), "uxtb x0, x1");
+        assert_eq!(ok.destination(), Some(Register::X0));
+        assert_eq!(ok.source_registers(), vec![Register::X1]);
+        assert!(!ok.modifies_flags());
+        assert!(ok.is_encodable_aarch64());
+
+        // SP rejected as rd.
+        assert!(
+            !Instruction::Uxtb {
+                rd: Register::SP,
+                rn: Register::X1,
+            }
+            .is_encodable_aarch64()
+        );
+        // SP rejected as rn.
+        assert!(
+            !Instruction::Uxtb {
+                rd: Register::X0,
+                rn: Register::SP,
+            }
+            .is_encodable_aarch64()
+        );
+        // XZR remains encodable (per the existing single-source policy).
+        assert!(
+            Instruction::Uxtb {
+                rd: Register::X0,
+                rn: Register::XZR,
+            }
+            .is_encodable_aarch64()
+        );
+    }
 }

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -448,14 +448,20 @@ impl Instruction {
                         && *rd != Register::SP
                         && *rn != Register::SP
                 }
-                // Issue #60: extended-register form. Shift 0..=4, SP rejected
-                // in every slot (conservative — matches the shifted-register
-                // policy; ARM ARM would allow SP for rd/rn but we defer that).
+                // Issue #60: extended-register form. Shift 0..=4. Both SP
+                // and XZR are rejected in the rd/rn slots: the encoding is
+                // `Xn|SP` (XSP), so register-number 31 in those slots is
+                // SP — accepting XZR (also reg 31) would silently alias to
+                // SP at encode time (codex review on #144). The inner-reg
+                // slot rejects SP for the same conservative reason as the
+                // shifted-register policy.
                 Operand::ExtendedRegister { reg, shift, .. } => {
                     *shift <= 4
                         && *reg != Register::SP
                         && *rd != Register::SP
+                        && *rd != Register::XZR
                         && *rn != Register::SP
+                        && *rn != Register::XZR
                 }
             },
 
@@ -510,9 +516,14 @@ impl Instruction {
                         && *rn != Register::SP
                 }
                 // Issue #60: extended-register form for CMP/CMN — same shift
-                // bound and SP rejection policy as ADD/SUB above, without rd.
+                // bound and SP/XZR rejection policy as ADD/SUB above, without
+                // rd. CMP/CMN's rn is XSP-encoded, so XZR would alias to SP
+                // (codex review on #144).
                 Operand::ExtendedRegister { reg, shift, .. } => {
-                    *shift <= 4 && *reg != Register::SP && *rn != Register::SP
+                    *shift <= 4
+                        && *reg != Register::SP
+                        && *rn != Register::SP
+                        && *rn != Register::XZR
                 }
             },
 
@@ -1757,8 +1768,11 @@ mod tests {
         };
         assert!(!bad_shift.is_encodable_aarch64());
 
-        // SP rejected as rd, rn, and as the inner register.
-        for victim in [Register::SP] {
+        // SP and XZR are both rejected in the rd/rn slots — the encoding's
+        // Xn|SP class would otherwise alias XZR (reg 31) to SP. The inner-
+        // reg slot only rejects SP (XZR is fine there; the source register
+        // is Xm or Wm and 31 ↔ XZR/WZR there). Codex review on #144.
+        for victim in [Register::SP, Register::XZR] {
             assert!(
                 !Instruction::Add {
                     rd: victim,
@@ -1783,19 +1797,32 @@ mod tests {
                 }
                 .is_encodable_aarch64()
             );
-            assert!(
-                !Instruction::Add {
-                    rd: Register::X0,
-                    rn: Register::X1,
-                    rm: Operand::ExtendedRegister {
-                        reg: victim,
-                        kind: ExtendKind::Uxtb,
-                        shift: 0,
-                    },
-                }
-                .is_encodable_aarch64()
-            );
         }
+        // Inner-reg slot: SP rejected, XZR allowed.
+        assert!(
+            !Instruction::Add {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::ExtendedRegister {
+                    reg: Register::SP,
+                    kind: ExtendKind::Uxtb,
+                    shift: 0,
+                },
+            }
+            .is_encodable_aarch64()
+        );
+        assert!(
+            Instruction::Add {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::ExtendedRegister {
+                    reg: Register::XZR,
+                    kind: ExtendKind::Uxtb,
+                    shift: 0,
+                },
+            }
+            .is_encodable_aarch64()
+        );
 
         // CMP/CMN: rn is allowed to be non-SP; rd doesn't apply.
         let cmp_ok = Instruction::Cmp {

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -1696,6 +1696,33 @@ mod tests {
     }
 
     #[test]
+    fn test_uxth_metadata_and_encodability() {
+        let ok = Instruction::Uxth {
+            rd: Register::X0,
+            rn: Register::X1,
+        };
+        assert_eq!(ok.to_string(), "uxth x0, x1");
+        assert_eq!(ok.destination(), Some(Register::X0));
+        assert_eq!(ok.source_registers(), vec![Register::X1]);
+        assert!(!ok.modifies_flags());
+        assert!(ok.is_encodable_aarch64());
+        assert!(
+            !Instruction::Uxth {
+                rd: Register::SP,
+                rn: Register::X1,
+            }
+            .is_encodable_aarch64()
+        );
+        assert!(
+            !Instruction::Uxth {
+                rd: Register::X0,
+                rn: Register::SP,
+            }
+            .is_encodable_aarch64()
+        );
+    }
+
+    #[test]
     fn test_sxtb_metadata_and_encodability() {
         // SXTB: register-only, single source, encodable on X-register pairs
         // except SP. Issue #60.

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -290,6 +290,31 @@ pub enum Instruction {
         rd: Register,
         rn: Register,
     },
+
+    // Standalone sign/zero-extend (UBFM/SBFM aliases). Issue #60.
+    // The Rn slot is architecturally a W-register for byte/half/word
+    // extends and X-register for the (out-of-scope) UXTX/SXTX. The IR
+    // models Rn as 64-bit X; semantics mask the low N bits explicitly.
+    Sxtb {
+        rd: Register,
+        rn: Register,
+    },
+    Sxth {
+        rd: Register,
+        rn: Register,
+    },
+    Sxtw {
+        rd: Register,
+        rn: Register,
+    },
+    Uxtb {
+        rd: Register,
+        rn: Register,
+    },
+    Uxth {
+        rd: Register,
+        rn: Register,
+    },
 }
 
 impl Instruction {
@@ -340,7 +365,12 @@ impl Instruction {
             | Instruction::Rbit { rd, .. }
             | Instruction::Rev { rd, .. }
             | Instruction::Rev32 { rd, .. }
-            | Instruction::Rev16 { rd, .. } => Some(*rd),
+            | Instruction::Rev16 { rd, .. }
+            | Instruction::Sxtb { rd, .. }
+            | Instruction::Sxth { rd, .. }
+            | Instruction::Sxtw { rd, .. }
+            | Instruction::Uxtb { rd, .. }
+            | Instruction::Uxth { rd, .. } => Some(*rd),
             // Comparison instructions only set flags, no destination register
             Instruction::Cmp { .. }
             | Instruction::Cmn { .. }
@@ -556,7 +586,12 @@ impl Instruction {
             | Instruction::Rbit { rd, rn }
             | Instruction::Rev { rd, rn }
             | Instruction::Rev32 { rd, rn }
-            | Instruction::Rev16 { rd, rn } => *rd != Register::SP && *rn != Register::SP,
+            | Instruction::Rev16 { rd, rn }
+            | Instruction::Sxtb { rd, rn }
+            | Instruction::Sxth { rd, rn }
+            | Instruction::Sxtw { rd, rn }
+            | Instruction::Uxtb { rd, rn }
+            | Instruction::Uxth { rd, rn } => *rd != Register::SP && *rn != Register::SP,
         }
     }
 
@@ -663,7 +698,12 @@ impl Instruction {
             | Instruction::Rbit { rn, .. }
             | Instruction::Rev { rn, .. }
             | Instruction::Rev32 { rn, .. }
-            | Instruction::Rev16 { rn, .. } => vec![*rn],
+            | Instruction::Rev16 { rn, .. }
+            | Instruction::Sxtb { rn, .. }
+            | Instruction::Sxth { rn, .. }
+            | Instruction::Sxtw { rn, .. }
+            | Instruction::Uxtb { rn, .. }
+            | Instruction::Uxth { rn, .. } => vec![*rn],
         }
     }
 }
@@ -756,6 +796,11 @@ impl fmt::Display for Instruction {
             Instruction::Rev { rd, rn } => write!(f, "rev {}, {}", rd, rn),
             Instruction::Rev32 { rd, rn } => write!(f, "rev32 {}, {}", rd, rn),
             Instruction::Rev16 { rd, rn } => write!(f, "rev16 {}, {}", rd, rn),
+            Instruction::Sxtb { rd, rn } => write!(f, "sxtb {}, {}", rd, rn),
+            Instruction::Sxth { rd, rn } => write!(f, "sxth {}, {}", rd, rn),
+            Instruction::Sxtw { rd, rn } => write!(f, "sxtw {}, {}", rd, rn),
+            Instruction::Uxtb { rd, rn } => write!(f, "uxtb {}, {}", rd, rn),
+            Instruction::Uxth { rd, rn } => write!(f, "uxth {}, {}", rd, rn),
         }
     }
 }

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -1696,6 +1696,33 @@ mod tests {
     }
 
     #[test]
+    fn test_sxth_metadata_and_encodability() {
+        let ok = Instruction::Sxth {
+            rd: Register::X0,
+            rn: Register::X1,
+        };
+        assert_eq!(ok.to_string(), "sxth x0, x1");
+        assert_eq!(ok.destination(), Some(Register::X0));
+        assert_eq!(ok.source_registers(), vec![Register::X1]);
+        assert!(!ok.modifies_flags());
+        assert!(ok.is_encodable_aarch64());
+        assert!(
+            !Instruction::Sxth {
+                rd: Register::SP,
+                rn: Register::X1,
+            }
+            .is_encodable_aarch64()
+        );
+        assert!(
+            !Instruction::Sxth {
+                rd: Register::X0,
+                rn: Register::SP,
+            }
+            .is_encodable_aarch64()
+        );
+    }
+
+    #[test]
     fn test_uxth_metadata_and_encodability() {
         let ok = Instruction::Uxth {
             rd: Register::X0,

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -448,6 +448,10 @@ impl Instruction {
                         && *rd != Register::SP
                         && *rn != Register::SP
                 }
+                // ExtendedRegister encodability tightening lands in a later
+                // slice; reject by default so logical opcodes inheriting this
+                // pattern keep the same conservative gate. Issue #60.
+                Operand::ExtendedRegister { .. } => false,
             },
 
             // AND/ORR/EOR: register operand or shifted-register (all 4 kinds, ROR allowed).
@@ -463,6 +467,8 @@ impl Instruction {
                         && *rd != Register::SP
                         && *rn != Register::SP
                 }
+                // Logical opcodes do not accept the extended-register form.
+                Operand::ExtendedRegister { .. } => false,
             },
 
             // Shift instructions: shift amount 0-63 for 64-bit registers.
@@ -474,6 +480,7 @@ impl Instruction {
                 Operand::Register(_) => true,
                 Operand::Immediate(amt) => *amt >= 0 && *amt <= 63,
                 Operand::ShiftedRegister { .. } => false,
+                Operand::ExtendedRegister { .. } => false,
             },
 
             // MUL/SDIV/UDIV: always register operands, always encodable
@@ -497,6 +504,7 @@ impl Instruction {
                         && *reg != Register::SP
                         && *rn != Register::SP
                 }
+                Operand::ExtendedRegister { .. } => false,
             },
 
             // TST: register operand or shifted-register (all 4 kinds, ROR allowed).
@@ -506,6 +514,7 @@ impl Instruction {
                 Operand::ShiftedRegister { reg, amount, .. } => {
                     *amount <= 63 && *reg != Register::SP && *rn != Register::SP
                 }
+                Operand::ExtendedRegister { .. } => false,
             },
 
             // Conditional select: always encodable (register-only)
@@ -535,6 +544,7 @@ impl Instruction {
                 Operand::Register(_) => true,
                 Operand::Immediate(imm) => *imm >= 0 && *imm <= 0xFFF,
                 Operand::ShiftedRegister { .. } => false,
+                Operand::ExtendedRegister { .. } => false,
             },
             // ANDS: register-only (same as AND). ShiftedRegister out of scope (#59).
             Instruction::Ands { rm, .. } => matches!(rm, Operand::Register(_)),
@@ -565,6 +575,7 @@ impl Instruction {
                     Operand::Register(reg) => *reg != Register::SP,
                     Operand::Immediate(imm) => (0..=31).contains(imm),
                     Operand::ShiftedRegister { .. } => false,
+                    Operand::ExtendedRegister { .. } => false,
                 }
             }
 
@@ -575,6 +586,7 @@ impl Instruction {
                 Operand::Register(_) => true,
                 Operand::Immediate(amt) => *amt >= 0 && *amt <= 63,
                 Operand::ShiftedRegister { .. } => false,
+                Operand::ExtendedRegister { .. } => false,
             },
 
             // Single-source bit-manipulation: register-only, Xn class (no SP).
@@ -610,6 +622,7 @@ impl Instruction {
                 match rm {
                     Operand::Register(r) => regs.push(*r),
                     Operand::ShiftedRegister { reg, .. } => regs.push(*reg),
+                    Operand::ExtendedRegister { reg, .. } => regs.push(*reg),
                     Operand::Immediate(_) => {}
                 }
                 regs
@@ -641,6 +654,7 @@ impl Instruction {
                 match rm {
                     Operand::Register(r) => regs.push(*r),
                     Operand::ShiftedRegister { reg, .. } => regs.push(*reg),
+                    Operand::ExtendedRegister { reg, .. } => regs.push(*reg),
                     Operand::Immediate(_) => {}
                 }
                 regs

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -1696,6 +1696,33 @@ mod tests {
     }
 
     #[test]
+    fn test_sxtw_metadata_and_encodability() {
+        let ok = Instruction::Sxtw {
+            rd: Register::X0,
+            rn: Register::X1,
+        };
+        assert_eq!(ok.to_string(), "sxtw x0, x1");
+        assert_eq!(ok.destination(), Some(Register::X0));
+        assert_eq!(ok.source_registers(), vec![Register::X1]);
+        assert!(!ok.modifies_flags());
+        assert!(ok.is_encodable_aarch64());
+        assert!(
+            !Instruction::Sxtw {
+                rd: Register::SP,
+                rn: Register::X1,
+            }
+            .is_encodable_aarch64()
+        );
+        assert!(
+            !Instruction::Sxtw {
+                rd: Register::X0,
+                rn: Register::SP,
+            }
+            .is_encodable_aarch64()
+        );
+    }
+
+    #[test]
     fn test_sxth_metadata_and_encodability() {
         let ok = Instruction::Sxth {
             rd: Register::X0,

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -448,10 +448,15 @@ impl Instruction {
                         && *rd != Register::SP
                         && *rn != Register::SP
                 }
-                // ExtendedRegister encodability tightening lands in a later
-                // slice; reject by default so logical opcodes inheriting this
-                // pattern keep the same conservative gate. Issue #60.
-                Operand::ExtendedRegister { .. } => false,
+                // Issue #60: extended-register form. Shift 0..=4, SP rejected
+                // in every slot (conservative — matches the shifted-register
+                // policy; ARM ARM would allow SP for rd/rn but we defer that).
+                Operand::ExtendedRegister { reg, shift, .. } => {
+                    *shift <= 4
+                        && *reg != Register::SP
+                        && *rd != Register::SP
+                        && *rn != Register::SP
+                }
             },
 
             // AND/ORR/EOR: register operand or shifted-register (all 4 kinds, ROR allowed).
@@ -504,7 +509,11 @@ impl Instruction {
                         && *reg != Register::SP
                         && *rn != Register::SP
                 }
-                Operand::ExtendedRegister { .. } => false,
+                // Issue #60: extended-register form for CMP/CMN — same shift
+                // bound and SP rejection policy as ADD/SUB above, without rd.
+                Operand::ExtendedRegister { reg, shift, .. } => {
+                    *shift <= 4 && *reg != Register::SP && *rn != Register::SP
+                }
             },
 
             // TST: register operand or shifted-register (all 4 kinds, ROR allowed).
@@ -1707,6 +1716,148 @@ mod tests {
         assert!(!umulh.modifies_flags());
         assert!(!umulh.reads_flags());
         assert!(umulh.is_encodable_aarch64());
+    }
+
+    #[test]
+    fn test_extended_register_arith_encodability() {
+        use crate::ir::ExtendKind;
+        // ADD x0, x1, x2, UXTB #2 — within shift range, not SP, accepted.
+        let ok = Instruction::Add {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::ExtendedRegister {
+                reg: Register::X2,
+                kind: ExtendKind::Uxtb,
+                shift: 2,
+            },
+        };
+        assert!(ok.is_encodable_aarch64());
+
+        // Shift = 4 is the boundary; still encodable.
+        let max_shift = Instruction::Sub {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::ExtendedRegister {
+                reg: Register::X2,
+                kind: ExtendKind::Sxtw,
+                shift: 4,
+            },
+        };
+        assert!(max_shift.is_encodable_aarch64());
+
+        // Shift = 5 is out of range and must be rejected.
+        let bad_shift = Instruction::Add {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::ExtendedRegister {
+                reg: Register::X2,
+                kind: ExtendKind::Uxtb,
+                shift: 5,
+            },
+        };
+        assert!(!bad_shift.is_encodable_aarch64());
+
+        // SP rejected as rd, rn, and as the inner register.
+        for victim in [Register::SP] {
+            assert!(
+                !Instruction::Add {
+                    rd: victim,
+                    rn: Register::X1,
+                    rm: Operand::ExtendedRegister {
+                        reg: Register::X2,
+                        kind: ExtendKind::Uxtb,
+                        shift: 0,
+                    },
+                }
+                .is_encodable_aarch64()
+            );
+            assert!(
+                !Instruction::Add {
+                    rd: Register::X0,
+                    rn: victim,
+                    rm: Operand::ExtendedRegister {
+                        reg: Register::X2,
+                        kind: ExtendKind::Uxtb,
+                        shift: 0,
+                    },
+                }
+                .is_encodable_aarch64()
+            );
+            assert!(
+                !Instruction::Add {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::ExtendedRegister {
+                        reg: victim,
+                        kind: ExtendKind::Uxtb,
+                        shift: 0,
+                    },
+                }
+                .is_encodable_aarch64()
+            );
+        }
+
+        // CMP/CMN: rn is allowed to be non-SP; rd doesn't apply.
+        let cmp_ok = Instruction::Cmp {
+            rn: Register::X1,
+            rm: Operand::ExtendedRegister {
+                reg: Register::X2,
+                kind: ExtendKind::Sxtb,
+                shift: 1,
+            },
+        };
+        assert!(cmp_ok.is_encodable_aarch64());
+        let cmn_ok = Instruction::Cmn {
+            rn: Register::X1,
+            rm: Operand::ExtendedRegister {
+                reg: Register::X2,
+                kind: ExtendKind::Uxth,
+                shift: 3,
+            },
+        };
+        assert!(cmn_ok.is_encodable_aarch64());
+    }
+
+    #[test]
+    fn test_extended_register_logical_rejected() {
+        use crate::ir::ExtendKind;
+        // AND/ORR/EOR/TST/Adds/Subs/Ands/Ror: ExtendedRegister rejected.
+        let er = Operand::ExtendedRegister {
+            reg: Register::X2,
+            kind: ExtendKind::Uxtb,
+            shift: 0,
+        };
+        assert!(
+            !Instruction::And {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: er,
+            }
+            .is_encodable_aarch64()
+        );
+        assert!(
+            !Instruction::Orr {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: er,
+            }
+            .is_encodable_aarch64()
+        );
+        assert!(
+            !Instruction::Eor {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: er,
+            }
+            .is_encodable_aarch64()
+        );
+        assert!(
+            !Instruction::Tst {
+                rn: Register::X1,
+                rm: er,
+            }
+            .is_encodable_aarch64()
+        );
     }
 
     #[test]

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -1696,6 +1696,35 @@ mod tests {
     }
 
     #[test]
+    fn test_sxtb_metadata_and_encodability() {
+        // SXTB: register-only, single source, encodable on X-register pairs
+        // except SP. Issue #60.
+        let ok = Instruction::Sxtb {
+            rd: Register::X0,
+            rn: Register::X1,
+        };
+        assert_eq!(ok.to_string(), "sxtb x0, x1");
+        assert_eq!(ok.destination(), Some(Register::X0));
+        assert_eq!(ok.source_registers(), vec![Register::X1]);
+        assert!(!ok.modifies_flags());
+        assert!(ok.is_encodable_aarch64());
+        assert!(
+            !Instruction::Sxtb {
+                rd: Register::SP,
+                rn: Register::X1,
+            }
+            .is_encodable_aarch64()
+        );
+        assert!(
+            !Instruction::Sxtb {
+                rd: Register::X0,
+                rn: Register::SP,
+            }
+            .is_encodable_aarch64()
+        );
+    }
+
+    #[test]
     fn test_uxtb_metadata_and_encodability() {
         // UXTB: register-only, single source, no flag effects, encodable on
         // any X-register pair except SP. Issue #60.

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -5,4 +5,4 @@ pub mod types;
 
 // Re-export commonly used types
 pub use instructions::Instruction;
-pub use types::{Condition, Operand, Register, ShiftKind};
+pub use types::{Condition, ExtendKind, Operand, Register, ShiftKind};

--- a/src/ir/types.rs
+++ b/src/ir/types.rs
@@ -185,8 +185,51 @@ impl fmt::Display for ShiftKind {
     }
 }
 
-/// Operand for instructions: a register, an immediate, or a shifted-register
-/// (`reg, kind #amount` where amount is 0..=63 enforced by `is_encodable_aarch64`).
+/// AArch64 extend kind for the extended-register operand form
+/// (`add x0, x1, w2, uxtb #2` etc.). Issue #60.
+///
+/// The inner register is architecturally a W-register for byte/half/word
+/// extends (UXTB/UXTH/UXTW, SXTB/SXTH/SXTW) and an X-register for the
+/// 64-bit extends (UXTX/SXTX). The IR models the inner register as
+/// 64-bit X and Display/encoder selectively project to the W form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ExtendKind {
+    Uxtb,
+    Uxth,
+    Uxtw,
+    Uxtx,
+    Sxtb,
+    Sxth,
+    Sxtw,
+    Sxtx,
+}
+
+impl ExtendKind {
+    /// Returns true if this extend kind operates on a 64-bit (X-form)
+    /// source register. UXTX/SXTX are the only such kinds.
+    pub fn is_x_form(&self) -> bool {
+        matches!(self, ExtendKind::Uxtx | ExtendKind::Sxtx)
+    }
+}
+
+impl fmt::Display for ExtendKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ExtendKind::Uxtb => write!(f, "uxtb"),
+            ExtendKind::Uxth => write!(f, "uxth"),
+            ExtendKind::Uxtw => write!(f, "uxtw"),
+            ExtendKind::Uxtx => write!(f, "uxtx"),
+            ExtendKind::Sxtb => write!(f, "sxtb"),
+            ExtendKind::Sxth => write!(f, "sxth"),
+            ExtendKind::Sxtw => write!(f, "sxtw"),
+            ExtendKind::Sxtx => write!(f, "sxtx"),
+        }
+    }
+}
+
+/// Operand for instructions: a register, an immediate, a shifted-register
+/// (`reg, kind #amount` where amount is 0..=63 enforced by `is_encodable_aarch64`),
+/// or an extended-register (`reg, extend-kind #shift` where shift is 0..=4).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Operand {
     Register(Register),
@@ -195,6 +238,11 @@ pub enum Operand {
         reg: Register,
         kind: ShiftKind,
         amount: u8,
+    },
+    ExtendedRegister {
+        reg: Register,
+        kind: ExtendKind,
+        shift: u8,
     },
 }
 
@@ -205,6 +253,22 @@ impl fmt::Display for Operand {
             Operand::Immediate(imm) => write!(f, "#{}", imm),
             Operand::ShiftedRegister { reg, kind, amount } => {
                 write!(f, "{}, {} #{}", reg, kind, amount)
+            }
+            Operand::ExtendedRegister { reg, kind, shift } => {
+                // Byte/half/word extends print the inner register as W-form;
+                // the 64-bit extends UXTX/SXTX print as X-form. The Display
+                // matches what Capstone emits after a roundtrip.
+                let inner = if kind.is_x_form() {
+                    format!("{}", reg)
+                } else {
+                    match reg.index() {
+                        Some(idx) => format!("w{}", idx),
+                        // SP has no W-form; fall back to its canonical name
+                        // (encodability gates SP out before any caller sees it).
+                        None => format!("{}", reg),
+                    }
+                };
+                write!(f, "{}, {} #{}", inner, kind, shift)
             }
         }
     }
@@ -342,6 +406,57 @@ mod tests {
         assert_eq!(format!("{}", Operand::Register(Register::X5)), "x5");
         assert_eq!(format!("{}", Operand::Immediate(42)), "#42");
         assert_eq!(format!("{}", Operand::Immediate(-1)), "#-1");
+    }
+
+    #[test]
+    fn test_extended_register_display_widths() {
+        // Issue #60: byte/half/word extend kinds print the inner register as
+        // a W-form; UXTX/SXTX print it as X-form. The shift always uses a
+        // `#<amount>` immediate.
+        assert_eq!(
+            format!(
+                "{}",
+                Operand::ExtendedRegister {
+                    reg: Register::X2,
+                    kind: ExtendKind::Uxtb,
+                    shift: 2,
+                }
+            ),
+            "w2, uxtb #2"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                Operand::ExtendedRegister {
+                    reg: Register::X5,
+                    kind: ExtendKind::Sxth,
+                    shift: 0,
+                }
+            ),
+            "w5, sxth #0"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                Operand::ExtendedRegister {
+                    reg: Register::X10,
+                    kind: ExtendKind::Sxtx,
+                    shift: 3,
+                }
+            ),
+            "x10, sxtx #3"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                Operand::ExtendedRegister {
+                    reg: Register::X1,
+                    kind: ExtendKind::Uxtx,
+                    shift: 4,
+                }
+            ),
+            "x1, uxtx #4"
+        );
     }
 
     #[test]

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -70,10 +70,11 @@ impl OperandType for Operand {
         match self {
             Operand::Register(r) => Some(*r),
             Operand::Immediate(_) => None,
-            // ShiftedRegister carries a register but is not a plain register
-            // operand; callers asking "is this a register?" should treat it as
-            // a distinct shape.
+            // ShiftedRegister/ExtendedRegister carry a register but are not
+            // plain register operands; callers asking "is this a register?"
+            // should treat them as distinct shapes.
             Operand::ShiftedRegister { .. } => None,
+            Operand::ExtendedRegister { .. } => None,
         }
     }
 
@@ -82,6 +83,7 @@ impl OperandType for Operand {
             Operand::Register(_) => None,
             Operand::Immediate(i) => Some(*i),
             Operand::ShiftedRegister { .. } => None,
+            Operand::ExtendedRegister { .. } => None,
         }
     }
 
@@ -1228,7 +1230,9 @@ fn mutate_operand<R: RngExt>(
     immediates: &[i64],
 ) -> Operand {
     match operand {
-        Operand::Register(_) | Operand::ShiftedRegister { .. } => {
+        Operand::Register(_)
+        | Operand::ShiftedRegister { .. }
+        | Operand::ExtendedRegister { .. } => {
             if rng.random_bool(0.7) {
                 Operand::Register(registers[rng.random_range(0..registers.len())])
             } else {
@@ -1252,7 +1256,9 @@ fn mutate_shift_operand<R: RngExt>(
 ) -> Operand {
     let shift_amounts: [i64; 7] = [0, 1, 2, 4, 8, 16, 32];
     match operand {
-        Operand::Register(_) | Operand::ShiftedRegister { .. } => {
+        Operand::Register(_)
+        | Operand::ShiftedRegister { .. }
+        | Operand::ExtendedRegister { .. } => {
             if rng.random_bool(0.5) {
                 Operand::Register(registers[rng.random_range(0..registers.len())])
             } else {

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -157,6 +157,11 @@ impl InstructionType for Instruction {
             Instruction::Umulh { .. } => 46,
             Instruction::Ccmp { .. } => 47,
             Instruction::Ccmn { .. } => 48,
+            Instruction::Sxtb { .. } => 49,
+            Instruction::Sxth { .. } => 50,
+            Instruction::Sxtw { .. } => 51,
+            Instruction::Uxtb { .. } => 52,
+            Instruction::Uxth { .. } => 53,
         }
     }
 
@@ -210,6 +215,11 @@ impl InstructionType for Instruction {
             Instruction::Umulh { .. } => "umulh",
             Instruction::Ccmp { .. } => "ccmp",
             Instruction::Ccmn { .. } => "ccmn",
+            Instruction::Sxtb { .. } => "sxtb",
+            Instruction::Sxth { .. } => "sxth",
+            Instruction::Sxtw { .. } => "sxtw",
+            Instruction::Uxtb { .. } => "uxtb",
+            Instruction::Uxth { .. } => "uxth",
         }
     }
 
@@ -838,6 +848,11 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     Instruction::Rev { rn, .. } => Instruction::Rev { rd: new_rd, rn },
                     Instruction::Rev32 { rn, .. } => Instruction::Rev32 { rd: new_rd, rn },
                     Instruction::Rev16 { rn, .. } => Instruction::Rev16 { rd: new_rd, rn },
+                    Instruction::Sxtb { rn, .. } => Instruction::Sxtb { rd: new_rd, rn },
+                    Instruction::Sxth { rn, .. } => Instruction::Sxth { rd: new_rd, rn },
+                    Instruction::Sxtw { rn, .. } => Instruction::Sxtw { rd: new_rd, rn },
+                    Instruction::Uxtb { rn, .. } => Instruction::Uxtb { rd: new_rd, rn },
+                    Instruction::Uxth { rn, .. } => Instruction::Uxth { rd: new_rd, rn },
                 }
             }
             2 => {
@@ -1158,6 +1173,26 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                         rn: registers[rng.random_range(0..registers.len())],
                     },
                     Instruction::Rev16 { rd, .. } => Instruction::Rev16 {
+                        rd,
+                        rn: registers[rng.random_range(0..registers.len())],
+                    },
+                    Instruction::Sxtb { rd, .. } => Instruction::Sxtb {
+                        rd,
+                        rn: registers[rng.random_range(0..registers.len())],
+                    },
+                    Instruction::Sxth { rd, .. } => Instruction::Sxth {
+                        rd,
+                        rn: registers[rng.random_range(0..registers.len())],
+                    },
+                    Instruction::Sxtw { rd, .. } => Instruction::Sxtw {
+                        rd,
+                        rn: registers[rng.random_range(0..registers.len())],
+                    },
+                    Instruction::Uxtb { rd, .. } => Instruction::Uxtb {
+                        rd,
+                        rn: registers[rng.random_range(0..registers.len())],
+                    },
+                    Instruction::Uxth { rd, .. } => Instruction::Uxth {
                         rd,
                         rn: registers[rng.random_range(0..registers.len())],
                     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -1929,12 +1929,24 @@ mod cli_helper_tests {
             ("rev", "x0, x1"),
             ("rev32", "x0, x1"),
             ("rev16", "x0, x1"),
+            // Issue #60: extended-register operand form for ADD/SUB/CMP/CMN
+            // and the five standalone UBFM/SBFM-alias mnemonics. Capstone
+            // emits W-form register names for byte/half/word kinds.
+            ("add", "x0, x1, w2, uxtb #2"),
+            ("sub", "x0, x1, w2, sxth #1"),
+            ("cmp", "x1, w2, uxtw #3"),
+            ("cmn", "x1, x2, sxtx #0"),
+            ("uxtb", "w0, w1"),
+            ("uxth", "w0, w1"),
+            ("sxtb", "x0, w1"),
+            ("sxth", "x0, w1"),
+            ("sxtw", "x0, w1"),
         ];
 
         // Tripwire: bump in lockstep when adding/removing rows. Catches
         // accidental row deletion and forces a re-read when adding a parser
         // mnemonic without a matching test row.
-        assert_eq!(cases.len(), 52);
+        assert_eq!(cases.len(), 61);
 
         for (mnem, ops) in cases {
             match convert_capstone_op(mnem, ops) {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -969,6 +969,8 @@ pub fn parse_line(line: &str) -> Result<LineResult, ParseLineError> {
             .map_err(ParseLineError::Other)?,
         "sxth" => parse_unary_rd_rn("sxth", &operands, |rd, rn| Instruction::Sxth { rd, rn })
             .map_err(ParseLineError::Other)?,
+        "sxtw" => parse_unary_rd_rn("sxtw", &operands, |rd, rn| Instruction::Sxtw { rd, rn })
+            .map_err(ParseLineError::Other)?,
         _ => return Err(ParseLineError::UnknownInstruction(opcode)),
     };
 
@@ -1600,6 +1602,22 @@ mod tests {
         let missing = file.path().with_extension("missing");
         let err = parse_assembly_file(&missing).unwrap_err();
         assert!(err.to_string().contains("failed to read file"));
+    }
+
+    #[test]
+    fn parse_sxtw_standalone() {
+        let parsed = match parse_line("sxtw x0, x1").unwrap() {
+            LineResult::Instruction(instr) => instr,
+            LineResult::Skip => panic!("unexpected skip"),
+        };
+        assert_eq!(
+            parsed,
+            Instruction::Sxtw {
+                rd: Register::X0,
+                rn: Register::X1,
+            }
+        );
+        assert_eq!(format!("{}", parsed), "sxtw x0, x1");
     }
 
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -333,6 +333,30 @@ where
     Ok(build(rd, rn))
 }
 
+/// Parse the standalone sign/zero-extend mnemonics SXTB/SXTH/SXTW/UXTB/UXTH.
+/// ARM ARM / Capstone canonical syntax:
+///   - `UXTB Wd, Wn` / `UXTH Wd, Wn` — both operands W-form.
+///   - `SXTB Xd, Wn` / `SXTH Xd, Wn` / `SXTW Xd, Wn` — X-dest, W-src.
+/// The IR stores everything as 64-bit X-registers; the semantics layer
+/// masks to the architectural width. Issue #60 follow-up after the codex
+/// P2 / claude-review note that the ELF round-trip path was rejecting
+/// Capstone's W-form output.
+fn parse_unary_extend<F>(mnemonic: &str, operands: &[&str], build: F) -> Result<Instruction, String>
+where
+    F: FnOnce(Register, Register) -> Instruction,
+{
+    if operands.len() != 2 {
+        return Err(format!(
+            "{} requires 2 operands, got {}",
+            mnemonic,
+            operands.len()
+        ));
+    }
+    let rd = parse_w_or_x_register(operands[0])?;
+    let rn = parse_w_or_x_register(operands[1])?;
+    Ok(build(rd, rn))
+}
+
 /// Parse NEG instruction
 fn parse_neg(operands: &[&str]) -> Result<Instruction, String> {
     if operands.len() != 2 {
@@ -1092,15 +1116,15 @@ pub fn parse_line(line: &str) -> Result<LineResult, ParseLineError> {
             .map_err(ParseLineError::Other)?,
         "rev16" => parse_unary_rd_rn("rev16", &operands, |rd, rn| Instruction::Rev16 { rd, rn })
             .map_err(ParseLineError::Other)?,
-        "uxtb" => parse_unary_rd_rn("uxtb", &operands, |rd, rn| Instruction::Uxtb { rd, rn })
+        "uxtb" => parse_unary_extend("uxtb", &operands, |rd, rn| Instruction::Uxtb { rd, rn })
             .map_err(ParseLineError::Other)?,
-        "sxtb" => parse_unary_rd_rn("sxtb", &operands, |rd, rn| Instruction::Sxtb { rd, rn })
+        "sxtb" => parse_unary_extend("sxtb", &operands, |rd, rn| Instruction::Sxtb { rd, rn })
             .map_err(ParseLineError::Other)?,
-        "uxth" => parse_unary_rd_rn("uxth", &operands, |rd, rn| Instruction::Uxth { rd, rn })
+        "uxth" => parse_unary_extend("uxth", &operands, |rd, rn| Instruction::Uxth { rd, rn })
             .map_err(ParseLineError::Other)?,
-        "sxth" => parse_unary_rd_rn("sxth", &operands, |rd, rn| Instruction::Sxth { rd, rn })
+        "sxth" => parse_unary_extend("sxth", &operands, |rd, rn| Instruction::Sxth { rd, rn })
             .map_err(ParseLineError::Other)?,
-        "sxtw" => parse_unary_rd_rn("sxtw", &operands, |rd, rn| Instruction::Sxtw { rd, rn })
+        "sxtw" => parse_unary_extend("sxtw", &operands, |rd, rn| Instruction::Sxtw { rd, rn })
             .map_err(ParseLineError::Other)?,
         _ => return Err(ParseLineError::UnknownInstruction(opcode)),
     };
@@ -1780,19 +1804,76 @@ mod tests {
 
     #[test]
     fn parse_w_form_arithmetic_rejected() {
-        // Issue #60 follow-up (Codex review): the IR does not model 32-bit
-        // W-form arithmetic. Accepting `w0..w30` only inside the extended-
-        // register tail keeps `add w0, w1, w2` (which would otherwise alias
-        // to a 64-bit ADD with the wrong semantics) a parse error.
+        // Issue #60 follow-up (Codex P1): the IR does not model 32-bit
+        // W-form arithmetic. `parse_register` rejects W-form globally so
+        // `add w0, w1, w2` (which would otherwise alias to a 64-bit ADD
+        // with the wrong semantics) remains a parse error.
         assert!(parse_line("add w0, w1, w2").is_err());
         assert!(parse_line("sub w3, w4, w5").is_err());
-        assert!(parse_line("uxtb w0, w1").is_err());
-        // The extended-register inner register still accepts W-form.
+        // The extended-register inner register accepts W-form.
         assert!(parse_line("add x0, x1, w2, uxtb #0").is_ok());
         assert!(parse_line("cmp x1, w2, sxth #1").is_ok());
         // UXTX/SXTX accept X-form inner register (still works through the
         // parse_w_or_x_register fallback to parse_register).
         assert!(parse_line("add x0, x1, x2, uxtx #2").is_ok());
+    }
+
+    #[test]
+    fn parse_standalone_extend_accepts_capstone_w_form() {
+        // Issue #60 follow-up (Codex P2 / claude-review): Capstone disassembles
+        // the standalone extends with W-form operands:
+        //   UXTB / UXTH:           `uxtb w0, w1` (both W)
+        //   SXTB / SXTH / SXTW:    `sxtb x0, w1` (X-dest, W-src)
+        // The parser must accept those exact forms so the ELF round-trip
+        // path (Capstone disasm → parser → IR) doesn't break.
+        let cases = [
+            (
+                "uxtb w0, w1",
+                Instruction::Uxtb {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                },
+            ),
+            (
+                "uxth w2, w3",
+                Instruction::Uxth {
+                    rd: Register::X2,
+                    rn: Register::X3,
+                },
+            ),
+            (
+                "sxtb x4, w5",
+                Instruction::Sxtb {
+                    rd: Register::X4,
+                    rn: Register::X5,
+                },
+            ),
+            (
+                "sxth x6, w7",
+                Instruction::Sxth {
+                    rd: Register::X6,
+                    rn: Register::X7,
+                },
+            ),
+            (
+                "sxtw x8, w9",
+                Instruction::Sxtw {
+                    rd: Register::X8,
+                    rn: Register::X9,
+                },
+            ),
+        ];
+        for (line, expected) in cases {
+            let parsed = match parse_line(line).unwrap_or_else(|e| panic!("{}: {:?}", line, e)) {
+                LineResult::Instruction(instr) => instr,
+                LineResult::Skip => panic!("unexpected skip for {}", line),
+            };
+            assert_eq!(parsed, expected, "round-trip failed for {}", line);
+        }
+        // The legacy X-form spelling we use internally for Display still
+        // parses correctly (e.g. `uxtb x0, x1` from older tests).
+        assert!(parse_line("uxtb x0, x1").is_ok());
+        assert!(parse_line("sxtw x0, x1").is_ok());
     }
 
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -130,7 +130,41 @@ pub fn parse_register(s: &str) -> Result<Register, String> {
         "x29" | "fp" => Ok(Register::X29),
         "x30" | "lr" => Ok(Register::X30),
         "xzr" | "wzr" => Ok(Register::XZR),
-        "sp" => Ok(Register::SP),
+        "sp" | "wsp" => Ok(Register::SP),
+        // Issue #60: accept W-form aliases for the inner register of the
+        // extended-register operand. The IR stores 64-bit X-registers
+        // exclusively; semantics mask to the correct width per ExtendKind.
+        "w0" => Ok(Register::X0),
+        "w1" => Ok(Register::X1),
+        "w2" => Ok(Register::X2),
+        "w3" => Ok(Register::X3),
+        "w4" => Ok(Register::X4),
+        "w5" => Ok(Register::X5),
+        "w6" => Ok(Register::X6),
+        "w7" => Ok(Register::X7),
+        "w8" => Ok(Register::X8),
+        "w9" => Ok(Register::X9),
+        "w10" => Ok(Register::X10),
+        "w11" => Ok(Register::X11),
+        "w12" => Ok(Register::X12),
+        "w13" => Ok(Register::X13),
+        "w14" => Ok(Register::X14),
+        "w15" => Ok(Register::X15),
+        "w16" => Ok(Register::X16),
+        "w17" => Ok(Register::X17),
+        "w18" => Ok(Register::X18),
+        "w19" => Ok(Register::X19),
+        "w20" => Ok(Register::X20),
+        "w21" => Ok(Register::X21),
+        "w22" => Ok(Register::X22),
+        "w23" => Ok(Register::X23),
+        "w24" => Ok(Register::X24),
+        "w25" => Ok(Register::X25),
+        "w26" => Ok(Register::X26),
+        "w27" => Ok(Register::X27),
+        "w28" => Ok(Register::X28),
+        "w29" => Ok(Register::X29),
+        "w30" => Ok(Register::X30),
         _ => Err(format!("unknown register: {}", s)),
     }
 }
@@ -532,15 +566,82 @@ fn parse_shifted_register_tail(mnem: &str, reg: Register, tail: &str) -> Result<
     })
 }
 
+/// Parse the trailing extend modifier (`"<kind> #<shift>"`) attached to an
+/// extended-register operand. Returns the assembled `Operand::ExtendedRegister`.
+/// Shift is 0..=4 (the ARM ARM imm3 field). Issue #60.
+fn parse_extended_register_tail(
+    mnem: &str,
+    reg: Register,
+    tail: &str,
+) -> Result<Operand, String> {
+    let tail = tail.trim();
+    let mut parts = tail.splitn(2, char::is_whitespace);
+    let kw = parts.next().unwrap_or("").trim();
+    let rest = parts.next().unwrap_or("").trim();
+    let kind = match kw.to_ascii_lowercase().as_str() {
+        "uxtb" => crate::ir::ExtendKind::Uxtb,
+        "uxth" => crate::ir::ExtendKind::Uxth,
+        "uxtw" => crate::ir::ExtendKind::Uxtw,
+        "uxtx" => crate::ir::ExtendKind::Uxtx,
+        "sxtb" => crate::ir::ExtendKind::Sxtb,
+        "sxth" => crate::ir::ExtendKind::Sxth,
+        "sxtw" => crate::ir::ExtendKind::Sxtw,
+        "sxtx" => crate::ir::ExtendKind::Sxtx,
+        _ => {
+            return Err(format!(
+                "{} extend kind must be one of uxtb/uxth/uxtw/uxtx/sxtb/sxth/sxtw/sxtx, got `{}`",
+                mnem, kw
+            ));
+        }
+    };
+    // The shift amount is the imm3 field of the ARM ARM encoding (0..=4).
+    // The `#` prefix is conventional but optional in our parser.
+    let shift = if rest.is_empty() {
+        0
+    } else {
+        match parse_operand(rest)? {
+            Operand::Immediate(v) => v,
+            _ => return Err(format!("{} extend shift must be an immediate", mnem)),
+        }
+    };
+    if !(0..=4).contains(&shift) {
+        return Err(format!(
+            "{} extend shift {} out of range (0..=4)",
+            mnem, shift
+        ));
+    }
+    Ok(Operand::ExtendedRegister {
+        reg,
+        kind,
+        shift: shift as u8,
+    })
+}
+
+/// Returns true if the lowercased keyword names an extend kind
+/// (UXTB/UXTH/UXTW/UXTX/SXTB/SXTH/SXTW/SXTX) rather than a shift kind.
+fn is_extend_keyword(kw: &str) -> bool {
+    matches!(
+        kw.to_ascii_lowercase().as_str(),
+        "uxtb" | "uxth" | "uxtw" | "uxtx" | "sxtb" | "sxth" | "sxtw" | "sxtx"
+    )
+}
+
 /// Parse the rm slot for the 3-operand arith/logical instructions
-/// (Add/Sub/And/Orr/Eor). Returns either the existing register/immediate form
-/// or a new shifted-register operand if a 4th comma-separated token is present.
+/// (Add/Sub/And/Orr/Eor). Returns the register/immediate form, a
+/// shifted-register operand, or an extended-register operand based on the
+/// shape and the keyword in the 4th token.
 fn parse_rm_3op(mnem: &str, operands: &[&str]) -> Result<Operand, String> {
     if operands.len() == 3 {
         parse_operand(operands[2])
     } else if operands.len() == 4 {
         let reg = parse_register(operands[2])?;
-        parse_shifted_register_tail(mnem, reg, operands[3])
+        let tail = operands[3].trim();
+        let kw = tail.split_whitespace().next().unwrap_or("");
+        if is_extend_keyword(kw) {
+            parse_extended_register_tail(mnem, reg, tail)
+        } else {
+            parse_shifted_register_tail(mnem, reg, tail)
+        }
     } else {
         Err(format!(
             "{} requires 3 or 4 operands, got {}",
@@ -743,7 +844,13 @@ fn parse_rm_2op(mnem: &str, operands: &[&str]) -> Result<Operand, String> {
         parse_operand(operands[1])
     } else if operands.len() == 3 {
         let reg = parse_register(operands[1])?;
-        parse_shifted_register_tail(mnem, reg, operands[2])
+        let tail = operands[2].trim();
+        let kw = tail.split_whitespace().next().unwrap_or("");
+        if is_extend_keyword(kw) {
+            parse_extended_register_tail(mnem, reg, tail)
+        } else {
+            parse_shifted_register_tail(mnem, reg, tail)
+        }
     } else {
         Err(format!(
             "{} requires 2 or 3 operands, got {}",
@@ -1608,6 +1715,58 @@ mod tests {
         let missing = file.path().with_extension("missing");
         let err = parse_assembly_file(&missing).unwrap_err();
         assert!(err.to_string().contains("failed to read file"));
+    }
+
+    #[test]
+    fn parse_add_extended_register_uxtb() {
+        use crate::ir::ExtendKind;
+        // Issue #60: `add x0, x1, w2, uxtb #2` produces an Add with an
+        // ExtendedRegister rm. The inner register parses as w2 (alias of x2).
+        let parsed = match parse_line("add x0, x1, w2, uxtb #2").unwrap() {
+            LineResult::Instruction(instr) => instr,
+            LineResult::Skip => panic!("unexpected skip"),
+        };
+        assert_eq!(
+            parsed,
+            Instruction::Add {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::ExtendedRegister {
+                    reg: Register::X2,
+                    kind: ExtendKind::Uxtb,
+                    shift: 2,
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn parse_cmp_extended_register_sxth() {
+        use crate::ir::ExtendKind;
+        let parsed = match parse_line("cmp x1, w2, sxth #1").unwrap() {
+            LineResult::Instruction(instr) => instr,
+            LineResult::Skip => panic!("unexpected skip"),
+        };
+        assert_eq!(
+            parsed,
+            Instruction::Cmp {
+                rn: Register::X1,
+                rm: Operand::ExtendedRegister {
+                    reg: Register::X2,
+                    kind: ExtendKind::Sxth,
+                    shift: 1,
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn parse_extended_register_rejects_oversized_shift() {
+        // Shift > 4 must be rejected at the parser (the encodability gate
+        // would also reject, but the parser's range check fires earlier).
+        assert!(parse_line("add x0, x1, w2, uxtb #5").is_err());
+        // And rejected for non-arith opcodes.
+        assert!(parse_line("and x0, x1, w2, uxtb #2").is_err());
     }
 
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -371,7 +371,15 @@ where
         parse_w_or_x_register(operands[0])?
     } else {
         let rd_str = operands[0].trim();
-        if rd_str.to_ascii_lowercase().starts_with('w') && rd_str.to_ascii_lowercase() != "wzr" {
+        // Reject W-form rd (e.g. `sxtb w0, w1`) before delegating to
+        // `parse_register`. WZR is also W-form but it's an alias for XZR
+        // that several callers still use, so allow it.
+        let is_w_form = rd_str
+            .as_bytes()
+            .first()
+            .is_some_and(|b| b.eq_ignore_ascii_case(&b'w'))
+            && !rd_str.eq_ignore_ascii_case("wzr");
+        if is_w_form {
             return Err(format!(
                 "{} destination must be X-form (the W-form `{} {}, ...` is a different 32-bit \
                  architectural instruction that this IR does not model)",

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -489,8 +489,8 @@ fn parse_movw_operands(mnem: &str, operands: &[&str]) -> Result<(Register, u16, 
         let s = match parse_operand(rest)? {
             Operand::Immediate(v) => v,
             Operand::Register(_)
-        | Operand::ShiftedRegister { .. }
-        | Operand::ExtendedRegister { .. } => {
+            | Operand::ShiftedRegister { .. }
+            | Operand::ExtendedRegister { .. } => {
                 return Err(format!("{} shift must be an immediate", mnem));
             }
         };
@@ -569,11 +569,7 @@ fn parse_shifted_register_tail(mnem: &str, reg: Register, tail: &str) -> Result<
 /// Parse the trailing extend modifier (`"<kind> #<shift>"`) attached to an
 /// extended-register operand. Returns the assembled `Operand::ExtendedRegister`.
 /// Shift is 0..=4 (the ARM ARM imm3 field). Issue #60.
-fn parse_extended_register_tail(
-    mnem: &str,
-    reg: Register,
-    tail: &str,
-) -> Result<Operand, String> {
+fn parse_extended_register_tail(mnem: &str, reg: Register, tail: &str) -> Result<Operand, String> {
     let tail = tail.trim();
     let mut parts = tail.splitn(2, char::is_whitespace);
     let kw = parts.next().unwrap_or("").trim();

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -963,6 +963,8 @@ pub fn parse_line(line: &str) -> Result<LineResult, ParseLineError> {
             .map_err(ParseLineError::Other)?,
         "uxtb" => parse_unary_rd_rn("uxtb", &operands, |rd, rn| Instruction::Uxtb { rd, rn })
             .map_err(ParseLineError::Other)?,
+        "sxtb" => parse_unary_rd_rn("sxtb", &operands, |rd, rn| Instruction::Sxtb { rd, rn })
+            .map_err(ParseLineError::Other)?,
         _ => return Err(ParseLineError::UnknownInstruction(opcode)),
     };
 
@@ -1594,6 +1596,22 @@ mod tests {
         let missing = file.path().with_extension("missing");
         let err = parse_assembly_file(&missing).unwrap_err();
         assert!(err.to_string().contains("failed to read file"));
+    }
+
+    #[test]
+    fn parse_sxtb_standalone() {
+        let parsed = match parse_line("sxtb x0, x1").unwrap() {
+            LineResult::Instruction(instr) => instr,
+            LineResult::Skip => panic!("unexpected skip"),
+        };
+        assert_eq!(
+            parsed,
+            Instruction::Sxtb {
+                rd: Register::X0,
+                rn: Register::X1,
+            }
+        );
+        assert_eq!(format!("{}", parsed), "sxtb x0, x1");
     }
 
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -965,6 +965,8 @@ pub fn parse_line(line: &str) -> Result<LineResult, ParseLineError> {
             .map_err(ParseLineError::Other)?,
         "sxtb" => parse_unary_rd_rn("sxtb", &operands, |rd, rn| Instruction::Sxtb { rd, rn })
             .map_err(ParseLineError::Other)?,
+        "uxth" => parse_unary_rd_rn("uxth", &operands, |rd, rn| Instruction::Uxth { rd, rn })
+            .map_err(ParseLineError::Other)?,
         _ => return Err(ParseLineError::UnknownInstruction(opcode)),
     };
 
@@ -1596,6 +1598,22 @@ mod tests {
         let missing = file.path().with_extension("missing");
         let err = parse_assembly_file(&missing).unwrap_err();
         assert!(err.to_string().contains("failed to read file"));
+    }
+
+    #[test]
+    fn parse_uxth_standalone() {
+        let parsed = match parse_line("uxth x0, x1").unwrap() {
+            LineResult::Instruction(instr) => instr,
+            LineResult::Skip => panic!("unexpected skip"),
+        };
+        assert_eq!(
+            parsed,
+            Instruction::Uxth {
+                rd: Register::X0,
+                rn: Register::X1,
+            }
+        );
+        assert_eq!(format!("{}", parsed), "uxth x0, x1");
     }
 
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -250,7 +250,7 @@ fn parse_mov(operands: &[&str]) -> Result<Instruction, String> {
     match src {
         Operand::Register(rn) => Ok(Instruction::MovReg { rd, rn }),
         Operand::Immediate(imm) => Ok(Instruction::MovImm { rd, imm }),
-        Operand::ShiftedRegister { .. } => {
+        Operand::ShiftedRegister { .. } | Operand::ExtendedRegister { .. } => {
             Err("mov second operand must be a register or immediate".to_string())
         }
     }
@@ -427,7 +427,9 @@ fn parse_movw_operands(mnem: &str, operands: &[&str]) -> Result<(Register, u16, 
     let rd = parse_register(operands[0])?;
     let imm_val = match parse_operand(operands[1])? {
         Operand::Immediate(v) => v,
-        Operand::Register(_) | Operand::ShiftedRegister { .. } => {
+        Operand::Register(_)
+        | Operand::ShiftedRegister { .. }
+        | Operand::ExtendedRegister { .. } => {
             return Err(format!("{} second operand must be an immediate", mnem));
         }
     };
@@ -452,7 +454,9 @@ fn parse_movw_operands(mnem: &str, operands: &[&str]) -> Result<(Register, u16, 
         }
         let s = match parse_operand(rest)? {
             Operand::Immediate(v) => v,
-            Operand::Register(_) | Operand::ShiftedRegister { .. } => {
+            Operand::Register(_)
+        | Operand::ShiftedRegister { .. }
+        | Operand::ExtendedRegister { .. } => {
                 return Err(format!("{} shift must be an immediate", mnem));
             }
         };
@@ -509,7 +513,9 @@ fn parse_shifted_register_tail(mnem: &str, reg: Register, tail: &str) -> Result<
     };
     let amt = match parse_operand(rest)? {
         Operand::Immediate(v) => v,
-        Operand::Register(_) | Operand::ShiftedRegister { .. } => {
+        Operand::Register(_)
+        | Operand::ShiftedRegister { .. }
+        | Operand::ExtendedRegister { .. } => {
             return Err(format!("{} shift amount must be an immediate", mnem));
         }
     };

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -961,6 +961,8 @@ pub fn parse_line(line: &str) -> Result<LineResult, ParseLineError> {
             .map_err(ParseLineError::Other)?,
         "rev16" => parse_unary_rd_rn("rev16", &operands, |rd, rn| Instruction::Rev16 { rd, rn })
             .map_err(ParseLineError::Other)?,
+        "uxtb" => parse_unary_rd_rn("uxtb", &operands, |rd, rn| Instruction::Uxtb { rd, rn })
+            .map_err(ParseLineError::Other)?,
         _ => return Err(ParseLineError::UnknownInstruction(opcode)),
     };
 
@@ -1592,5 +1594,22 @@ mod tests {
         let missing = file.path().with_extension("missing");
         let err = parse_assembly_file(&missing).unwrap_err();
         assert!(err.to_string().contains("failed to read file"));
+    }
+
+    #[test]
+    fn parse_uxtb_standalone() {
+        // Issue #60: the standalone UXTB mnemonic produces Instruction::Uxtb.
+        let parsed = match parse_line("uxtb x0, x1").unwrap() {
+            LineResult::Instruction(instr) => instr,
+            LineResult::Skip => panic!("unexpected skip"),
+        };
+        assert_eq!(
+            parsed,
+            Instruction::Uxtb {
+                rd: Register::X0,
+                rn: Register::X1,
+            }
+        );
+        assert_eq!(format!("{}", parsed), "uxtb x0, x1");
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -334,13 +334,15 @@ where
 }
 
 /// Parse the standalone sign/zero-extend mnemonics SXTB/SXTH/SXTW/UXTB/UXTH.
+///
 /// ARM ARM / Capstone canonical syntax:
-///   - `UXTB Wd, Wn` / `UXTH Wd, Wn` — both operands W-form.
-///   - `SXTB Xd, Wn` / `SXTH Xd, Wn` / `SXTW Xd, Wn` — X-dest, W-src.
-/// The IR stores everything as 64-bit X-registers; the semantics layer
-/// masks to the architectural width. Issue #60 follow-up after the codex
-/// P2 / claude-review note that the ELF round-trip path was rejecting
-/// Capstone's W-form output.
+///
+/// - `UXTB Wd, Wn` / `UXTH Wd, Wn` — both operands W-form.
+/// - `SXTB Xd, Wn` / `SXTH Xd, Wn` / `SXTW Xd, Wn` — X-dest, W-src.
+///
+/// The IR stores everything as 64-bit X-registers; the semantics layer masks
+/// to the architectural width. The W-form acceptance is scoped to this
+/// helper so non-extend opcodes keep rejecting bare W-form names.
 fn parse_unary_extend<F>(mnemonic: &str, operands: &[&str], build: F) -> Result<Instruction, String>
 where
     F: FnOnce(Register, Register) -> Instruction,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -130,10 +130,25 @@ pub fn parse_register(s: &str) -> Result<Register, String> {
         "x29" | "fp" => Ok(Register::X29),
         "x30" | "lr" => Ok(Register::X30),
         "xzr" | "wzr" => Ok(Register::XZR),
-        "sp" | "wsp" => Ok(Register::SP),
-        // Issue #60: accept W-form aliases for the inner register of the
-        // extended-register operand. The IR stores 64-bit X-registers
-        // exclusively; semantics mask to the correct width per ExtendKind.
+        "sp" => Ok(Register::SP),
+        _ => Err(format!("unknown register: {}", s)),
+    }
+}
+
+/// Parse a register that may be written in W-form. Scoped to the inner
+/// register of `Operand::ExtendedRegister`, where the ARM ARM architecturally
+/// writes byte/half/word extends with a W-form source and UXTX/SXTX with an
+/// X-form source. Issue #60.
+///
+/// Accepting W-form names is **only** valid here — `parse_register` itself
+/// still rejects them, so e.g. `add w0, w1, w2` (a 32-bit ADD that this IR
+/// does not model) remains a parse error instead of silently parsing as a
+/// 64-bit ADD.
+pub fn parse_w_or_x_register(s: &str) -> Result<Register, String> {
+    if let Ok(reg) = parse_register(s) {
+        return Ok(reg);
+    }
+    match s.to_lowercase().as_str() {
         "w0" => Ok(Register::X0),
         "w1" => Ok(Register::X1),
         "w2" => Ok(Register::X2),
@@ -165,6 +180,7 @@ pub fn parse_register(s: &str) -> Result<Register, String> {
         "w28" => Ok(Register::X28),
         "w29" => Ok(Register::X29),
         "w30" => Ok(Register::X30),
+        "wsp" => Ok(Register::SP),
         _ => Err(format!("unknown register: {}", s)),
     }
 }
@@ -630,12 +646,15 @@ fn parse_rm_3op(mnem: &str, operands: &[&str]) -> Result<Operand, String> {
     if operands.len() == 3 {
         parse_operand(operands[2])
     } else if operands.len() == 4 {
-        let reg = parse_register(operands[2])?;
         let tail = operands[3].trim();
         let kw = tail.split_whitespace().next().unwrap_or("");
         if is_extend_keyword(kw) {
+            // Extended-register form: the inner register may be W-form for
+            // byte/half/word kinds. Issue #60.
+            let reg = parse_w_or_x_register(operands[2])?;
             parse_extended_register_tail(mnem, reg, tail)
         } else {
+            let reg = parse_register(operands[2])?;
             parse_shifted_register_tail(mnem, reg, tail)
         }
     } else {
@@ -839,12 +858,15 @@ fn parse_rm_2op(mnem: &str, operands: &[&str]) -> Result<Operand, String> {
     if operands.len() == 2 {
         parse_operand(operands[1])
     } else if operands.len() == 3 {
-        let reg = parse_register(operands[1])?;
         let tail = operands[2].trim();
         let kw = tail.split_whitespace().next().unwrap_or("");
         if is_extend_keyword(kw) {
+            // Extended-register form: the inner register may be W-form for
+            // byte/half/word kinds. Issue #60.
+            let reg = parse_w_or_x_register(operands[1])?;
             parse_extended_register_tail(mnem, reg, tail)
         } else {
+            let reg = parse_register(operands[1])?;
             parse_shifted_register_tail(mnem, reg, tail)
         }
     } else {
@@ -1754,6 +1776,23 @@ mod tests {
                 },
             }
         );
+    }
+
+    #[test]
+    fn parse_w_form_arithmetic_rejected() {
+        // Issue #60 follow-up (Codex review): the IR does not model 32-bit
+        // W-form arithmetic. Accepting `w0..w30` only inside the extended-
+        // register tail keeps `add w0, w1, w2` (which would otherwise alias
+        // to a 64-bit ADD with the wrong semantics) a parse error.
+        assert!(parse_line("add w0, w1, w2").is_err());
+        assert!(parse_line("sub w3, w4, w5").is_err());
+        assert!(parse_line("uxtb w0, w1").is_err());
+        // The extended-register inner register still accepts W-form.
+        assert!(parse_line("add x0, x1, w2, uxtb #0").is_ok());
+        assert!(parse_line("cmp x1, w2, sxth #1").is_ok());
+        // UXTX/SXTX accept X-form inner register (still works through the
+        // parse_w_or_x_register fallback to parse_register).
+        assert!(parse_line("add x0, x1, x2, uxtx #2").is_ok());
     }
 
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -337,13 +337,24 @@ where
 ///
 /// ARM ARM / Capstone canonical syntax:
 ///
-/// - `UXTB Wd, Wn` / `UXTH Wd, Wn` — both operands W-form.
-/// - `SXTB Xd, Wn` / `SXTH Xd, Wn` / `SXTW Xd, Wn` — X-dest, W-src.
+/// - `UXTB Wd, Wn` / `UXTH Wd, Wn` — both operands W-form. The IR models
+///   these as 64-bit ops with the upper 32 bits zeroed (which is the W-form
+///   semantics on AArch64), so X-spelling for rd is also accepted.
+/// - `SXTB Xd, Wn` / `SXTH Xd, Wn` / `SXTW Xd, Wn` — X-dest, W-src. There is
+///   also a 32-bit `SXTB Wd, Wn` architectural form which writes only Wd and
+///   zeroes the upper half of Xd — that is *not* what the IR models, so
+///   `sxtb w0, w1` is rejected by this parser to avoid silent semantic
+///   erasure (codex P1 on #144).
 ///
 /// The IR stores everything as 64-bit X-registers; the semantics layer masks
 /// to the architectural width. The W-form acceptance is scoped to this
 /// helper so non-extend opcodes keep rejecting bare W-form names.
-fn parse_unary_extend<F>(mnemonic: &str, operands: &[&str], build: F) -> Result<Instruction, String>
+fn parse_unary_extend<F>(
+    mnemonic: &str,
+    operands: &[&str],
+    allow_w_dest: bool,
+    build: F,
+) -> Result<Instruction, String>
 where
     F: FnOnce(Register, Register) -> Instruction,
 {
@@ -354,8 +365,21 @@ where
             operands.len()
         ));
     }
-    let rd = parse_w_or_x_register(operands[0])?;
+    // Rn is W-form (or X for the IR's X-spelling fallback) for every kind.
     let rn = parse_w_or_x_register(operands[1])?;
+    let rd = if allow_w_dest {
+        parse_w_or_x_register(operands[0])?
+    } else {
+        let rd_str = operands[0].trim();
+        if rd_str.to_ascii_lowercase().starts_with('w') && rd_str.to_ascii_lowercase() != "wzr" {
+            return Err(format!(
+                "{} destination must be X-form (the W-form `{} {}, ...` is a different 32-bit \
+                 architectural instruction that this IR does not model)",
+                mnemonic, mnemonic, rd_str
+            ));
+        }
+        parse_register(rd_str)?
+    };
     Ok(build(rd, rn))
 }
 
@@ -1118,16 +1142,35 @@ pub fn parse_line(line: &str) -> Result<LineResult, ParseLineError> {
             .map_err(ParseLineError::Other)?,
         "rev16" => parse_unary_rd_rn("rev16", &operands, |rd, rn| Instruction::Rev16 { rd, rn })
             .map_err(ParseLineError::Other)?,
-        "uxtb" => parse_unary_extend("uxtb", &operands, |rd, rn| Instruction::Uxtb { rd, rn })
-            .map_err(ParseLineError::Other)?,
-        "sxtb" => parse_unary_extend("sxtb", &operands, |rd, rn| Instruction::Sxtb { rd, rn })
-            .map_err(ParseLineError::Other)?,
-        "uxth" => parse_unary_extend("uxth", &operands, |rd, rn| Instruction::Uxth { rd, rn })
-            .map_err(ParseLineError::Other)?,
-        "sxth" => parse_unary_extend("sxth", &operands, |rd, rn| Instruction::Sxth { rd, rn })
-            .map_err(ParseLineError::Other)?,
-        "sxtw" => parse_unary_extend("sxtw", &operands, |rd, rn| Instruction::Sxtw { rd, rn })
-            .map_err(ParseLineError::Other)?,
+        // UXTB/UXTH: Wd-write form is the only architectural form; accepting
+        // X-spelling for rd is just the IR's naming convention.
+        "uxtb" => parse_unary_extend("uxtb", &operands, true, |rd, rn| Instruction::Uxtb {
+            rd,
+            rn,
+        })
+        .map_err(ParseLineError::Other)?,
+        "uxth" => parse_unary_extend("uxth", &operands, true, |rd, rn| Instruction::Uxth {
+            rd,
+            rn,
+        })
+        .map_err(ParseLineError::Other)?,
+        // SXTB/SXTH/SXTW: X-dest only. The 32-bit `Wd` form is a distinct
+        // architectural instruction that this IR does not model.
+        "sxtb" => parse_unary_extend("sxtb", &operands, false, |rd, rn| Instruction::Sxtb {
+            rd,
+            rn,
+        })
+        .map_err(ParseLineError::Other)?,
+        "sxth" => parse_unary_extend("sxth", &operands, false, |rd, rn| Instruction::Sxth {
+            rd,
+            rn,
+        })
+        .map_err(ParseLineError::Other)?,
+        "sxtw" => parse_unary_extend("sxtw", &operands, false, |rd, rn| Instruction::Sxtw {
+            rd,
+            rn,
+        })
+        .map_err(ParseLineError::Other)?,
         _ => return Err(ParseLineError::UnknownInstruction(opcode)),
     };
 
@@ -1876,6 +1919,30 @@ mod tests {
         // parses correctly (e.g. `uxtb x0, x1` from older tests).
         assert!(parse_line("uxtb x0, x1").is_ok());
         assert!(parse_line("sxtw x0, x1").is_ok());
+    }
+
+    #[test]
+    fn parse_sxt_rejects_w_destination() {
+        // Issue #60 follow-up (Codex P1 on the rebased branch): `sxtb w0, w1`
+        // is the 32-bit-Wd-write form architecturally — distinct from the
+        // X-dest SXTB the IR models. Accepting it would silently erase the
+        // width and let the optimizer emit Xd-write bytes against W-dest
+        // input. The parser must refuse.
+        for line in ["sxtb w0, w1", "sxth w0, w1", "sxtw w0, w1"] {
+            assert!(
+                parse_line(line).is_err(),
+                "{} should reject W-form destination",
+                line
+            );
+        }
+        // The X-form destination is the correct spelling for the IR's model.
+        assert!(parse_line("sxtb x0, w1").is_ok());
+        assert!(parse_line("sxth x0, w1").is_ok());
+        assert!(parse_line("sxtw x0, w1").is_ok());
+        // UXTB/UXTH accept both W- and X-form rd (they are not architecturally
+        // distinct — Xd is just the IR's spelling convention).
+        assert!(parse_line("uxtb w0, w1").is_ok());
+        assert!(parse_line("uxtb x0, w1").is_ok());
     }
 
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -967,6 +967,8 @@ pub fn parse_line(line: &str) -> Result<LineResult, ParseLineError> {
             .map_err(ParseLineError::Other)?,
         "uxth" => parse_unary_rd_rn("uxth", &operands, |rd, rn| Instruction::Uxth { rd, rn })
             .map_err(ParseLineError::Other)?,
+        "sxth" => parse_unary_rd_rn("sxth", &operands, |rd, rn| Instruction::Sxth { rd, rn })
+            .map_err(ParseLineError::Other)?,
         _ => return Err(ParseLineError::UnknownInstruction(opcode)),
     };
 
@@ -1598,6 +1600,22 @@ mod tests {
         let missing = file.path().with_extension("missing");
         let err = parse_assembly_file(&missing).unwrap_err();
         assert!(err.to_string().contains("failed to read file"));
+    }
+
+    #[test]
+    fn parse_sxth_standalone() {
+        let parsed = match parse_line("sxth x0, x1").unwrap() {
+            LineResult::Instruction(instr) => instr,
+            LineResult::Skip => panic!("unexpected skip"),
+        };
+        assert_eq!(
+            parsed,
+            Instruction::Sxth {
+                rd: Register::X0,
+                rn: Register::X1,
+            }
+        );
+        assert_eq!(format!("{}", parsed), "sxth x0, x1");
     }
 
     #[test]

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -477,9 +477,10 @@ pub fn generate_random_instruction<R: rand::RngExt>(
                 Operand::Register(r) => Operand::Register(r),
                 Operand::Immediate(v) => Operand::Immediate(v.rem_euclid(32)),
                 // random_operand only returns Register/Immediate, but the
-                // compiler can't prove that — drop ShiftedRegister to a plain
-                // register (CCMP rejects shifted form anyway).
-                Operand::ShiftedRegister { reg, .. } => Operand::Register(reg),
+                // compiler can't prove that — drop ShiftedRegister/Extended-
+                // Register to a plain register (CCMP rejects both forms).
+                Operand::ShiftedRegister { reg, .. }
+                | Operand::ExtendedRegister { reg, .. } => Operand::Register(reg),
             };
             let nzcv = (rng.random::<u32>() & 0x0F) as u8;
             let cond = crate::ir::types::Condition::random_normal(rng);

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -126,7 +126,11 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
                     ExtendKind::Sxtx,
                 ] {
                     for shift in 0u8..=4 {
-                        let er = Operand::ExtendedRegister { reg: rm, kind, shift };
+                        let er = Operand::ExtendedRegister {
+                            reg: rm,
+                            kind,
+                            shift,
+                        };
                         instrs.push(Instruction::Add { rd, rn, rm: er });
                         instrs.push(Instruction::Sub { rd, rn, rm: er });
                         instrs.push(Instruction::Cmp { rn, rm: er });
@@ -502,8 +506,9 @@ pub fn generate_random_instruction<R: rand::RngExt>(
                 // random_operand only returns Register/Immediate, but the
                 // compiler can't prove that — drop ShiftedRegister/Extended-
                 // Register to a plain register (CCMP rejects both forms).
-                Operand::ShiftedRegister { reg, .. }
-                | Operand::ExtendedRegister { reg, .. } => Operand::Register(reg),
+                Operand::ShiftedRegister { reg, .. } | Operand::ExtendedRegister { reg, .. } => {
+                    Operand::Register(reg)
+                }
             };
             let nzcv = (rng.random::<u32>() & 0x0F) as u8;
             let cond = crate::ir::types::Condition::random_normal(rng);

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -185,6 +185,7 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
             instrs.push(Instruction::Rev16 { rd, rn });
             instrs.push(Instruction::Uxtb { rd, rn });
             instrs.push(Instruction::Sxtb { rd, rn });
+            instrs.push(Instruction::Uxth { rd, rn });
         }
 
         // Multiply-accumulate family. MADD/MSUB take a 4th register slot
@@ -924,6 +925,23 @@ mod tests {
         for &rd in &regs {
             for &rn in &regs {
                 let expected = Instruction::Uxtb { rd, rn };
+                assert!(
+                    candidates.contains(&expected),
+                    "enumeration missing {}",
+                    expected
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn enumerate_emits_uxth_for_each_register_pair() {
+        let regs = vec![Register::X0, Register::X1, Register::X2];
+        let imms = vec![];
+        let candidates = generate_all_instructions(&regs, &imms);
+        for &rd in &regs {
+            for &rn in &regs {
+                let expected = Instruction::Uxth { rd, rn };
                 assert!(
                     candidates.contains(&expected),
                     "enumeration missing {}",

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -187,6 +187,7 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
             instrs.push(Instruction::Sxtb { rd, rn });
             instrs.push(Instruction::Uxth { rd, rn });
             instrs.push(Instruction::Sxth { rd, rn });
+            instrs.push(Instruction::Sxtw { rd, rn });
         }
 
         // Multiply-accumulate family. MADD/MSUB take a 4th register slot
@@ -926,6 +927,23 @@ mod tests {
         for &rd in &regs {
             for &rn in &regs {
                 let expected = Instruction::Uxtb { rd, rn };
+                assert!(
+                    candidates.contains(&expected),
+                    "enumeration missing {}",
+                    expected
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn enumerate_emits_sxtw_for_each_register_pair() {
+        let regs = vec![Register::X0, Register::X1, Register::X2];
+        let imms = vec![];
+        let candidates = generate_all_instructions(&regs, &imms);
+        for &rd in &regs {
+            for &rn in &regs {
+                let expected = Instruction::Sxtw { rd, rn };
                 assert!(
                     candidates.contains(&expected),
                     "enumeration missing {}",

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -186,6 +186,7 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
             instrs.push(Instruction::Uxtb { rd, rn });
             instrs.push(Instruction::Sxtb { rd, rn });
             instrs.push(Instruction::Uxth { rd, rn });
+            instrs.push(Instruction::Sxth { rd, rn });
         }
 
         // Multiply-accumulate family. MADD/MSUB take a 4th register slot
@@ -925,6 +926,23 @@ mod tests {
         for &rd in &regs {
             for &rn in &regs {
                 let expected = Instruction::Uxtb { rd, rn };
+                assert!(
+                    candidates.contains(&expected),
+                    "enumeration missing {}",
+                    expected
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn enumerate_emits_sxth_for_each_register_pair() {
+        let regs = vec![Register::X0, Register::X1, Register::X2];
+        let imms = vec![];
+        let candidates = generate_all_instructions(&regs, &imms);
+        for &rd in &regs {
+            for &rn in &regs {
+                let expected = Instruction::Sxth { rd, rn };
                 assert!(
                     candidates.contains(&expected),
                     "enumeration missing {}",

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -110,10 +110,12 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
                     instrs.push(Instruction::Orr { rd, rn, rm: sr_ror });
                     instrs.push(Instruction::Eor { rd, rn, rm: sr_ror });
                 }
-                // Issue #60: extended-register form for ADD/SUB/CMP/CMN.
-                // Shift in 0..=4 (the imm3 field). Eight kinds × five shifts
-                // produces 40 extra candidates per (rd, rn, rm) triple, which
-                // is comparable to the shifted-register pool above.
+                // Issue #60: extended-register form for ADD/SUB. Cmp/Cmn
+                // are produced once-per-(rn,rm,kind,shift) further below
+                // (outside the `rd` loop), since they have no destination
+                // register — duplicating them by rd just inflates the
+                // candidate pool with identical instructions (codex P2 on
+                // #144).
                 use crate::ir::ExtendKind;
                 for kind in [
                     ExtendKind::Uxtb,
@@ -133,8 +135,6 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
                         };
                         instrs.push(Instruction::Add { rd, rn, rm: er });
                         instrs.push(Instruction::Sub { rd, rn, rm: er });
-                        instrs.push(Instruction::Cmp { rn, rm: er });
-                        instrs.push(Instruction::Cmn { rn, rm: er });
                     }
                 }
             }
@@ -299,6 +299,39 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
                         nzcv,
                         cond,
                     });
+                }
+            }
+        }
+    }
+
+    // Issue #60: ExtendedRegister CMP/CMN candidates. These instructions
+    // have no destination register, so emitting them per-rd (as the
+    // shifted-register block above does) produced N identical copies per
+    // (rn, rm, kind, shift) tuple (codex P2 on #144). Generate once per
+    // unique (rn, rm, kind, shift) instead.
+    {
+        use crate::ir::ExtendKind;
+        for &rn in registers {
+            for &rm in registers {
+                for kind in [
+                    ExtendKind::Uxtb,
+                    ExtendKind::Uxth,
+                    ExtendKind::Uxtw,
+                    ExtendKind::Uxtx,
+                    ExtendKind::Sxtb,
+                    ExtendKind::Sxth,
+                    ExtendKind::Sxtw,
+                    ExtendKind::Sxtx,
+                ] {
+                    for shift in 0u8..=4 {
+                        let er = Operand::ExtendedRegister {
+                            reg: rm,
+                            kind,
+                            shift,
+                        };
+                        instrs.push(Instruction::Cmp { rn, rm: er });
+                        instrs.push(Instruction::Cmn { rn, rm: er });
+                    }
                 }
             }
         }
@@ -1008,6 +1041,39 @@ mod tests {
             )
         });
         assert!(has_sxth, "enumeration missing CMP with SXTH extended-reg");
+    }
+
+    #[test]
+    fn enumerate_does_not_duplicate_extended_register_cmp_cmn() {
+        // Issue #60 follow-up (codex P2 on #144): CMP/CMN have no destination
+        // register, so the per-rd loop used to emit each
+        // `cmp rn, rm, <extend> #shift` candidate N times for an N-register
+        // pool. The fix moves CMP/CMN out of the rd loop; each unique
+        // (rn, rm, kind, shift) tuple now appears exactly once.
+        let regs = vec![Register::X0, Register::X1, Register::X2];
+        let imms = vec![];
+        let candidates = generate_all_instructions(&regs, &imms);
+        let count_cmp_uxtb_x1_x2_shift0 = candidates
+            .iter()
+            .filter(|c| {
+                matches!(
+                    c,
+                    Instruction::Cmp {
+                        rn: Register::X1,
+                        rm: Operand::ExtendedRegister {
+                            reg: Register::X2,
+                            kind: crate::ir::ExtendKind::Uxtb,
+                            shift: 0,
+                        },
+                    }
+                )
+            })
+            .count();
+        assert_eq!(
+            count_cmp_uxtb_x1_x2_shift0, 1,
+            "CMP X1, X2, UXTB #0 must appear exactly once (got {})",
+            count_cmp_uxtb_x1_x2_shift0
+        );
     }
 
     #[test]

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -184,6 +184,7 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
             instrs.push(Instruction::Rev32 { rd, rn });
             instrs.push(Instruction::Rev16 { rd, rn });
             instrs.push(Instruction::Uxtb { rd, rn });
+            instrs.push(Instruction::Sxtb { rd, rn });
         }
 
         // Multiply-accumulate family. MADD/MSUB take a 4th register slot
@@ -923,6 +924,23 @@ mod tests {
         for &rd in &regs {
             for &rn in &regs {
                 let expected = Instruction::Uxtb { rd, rn };
+                assert!(
+                    candidates.contains(&expected),
+                    "enumeration missing {}",
+                    expected
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn enumerate_emits_sxtb_for_each_register_pair() {
+        let regs = vec![Register::X0, Register::X1, Register::X2];
+        let imms = vec![];
+        let candidates = generate_all_instructions(&regs, &imms);
+        for &rd in &regs {
+            for &rn in &regs {
+                let expected = Instruction::Sxtb { rd, rn };
                 assert!(
                     candidates.contains(&expected),
                     "enumeration missing {}",

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -597,6 +597,11 @@ pub fn opcode_id(instr: &Instruction) -> u8 {
         Instruction::Umulh { .. } => 46,
         Instruction::Ccmp { .. } => 47,
         Instruction::Ccmn { .. } => 48,
+        Instruction::Sxtb { .. } => 49,
+        Instruction::Sxth { .. } => 50,
+        Instruction::Sxtw { .. } => 51,
+        Instruction::Uxtb { .. } => 52,
+        Instruction::Uxth { .. } => 53,
     }
 }
 

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -174,7 +174,8 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
             instrs.push(Instruction::Negs { rd, rm });
         }
 
-        // Single-source bit-manipulation: CLZ / CLS / RBIT / REV / REV32 / REV16.
+        // Single-source bit-manipulation: CLZ / CLS / RBIT / REV / REV32 /
+        // REV16, plus the standalone extends UXTB (#60 — siblings follow).
         for &rn in registers {
             instrs.push(Instruction::Clz { rd, rn });
             instrs.push(Instruction::Cls { rd, rn });
@@ -182,6 +183,7 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
             instrs.push(Instruction::Rev { rd, rn });
             instrs.push(Instruction::Rev32 { rd, rn });
             instrs.push(Instruction::Rev16 { rd, rn });
+            instrs.push(Instruction::Uxtb { rd, rn });
         }
 
         // Multiply-accumulate family. MADD/MSUB take a 4th register slot
@@ -908,5 +910,25 @@ mod tests {
             rn: Register::X1,
             rm: Operand::Immediate(0),
         }));
+    }
+
+    #[test]
+    fn enumerate_emits_uxtb_for_each_register_pair() {
+        // Issue #60: every (rd, rn) pair in the pool must produce a
+        // candidate Instruction::Uxtb { rd, rn }, mirroring the existing
+        // single-source bit-manipulation enumeration block.
+        let regs = vec![Register::X0, Register::X1, Register::X2];
+        let imms = vec![];
+        let candidates = generate_all_instructions(&regs, &imms);
+        for &rd in &regs {
+            for &rn in &regs {
+                let expected = Instruction::Uxtb { rd, rn };
+                assert!(
+                    candidates.contains(&expected),
+                    "enumeration missing {}",
+                    expected
+                );
+            }
+        }
     }
 }

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -110,6 +110,29 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
                     instrs.push(Instruction::Orr { rd, rn, rm: sr_ror });
                     instrs.push(Instruction::Eor { rd, rn, rm: sr_ror });
                 }
+                // Issue #60: extended-register form for ADD/SUB/CMP/CMN.
+                // Shift in 0..=4 (the imm3 field). Eight kinds × five shifts
+                // produces 40 extra candidates per (rd, rn, rm) triple, which
+                // is comparable to the shifted-register pool above.
+                use crate::ir::ExtendKind;
+                for kind in [
+                    ExtendKind::Uxtb,
+                    ExtendKind::Uxth,
+                    ExtendKind::Uxtw,
+                    ExtendKind::Uxtx,
+                    ExtendKind::Sxtb,
+                    ExtendKind::Sxth,
+                    ExtendKind::Sxtw,
+                    ExtendKind::Sxtx,
+                ] {
+                    for shift in 0u8..=4 {
+                        let er = Operand::ExtendedRegister { reg: rm, kind, shift };
+                        instrs.push(Instruction::Add { rd, rn, rm: er });
+                        instrs.push(Instruction::Sub { rd, rn, rm: er });
+                        instrs.push(Instruction::Cmp { rn, rm: er });
+                        instrs.push(Instruction::Cmn { rn, rm: er });
+                    }
+                }
             }
 
             // Shift operations with immediate shift amount (0-63 is valid, but we use small values)
@@ -935,6 +958,51 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn enumerate_emits_add_with_extended_register() {
+        // Issue #60: the enumerator must emit at least one
+        // ADD candidate per (rd, rn, rm, kind, shift) tuple with the
+        // extended-register operand form, so the search can discover the
+        // collapse pattern UXTB+ADD ≡ ADD,UXTB.
+        let regs = vec![Register::X0, Register::X1, Register::X2];
+        let imms = vec![];
+        let candidates = generate_all_instructions(&regs, &imms);
+        let has_uxtb = candidates.iter().any(|c| {
+            matches!(
+                c,
+                Instruction::Add {
+                    rm: Operand::ExtendedRegister {
+                        kind: crate::ir::ExtendKind::Uxtb,
+                        shift: 0,
+                        ..
+                    },
+                    ..
+                }
+            )
+        });
+        assert!(has_uxtb, "enumeration missing ADD with UXTB extended-reg");
+    }
+
+    #[test]
+    fn enumerate_emits_cmp_with_extended_register() {
+        let regs = vec![Register::X0, Register::X1, Register::X2];
+        let imms = vec![];
+        let candidates = generate_all_instructions(&regs, &imms);
+        let has_sxth = candidates.iter().any(|c| {
+            matches!(
+                c,
+                Instruction::Cmp {
+                    rm: Operand::ExtendedRegister {
+                        kind: crate::ir::ExtendKind::Sxth,
+                        ..
+                    },
+                    ..
+                }
+            )
+        });
+        assert!(has_sxth, "enumeration missing CMP with SXTH extended-reg");
     }
 
     #[test]

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -268,13 +268,19 @@ impl Mutator {
                     *rm = self.random_register(rng);
                 }
             }
-            // Single-source bit-manipulation: CLZ, CLS, RBIT, REV, REV32, REV16.
+            // Single-source bit-manipulation: CLZ, CLS, RBIT, REV, REV32, REV16,
+            // plus the standalone extends SXTB/SXTH/SXTW/UXTB/UXTH (issue #60).
             Instruction::Clz { rd, rn }
             | Instruction::Cls { rd, rn }
             | Instruction::Rbit { rd, rn }
             | Instruction::Rev { rd, rn }
             | Instruction::Rev32 { rd, rn }
-            | Instruction::Rev16 { rd, rn } => {
+            | Instruction::Rev16 { rd, rn }
+            | Instruction::Sxtb { rd, rn }
+            | Instruction::Sxth { rd, rn }
+            | Instruction::Sxtw { rd, rn }
+            | Instruction::Uxtb { rd, rn }
+            | Instruction::Uxth { rd, rn } => {
                 if rng.random_bool(0.5) {
                     *rd = self.random_register(rng);
                 } else {
@@ -583,6 +589,13 @@ impl Mutator {
                 4 => Instruction::Rev32 { rd, rn },
                 _ => Instruction::Rev16 { rd, rn },
             },
+            // SXTB/SXTH/SXTW/UXTB/UXTH: bridging chains land in a later slice.
+            // Issue #60.
+            Instruction::Sxtb { rd, rn } => Instruction::Sxtb { rd, rn },
+            Instruction::Sxth { rd, rn } => Instruction::Sxth { rd, rn },
+            Instruction::Sxtw { rd, rn } => Instruction::Sxtw { rd, rn },
+            Instruction::Uxtb { rd, rn } => Instruction::Uxtb { rd, rn },
+            Instruction::Uxth { rd, rn } => Instruction::Uxth { rd, rn },
             // Move-wide cluster: MOVN ↔ MOVZ ↔ MOVK (all share rd/imm/shift),
             // plus a single MovImm bridge anchored at MOVZ.
             //

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -39,9 +39,12 @@ fn strip_ror_for_arith(rm: Operand) -> Operand {
 fn clamp_to_register<R: RngExt>(rm: Operand, registers: &[Register], rng: &mut R) -> Operand {
     match rm {
         Operand::Register(_) => rm,
-        // ShiftedRegister carries a real register; preserve it as a plain
-        // register (drop the shift) when the destination opcode is register-only.
-        Operand::ShiftedRegister { reg, .. } => Operand::Register(reg),
+        // ShiftedRegister/ExtendedRegister carry a real register; preserve
+        // it as a plain register (drop the modifier) when the destination
+        // opcode is register-only.
+        Operand::ShiftedRegister { reg, .. } | Operand::ExtendedRegister { reg, .. } => {
+            Operand::Register(reg)
+        }
         Operand::Immediate(_) => {
             if registers.is_empty() {
                 rm
@@ -236,10 +239,12 @@ impl Mutator {
                         *rm = match self.random_operand(rng) {
                             Operand::Register(r) => Operand::Register(r),
                             Operand::Immediate(v) => Operand::Immediate(v.rem_euclid(32)),
-                            // CCMP/CCMN reject shifted-register operands;
-                            // collapse to a plain register (consistent with
-                            // candidate::generate_random_instruction case 27).
-                            Operand::ShiftedRegister { reg, .. } => Operand::Register(reg),
+                            // CCMP/CCMN reject shifted-register or extended-
+                            // register operands; collapse to a plain register
+                            // (consistent with candidate::generate_random_-
+                            // instruction case 27).
+                            Operand::ShiftedRegister { reg, .. }
+                            | Operand::ExtendedRegister { reg, .. } => Operand::Register(reg),
                         };
                     }
                     2 => *nzcv = (rng.random::<u32>() & 0x0F) as u8,

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -1930,4 +1930,32 @@ mod tests {
         let after = apply_instruction_concrete(state, &ccmp);
         assert!(after.get_flags().z);
     }
+
+    #[test]
+    fn test_uxtb_extracts_low_byte() {
+        // UXTB X0, X1 with X1 = 0xDEAD_BEEF_CAFE_5678 → X0 = 0x78.
+        let state = state_with(vec![(Register::X1, 0xDEAD_BEEF_CAFE_5678)]);
+        let after = apply_instruction_concrete(
+            state,
+            &Instruction::Uxtb {
+                rd: Register::X0,
+                rn: Register::X1,
+            },
+        );
+        assert_eq!(after.get_register(Register::X0).as_u64(), 0x78);
+    }
+
+    #[test]
+    fn test_uxtb_zero_extends() {
+        // The high bits of X1 must NOT bleed into X0 — UXTB zero-extends.
+        let state = state_with(vec![(Register::X1, 0xFFFF_FFFF_FFFF_FFFF)]);
+        let after = apply_instruction_concrete(
+            state,
+            &Instruction::Uxtb {
+                rd: Register::X0,
+                rn: Register::X1,
+            },
+        );
+        assert_eq!(after.get_register(Register::X0).as_u64(), 0xFF);
+    }
 }

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -387,6 +387,31 @@ pub fn apply_instruction_concrete(
                 ((value & 0xFF00_FF00_FF00_FF00) >> 8) | ((value & 0x00FF_00FF_00FF_00FF) << 8);
             state.set_register(*rd, ConcreteValue::new(result));
         }
+        // SXTB/SXTH/SXTW: extract low N bits, sign-extend to 64. Issue #60.
+        Instruction::Sxtb { rd, rn } => {
+            let value = state.get_register(*rn).as_u64();
+            let result = (value as i8) as i64 as u64;
+            state.set_register(*rd, ConcreteValue::new(result));
+        }
+        Instruction::Sxth { rd, rn } => {
+            let value = state.get_register(*rn).as_u64();
+            let result = (value as i16) as i64 as u64;
+            state.set_register(*rd, ConcreteValue::new(result));
+        }
+        Instruction::Sxtw { rd, rn } => {
+            let value = state.get_register(*rn).as_u64();
+            let result = (value as i32) as i64 as u64;
+            state.set_register(*rd, ConcreteValue::new(result));
+        }
+        // UXTB/UXTH: extract low N bits, zero-extend to 64. Issue #60.
+        Instruction::Uxtb { rd, rn } => {
+            let value = state.get_register(*rn).as_u64();
+            state.set_register(*rd, ConcreteValue::new(value & 0xFF));
+        }
+        Instruction::Uxth { rd, rn } => {
+            let value = state.get_register(*rn).as_u64();
+            state.set_register(*rd, ConcreteValue::new(value & 0xFFFF));
+        }
     }
     state
 }

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -1947,6 +1947,55 @@ mod tests {
     }
 
     #[test]
+    fn test_add_with_uxtb_extended_register_operand() {
+        // Issue #60: ADD X0, X1, X2, UXTB #2 takes the low byte of X2,
+        // zero-extends it to 64, shifts left by 2, then adds X1.
+        // X1 = 0x100, X2 = 0xDEAD_BEEF_CAFE_5678 → byte = 0x78 → shifted
+        // by 2 = 0x1E0 → + 0x100 = 0x2E0.
+        let state = state_with(vec![
+            (Register::X1, 0x100),
+            (Register::X2, 0xDEAD_BEEF_CAFE_5678),
+        ]);
+        let after = apply_instruction_concrete(
+            state,
+            &Instruction::Add {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::ExtendedRegister {
+                    reg: Register::X2,
+                    kind: crate::ir::ExtendKind::Uxtb,
+                    shift: 2,
+                },
+            },
+        );
+        assert_eq!(after.get_register(Register::X0).as_u64(), 0x2E0);
+    }
+
+    #[test]
+    fn test_sub_with_sxtb_extended_register_operand() {
+        // ADD/SUB with SXTB must sign-extend the low byte. If X2's low byte
+        // is 0xFF (i.e. -1 as i8), then SUB X0, X1, X2, SXTB #0 computes
+        // X1 - (-1) = X1 + 1.
+        let state = state_with(vec![
+            (Register::X1, 100),
+            (Register::X2, 0xFF),
+        ]);
+        let after = apply_instruction_concrete(
+            state,
+            &Instruction::Sub {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::ExtendedRegister {
+                    reg: Register::X2,
+                    kind: crate::ir::ExtendKind::Sxtb,
+                    shift: 0,
+                },
+            },
+        );
+        assert_eq!(after.get_register(Register::X0).as_u64(), 101);
+    }
+
+    #[test]
     fn test_uxtb_extracts_low_byte() {
         // UXTB X0, X1 with X1 = 0xDEAD_BEEF_CAFE_5678 → X0 = 0x78.
         let state = state_with(vec![(Register::X1, 0xDEAD_BEEF_CAFE_5678)]);

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -1976,10 +1976,7 @@ mod tests {
         // ADD/SUB with SXTB must sign-extend the low byte. If X2's low byte
         // is 0xFF (i.e. -1 as i8), then SUB X0, X1, X2, SXTB #0 computes
         // X1 - (-1) = X1 + 1.
-        let state = state_with(vec![
-            (Register::X1, 100),
-            (Register::X2, 0xFF),
-        ]);
+        let state = state_with(vec![(Register::X1, 100), (Register::X2, 0xFF)]);
         let after = apply_instruction_concrete(
             state,
             &Instruction::Sub {

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -19,6 +19,21 @@ fn eval_operand(state: &ConcreteMachineState, operand: &Operand) -> ConcreteValu
             };
             ConcreteValue::new(shifted)
         }
+        // Issue #60: extract low N bits, sign/zero-extend to 64, then shl.
+        Operand::ExtendedRegister { reg, kind, shift } => {
+            let value = state.get_register(*reg).as_u64();
+            let extended = match kind {
+                crate::ir::ExtendKind::Uxtb => value & 0xFF,
+                crate::ir::ExtendKind::Uxth => value & 0xFFFF,
+                crate::ir::ExtendKind::Uxtw => value & 0xFFFF_FFFF,
+                crate::ir::ExtendKind::Uxtx => value,
+                crate::ir::ExtendKind::Sxtb => (value as i8) as i64 as u64,
+                crate::ir::ExtendKind::Sxth => (value as i16) as i64 as u64,
+                crate::ir::ExtendKind::Sxtw => (value as i32) as i64 as u64,
+                crate::ir::ExtendKind::Sxtx => value,
+            };
+            ConcreteValue::new(extended.wrapping_shl(*shift as u32))
+        }
     }
 }
 

--- a/src/semantics/cost.rs
+++ b/src/semantics/cost.rs
@@ -73,7 +73,12 @@ fn instruction_latency(instr: &Instruction) -> u64 {
         | Instruction::Rbit { .. }
         | Instruction::Rev { .. }
         | Instruction::Rev32 { .. }
-        | Instruction::Rev16 { .. } => 1,
+        | Instruction::Rev16 { .. }
+        | Instruction::Sxtb { .. }
+        | Instruction::Sxth { .. }
+        | Instruction::Sxtw { .. }
+        | Instruction::Uxtb { .. }
+        | Instruction::Uxth { .. } => 1,
     }
 }
 

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -661,6 +661,62 @@ mod tests {
         );
     }
 
+    /// Issue #60 end-to-end discovery test: the enumerator's candidate set
+    /// contains a length-1 instruction equivalent to the 2-instruction
+    /// `UXTB t, X2 ; ADD X0, X1, t` target sequence — namely the
+    /// extended-register form `ADD X0, X1, X2, UXTB #0`. This is the
+    /// canonical acceptance criterion for issue #60.
+    #[test]
+    fn test_optimizer_discovers_extended_register_collapse() {
+        use crate::ir::ExtendKind;
+        use crate::search::candidate::generate_all_instructions;
+
+        // Target sequence: UXTB X10, X2 ; ADD X0, X1, X10.
+        let target = vec![
+            Instruction::Uxtb {
+                rd: Register::X10,
+                rn: Register::X2,
+            },
+            Instruction::Add {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Register(Register::X10),
+            },
+        ];
+
+        // Live-out is just X0; the temp X10 is dead after the sequence.
+        let config = EquivalenceConfig {
+            live_out: LiveOut::from_registers(vec![Register::X0]),
+            ..Default::default()
+        };
+
+        // Small pool keeps enumeration tractable for a unit test.
+        let regs = vec![Register::X0, Register::X1, Register::X2, Register::X10];
+        let imms = vec![0i64];
+        let candidates = generate_all_instructions(&regs, &imms);
+
+        let discovered = candidates.iter().find(|c| {
+            matches!(
+                c,
+                Instruction::Add {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::ExtendedRegister {
+                        reg: Register::X2,
+                        kind: ExtendKind::Uxtb,
+                        shift: 0,
+                    },
+                }
+            ) && check_equivalence_with_config(&target, std::slice::from_ref(*c), &config)
+                == EquivalenceResult::Equivalent
+        });
+
+        assert!(
+            discovered.is_some(),
+            "enumerative search must discover `ADD X0, X1, X2, UXTB #0` as equivalent to UXTB+ADD"
+        );
+    }
+
     /// Issue #59 end-to-end discovery test: the enumerator's candidate set
     /// contains a length-1 instruction equivalent to the 2-instruction
     /// `LSL t, X2, #3 ; ADD X0, X1, t` target sequence — namely the

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -1057,6 +1057,97 @@ mod tests {
     }
 
     #[test]
+    fn test_extended_register_acceptance_uxtb() {
+        // Issue #60 acceptance: SMT proves
+        //   UXTB x10, x2 ; ADD x0, x1, x10
+        // ≡ ADD x0, x1, x2, UXTB #0
+        // (modulo the temp x10 — restrict the equivalence to the live-out
+        // x0). The split sequence relies on the standalone UXTB
+        // instruction added in earlier slices; the fused sequence uses
+        // the new Operand::ExtendedRegister form.
+        let initial = MachineState::new_symbolic("pre");
+
+        let seq_split = vec![
+            Instruction::Uxtb {
+                rd: Register::X10,
+                rn: Register::X2,
+            },
+            Instruction::Add {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Register(Register::X10),
+            },
+        ];
+        let seq_fused = vec![Instruction::Add {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::ExtendedRegister {
+                reg: Register::X2,
+                kind: crate::ir::ExtendKind::Uxtb,
+                shift: 0,
+            },
+        }];
+
+        let s1 = apply_sequence(initial.clone(), &seq_split);
+        let s2 = apply_sequence(initial, &seq_fused);
+
+        let solver = Solver::new();
+        solver.assert(
+            s1.get_register(Register::X0)
+                .eq(s2.get_register(Register::X0))
+                .not(),
+        );
+        assert_eq!(solver.check(), SatResult::Unsat);
+    }
+
+    #[test]
+    fn test_extended_register_acceptance_sxth_with_shift() {
+        // Issue #60: signed halfword extend with non-zero shift.
+        //   SXTH x10, x2 ; LSL x10, x10, #3 ; ADD x0, x1, x10
+        // ≡ ADD x0, x1, x2, SXTH #3
+        // The split form needs an extra LSL because the standalone SXTH
+        // doesn't carry a shift; the fused form folds both into one arith.
+        let initial = MachineState::new_symbolic("pre");
+
+        let seq_split = vec![
+            Instruction::Sxth {
+                rd: Register::X10,
+                rn: Register::X2,
+            },
+            Instruction::Lsl {
+                rd: Register::X10,
+                rn: Register::X10,
+                shift: Operand::Immediate(3),
+            },
+            Instruction::Add {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Register(Register::X10),
+            },
+        ];
+        let seq_fused = vec![Instruction::Add {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::ExtendedRegister {
+                reg: Register::X2,
+                kind: crate::ir::ExtendKind::Sxth,
+                shift: 3,
+            },
+        }];
+
+        let s1 = apply_sequence(initial.clone(), &seq_split);
+        let s2 = apply_sequence(initial, &seq_fused);
+
+        let solver = Solver::new();
+        solver.assert(
+            s1.get_register(Register::X0)
+                .eq(s2.get_register(Register::X0))
+                .not(),
+        );
+        assert_eq!(solver.check(), SatResult::Unsat);
+    }
+
+    #[test]
     fn test_uxtb_extracts_low_byte() {
         // UXTB extracts the low 8 bits of the source and zero-extends to 64.
         // MOV x1, #0x5678; UXTB x0, x1  ≡  MOV x0, #0x78.

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -220,7 +220,7 @@ impl MachineState {
                 if *shift == 0 {
                     extended
                 } else {
-                    extended.bvshl(&BV::from_u64(*shift as u64, 64))
+                    extended.bvshl(BV::from_u64(*shift as u64, 64))
                 }
             }
         }
@@ -1165,7 +1165,7 @@ mod tests {
         let final_state = apply_sequence(initial, &seq);
         let final_x0 = final_state.get_register(Register::X0);
         let solver = Solver::new();
-        solver.assert(&final_x0.eq(&BV::from_u64(0x78, 64)).not());
+        solver.assert(&final_x0.eq(BV::from_u64(0x78, 64)).not());
         assert_eq!(
             solver.check(),
             SatResult::Unsat,

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -1166,7 +1166,11 @@ mod tests {
         let final_x0 = final_state.get_register(Register::X0);
         let solver = Solver::new();
         solver.assert(&final_x0.eq(&BV::from_u64(0x78, 64)).not());
-        assert_eq!(solver.check(), SatResult::Unsat, "UXTB(0x5678) must be 0x78");
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "UXTB(0x5678) must be 0x78"
+        );
     }
 
     #[test]

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -1165,7 +1165,7 @@ mod tests {
         let final_state = apply_sequence(initial, &seq);
         let final_x0 = final_state.get_register(Register::X0);
         let solver = Solver::new();
-        solver.assert(&final_x0.eq(BV::from_u64(0x78, 64)).not());
+        solver.assert(final_x0.eq(BV::from_u64(0x78, 64)).not());
         assert_eq!(
             solver.check(),
             SatResult::Unsat,

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -203,6 +203,26 @@ impl MachineState {
                     crate::ir::ShiftKind::Ror => bv_ror_64(&value, &amt),
                 }
             }
+            // Issue #60: ExtendedRegister extracts the low N bits, then
+            // sign/zero-extends to 64 and finally shifts left by `shift`.
+            Operand::ExtendedRegister { reg, kind, shift } => {
+                let value = self.get_register(*reg).clone();
+                let extended = match kind {
+                    crate::ir::ExtendKind::Uxtb => value.extract(7, 0).zero_ext(56),
+                    crate::ir::ExtendKind::Uxth => value.extract(15, 0).zero_ext(48),
+                    crate::ir::ExtendKind::Uxtw => value.extract(31, 0).zero_ext(32),
+                    crate::ir::ExtendKind::Uxtx => value,
+                    crate::ir::ExtendKind::Sxtb => value.extract(7, 0).sign_ext(56),
+                    crate::ir::ExtendKind::Sxth => value.extract(15, 0).sign_ext(48),
+                    crate::ir::ExtendKind::Sxtw => value.extract(31, 0).sign_ext(32),
+                    crate::ir::ExtendKind::Sxtx => value,
+                };
+                if *shift == 0 {
+                    extended
+                } else {
+                    extended.bvshl(&BV::from_u64(*shift as u64, 64))
+                }
+            }
         }
     }
 }

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -687,6 +687,33 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let result = h3.concat(&h2).concat(&h1).concat(&h0);
             state.set_register(*rd, result);
         }
+        // SXTB/SXTH/SXTW: extract low N bits, sign-extend to 64. Issue #60.
+        // UXTB/UXTH: extract low N bits, zero-extend to 64. Issue #60.
+        Instruction::Sxtb { rd, rn } => {
+            let value = state.get_register(*rn).clone();
+            let result = value.extract(7, 0).sign_ext(56);
+            state.set_register(*rd, result);
+        }
+        Instruction::Sxth { rd, rn } => {
+            let value = state.get_register(*rn).clone();
+            let result = value.extract(15, 0).sign_ext(48);
+            state.set_register(*rd, result);
+        }
+        Instruction::Sxtw { rd, rn } => {
+            let value = state.get_register(*rn).clone();
+            let result = value.extract(31, 0).sign_ext(32);
+            state.set_register(*rd, result);
+        }
+        Instruction::Uxtb { rd, rn } => {
+            let value = state.get_register(*rn).clone();
+            let result = value.extract(7, 0).zero_ext(56);
+            state.set_register(*rd, result);
+        }
+        Instruction::Uxth { rd, rn } => {
+            let value = state.get_register(*rn).clone();
+            let result = value.extract(15, 0).zero_ext(48);
+            state.set_register(*rd, result);
+        }
     }
     state
 }
@@ -1007,6 +1034,28 @@ mod tests {
     #[test]
     fn test_rev16_smt_is_involution() {
         assert_involution(|rd, rn| Instruction::Rev16 { rd, rn }, "REV16");
+    }
+
+    #[test]
+    fn test_uxtb_extracts_low_byte() {
+        // UXTB extracts the low 8 bits of the source and zero-extends to 64.
+        // MOV x1, #0x5678; UXTB x0, x1  ≡  MOV x0, #0x78.
+        let initial = MachineState::new_symbolic("pre");
+        let seq = vec![
+            Instruction::MovImm {
+                rd: Register::X1,
+                imm: 0x5678,
+            },
+            Instruction::Uxtb {
+                rd: Register::X0,
+                rn: Register::X1,
+            },
+        ];
+        let final_state = apply_sequence(initial, &seq);
+        let final_x0 = final_state.get_register(Register::X0);
+        let solver = Solver::new();
+        solver.assert(&final_x0.eq(&BV::from_u64(0x78, 64)).not());
+        assert_eq!(solver.check(), SatResult::Unsat, "UXTB(0x5678) must be 0x78");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `Operand::ExtendedRegister { reg, kind, shift }` for AArch64 ADD/SUB/CMP/CMN, with `ExtendKind` covering all eight ARM ARM kinds (UXTB/UXTH/UXTW/UXTX/SXTB/SXTH/SXTW/SXTX) and shift in `0..=4`.
- Adds the five standalone instructions SXTB/SXTH/SXTW/UXTB/UXTH (UBFM/SBFM aliases) as own IR variants, threaded through SMT semantics, concrete semantics, cost model, parser, dynasm encoder, candidate enumeration, ISA layer, and stochastic mutation.
- Proves the issue's stated SMT acceptance criterion in `test_extended_register_acceptance_uxtb` (`UXTB+ADD ≡ ADD,UXTB`) and verifies end-to-end discovery in `test_optimizer_discovers_extended_register_collapse`.

## Highlights
- **Encodability policy**: SP is rejected as rd/rn/inner-reg across the board (conservative, matches the shifted-register precedent from #59). ARM ARM would allow SP in the X-form; lifting that gate is a follow-up.
- **Register form**: IR keeps 64-bit X-form everywhere. The encoder selects `W()` for byte/half/word kinds and `X()` for UXTX/SXTX; `Display` mirrors the encoder so Capstone round-trips match.
- **Stochastic mutation**: the variant is mutation-frozen for now (no `random_extended_register` helper, no opcode bridges). Adding it is a polish slice; the issue's acceptance is met without it.
- **Search-space cost**: candidate enumeration adds 40 ExtendedRegister candidates per (rd, rn, rm) triple and 5 standalone candidates per (rd, rn) pair. Comparable to the shifted-register expansion in #59.

## Test plan
- [x] `cargo test --bin s11` — 581 unit tests pass (+18 from main).
- [x] `cargo fmt --check` clean.
- [x] `./ci_check.sh` green (fmt + build + unit tests + AArch64 test-binary builds + full integration test suite).
- [x] SMT acceptance: `test_extended_register_acceptance_uxtb`, `test_extended_register_acceptance_sxth_with_shift`.
- [x] Capstone round-trip: `test_extended_register_encoder_round_trip` covers UXTB/SXTH/UXTW/UXTX on ADD/SUB/CMP plus the five standalone `test_<mnem>_encoder_round_trip` tests.
- [x] Discovery: `test_optimizer_discovers_extended_register_collapse` — enumerator finds `ADD X0, X1, X2, UXTB #0` ≡ `UXTB X10, X2; ADD X0, X1, X10` under live-out X0.
- [x] Encodability gating: `test_extended_register_arith_encodability` (shift boundary, SP rejection) and `test_extended_register_logical_rejected` (AND/ORR/EOR/TST reject the variant).

Closes #60.