### PR TITLE
ISA trait collapse: ADR-0004 + first safety-net parity tests (#77)

### DIFF
--- a/build_tests.sh
+++ b/build_tests.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
 # Build script for AArch64 + x86 test binaries.
+#
+# Issue #77 stage 3 step 26 will add RISC-V test-binary builds using
+# riscv{32,64}-linux-gnu-gcc, gracefully skipped when the toolchain is
+# absent (mirroring the existing gcc -m32 precedent). Blocked on step 23's
+# RISC-V semantics work — useful RISC-V integration tests need
+# `s11 disasm` and `s11 equiv` (asm-text) to produce meaningful output,
+# which requires the concrete + SMT executors.
 set -e
 
 echo "Building AArch64 test binaries..."

--- a/docs/adr/0004-isa-trait-collapse.md
+++ b/docs/adr/0004-isa-trait-collapse.md
@@ -1,0 +1,94 @@
+# ADR-0004 — Collapse parallel AArch64 / x86 / RISC-V pipelines onto the `ISA` trait surface
+
+Status: Accepted
+Date: 2026-05-16
+
+## Context
+
+Issue #77 calls for collapsing the parallel AArch64, x86 and RISC-V pipelines onto the existing trait surface in `src/isa/traits.rs`. As of today the `ISA` / `InstructionType` / `OperandType` / `RegisterType` / `InstructionGenerator` traits have impls on every backend, but four others — `ConcreteExecutor`, `SymbolicExecutor`, `CostModel`, `Assembler` — have **no implementations** and are bypassed by free functions in `src/semantics/{concrete,smt,cost,equivalence}.rs` and their `_x86` siblings, plus `src/assembler/{mod,x86}.rs`. The search layer (`src/search/`), the validation layer (`src/validation/`), and the CLI in `src/main.rs` all reference `crate::ir::Instruction` directly, with a duplicated x86 pipeline (`optimize_elf_binary_x86`, `convert_to_x86_ir`, etc.) sitting beside the AArch64 path. RISC-V is rejected at `src/main.rs:1558-1563` even though `src/isa/riscv.rs` (1185 lines) implements the existing trait surface.
+
+The refactor lands in three stages — (1) lift AArch64 onto the four trait gaps as a no-functional-change refactor, (2) port x86 onto the same surface and delete the `*_x86.rs` parallel files, (3) wire RISC-V through end-to-end. Several cross-cutting design choices are needed before stage 1 code begins, and once chosen they thread through every consumer. This ADR records those choices.
+
+The decisions below are not a menu of alternatives. They are commitments made in the plan at `.ultraplan/unify-isa-traits.md` after parallel codebase exploration and adversarial review.
+
+## Decisions
+
+### 1. Width as an associated type `type Width: BVWidth` on `ISA`
+
+Width threads as an associated type, not a const generic. A new `BVWidth` trait with `const BITS: u32;` and `type Value: Copy + Debug + Eq + Hash;` is added beside `ISA` in `src/isa/traits.rs`. Marker types `U32` and `U64` implement `BVWidth`. `ISA::register_width()` (`src/isa/traits.rs:111`) keeps its current signature but returns `Self::Width::BITS` by default.
+
+Rationale: bounds explosion is worse with const generics in current Rust (each generic function picks up an `<const W: u32>` parameter that has to be repeated and constrained at every callsite); const generics also cannot be lifted into trait associated types without `feature(generic_const_exprs)`. The associated-type variant mirrors how `X86_64` and `X86_32` already share one instruction enum while differing in metadata (`src/isa/x86.rs:321-388`).
+
+### 2. Stochastic `Mutator` as `type Mutator` on `ISA`
+
+The free `Mutator` type (`src/search/stochastic/mutation.rs:71-100`) becomes accessible via `<I as ISA>::Mutator`. A new helper trait `ISAMutator<I: InstructionType>` defines the surface (`new`, `mutate`, `default_weights`). The AArch64 mutator body — including the `Operand::ExtendedRegister` handling at `mutation.rs:45,247` added by PR #144 — stays in `src/search/stochastic/mutation.rs`; only a newtype wrapper `AArch64Mutator(Mutator)` is added at the bottom of the file with the `ISAMutator<Instruction>` impl.
+
+Rationale: `InstructionGenerator::mutate` (`src/isa/traits.rs:204-210`) already exists but no consumer routes through it; stochastic search uses its own free `Mutator`. Promoting the free type to `<I as ISA>::Mutator` keeps the existing AArch64 behaviour byte-identical (no file move means the cyclic dep on `crate::search::candidate::generate_random_instruction` at `mutation.rs:14,778` is contained). `InstructionGenerator::mutate` survives as the single-instruction mutate primitive; `ISAMutator` carries the multi-strategy machinery.
+
+### 3. Parser stays AArch64-only until stage 3
+
+A `<I as ISA>::Parser` associated type with an `ISAParser<I>` helper trait is introduced in stage 3 step 25. Until then, `parser::parse_line` (`src/parser/mod.rs:1063-1186`) stays AArch64-only. When the associated type lands, `AArch64Parser` is a thin newtype that delegates to the existing `parse_line` body — the project CLAUDE.md `convert_to_ir → parse_line` delegation contract is preserved byte-for-byte; x86 keeps its own `convert_to_x86_ir` (`src/main.rs:969-1004`) without a corresponding `parse_line`, and RISC-V gets `convert_to_riscv_ir`.
+
+Rationale: text-input flows (`s11 equiv`, `--algorithm llm`) are AArch64-only for the foreseeable future; the binary-path Capstone → IR conversion is already per-ISA (`convert_to_ir`, `convert_to_x86_ir`). A premature generic parser would force x86 and RISC-V to ship asm-text parsers they don't currently need.
+
+### 4. `OperandType` is **not** extended to carry `ExtendedRegister`
+
+`Operand::ExtendedRegister` (introduced by PR #144) carries an `ExtendKind` and shift amount. The current `OperandType` trait surface (`src/isa/traits.rs:34-63`) — `as_register / as_immediate / from_register / from_immediate` — cannot represent this losslessly. Rather than extend the trait to admit it, the mutator (decision 2) stays per-ISA and so does any code that needs to round-trip the full operand grammar. `OperandType` keeps its current scope: a small lowest-common-denominator surface used by code that doesn't need full operand structure.
+
+Rationale: the only consumer that round-trips full operand structure is the stochastic mutator, and mutators are already per-ISA. Generalising `OperandType` to cover every ISA's operand grammar (extended registers for AArch64, ModR/M-shaped operands for x86, future RISC-V operand encodings) would balloon the trait and provide no real abstraction win.
+
+### 5. `LiveOutMask<R>` replaces `LiveOut` and `X86LiveOutMask`; `flags_live` lives on the mask
+
+A new generic `pub struct LiveOutMask<R: RegisterType> { regs: HashSet<R>, flags_live: bool }` is added to `src/semantics/live_out.rs` in stage 1 step 7. AArch64's existing `LiveOut` becomes a type alias `pub type LiveOut = LiveOutMask<crate::ir::Register>;`. In stage 2 step 16, `X86LiveOutMask` (`src/semantics/state.rs:397-441`) is deleted and x86 callers move to `LiveOutMask<X86Register>`. RISC-V uses `LiveOutMask<RiscVRegister>` with `flags_live` always `false`.
+
+Today's asymmetry — x86 puts `flags_live` on the mask, AArch64 puts it on `EquivalenceConfig.flags_live` — resolves in x86's favour. The AArch64 `EquivalenceConfig.flags_live` field is removed in stage 1 step 9; consumers consult `live_out.flags_live` instead.
+
+Rationale: `flags_live` is a property of the live-out contract, not of the equivalence configuration. The x86 location is the principled one. ADR-0002 ("LLM-assisted search MVP refuses targets with flags live-out") remains the authoritative statement about how `flags_live` is propagated for the LLM flow; this ADR only changes *where* the bit is stored.
+
+### 6. `ConcreteValue` keeps `u64` storage and masks on **write**
+
+`ConcreteValue` (`src/semantics/state.rs:224`) keeps its `pub u64` field. A new `ConcreteValue::new(width: u32, raw: u64)` constructor applies `mask_to_width(raw, width)` (`src/semantics/state.rs:189-197`) before storing. All write paths route through this constructor or through `ConcreteMachineState::set_register`, which already masks on write for x86 at `src/semantics/state.rs:374-378`. Reads return the stored `u64` unchanged.
+
+Rationale: mask-on-read is the trap. The same `u64` field, written by two callers under different widths, would compare differently under `Hash`/`Eq` (and silently diverge in `find_counterexample` diff loops at `src/semantics/equivalence.rs:342-431`) even though both values mask to the same canonical form. Mask-on-write commits the canonical form to memory and matches the existing x86 invariant.
+
+### 7. `type Flags` bounds; `FlagsAnalysis` helper trait introduced in stage 1 step 5
+
+`ISA` gains `type Flags: Clone + Debug + Default + PartialEq + Eq + Hash;`. AArch64 sets `type Flags = ConditionFlags`, x86 sets `type Flags = Eflags`, RISC-V sets `type Flags = ();`. A new helper trait
+
+```
+pub trait FlagsAnalysis<I: InstructionType> {
+    fn modifies_flags(instr: &I) -> bool;
+    fn reads_flags(instr: &I) -> bool;
+}
+```
+
+is added in stage 1 step 5 with one impl per ISA marker. `equivalence::flag_writers_diverge` (`src/semantics/equivalence.rs:32-72`) and `validation::live_out::flags_live_out` (`src/validation/live_out.rs:96`) both consume `FlagsAnalysis::modifies_flags`, NOT `InstructionType::has_side_effects`. The x86 `has_side_effects` impl (`src/isa/x86.rs:283-291`) returns `true` for everything except `MOV`, which is much broader than flag-writing and would over-trigger; the principled hook is `modifies_flags`.
+
+Rationale: keeping flag analysis as a separate trait (not a method on `InstructionType`) avoids a "default impl returns false, easy to forget to override" trap. The `FlagsAnalysis<I> for AArch64` impl delegates to the existing inherent `Instruction::modifies_flags()` / `Instruction::reads_flags()` (defined in `src/ir/instructions.rs`).
+
+### 8. RISC-V assembler strategy is deferred to ADR-0005
+
+`dynasm-rs` 5.0.0 (`Cargo.toml:18-19`) has no RISC-V backend. The choice between (a) an alternative encoder crate (e.g. `riscv-encoding`), (b) shipping `s11` for RISC-V without ELF patching, or (c) subprocessing to `riscv64-linux-gnu-as` is non-trivial enough to warrant its own ADR. ADR-0005 will be written at stage 3 step 22, immediately before the assembler impl is added to `src/isa/riscv.rs`.
+
+Rationale: stage 1 and stage 2 are unaffected by this decision; deferring it does not block anything. Forcing it now would either prematurely commit a dependency choice or stall the refactor on an irrelevant question.
+
+## Consequences
+
+**Positive:**
+- The four trait gaps (`ConcreteExecutor`, `SymbolicExecutor`, `CostModel`, `Assembler`) get their first implementations and start carrying real weight. The trait surface stops being aspirational.
+- The four `*_x86.rs` parallel files (`src/semantics/{concrete,smt,cost}_x86.rs`, `src/search/candidate_x86.rs`) plus `X86EquivalenceConfig` and `optimize_elf_binary_x86` disappear in stage 2 — the diff is a net deletion.
+- A single principled width abstraction (`type Width: BVWidth`) replaces today's scattered hardcoded `64` literals in `src/semantics/smt.rs` and `src/semantics/concrete.rs` (~91 sites per the exploration audit).
+- The `flag_writers_diverge` substitution moves from "AArch64 inherent method" to "trait dispatch", which means x86 stops being silently mishandled by any future consumer that reaches for `has_side_effects`.
+- RISC-V's existing 1185 lines of trait scaffolding in `src/isa/riscv.rs` actually get exercised once the consumer layer is generic.
+
+**Negative / scope:**
+- Stage 1 is a no-functional-change refactor for AArch64. It moves a lot of code without adding any new capability. Reviewer attention has to come from the safety-net tests (stage 1 step 2: per-opcode SMT-vs-concrete parity, parallel clean-shutdown, mutation encodability invariant), not from new behaviour.
+- Bounds get verbose at use sites. A worker that needs concrete + symbolic + cost + generator + assembler picks up four trait bounds plus `I::Instruction: 'static + Send + Sync`. If the noise becomes painful, the plan permits introducing an umbrella `trait SuperoptimizerISA: ISA where ...` — but that's a stage-1-late call, not a stage-0 commitment.
+- The LLM-assisted search stays AArch64-only by explicit constraint (`impl SearchAlgorithm<AArch64> for LlmSearch` in stage 1 step 13). ADR-0003 already documented the AArch64-only prompt and parse path; this ADR does not change that.
+- Operand grammar stays per-ISA (decision 4). Anyone who later wants a generic optimizer pass that walks operand structure will need to either add a per-ISA visitor or extend `OperandType`.
+
+**Reversibility:**
+- Decision 1 (width as associated type vs const generic) is the hardest to reverse — every generic function in the refactored consumer layer depends on it. Switching to const generics later means re-touching every `<I: ISA>` bound. Picked deliberately as the safer choice given today's Rust.
+- Decision 2 (`type Mutator` on `ISA` vs on `InstructionGenerator`) is moderately reversible. Moving the associated type later means updating every ISA impl block, but no consumer signature changes (consumers reach through the trait either way).
+- Decision 5 (`LiveOutMask<R>` with `flags_live` on the mask) is reversible by promoting `flags_live` back to `EquivalenceConfig` or to a third location; every consumer of `flags_live` is contained in `src/semantics/equivalence.rs` and `src/validation/live_out.rs`.
+- Decisions 3, 4, 6, 7, 8 are all individually reversible without disturbing the rest of the plan. Decision 8 in particular is deliberately deferred.

--- a/docs/adr/0005-riscv-assembler-strategy.md
+++ b/docs/adr/0005-riscv-assembler-strategy.md
@@ -1,0 +1,39 @@
+# ADR-0005 — RISC-V backend ships without machine-code emission in its first iteration
+
+Status: Accepted
+Date: 2026-05-16
+
+## Context
+
+ADR-0004 deferred the RISC-V assembler decision to its own ADR. Issue #77 stage 3 step 23 onwards requires that `<RiscV32 as ISA>::Assembler` and `<RiscV64 as ISA>::Assembler` either return real machine code, or be explicitly stubbed as "unavailable".
+
+The constraint is external: `dynasm`/`dynasmrt` 5.0.0 (`Cargo.toml:18-19`) — the assembler s11 uses for AArch64 (`src/assembler/mod.rs`) and both x86 variants (`src/assembler/x86.rs`) — has no RISC-V backend upstream. There is no dynasm RISC-V crate published and no in-progress upstream patch as of the writing of this ADR.
+
+Three options:
+
+1. **Bring in an alternative encoder.** Either a crate (`riscv-encoding`, `riscv-isa`, etc.) or a hand-rolled RV32I/RV64I encoder. Adds a new dependency or maintenance burden; lets `s11 opt <riscv.elf>` produce verified ELF patches.
+2. **Ship RISC-V without ELF patching.** `s11 opt <riscv.elf>` returns an error (or printable-asm-only output) telling the user "RISC-V optimization is disabled in this build (no assembler backend)". `s11 disasm <riscv.elf>` and `s11 equiv` for RISC-V assembly text remain functional. The trait impl returns `Err("RISC-V assembler not yet implemented")`.
+3. **Subprocess to host `riscv64-linux-gnu-as`.** Reuses GNU AS; lets the build run on systems that have the cross-toolchain installed. Adds runtime dependency on a toolchain and a fork/exec per assemble call.
+
+## Decision
+
+Option 2. The first RISC-V PR ships with `<RiscV32 as ISA>::Assembler::assemble` and `<RiscV64 as ISA>::Assembler::assemble` returning `Err`, and the CLI route through `optimize_elf_binary_generic` surfaces a clear "RISC-V optimization disabled" error when the user asks for an opt pass on a RISC-V ELF. `s11 disasm` works unchanged because it does not call the assembler.
+
+Concretely:
+
+- `src/isa/riscv.rs` adds `impl Assembler<RiscVInstruction> for RiscV32` / `for RiscV64`; `assemble` returns `Err("RISC-V machine-code emission is not yet implemented; pass --algorithm enumerative for assembly-text output only".into())`; `can_assemble` returns `false` for every instruction so the search pipeline filters them out before reaching the assembler. (Returning `false` from `can_assemble` is consistent with how the trait was designed in step 8 — an assembler that cannot encode the instruction reports it cannot, regardless of why.)
+- A follow-up RISC-V issue tracks "Add real assembler backend (option 1 or 3)".
+- A `--features riscv-encoder` Cargo feature is **not** added in the first PR — it would imply that the path is supported, only requiring opt-in. We prefer the honest "not implemented" state until someone owns option 1 or 3.
+
+## Consequences
+
+**Positive:**
+- The first RISC-V PR is small. It wires Capstone, `DetectedArch`, the concrete and SMT executors, the parser, and the test fixtures — the assembler is a one-line `Err`.
+- Users get useful coverage immediately: disassembly, equivalence checking on assembly-text RISC-V sequences, and the trait surface is fully populated so future assembler work doesn't need to retrofit the CLI.
+- The decision is contained to one trait method. If option 1 lands later, the only file that changes is `src/isa/riscv.rs`'s `Assembler` impl body; no consumer migration is needed.
+
+**Negative:**
+- `s11 opt <riscv.elf>` is not functional. Users who try it see an error message. This is the user-visible price of shipping the broader trait collapse without waiting for a working RISC-V encoder.
+- Test coverage for the RISC-V SMT + concrete executors is asm-text-only; no round-trip-from-ELF integration test is possible until the assembler exists.
+
+**Reversibility:** trivial. The decision is one trait method's body. Switching to option 1 (alternative encoder) or option 3 (subprocess) is a single PR that swaps the `Err(...)` for real encoding, with no cross-cutting consequences.

--- a/src/elf_patcher/mod.rs
+++ b/src/elf_patcher/mod.rs
@@ -21,6 +21,14 @@ const X86_NOP_TABLE: [&[u8]; 10] = [
 /// Architecture detected from the ELF `e_machine` field. Drives
 /// per-arch behaviours: instruction alignment for window validation
 /// and NOP byte choice for padding.
+///
+/// Issue #77 stage 3 step 24: this enum will gain `RiscV32` and `RiscV64`
+/// variants alongside the assembler stub from step 23.
+/// `instruction_alignment` will return 4 for both; `nop_bytes` will return
+/// `[0x13, 0x00, 0x00, 0x00]` (addi x0, x0, 0). `from_e_machine` extends
+/// to consume `e_ident[EI_CLASS]` so the `EM_RISCV` machine number can
+/// disambiguate RV32 vs RV64. Blocked on the from-scratch RISC-V
+/// semantics work tracked in the same follow-up that completes step 23.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DetectedArch {
     Aarch64,

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -21,6 +21,7 @@ impl ISA for AArch64 {
     type Instruction = Instruction;
     type Width = crate::isa::traits::U64;
     type Flags = crate::semantics::state::ConditionFlags;
+    type Mutator = crate::search::stochastic::mutation::AArch64Mutator;
 
     fn name(&self) -> &'static str {
         "AArch64"

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -53,6 +53,65 @@ impl crate::isa::traits::FlagsAnalysis<Instruction> for AArch64 {
     }
 }
 
+impl crate::isa::traits::ConcreteExecutor<Instruction> for AArch64 {
+    type Value = u64;
+    type State = crate::semantics::state::ConcreteMachineState;
+
+    fn execute_instruction(&self, state: Self::State, instruction: &Instruction) -> Self::State {
+        crate::semantics::concrete::apply_instruction_concrete(state, instruction)
+    }
+
+    fn new_zeroed_state(&self) -> Self::State {
+        crate::semantics::state::ConcreteMachineState::new_zeroed()
+    }
+
+    fn state_from_values(&self, values: std::collections::HashMap<Register, u64>) -> Self::State {
+        crate::semantics::state::ConcreteMachineState::from_values(values)
+    }
+
+    fn get_register(&self, state: &Self::State, reg: Register) -> u64 {
+        state.get_register(reg).as_u64()
+    }
+
+    fn set_register(&self, state: &mut Self::State, reg: Register, value: u64) {
+        state.set_register(reg, crate::semantics::state::ConcreteValue::new(value));
+    }
+}
+
+impl crate::isa::traits::SymbolicExecutor<Instruction> for AArch64 {
+    type State = crate::semantics::smt::MachineState;
+
+    fn execute_instruction(&self, state: Self::State, instruction: &Instruction) -> Self::State {
+        crate::semantics::smt::apply_instruction(state, instruction)
+    }
+
+    fn new_symbolic_state(&self, prefix: &str) -> Self::State {
+        crate::semantics::smt::MachineState::new_symbolic(prefix)
+    }
+}
+
+impl crate::isa::traits::CostModel<Instruction> for AArch64 {
+    fn instruction_cost(&self, instruction: &Instruction) -> u64 {
+        crate::semantics::cost::instruction_cost(
+            instruction,
+            &crate::semantics::cost::CostMetric::InstructionCount,
+        )
+    }
+}
+
+impl crate::isa::traits::Assembler<Instruction> for AArch64 {
+    fn assemble(&mut self, instructions: &[Instruction]) -> Result<Vec<u8>, String> {
+        crate::assembler::AArch64Assembler::new().assemble_instructions(instructions)
+    }
+
+    /// Bridges the inherent `Instruction::is_encodable_aarch64()` so step 11
+    /// can swap `is_sequence_encodable` for trait dispatch without losing
+    /// behaviour.
+    fn can_assemble(&self, instruction: &Instruction) -> bool {
+        instruction.is_encodable_aarch64()
+    }
+}
+
 impl RegisterType for Register {
     fn index(&self) -> Option<u8> {
         Register::index(self)

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -102,7 +102,10 @@ impl crate::isa::traits::CostModel<Instruction> for AArch64 {
 
 impl crate::isa::traits::Assembler<Instruction> for AArch64 {
     fn assemble(&mut self, instructions: &[Instruction]) -> Result<Vec<u8>, String> {
-        crate::assembler::AArch64Assembler::new().assemble_instructions(instructions)
+        // base_address=0 is correct for unbranching sequences (no PC-relative
+        // encoding involved). Trait callers that need real branch targets
+        // should reach for `AArch64Assembler` directly with their base_address.
+        crate::assembler::AArch64Assembler::new().assemble_instructions(instructions, 0)
     }
 
     /// Bridges the inherent `Instruction::is_encodable_aarch64()` so step 11

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -20,6 +20,7 @@ impl ISA for AArch64 {
     type Operand = Operand;
     type Instruction = Instruction;
     type Width = crate::isa::traits::U64;
+    type Flags = crate::semantics::state::ConditionFlags;
 
     fn name(&self) -> &'static str {
         "AArch64"
@@ -39,6 +40,16 @@ impl ISA for AArch64 {
 
     fn zero_register(&self) -> Option<Self::Register> {
         Some(Register::XZR)
+    }
+}
+
+impl crate::isa::traits::FlagsAnalysis<Instruction> for AArch64 {
+    fn modifies_flags(instr: &Instruction) -> bool {
+        instr.modifies_flags()
+    }
+
+    fn reads_flags(instr: &Instruction) -> bool {
+        instr.reads_flags()
     }
 }
 

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -19,6 +19,7 @@ impl ISA for AArch64 {
     type Register = Register;
     type Operand = Operand;
     type Instruction = Instruction;
+    type Width = crate::isa::traits::U64;
 
     fn name(&self) -> &'static str {
         "AArch64"
@@ -26,10 +27,6 @@ impl ISA for AArch64 {
 
     fn register_count(&self) -> usize {
         31 // X0-X30, plus XZR
-    }
-
-    fn register_width(&self) -> u32 {
-        64
     }
 
     fn instruction_size(&self) -> Option<usize> {

--- a/src/isa/mod.rs
+++ b/src/isa/mod.rs
@@ -10,8 +10,8 @@ pub mod x86;
 
 #[allow(unused_imports)]
 pub use traits::{
-    Assembler, BVWidth, ConcreteExecutor, CostModel, FlagsAnalysis, ISA, InstructionGenerator,
-    InstructionType, OperandType, RegisterType, SymbolicExecutor, U32, U64,
+    Assembler, BVWidth, ConcreteExecutor, CostModel, FlagsAnalysis, ISA, ISAMutator,
+    InstructionGenerator, InstructionType, OperandType, RegisterType, SymbolicExecutor, U32, U64,
 };
 
 #[allow(unused_imports)]

--- a/src/isa/mod.rs
+++ b/src/isa/mod.rs
@@ -10,8 +10,8 @@ pub mod x86;
 
 #[allow(unused_imports)]
 pub use traits::{
-    Assembler, ConcreteExecutor, CostModel, ISA, InstructionGenerator, InstructionType,
-    OperandType, RegisterType, SymbolicExecutor,
+    Assembler, BVWidth, ConcreteExecutor, CostModel, FlagsAnalysis, ISA, InstructionGenerator,
+    InstructionType, OperandType, RegisterType, SymbolicExecutor, U32, U64,
 };
 
 #[allow(unused_imports)]

--- a/src/isa/riscv.rs
+++ b/src/isa/riscv.rs
@@ -460,6 +460,7 @@ impl ISA for RiscV32 {
     type Operand = RiscVOperand;
     type Instruction = RiscVInstruction;
     type Width = crate::isa::traits::U32;
+    type Flags = ();
 
     fn name(&self) -> &'static str {
         "RISC-V 32"
@@ -491,6 +492,7 @@ impl ISA for RiscV64 {
     type Operand = RiscVOperand;
     type Instruction = RiscVInstruction;
     type Width = crate::isa::traits::U64;
+    type Flags = ();
 
     fn name(&self) -> &'static str {
         "RISC-V 64"
@@ -510,6 +512,27 @@ impl ISA for RiscV64 {
 
     fn zero_register(&self) -> Option<Self::Register> {
         Some(RiscVRegister::X0)
+    }
+}
+
+impl crate::isa::traits::FlagsAnalysis<RiscVInstruction> for RiscV32 {
+    fn modifies_flags(_instr: &RiscVInstruction) -> bool {
+        // RISC-V has no condition flags.
+        false
+    }
+
+    fn reads_flags(_instr: &RiscVInstruction) -> bool {
+        false
+    }
+}
+
+impl crate::isa::traits::FlagsAnalysis<RiscVInstruction> for RiscV64 {
+    fn modifies_flags(_instr: &RiscVInstruction) -> bool {
+        false
+    }
+
+    fn reads_flags(_instr: &RiscVInstruction) -> bool {
+        false
     }
 }
 

--- a/src/isa/riscv.rs
+++ b/src/isa/riscv.rs
@@ -459,16 +459,13 @@ impl ISA for RiscV32 {
     type Register = RiscVRegister;
     type Operand = RiscVOperand;
     type Instruction = RiscVInstruction;
+    type Width = crate::isa::traits::U32;
 
     fn name(&self) -> &'static str {
         "RISC-V 32"
     }
 
     fn register_count(&self) -> usize {
-        32
-    }
-
-    fn register_width(&self) -> u32 {
         32
     }
 
@@ -493,6 +490,7 @@ impl ISA for RiscV64 {
     type Register = RiscVRegister;
     type Operand = RiscVOperand;
     type Instruction = RiscVInstruction;
+    type Width = crate::isa::traits::U64;
 
     fn name(&self) -> &'static str {
         "RISC-V 64"
@@ -500,10 +498,6 @@ impl ISA for RiscV64 {
 
     fn register_count(&self) -> usize {
         32
-    }
-
-    fn register_width(&self) -> u32 {
-        64
     }
 
     fn instruction_size(&self) -> Option<usize> {

--- a/src/isa/riscv.rs
+++ b/src/isa/riscv.rs
@@ -538,8 +538,49 @@ impl crate::isa::traits::FlagsAnalysis<RiscVInstruction> for RiscV64 {
     }
 }
 
-/// Stub RISC-V mutator (#77 stage 1 step 10). Real body lands in stage 3
-/// step 23 when RISC-V wires through end-to-end.
+/// `Assembler<RiscVInstruction>` per ADR-0005: dynasm-rs has no RISC-V
+/// backend, so `<RiscV32/64 as Assembler>::assemble` returns `Err` and
+/// `can_assemble` returns `false` (search pipeline pre-filters everything
+/// out). A follow-up PR swaps the Err for a real encoder.
+impl crate::isa::traits::Assembler<RiscVInstruction> for RiscV32 {
+    fn assemble(&mut self, _instructions: &[RiscVInstruction]) -> Result<Vec<u8>, String> {
+        Err(
+            "RISC-V machine-code emission is not yet implemented (ADR-0005); \
+             pass --algorithm enumerative for assembly-text output only"
+                .into(),
+        )
+    }
+
+    fn can_assemble(&self, _instruction: &RiscVInstruction) -> bool {
+        false
+    }
+}
+
+impl crate::isa::traits::Assembler<RiscVInstruction> for RiscV64 {
+    fn assemble(&mut self, _instructions: &[RiscVInstruction]) -> Result<Vec<u8>, String> {
+        Err(
+            "RISC-V machine-code emission is not yet implemented (ADR-0005); \
+             pass --algorithm enumerative for assembly-text output only"
+                .into(),
+        )
+    }
+
+    fn can_assemble(&self, _instruction: &RiscVInstruction) -> bool {
+        false
+    }
+}
+
+// Note: `ConcreteExecutor<RiscVInstruction>`, `SymbolicExecutor<RiscVInstruction>`,
+// and `CostModel<RiscVInstruction>` impls for RiscV32 / RiscV64 are intentionally
+// **not** added here. Each needs a from-scratch semantics implementation for the
+// 16 mnemonics (`riscv.rs:233-318`) — there are no existing free functions to
+// delegate to (the AArch64/x86 step 8 + step 17 pattern depended on
+// pre-existing `apply_instruction_concrete`/`smt`/`cost` helpers). That
+// implementation work is tracked as a follow-up RISC-V issue; the assembler
+// stub above lets the rest of the trait surface compile end-to-end.
+
+/// Stub RISC-V mutator (#77 stage 1 step 10). Real body lands in the same
+/// follow-up RISC-V issue that adds the concrete + SMT executor bodies.
 #[derive(Debug, Default, Clone)]
 pub struct RiscVMutator;
 

--- a/src/isa/riscv.rs
+++ b/src/isa/riscv.rs
@@ -461,6 +461,7 @@ impl ISA for RiscV32 {
     type Instruction = RiscVInstruction;
     type Width = crate::isa::traits::U32;
     type Flags = ();
+    type Mutator = RiscVMutator;
 
     fn name(&self) -> &'static str {
         "RISC-V 32"
@@ -493,6 +494,7 @@ impl ISA for RiscV64 {
     type Instruction = RiscVInstruction;
     type Width = crate::isa::traits::U64;
     type Flags = ();
+    type Mutator = RiscVMutator;
 
     fn name(&self) -> &'static str {
         "RISC-V 64"
@@ -533,6 +535,21 @@ impl crate::isa::traits::FlagsAnalysis<RiscVInstruction> for RiscV64 {
 
     fn reads_flags(_instr: &RiscVInstruction) -> bool {
         false
+    }
+}
+
+/// Stub RISC-V mutator (#77 stage 1 step 10). Real body lands in stage 3
+/// step 23 when RISC-V wires through end-to-end.
+#[derive(Debug, Default, Clone)]
+pub struct RiscVMutator;
+
+impl crate::isa::traits::ISAMutator<RiscVInstruction> for RiscVMutator {
+    fn mutate<R: rand::RngExt>(
+        &self,
+        _rng: &mut R,
+        sequence: &[RiscVInstruction],
+    ) -> Vec<RiscVInstruction> {
+        sequence.to_vec()
     }
 }
 

--- a/src/isa/traits.rs
+++ b/src/isa/traits.rs
@@ -129,6 +129,9 @@ pub trait ISA: Send + Sync + Clone {
     /// The register width as an associated type (ADR-0004 decision 1).
     /// Used to size Z3 bitvectors and to type concrete value storage.
     type Width: BVWidth;
+    /// Condition-code / flag state for this ISA (ADR-0004 decision 7).
+    /// AArch64 NZCV, x86 EFLAGS, or `()` for ISAs without flags.
+    type Flags: Clone + Debug + Default + PartialEq + Eq + Hash;
 
     /// Name of this ISA (e.g., "AArch64", "RISC-V")
     fn name(&self) -> &'static str;
@@ -252,4 +255,19 @@ pub trait Assembler<I: InstructionType>: Send + Sync {
 
     /// Check if an instruction can be assembled
     fn can_assemble(&self, instruction: &I) -> bool;
+}
+
+/// Per-ISA flag-analysis hook (ADR-0004 decision 7).
+///
+/// `flag_writers_diverge` and `validation::live_out::flags_live_out` consume
+/// this trait, NOT `InstructionType::has_side_effects` — the latter is too
+/// coarse on x86 (returns `true` for everything except MOV), so reusing it
+/// for flag analysis would over-trigger and tank optimisation quality.
+pub trait FlagsAnalysis<I: InstructionType>: Send + Sync {
+    /// Returns true if `instr` writes any flag bit.
+    fn modifies_flags(instr: &I) -> bool;
+
+    /// Returns true if `instr` reads any flag bit (e.g., CSEL, conditional
+    /// branches). RISC-V impls return false unconditionally.
+    fn reads_flags(instr: &I) -> bool;
 }

--- a/src/isa/traits.rs
+++ b/src/isa/traits.rs
@@ -132,6 +132,8 @@ pub trait ISA: Send + Sync + Clone {
     /// Condition-code / flag state for this ISA (ADR-0004 decision 7).
     /// AArch64 NZCV, x86 EFLAGS, or `()` for ISAs without flags.
     type Flags: Clone + Debug + Default + PartialEq + Eq + Hash;
+    /// Stochastic-search mutator for this ISA (ADR-0004 decision 2).
+    type Mutator: ISAMutator<Self::Instruction>;
 
     /// Name of this ISA (e.g., "AArch64", "RISC-V")
     fn name(&self) -> &'static str;
@@ -255,6 +257,19 @@ pub trait Assembler<I: InstructionType>: Send + Sync {
 
     /// Check if an instruction can be assembled
     fn can_assemble(&self, instruction: &I) -> bool;
+}
+
+/// Per-ISA mutator hook for stochastic search (ADR-0004 decision 2).
+///
+/// `<I as ISA>::Mutator` promotes the free `Mutator` type at
+/// `src/search/stochastic/mutation.rs:71-100` so MCMC can route through trait
+/// dispatch. Construction (registers, immediates, weights) is per-impl because
+/// the construction shape varies between ISAs; this trait pins only the
+/// observable `mutate` surface so the search algorithm can stay generic.
+pub trait ISAMutator<I: InstructionType>: Send + Sync {
+    /// Apply a random mutation to `sequence` and return the (possibly equal)
+    /// mutated sequence.
+    fn mutate<R: rand::RngExt>(&self, rng: &mut R, sequence: &[I]) -> Vec<I>;
 }
 
 /// Per-ISA flag-analysis hook (ADR-0004 decision 7).

--- a/src/isa/traits.rs
+++ b/src/isa/traits.rs
@@ -9,6 +9,32 @@ use std::fmt::{Debug, Display};
 use std::hash::Hash;
 
 use rand::RngExt;
+/// Bitvector width marker.
+///
+/// Each ISA carries its register width as an associated type implementing this
+/// trait (per ADR-0004 decision 1). Width-aware SMT lowering uses `BITS` to
+/// size Z3 BVs; concrete state may use `Value` as the storage type.
+pub trait BVWidth: Send + Sync + Clone + Copy + Debug {
+    /// The width in bits (32 or 64 for the ISAs s11 currently targets).
+    const BITS: u32;
+}
+
+/// Width marker for 32-bit ISAs (x86-32, RV32).
+#[derive(Debug, Clone, Copy)]
+pub struct U32;
+
+impl BVWidth for U32 {
+    const BITS: u32 = 32;
+}
+
+/// Width marker for 64-bit ISAs (AArch64, x86-64, RV64).
+#[derive(Debug, Clone, Copy)]
+pub struct U64;
+
+impl BVWidth for U64 {
+    const BITS: u32 = 64;
+}
+
 /// Trait for register types
 pub trait RegisterType:
     Clone + Copy + PartialEq + Eq + Hash + Debug + Display + Send + Sync
@@ -100,6 +126,9 @@ pub trait ISA: Send + Sync + Clone {
     type Operand: OperandType<Register = Self::Register>;
     /// The instruction type for this ISA
     type Instruction: InstructionType<Register = Self::Register, Operand = Self::Operand>;
+    /// The register width as an associated type (ADR-0004 decision 1).
+    /// Used to size Z3 bitvectors and to type concrete value storage.
+    type Width: BVWidth;
 
     /// Name of this ISA (e.g., "AArch64", "RISC-V")
     fn name(&self) -> &'static str;
@@ -107,8 +136,11 @@ pub trait ISA: Send + Sync + Clone {
     /// Number of general-purpose registers
     fn register_count(&self) -> usize;
 
-    /// Register bit width (e.g., 64 for AArch64, 32 for ARM)
-    fn register_width(&self) -> u32;
+    /// Register bit width (e.g., 64 for AArch64, 32 for ARM).
+    /// Default impl returns `Self::Width::BITS`; backends should not override.
+    fn register_width(&self) -> u32 {
+        Self::Width::BITS
+    }
 
     /// Instruction size in bytes (fixed-width ISAs like ARM)
     fn instruction_size(&self) -> Option<usize>;

--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -323,6 +323,7 @@ impl ISA for X86_64 {
     type Operand = X86Operand;
     type Instruction = X86Instruction;
     type Width = crate::isa::traits::U64;
+    type Flags = crate::semantics::state::Eflags;
 
     fn name(&self) -> &'static str {
         "x86-64"
@@ -359,6 +360,7 @@ impl ISA for X86_32 {
     type Operand = X86Operand;
     type Instruction = X86Instruction;
     type Width = crate::isa::traits::U32;
+    type Flags = crate::semantics::state::Eflags;
 
     fn name(&self) -> &'static str {
         "x86-32"
@@ -378,6 +380,36 @@ impl ISA for X86_32 {
 
     fn zero_register(&self) -> Option<X86Register> {
         None
+    }
+}
+
+/// Helper used by both `FlagsAnalysis<X86Instruction> for X86_64` and
+/// `for X86_32`: every x86 mnemonic except `Mov*` writes EFLAGS.
+fn x86_modifies_flags(instr: &X86Instruction) -> bool {
+    !matches!(
+        instr,
+        X86Instruction::MovReg { .. } | X86Instruction::MovImm { .. }
+    )
+}
+
+impl crate::isa::traits::FlagsAnalysis<X86Instruction> for X86_64 {
+    fn modifies_flags(instr: &X86Instruction) -> bool {
+        x86_modifies_flags(instr)
+    }
+
+    fn reads_flags(_instr: &X86Instruction) -> bool {
+        // No conditional ops in the current x86 mnemonic set.
+        false
+    }
+}
+
+impl crate::isa::traits::FlagsAnalysis<X86Instruction> for X86_32 {
+    fn modifies_flags(instr: &X86Instruction) -> bool {
+        x86_modifies_flags(instr)
+    }
+
+    fn reads_flags(_instr: &X86Instruction) -> bool {
+        false
     }
 }
 

--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -322,6 +322,7 @@ impl ISA for X86_64 {
     type Register = X86Register;
     type Operand = X86Operand;
     type Instruction = X86Instruction;
+    type Width = crate::isa::traits::U64;
 
     fn name(&self) -> &'static str {
         "x86-64"
@@ -329,10 +330,6 @@ impl ISA for X86_64 {
 
     fn register_count(&self) -> usize {
         16
-    }
-
-    fn register_width(&self) -> u32 {
-        64
     }
 
     fn instruction_size(&self) -> Option<usize> {
@@ -361,6 +358,7 @@ impl ISA for X86_32 {
     type Register = X86Register;
     type Operand = X86Operand;
     type Instruction = X86Instruction;
+    type Width = crate::isa::traits::U32;
 
     fn name(&self) -> &'static str {
         "x86-32"
@@ -368,10 +366,6 @@ impl ISA for X86_32 {
 
     fn register_count(&self) -> usize {
         8
-    }
-
-    fn register_width(&self) -> u32 {
-        32
     }
 
     fn instruction_size(&self) -> Option<usize> {

--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -324,6 +324,7 @@ impl ISA for X86_64 {
     type Instruction = X86Instruction;
     type Width = crate::isa::traits::U64;
     type Flags = crate::semantics::state::Eflags;
+    type Mutator = X86Mutator;
 
     fn name(&self) -> &'static str {
         "x86-64"
@@ -361,6 +362,7 @@ impl ISA for X86_32 {
     type Instruction = X86Instruction;
     type Width = crate::isa::traits::U32;
     type Flags = crate::semantics::state::Eflags;
+    type Mutator = X86Mutator;
 
     fn name(&self) -> &'static str {
         "x86-32"
@@ -410,6 +412,22 @@ impl crate::isa::traits::FlagsAnalysis<X86Instruction> for X86_32 {
 
     fn reads_flags(_instr: &X86Instruction) -> bool {
         false
+    }
+}
+
+/// Stub x86 mutator (#77 stage 1 step 10). Returns its input unchanged; the
+/// real x86 mutator body lands in stage 2 step 17 when x86 stochastic search
+/// is wired through the trait surface.
+#[derive(Debug, Default, Clone)]
+pub struct X86Mutator;
+
+impl crate::isa::traits::ISAMutator<X86Instruction> for X86Mutator {
+    fn mutate<R: rand::RngExt>(
+        &self,
+        _rng: &mut R,
+        sequence: &[X86Instruction],
+    ) -> Vec<X86Instruction> {
+        sequence.to_vec()
     }
 }
 

--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -415,6 +415,163 @@ impl crate::isa::traits::FlagsAnalysis<X86Instruction> for X86_32 {
     }
 }
 
+// --- Trait surface impls (#77 stage 2 step 17) ---
+// Each impl delegates to the existing free function so the parallel
+// pipeline files (concrete_x86.rs / smt_x86.rs / cost_x86.rs /
+// assembler/x86.rs) can be deleted in stage 2 step 18 once stage 1's
+// SearchAlgorithm<I> follow-up wires the consumer side through these
+// trait impls.
+
+impl crate::isa::traits::ConcreteExecutor<X86Instruction> for X86_64 {
+    type Value = u64;
+    type State = crate::semantics::state::X86ConcreteMachineState;
+
+    fn execute_instruction(&self, state: Self::State, instruction: &X86Instruction) -> Self::State {
+        crate::semantics::concrete_x86::apply_instruction_concrete_x86(state, instruction)
+    }
+
+    fn new_zeroed_state(&self) -> Self::State {
+        crate::semantics::state::X86ConcreteMachineState::new_zeroed(64)
+    }
+
+    fn state_from_values(
+        &self,
+        values: std::collections::HashMap<X86Register, u64>,
+    ) -> Self::State {
+        let mut state = crate::semantics::state::X86ConcreteMachineState::new_zeroed(64);
+        for (reg, val) in values {
+            state.set_register(reg, crate::semantics::state::ConcreteValue::new(val));
+        }
+        state
+    }
+
+    fn get_register(&self, state: &Self::State, reg: X86Register) -> u64 {
+        state.get_register(reg).as_u64()
+    }
+
+    fn set_register(&self, state: &mut Self::State, reg: X86Register, value: u64) {
+        state.set_register(reg, crate::semantics::state::ConcreteValue::new(value));
+    }
+}
+
+impl crate::isa::traits::ConcreteExecutor<X86Instruction> for X86_32 {
+    type Value = u64;
+    type State = crate::semantics::state::X86ConcreteMachineState;
+
+    fn execute_instruction(&self, state: Self::State, instruction: &X86Instruction) -> Self::State {
+        crate::semantics::concrete_x86::apply_instruction_concrete_x86(state, instruction)
+    }
+
+    fn new_zeroed_state(&self) -> Self::State {
+        crate::semantics::state::X86ConcreteMachineState::new_zeroed(32)
+    }
+
+    fn state_from_values(
+        &self,
+        values: std::collections::HashMap<X86Register, u64>,
+    ) -> Self::State {
+        let mut state = crate::semantics::state::X86ConcreteMachineState::new_zeroed(32);
+        for (reg, val) in values {
+            state.set_register(reg, crate::semantics::state::ConcreteValue::new(val));
+        }
+        state
+    }
+
+    fn get_register(&self, state: &Self::State, reg: X86Register) -> u64 {
+        state.get_register(reg).as_u64()
+    }
+
+    fn set_register(&self, state: &mut Self::State, reg: X86Register, value: u64) {
+        state.set_register(reg, crate::semantics::state::ConcreteValue::new(value));
+    }
+}
+
+impl crate::isa::traits::SymbolicExecutor<X86Instruction> for X86_64 {
+    type State = crate::semantics::smt_x86::MachineStateX86;
+
+    fn execute_instruction(&self, state: Self::State, instruction: &X86Instruction) -> Self::State {
+        crate::semantics::smt_x86::apply_instruction(state, instruction)
+    }
+
+    fn new_symbolic_state(&self, prefix: &str) -> Self::State {
+        crate::semantics::smt_x86::MachineStateX86::new_symbolic(prefix, 64)
+    }
+}
+
+impl crate::isa::traits::SymbolicExecutor<X86Instruction> for X86_32 {
+    type State = crate::semantics::smt_x86::MachineStateX86;
+
+    fn execute_instruction(&self, state: Self::State, instruction: &X86Instruction) -> Self::State {
+        crate::semantics::smt_x86::apply_instruction(state, instruction)
+    }
+
+    fn new_symbolic_state(&self, prefix: &str) -> Self::State {
+        crate::semantics::smt_x86::MachineStateX86::new_symbolic(prefix, 32)
+    }
+}
+
+impl crate::isa::traits::CostModel<X86Instruction> for X86_64 {
+    fn instruction_cost(&self, instruction: &X86Instruction) -> u64 {
+        crate::semantics::cost_x86::instruction_cost(
+            instruction,
+            &crate::semantics::cost::CostMetric::InstructionCount,
+            64,
+        )
+    }
+}
+
+impl crate::isa::traits::CostModel<X86Instruction> for X86_32 {
+    fn instruction_cost(&self, instruction: &X86Instruction) -> u64 {
+        crate::semantics::cost_x86::instruction_cost(
+            instruction,
+            &crate::semantics::cost::CostMetric::InstructionCount,
+            32,
+        )
+    }
+}
+
+impl crate::isa::traits::Assembler<X86Instruction> for X86_64 {
+    fn assemble(&mut self, instructions: &[X86Instruction]) -> Result<Vec<u8>, String> {
+        crate::assembler::x86::X86Assembler::new_64().assemble_instructions(instructions)
+    }
+
+    fn can_assemble(&self, _instruction: &X86Instruction) -> bool {
+        // The 14 x86 mnemonics in this enum are all encodable in 64-bit mode.
+        true
+    }
+}
+
+impl crate::isa::traits::Assembler<X86Instruction> for X86_32 {
+    fn assemble(&mut self, instructions: &[X86Instruction]) -> Result<Vec<u8>, String> {
+        crate::assembler::x86::X86Assembler::new_32().assemble_instructions(instructions)
+    }
+
+    fn can_assemble(&self, instruction: &X86Instruction) -> bool {
+        // In 32-bit mode, R8..R15 are illegal. The x86 assembler's reg_index_32
+        // rejects them; reproduce the same check here so trait dispatch can
+        // pre-filter sequences before invoking the heavier assemble path.
+        fn reg_ok_32(r: X86Register) -> bool {
+            r.index().is_some_and(|i| i < 8)
+        }
+        match instruction {
+            X86Instruction::MovReg { rd, rs }
+            | X86Instruction::AddReg { rd, rs }
+            | X86Instruction::SubReg { rd, rs }
+            | X86Instruction::AndReg { rd, rs }
+            | X86Instruction::OrReg { rd, rs }
+            | X86Instruction::XorReg { rd, rs } => reg_ok_32(*rd) && reg_ok_32(*rs),
+            X86Instruction::MovImm { rd, .. }
+            | X86Instruction::AddImm { rd, .. }
+            | X86Instruction::SubImm { rd, .. }
+            | X86Instruction::AndImm { rd, .. }
+            | X86Instruction::OrImm { rd, .. }
+            | X86Instruction::XorImm { rd, .. } => reg_ok_32(*rd),
+            X86Instruction::CmpReg { rn, rs } => reg_ok_32(*rn) && reg_ok_32(*rs),
+            X86Instruction::CmpImm { rn, .. } => reg_ok_32(*rn),
+        }
+    }
+}
+
 /// Stub x86 mutator (#77 stage 1 step 10). Returns its input unchanged; the
 /// real x86 mutator body lands in stage 2 step 17 when x86 stochastic search
 /// is wired through the trait surface.

--- a/src/main.rs
+++ b/src/main.rs
@@ -410,9 +410,15 @@ struct OptimizationOptions {
 // indirectly through the existing free functions, which step 8 wired to the
 // trait impls. Stage 2 step 20 merges this function with
 // `optimize_elf_binary_x86` into a single `optimize_elf_binary_generic<I: ISA>`
-// once x86 has its own SearchAlgorithm impl (stage 2 step 17). For now the
-// AArch64-typed signature is preserved so existing callers do not need
-// turbofish.
+// once x86 has its own SearchAlgorithm impl. For now the AArch64-typed
+// signature is preserved so existing callers do not need turbofish.
+//
+// Step 20 status: BLOCKED on the SearchAlgorithm<I> follow-up to step 11.
+// `optimize_elf_binary_x86` uses `find_shorter_equivalent_x86` which directly
+// drives the candidate enumerator over X86Instruction — there is no x86
+// SearchAlgorithm impl to dispatch to. Once that lands, the merge is
+// mechanical: `match detect_cli_arch_from_elf(...) { Aarch64 => ::<AArch64>,
+// X86_64 => ::<X86_64>, X86_32 => ::<X86_32>, Riscv* => stage 3 }`.
 fn optimize_elf_binary(
     path: &Path,
     start_addr: u64,

--- a/src/main.rs
+++ b/src/main.rs
@@ -404,6 +404,15 @@ struct OptimizationOptions {
 
 // --- Optimization Function ---
 
+// Issue #77 stage 1 step 15 note: this AArch64 optimization path consumes the
+// new trait-surface scaffolding (`<AArch64 as ConcreteExecutor<Instruction>>`,
+// `<AArch64 as SymbolicExecutor<Instruction>>`, `<AArch64 as Assembler<...>>`)
+// indirectly through the existing free functions, which step 8 wired to the
+// trait impls. Stage 2 step 20 merges this function with
+// `optimize_elf_binary_x86` into a single `optimize_elf_binary_generic<I: ISA>`
+// once x86 has its own SearchAlgorithm impl (stage 2 step 17). For now the
+// AArch64-typed signature is preserved so existing callers do not need
+// turbofish.
 fn optimize_elf_binary(
     path: &Path,
     start_addr: u64,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,6 +1,15 @@
 //! Assembly text parser for AArch64 instructions
 //!
 //! Parses GNU assembler syntax into the IR representation.
+//!
+//! Issue #77 stage 3 step 25 wraps this module's `parse_line` in a thin
+//! `AArch64Parser` newtype implementing `ISAParser<Instruction>` (a new
+//! associated type to be added on `ISA`). The contract is byte-for-byte
+//! identical — the newtype just dispatches through the trait. `convert_to_ir`
+//! in main.rs continues to delegate to `parse_line` per the project
+//! CLAUDE.md invariant. RISC-V gets `convert_to_riscv_ir` (binary path only;
+//! no asm-text parser until a follow-up). Blocked on step 23's RISC-V
+//! semantics work.
 
 use std::fmt;
 use std::path::Path;

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -2,10 +2,27 @@
 
 use crate::ir::instructions::MOVW_LEGAL_SHIFTS;
 use crate::ir::{Instruction, Operand, Register};
+use crate::isa::{AArch64, Assembler, InstructionType};
 
-/// Check if all instructions in a sequence can be encoded in AArch64 machine code.
+/// Generic encodability check: for any `<I: InstructionType, A: Assembler<I>>`,
+/// returns true iff every instruction passes `A::can_assemble`.
+///
+/// Added in #77 stage 1 step 11 as the canonical generic helper so x86 (stage
+/// 2 step 17) and RISC-V (stage 3 step 23) reuse the same shape. Today the
+/// only consumer is the AArch64 thin wrapper `is_sequence_encodable` below.
+pub fn is_sequence_encodable_for<I: InstructionType, A: Assembler<I>>(
+    sequence: &[I],
+    assembler: &A,
+) -> bool {
+    sequence.iter().all(|instr| assembler.can_assemble(instr))
+}
+
+/// Check if all instructions in a sequence can be encoded in AArch64 machine
+/// code. Routes through the generic `is_sequence_encodable_for` helper with
+/// the AArch64 marker (step 8's `Assembler::can_assemble` bridges
+/// `Instruction::is_encodable_aarch64()`).
 pub fn is_sequence_encodable(sequence: &[Instruction]) -> bool {
-    sequence.iter().all(|instr| instr.is_encodable_aarch64())
+    is_sequence_encodable_for(sequence, &AArch64)
 }
 
 /// Generate all encodable instructions using the given registers and immediates.

--- a/src/search/llm/mod.rs
+++ b/src/search/llm/mod.rs
@@ -79,6 +79,14 @@ impl LlmSearch {
     }
 }
 
+// ADR-0004 decision 3 (reaffirming ADR-0003): the LLM-assisted search path is
+// **AArch64-only by design**. The prompt body (src/search/llm/prompt.rs:20-46)
+// names "AArch64 superoptimizer" and renders AArch64 registers directly; the
+// response parser routes through `parser::parse_line` which is AArch64-only.
+// When stage 2 step 17 makes `SearchAlgorithm` generic over `<I: ISA>`, this
+// impl will be constrained to `SearchAlgorithm<AArch64>` so the LLM flow
+// cannot accidentally be invoked for x86 / RISC-V. Today the trait is
+// non-generic, so the constraint is implicit.
 impl SearchAlgorithm for LlmSearch {
     fn search(
         &mut self,

--- a/src/search/llm/prompt.rs
+++ b/src/search/llm/prompt.rs
@@ -1,4 +1,11 @@
 //! Prompt construction for the Codex-assisted search loop.
+//!
+//! AArch64-only by design (ADR-0003, reaffirmed by ADR-0004 decision 3, and
+//! restated by issue #77 stage 3 step 27): the prompt body names "AArch64
+//! superoptimizer" and renders AArch64 registers; the response parser
+//! delegates to `parser::parse_line` which only accepts AArch64 mnemonics.
+//! The LLM flow stays AArch64-only across all stages of #77 — no
+//! generification of this module is planned.
 
 use crate::ir::{Instruction, Register};
 use crate::semantics::live_out::LiveOutRegisters;

--- a/src/search/parallel/channel.rs
+++ b/src/search/parallel/channel.rs
@@ -1,4 +1,12 @@
 //! Solution sharing channel for parallel search workers.
+//!
+//! Issue #77 stage 1 step 12 note: these message and channel types are
+//! AArch64-typed (`Vec<Instruction>` on the payload). Genericising them over
+//! `<I: ISA>` adds `I::Instruction: 'static + Send + Sync` bounds across the
+//! whole worker spawn machinery; doing so before a second consumer exists
+//! adds churn without benefit. The generic form lands in stage 2 step 17 when
+//! `StochasticSearch<I>` materialises for x86 and the parallel coordinator
+//! gets a real second-arch user.
 
 #![allow(dead_code)]
 

--- a/src/search/parallel/coordinator.rs
+++ b/src/search/parallel/coordinator.rs
@@ -370,4 +370,57 @@ mod tests {
         // Should aggregate candidates from both workers
         assert!(result.total_statistics.candidates_evaluated > 0);
     }
+
+    // Issue #77 stage 1 step 2 safety net:
+    // verify that every spawned worker reports Finished and that no per-worker
+    // statistics are silently dropped. Stage 1 step 12 genericises the
+    // coordinator + channel types over <I: ISA>; this test must keep passing
+    // through that refactor. Iteration count is sized so all workers finish
+    // naturally well inside the timeout (the current stochastic worker does
+    // not check CoordinatorMessage::Stop mid-search; timeout-driven shutdown
+    // is out of scope here).
+    #[test]
+    fn test_parallel_search_no_dropped_finished_messages() {
+        let target = mov_add_sequence();
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
+
+        let search_config = SearchConfig::default()
+            .with_registers(vec![Register::X0, Register::X1])
+            .with_immediates(vec![0, 1, 2])
+            .with_stochastic(StochasticConfig::default().with_iterations(200));
+
+        let num_workers = 4;
+        let parallel_config = ParallelConfig::default()
+            .with_workers(num_workers)
+            .with_symbolic(false)
+            .with_seed(42)
+            .with_timeout(Duration::from_secs(30));
+
+        let result = run_parallel_search(&target, &live_out, &search_config, &parallel_config);
+
+        // Every worker reported its stats (no dropped Finished messages).
+        assert_eq!(
+            result.worker_statistics.len(),
+            num_workers,
+            "expected {} worker stat entries, got {}",
+            num_workers,
+            result.worker_statistics.len(),
+        );
+
+        // Each worker_id appears exactly once across [0, num_workers).
+        let mut ids: Vec<usize> = result
+            .worker_statistics
+            .iter()
+            .map(|(id, _, _)| *id)
+            .collect();
+        ids.sort();
+        let expected: Vec<usize> = (0..num_workers).collect();
+        assert_eq!(ids, expected, "worker IDs should cover 0..{}", num_workers);
+
+        // At least one candidate was evaluated overall (sanity).
+        assert!(
+            result.total_statistics.candidates_evaluated > 0,
+            "expected workers to evaluate at least one candidate",
+        );
+    }
 }

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -69,6 +69,7 @@ pub enum MutationType {
 }
 
 /// Mutator for instruction sequences
+#[derive(Debug)]
 pub struct Mutator {
     registers: Vec<Register>,
     immediates: Vec<i64>,
@@ -966,6 +967,31 @@ impl Mutator {
         } else {
             Operand::Immediate(1)
         }
+    }
+}
+
+/// AArch64 mutator newtype exposing the free `Mutator` through the
+/// `ISAMutator<Instruction>` trait (#77 stage 1 step 10, ADR-0004 decision 2).
+/// The body stays in `src/search/stochastic/mutation.rs` to avoid moving the
+/// cyclic dep on `crate::search::candidate::generate_random_instruction`; the
+/// newtype just re-exposes the same surface under the trait name.
+#[derive(Debug)]
+pub struct AArch64Mutator(Mutator);
+
+impl AArch64Mutator {
+    pub fn new(registers: Vec<Register>, immediates: Vec<i64>, weights: MutationWeights) -> Self {
+        Self(Mutator::new(registers, immediates, weights))
+    }
+
+    /// Access the inner free `Mutator` for consumers that haven't migrated yet.
+    pub fn inner(&self) -> &Mutator {
+        &self.0
+    }
+}
+
+impl crate::isa::ISAMutator<Instruction> for AArch64Mutator {
+    fn mutate<R: RngExt>(&self, rng: &mut R, sequence: &[Instruction]) -> Vec<Instruction> {
+        self.0.mutate(rng, sequence)
     }
 }
 

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -1012,6 +1012,9 @@ pub fn mutate_opcode_in_place<R: RngExt>(rng: &mut R, instr: &mut Instruction) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
 
     fn default_mutator() -> Mutator {
         Mutator::new(
@@ -1409,6 +1412,83 @@ mod tests {
                 "mutation changed the terminator: got {:?}",
                 mutated
             );
+        }
+    }
+
+    // Issue #77 stage 1 step 2 safety net:
+    // every output of `Mutator::mutate` must be a well-formed `Vec<Instruction>`
+    // that the encodability filter (`crate::search::candidate::is_sequence_encodable`)
+    // can classify without panicking. Stage 1 step 10 promotes the mutator to
+    // <I as ISA>::Mutator and stage 1 step 11 swaps the filter to
+    // <I as ISA>::Assembler::can_assemble; this invariant must keep holding.
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(64))]
+
+        #[test]
+        fn mutator_output_is_classifiable(seed in 0u64..10_000) {
+            let mutator = default_mutator();
+            let mut rng = StdRng::seed_from_u64(seed);
+
+            let starting_sequences = vec![
+                vec![Instruction::MovImm { rd: Register::X0, imm: 0 }],
+                vec![Instruction::Add {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::Register(Register::X2),
+                }],
+                vec![
+                    Instruction::MovReg { rd: Register::X0, rn: Register::X1 },
+                    Instruction::Add {
+                        rd: Register::X0,
+                        rn: Register::X0,
+                        rm: Operand::Immediate(1),
+                    },
+                ],
+                vec![Instruction::And {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::ShiftedRegister {
+                        reg: Register::X2,
+                        kind: crate::ir::ShiftKind::Ror,
+                        amount: 4,
+                    },
+                }],
+            ];
+
+            for seq in &starting_sequences {
+                // Run several mutations off this seeded RNG so we cover a
+                // range of MutationType selections per seed.
+                for _ in 0..16 {
+                    let mutated = mutator.mutate(&mut rng, seq);
+
+                    // Encodability classification must succeed without panic.
+                    let _ = crate::search::candidate::is_sequence_encodable(&mutated);
+
+                    // Every register the mutated instruction references must
+                    // be either in the configured pool or one of the special
+                    // registers (XZR, SP).
+                    for instr in &mutated {
+                        for r in instr.source_registers() {
+                            prop_assert!(
+                                mutator.registers.contains(&r)
+                                    || matches!(r, Register::XZR | Register::SP),
+                                "mutated instruction {:?} uses source register {:?} \
+                                 outside the configured pool {:?}",
+                                instr, r, mutator.registers,
+                            );
+                        }
+                        if let Some(rd) = instr.destination() {
+                            prop_assert!(
+                                mutator.registers.contains(&rd)
+                                    || matches!(rd, Register::XZR | Register::SP),
+                                "mutated instruction {:?} writes destination \
+                                 register {:?} outside the configured pool {:?}",
+                                instr, rd, mutator.registers,
+                            );
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/src/semantics/concrete_x86.rs
+++ b/src/semantics/concrete_x86.rs
@@ -1,6 +1,15 @@
 //! Concrete (non-symbolic) interpreter for the x86 backend.
 //!
 //! Mirrors `semantics::concrete::apply_instruction_concrete` but over
+//! ## Deletion gate
+//!
+//! Issue #77 stage 2 step 18 plans to delete this file once
+//! `optimize_elf_binary_x86` (src/main.rs) and the x86 unit tests below
+//! route through `<X86_64 as ConcreteExecutor<X86Instruction>>::execute_instruction`
+//! (added in step 17). That migration is blocked on the
+//! SearchAlgorithm<I> follow-up to step 11. Until then this file is the
+//! authoritative x86 concrete interpreter and the trait impl delegates here.
+//!
 //! `X86Instruction` and `X86ConcreteMachineState`. Operand widths follow
 //! `state.width()` — writes to registers are already masked by the
 //! state, and flag computation receives the correct width.

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -1,4 +1,14 @@
 //! Semantic equivalence checking for instruction sequences
+//!
+//! Issue #77 stage 2 step 19 plans to delete `X86EquivalenceConfig`,
+//! `check_equivalence_x86`, and `run_fast_path_x86` once
+//! `EquivalenceConfig<I>` is wired to consume `LiveOutMask<I::Register>`
+//! and the SearchAlgorithm<I> follow-up to step 11 lands. The CMP-presence
+//! heuristic in `run_fast_path_x86` merges into the generic `run_fast_path`
+//! as an `I::Flags`-aware optimisation (only triggers when `I::Flags != ()`).
+//! Today the x86 path still owns its config + entry points; the AArch64
+//! equivalence path consumes the generic surface via the trait route step 9
+//! introduced.
 
 #![allow(dead_code)]
 

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -343,6 +343,15 @@ fn build_smt_solver(
     let final_state1 = apply_sequence(initial_state.clone(), seq1);
     let final_state2 = apply_sequence(initial_state, seq2);
 
+    // Safety guard added in issue #77 step 6: catch any future caller that
+    // splices states of mismatched width before Z3 panics on a BV-sort
+    // mismatch deep inside `states_not_equal_for_live_out`.
+    debug_assert_eq!(
+        final_state1.width(),
+        final_state2.width(),
+        "build_smt_solver: width mismatch between sequence final states",
+    );
+
     solver.assert(states_not_equal_for_live_out(
         &final_state1,
         &final_state2,

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -13,7 +13,6 @@ use crate::semantics::smt::{
     states_not_equal_for_live_out,
 };
 use crate::semantics::state::ConcreteMachineState;
-use crate::validation::live_out::flags_live_out;
 use crate::validation::random::{
     RandomInputConfig, generate_edge_case_inputs, generate_random_inputs,
 };
@@ -30,10 +29,19 @@ use z3::SatResult;
 /// (`flags_live = false`), the guard would otherwise reject sound rewrites
 /// such as `cmp x0, #0` ≡ `<empty>` under a register-only live-out mask, so
 /// the call site gates this check on flag liveness.
+///
+/// Issue #77 step 9: rather than reach for `Instruction::modifies_flags()` via
+/// `flags_live_out`, we route through the `FlagsAnalysis<I>` trait (ADR-0004
+/// decision 7). This lets the same guard ship for x86 in stage 2 without
+/// accidentally substituting `InstructionType::has_side_effects` (which would
+/// over-trigger — x86's impl returns `true` for everything except MOV).
 fn flag_writers_diverge(target: &[Instruction], candidate: &[Instruction]) -> bool {
-    let tw = flags_live_out(target);
-    let cw = flags_live_out(candidate);
-    tw != cw
+    use crate::isa::{AArch64, FlagsAnalysis};
+    fn writes_any_flag(seq: &[Instruction]) -> bool {
+        seq.iter()
+            .any(<AArch64 as FlagsAnalysis<Instruction>>::modifies_flags)
+    }
+    writes_any_flag(target) != writes_any_flag(candidate)
 }
 
 /// Combined pre-SMT soundness guard. Single source of truth for the

--- a/src/semantics/live_out.rs
+++ b/src/semantics/live_out.rs
@@ -27,6 +27,7 @@ pub struct LiveOutMask<R: RegisterType> {
     flags_live: bool,
 }
 
+#[allow(dead_code)] // public API, wired in #77 stage 1 step 9
 impl<R: RegisterType> LiveOutMask<R> {
     /// Empty mask, flags not live.
     pub fn empty() -> Self {

--- a/src/semantics/live_out.rs
+++ b/src/semantics/live_out.rs
@@ -3,10 +3,87 @@
 //! `LiveOut` names the full observable architectural state contract. Today the
 //! only populated slice is `LiveOutRegisters`; condition state, memory, and PC
 //! can be added beside it without renaming the search/equivalence boundary.
+//!
+//! `LiveOutMask<R>` (added in #77 stage 1 step 7) is the per-ISA-register
+//! generic shape that stage 1 step 9 wires into `EquivalenceConfig<I>` and
+//! stage 2 step 16 lifts to subsume `X86LiveOutMask`. `flags_live` lives on
+//! the mask per ADR-0004 decision 5.
 
 use crate::ir::Register;
+use crate::isa::RegisterType;
 use std::collections::HashSet;
 use std::fmt;
+
+/// Generic live-out mask parameterised on register type.
+///
+/// Carries a `flags_live: bool` field so condition-state live-out is part of
+/// the same contract object. Stage 1 step 9 migrates `EquivalenceConfig` to
+/// `EquivalenceConfig<I>` and threads this type through every consumer; stage
+/// 2 step 16 replaces the parallel `X86LiveOutMask` with
+/// `LiveOutMask<X86Register>` and drops the duplicate type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LiveOutMask<R: RegisterType> {
+    regs: HashSet<R>,
+    flags_live: bool,
+}
+
+impl<R: RegisterType> LiveOutMask<R> {
+    /// Empty mask, flags not live.
+    pub fn empty() -> Self {
+        Self {
+            regs: HashSet::new(),
+            flags_live: false,
+        }
+    }
+
+    /// Mask from a register slice, flags not live.
+    pub fn from_registers(regs: Vec<R>) -> Self {
+        Self {
+            regs: regs.into_iter().collect(),
+            flags_live: false,
+        }
+    }
+
+    /// Add a register to the live-out set (zero registers are silently dropped).
+    pub fn add(&mut self, reg: R) {
+        if !reg.is_zero_register() {
+            self.regs.insert(reg);
+        }
+    }
+
+    /// Returns true if `reg` is live-out.
+    pub fn contains(&self, reg: R) -> bool {
+        self.regs.contains(&reg)
+    }
+
+    /// Iterate over live-out registers.
+    pub fn iter(&self) -> impl Iterator<Item = &R> {
+        self.regs.iter()
+    }
+
+    /// Number of live-out registers.
+    pub fn len(&self) -> usize {
+        self.regs.len()
+    }
+
+    /// True if the mask contains no registers (flag-only liveness still
+    /// possible if `flags_live()` returns true).
+    pub fn is_empty(&self) -> bool {
+        self.regs.is_empty()
+    }
+
+    /// True if the condition flags are part of the live-out contract.
+    #[allow(dead_code)] // wired in #77 stage 1 step 9
+    pub fn flags_live(&self) -> bool {
+        self.flags_live
+    }
+
+    /// Set whether the condition flags are live-out.
+    #[allow(dead_code)] // wired in #77 stage 1 step 9
+    pub fn set_flags_live(&mut self, live: bool) {
+        self.flags_live = live;
+    }
+}
 
 /// Observable architectural state that must match after executing a sequence.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -188,5 +265,33 @@ mod tests {
         let live_out = LiveOut::from_registers(vec![Register::X0]);
         assert!(live_out.contains_register(Register::X0));
         assert_eq!(live_out.registers().len(), 1);
+    }
+
+    // Issue #77 stage 1 step 7: generic LiveOutMask coverage.
+    #[test]
+    fn test_live_out_mask_aarch64_basics() {
+        let mut mask: LiveOutMask<Register> = LiveOutMask::empty();
+        assert!(mask.is_empty());
+        assert!(!mask.flags_live());
+
+        mask.add(Register::X0);
+        mask.add(Register::X1);
+        mask.add(Register::XZR); // zero register is dropped
+        assert_eq!(mask.len(), 2);
+        assert!(mask.contains(Register::X0));
+        assert!(mask.contains(Register::X1));
+        assert!(!mask.contains(Register::XZR));
+
+        mask.set_flags_live(true);
+        assert!(mask.flags_live());
+    }
+
+    #[test]
+    fn test_live_out_mask_from_registers() {
+        let mask: LiveOutMask<Register> =
+            LiveOutMask::from_registers(vec![Register::X0, Register::X5, Register::X30]);
+        assert_eq!(mask.len(), 3);
+        assert!(mask.contains(Register::X5));
+        assert!(!mask.flags_live());
     }
 }

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -1936,6 +1936,71 @@ mod tests {
         );
     }
 
+    /// Extended parity helper supporting flag pre-state and flag post-state
+    /// agreement. Used by flag-setting (CMP/CMN/TST/ADDS/SUBS/ANDS/BICS/NEGS),
+    /// conditional (CSEL/CSINC/CSINV/CSNEG/CSET/CSETM), and flag+condition
+    /// (CCMP/CCMN) opcodes.
+    fn assert_concrete_smt_parity_full(
+        instr: &Instruction,
+        pre_values: &[(Register, u64)],
+        pre_flags: Option<crate::semantics::state::ConditionFlags>,
+        dest: Option<Register>,
+        check_post_flags: bool,
+    ) {
+        use crate::semantics::concrete::apply_instruction_concrete;
+        use crate::semantics::state::{ConcreteMachineState, ConcreteValue};
+
+        let mut concrete_pre = ConcreteMachineState::new_zeroed();
+        for &(reg, val) in pre_values {
+            concrete_pre.set_register(reg, ConcreteValue::new(val));
+        }
+        if let Some(flags) = pre_flags.clone() {
+            concrete_pre.set_flags(flags);
+        }
+        let concrete_post = apply_instruction_concrete(concrete_pre, instr);
+
+        let symbolic_pre = MachineState::new_symbolic("pre");
+        let solver = Solver::new();
+        for &(reg, val) in pre_values {
+            solver.assert(&symbolic_pre.get_register(reg).eq(&BV::from_u64(val, 64)));
+        }
+        if let Some(flags) = &pre_flags {
+            solver.assert(&symbolic_pre.n.eq(&BV::from_u64(flags.n as u64, 1)));
+            solver.assert(&symbolic_pre.z.eq(&BV::from_u64(flags.z as u64, 1)));
+            solver.assert(&symbolic_pre.c.eq(&BV::from_u64(flags.c as u64, 1)));
+            solver.assert(&symbolic_pre.v.eq(&BV::from_u64(flags.v as u64, 1)));
+        }
+        let symbolic_post = apply_instruction(symbolic_pre, instr);
+
+        let mut disagreements: Vec<z3::ast::Bool> = Vec::new();
+        if let Some(d) = dest {
+            let expected = BV::from_u64(concrete_post.get_register(d).as_u64(), 64);
+            disagreements.push(symbolic_post.get_register(d).eq(&expected).not());
+        }
+        if check_post_flags {
+            let cf = concrete_post.get_flags();
+            disagreements.push(symbolic_post.n.eq(&BV::from_u64(cf.n as u64, 1)).not());
+            disagreements.push(symbolic_post.z.eq(&BV::from_u64(cf.z as u64, 1)).not());
+            disagreements.push(symbolic_post.c.eq(&BV::from_u64(cf.c as u64, 1)).not());
+            disagreements.push(symbolic_post.v.eq(&BV::from_u64(cf.v as u64, 1)).not());
+        }
+        assert!(
+            !disagreements.is_empty(),
+            "assert_concrete_smt_parity_full needs either dest or check_post_flags"
+        );
+        let refs: Vec<&z3::ast::Bool> = disagreements.iter().collect();
+        solver.assert(&z3::ast::Bool::or(&refs));
+
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "concrete/SMT parity violation: {:?} pre={:x?} pre_flags={:?}",
+            instr,
+            pre_values,
+            pre_flags,
+        );
+    }
+
     #[test]
     fn test_mov_reg_concrete_smt_parity() {
         let instr = Instruction::MovReg {
@@ -2676,6 +2741,431 @@ mod tests {
                 &[(Register::X1, v1), (Register::X2, v2)],
                 Register::X0,
             );
+        }
+    }
+
+    #[test]
+    fn test_cmp_reg_concrete_smt_parity() {
+        use crate::semantics::state::ConditionFlags;
+        // CMP rn, rm sets flags via subtraction, doesn't write a register.
+        let instr = Instruction::Cmp {
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        };
+        let samples: &[(u64, u64)] = &[
+            (0, 0),                                         // equal: Z=1
+            (1, 0),                                         // pos minus zero
+            (0, 1),                                         // borrow: N=1, C=0
+            (0x8000_0000_0000_0000, 1),                     // overflow: V=1
+            (0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), // all-ones equal
+        ];
+        for &(v1, v2) in samples {
+            assert_concrete_smt_parity_full(
+                &instr,
+                &[(Register::X1, v1), (Register::X2, v2)],
+                Some(ConditionFlags::default()),
+                None,
+                true,
+            );
+        }
+    }
+
+    #[test]
+    fn test_cmn_reg_concrete_smt_parity() {
+        use crate::semantics::state::ConditionFlags;
+        let instr = Instruction::Cmn {
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        };
+        let samples: &[(u64, u64)] = &[
+            (0, 0),
+            (1, 0xFFFF_FFFF_FFFF_FFFF), // sum wraps to 0 -> Z=1, C=1
+            (0x7FFF_FFFF_FFFF_FFFF, 1), // overflow: V=1
+            (0xFFFF_FFFF_FFFF_FFFF, 1), // wraps to 0
+        ];
+        for &(v1, v2) in samples {
+            assert_concrete_smt_parity_full(
+                &instr,
+                &[(Register::X1, v1), (Register::X2, v2)],
+                Some(ConditionFlags::default()),
+                None,
+                true,
+            );
+        }
+    }
+
+    #[test]
+    fn test_tst_reg_concrete_smt_parity() {
+        use crate::semantics::state::ConditionFlags;
+        // TST is AND for flags; doesn't write rd.
+        let instr = Instruction::Tst {
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        };
+        let samples: &[(u64, u64)] = &[
+            (0, 0xFFFF_FFFF_FFFF_FFFF),                     // result=0 -> Z=1
+            (0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), // result=all-ones -> N=1
+            (0xAAAA_AAAA_AAAA_AAAA, 0x5555_5555_5555_5555), // result=0
+            (0xDEAD, 0xFFFF),                               // mixed
+        ];
+        for &(v1, v2) in samples {
+            assert_concrete_smt_parity_full(
+                &instr,
+                &[(Register::X1, v1), (Register::X2, v2)],
+                Some(ConditionFlags::default()),
+                None,
+                true,
+            );
+        }
+    }
+
+    #[test]
+    fn test_adds_reg_concrete_smt_parity() {
+        use crate::semantics::state::ConditionFlags;
+        let instr = Instruction::Adds {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        };
+        let samples: &[(u64, u64)] = &[
+            (0, 0),
+            (1, 0xFFFF_FFFF_FFFF_FFFF), // sum wraps to 0 -> Z=1, C=1
+            (0x8000_0000_0000_0000, 0x8000_0000_0000_0000), // both negative, V=1
+            (0x7FFF_FFFF_FFFF_FFFF, 1), // positive overflow: V=1
+        ];
+        for &(v1, v2) in samples {
+            assert_concrete_smt_parity_full(
+                &instr,
+                &[(Register::X1, v1), (Register::X2, v2)],
+                Some(ConditionFlags::default()),
+                Some(Register::X0),
+                true,
+            );
+        }
+    }
+
+    #[test]
+    fn test_subs_reg_concrete_smt_parity() {
+        use crate::semantics::state::ConditionFlags;
+        let instr = Instruction::Subs {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        };
+        let samples: &[(u64, u64)] = &[(0, 0), (0, 1), (1, 0), (0x8000_0000_0000_0000, 1)];
+        for &(v1, v2) in samples {
+            assert_concrete_smt_parity_full(
+                &instr,
+                &[(Register::X1, v1), (Register::X2, v2)],
+                Some(ConditionFlags::default()),
+                Some(Register::X0),
+                true,
+            );
+        }
+    }
+
+    #[test]
+    fn test_ands_reg_concrete_smt_parity() {
+        use crate::semantics::state::ConditionFlags;
+        let instr = Instruction::Ands {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        };
+        let samples: &[(u64, u64)] = &[
+            (0, 0xFFFF_FFFF_FFFF_FFFF),
+            (0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF),
+            (0xAAAA_AAAA_AAAA_AAAA, 0x5555_5555_5555_5555),
+            (0xDEAD, 0xFFFF),
+        ];
+        for &(v1, v2) in samples {
+            assert_concrete_smt_parity_full(
+                &instr,
+                &[(Register::X1, v1), (Register::X2, v2)],
+                Some(ConditionFlags::default()),
+                Some(Register::X0),
+                true,
+            );
+        }
+    }
+
+    #[test]
+    fn test_bics_reg_concrete_smt_parity() {
+        use crate::semantics::state::ConditionFlags;
+        let instr = Instruction::Bics {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        };
+        let samples: &[(u64, u64)] = &[
+            (0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF),
+            (0xFFFF_FFFF_FFFF_FFFF, 0),
+            (0xAAAA_AAAA_AAAA_AAAA, 0xAAAA_AAAA_AAAA_AAAA),
+        ];
+        for &(v1, v2) in samples {
+            assert_concrete_smt_parity_full(
+                &instr,
+                &[(Register::X1, v1), (Register::X2, v2)],
+                Some(ConditionFlags::default()),
+                Some(Register::X0),
+                true,
+            );
+        }
+    }
+
+    #[test]
+    fn test_negs_reg_concrete_smt_parity() {
+        use crate::semantics::state::ConditionFlags;
+        let instr = Instruction::Negs {
+            rd: Register::X0,
+            rm: Register::X1,
+        };
+        for v1 in &[0_u64, 1, 0x8000_0000_0000_0000, 0xFFFF_FFFF_FFFF_FFFF] {
+            assert_concrete_smt_parity_full(
+                &instr,
+                &[(Register::X1, *v1)],
+                Some(ConditionFlags::default()),
+                Some(Register::X0),
+                true,
+            );
+        }
+    }
+
+    #[test]
+    fn test_csel_concrete_smt_parity() {
+        use crate::ir::Condition;
+        use crate::semantics::state::ConditionFlags;
+        // CSEL reads flags + rn/rm and conditionally selects.
+        let instr_eq = Instruction::Csel {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+            cond: Condition::EQ,
+        };
+        let pre_flags = [
+            ConditionFlags {
+                n: false,
+                z: true,
+                c: false,
+                v: false,
+            }, // EQ holds
+            ConditionFlags::default(), // EQ fails
+        ];
+        for pf in &pre_flags {
+            assert_concrete_smt_parity_full(
+                &instr_eq,
+                &[(Register::X1, 0x1111), (Register::X2, 0x2222)],
+                Some(*pf),
+                Some(Register::X0),
+                false,
+            );
+        }
+    }
+
+    #[test]
+    fn test_csinc_concrete_smt_parity() {
+        use crate::ir::Condition;
+        use crate::semantics::state::ConditionFlags;
+        let instr = Instruction::Csinc {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+            cond: Condition::NE,
+        };
+        let pre_flags = [
+            ConditionFlags::default(),
+            ConditionFlags {
+                n: false,
+                z: true,
+                c: false,
+                v: false,
+            },
+        ];
+        for pf in &pre_flags {
+            assert_concrete_smt_parity_full(
+                &instr,
+                &[
+                    (Register::X1, 0x1111),
+                    (Register::X2, 0xFFFF_FFFF_FFFF_FFFF),
+                ],
+                Some(*pf),
+                Some(Register::X0),
+                false,
+            );
+        }
+    }
+
+    #[test]
+    fn test_csinv_concrete_smt_parity() {
+        use crate::ir::Condition;
+        use crate::semantics::state::ConditionFlags;
+        let instr = Instruction::Csinv {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+            cond: Condition::CS,
+        };
+        let pre_flags = [
+            ConditionFlags::default(),
+            ConditionFlags {
+                n: false,
+                z: false,
+                c: true,
+                v: false,
+            },
+        ];
+        for pf in &pre_flags {
+            assert_concrete_smt_parity_full(
+                &instr,
+                &[
+                    (Register::X1, 0xAAAA_AAAA_AAAA_AAAA),
+                    (Register::X2, 0x5555_5555_5555_5555),
+                ],
+                Some(*pf),
+                Some(Register::X0),
+                false,
+            );
+        }
+    }
+
+    #[test]
+    fn test_csneg_concrete_smt_parity() {
+        use crate::ir::Condition;
+        use crate::semantics::state::ConditionFlags;
+        let instr = Instruction::Csneg {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+            cond: Condition::MI,
+        };
+        let pre_flags = [
+            ConditionFlags::default(),
+            ConditionFlags {
+                n: true,
+                z: false,
+                c: false,
+                v: false,
+            },
+        ];
+        for pf in &pre_flags {
+            assert_concrete_smt_parity_full(
+                &instr,
+                &[(Register::X1, 0x1234), (Register::X2, 0x5678_9ABC)],
+                Some(*pf),
+                Some(Register::X0),
+                false,
+            );
+        }
+    }
+
+    #[test]
+    fn test_cset_concrete_smt_parity() {
+        use crate::ir::Condition;
+        use crate::semantics::state::ConditionFlags;
+        let instr = Instruction::Cset {
+            rd: Register::X0,
+            cond: Condition::EQ,
+        };
+        let pre_flags = [
+            ConditionFlags::default(),
+            ConditionFlags {
+                n: false,
+                z: true,
+                c: false,
+                v: false,
+            },
+        ];
+        for pf in &pre_flags {
+            assert_concrete_smt_parity_full(&instr, &[], Some(*pf), Some(Register::X0), false);
+        }
+    }
+
+    #[test]
+    fn test_csetm_concrete_smt_parity() {
+        use crate::ir::Condition;
+        use crate::semantics::state::ConditionFlags;
+        let instr = Instruction::Csetm {
+            rd: Register::X0,
+            cond: Condition::NE,
+        };
+        let pre_flags = [
+            ConditionFlags::default(),
+            ConditionFlags {
+                n: false,
+                z: true,
+                c: false,
+                v: false,
+            },
+        ];
+        for pf in &pre_flags {
+            assert_concrete_smt_parity_full(&instr, &[], Some(*pf), Some(Register::X0), false);
+        }
+    }
+
+    #[test]
+    fn test_ccmp_concrete_smt_parity() {
+        use crate::ir::Condition;
+        use crate::semantics::state::ConditionFlags;
+        // CCMP: if cond holds, run SUB and set NZCV from it; else load nzcv literal.
+        let instr = Instruction::Ccmp {
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+            nzcv: 0b1010, // N=1, Z=0, C=1, V=0
+            cond: Condition::EQ,
+        };
+        let pre_flags = [
+            ConditionFlags {
+                n: false,
+                z: true,
+                c: false,
+                v: false,
+            }, // EQ holds -> use SUB result
+            ConditionFlags::default(), // EQ fails -> use nzcv literal
+        ];
+        let val_samples = [(0u64, 0u64), (5u64, 3u64)];
+        for pf in &pre_flags {
+            for &(v1, v2) in &val_samples {
+                assert_concrete_smt_parity_full(
+                    &instr,
+                    &[(Register::X1, v1), (Register::X2, v2)],
+                    Some(*pf),
+                    None,
+                    true,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_ccmn_concrete_smt_parity() {
+        use crate::ir::Condition;
+        use crate::semantics::state::ConditionFlags;
+        let instr = Instruction::Ccmn {
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+            nzcv: 0b0011,
+            cond: Condition::NE,
+        };
+        let pre_flags = [
+            ConditionFlags::default(),
+            ConditionFlags {
+                n: false,
+                z: true,
+                c: false,
+                v: false,
+            },
+        ];
+        let val_samples = [(0u64, 0u64), (5u64, 3u64)];
+        for pf in &pre_flags {
+            for &(v1, v2) in &val_samples {
+                assert_concrete_smt_parity_full(
+                    &instr,
+                    &[(Register::X1, v1), (Register::X2, v2)],
+                    Some(*pf),
+                    None,
+                    true,
+                );
+            }
         }
     }
 

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -2202,6 +2202,484 @@ mod tests {
     }
 
     #[test]
+    fn test_mov_imm_concrete_smt_parity() {
+        // MOV (immediate alias). imm range is [0, 0xFFFF] per the AArch64
+        // immediate-form spec; the parser refuses anything wider.
+        for imm in &[0_i64, 1, 0x100, 0x1234, 0xFFFF] {
+            let instr = Instruction::MovImm {
+                rd: Register::X0,
+                imm: *imm,
+            };
+            assert_concrete_smt_parity(&instr, &[], Register::X0);
+        }
+    }
+
+    #[test]
+    fn test_mvn_reg_concrete_smt_parity() {
+        let instr = Instruction::Mvn {
+            rd: Register::X0,
+            rm: Register::X1,
+        };
+        for v1 in &[0_u64, 0xFFFF_FFFF_FFFF_FFFF, 0xAAAA_AAAA_AAAA_AAAA, 0xDEAD] {
+            assert_concrete_smt_parity(&instr, &[(Register::X1, *v1)], Register::X0);
+        }
+    }
+
+    #[test]
+    fn test_neg_reg_concrete_smt_parity() {
+        let instr = Instruction::Neg {
+            rd: Register::X0,
+            rm: Register::X1,
+        };
+        for v1 in &[
+            0_u64,
+            1,
+            0xFFFF_FFFF_FFFF_FFFF,
+            0x8000_0000_0000_0000,
+            0xDEAD,
+        ] {
+            assert_concrete_smt_parity(&instr, &[(Register::X1, *v1)], Register::X0);
+        }
+    }
+
+    #[test]
+    fn test_bic_reg_concrete_smt_parity() {
+        let instr = Instruction::Bic {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        };
+        let samples: &[(u64, u64)] = &[
+            (0, 0xFFFF_FFFF_FFFF_FFFF),
+            (0xFFFF_FFFF_FFFF_FFFF, 0xAAAA_AAAA_AAAA_AAAA),
+            (0xDEAD_BEEF_CAFE_BABE, 0x0123_4567_89AB_CDEF),
+        ];
+        for &(v1, v2) in samples {
+            assert_concrete_smt_parity(
+                &instr,
+                &[(Register::X1, v1), (Register::X2, v2)],
+                Register::X0,
+            );
+        }
+    }
+
+    #[test]
+    fn test_orn_reg_concrete_smt_parity() {
+        let instr = Instruction::Orn {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        };
+        let samples: &[(u64, u64)] = &[
+            (0, 0xFFFF_FFFF_FFFF_FFFF),
+            (0xFFFF_FFFF_FFFF_FFFF, 0),
+            (0xDEAD_BEEF_CAFE_BABE, 0x0123_4567_89AB_CDEF),
+        ];
+        for &(v1, v2) in samples {
+            assert_concrete_smt_parity(
+                &instr,
+                &[(Register::X1, v1), (Register::X2, v2)],
+                Register::X0,
+            );
+        }
+    }
+
+    #[test]
+    fn test_eon_reg_concrete_smt_parity() {
+        let instr = Instruction::Eon {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        };
+        let samples: &[(u64, u64)] = &[
+            (0, 0xFFFF_FFFF_FFFF_FFFF),
+            (0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF),
+            (0xDEAD_BEEF_CAFE_BABE, 0x0123_4567_89AB_CDEF),
+        ];
+        for &(v1, v2) in samples {
+            assert_concrete_smt_parity(
+                &instr,
+                &[(Register::X1, v1), (Register::X2, v2)],
+                Register::X0,
+            );
+        }
+    }
+
+    #[test]
+    fn test_ror_imm_concrete_smt_parity() {
+        // ROR: rotate right; concrete uses `rotate_right(amount & 31)` semantics
+        // adjusted for 64-bit (`& 63`). SMT uses bv_ror_64 helper.
+        let values: &[u64] = &[
+            0,
+            1,
+            0xFFFF_FFFF_FFFF_FFFF,
+            0x8000_0000_0000_0000,
+            0x1234_5678_9ABC_DEF0,
+        ];
+        let shifts: &[i64] = &[0, 1, 8, 32, 63];
+        for &v1 in values {
+            for &shift in shifts {
+                let instr = Instruction::Ror {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    shift: Operand::Immediate(shift),
+                };
+                assert_concrete_smt_parity(&instr, &[(Register::X1, v1)], Register::X0);
+            }
+        }
+    }
+
+    #[test]
+    fn test_clz_concrete_smt_parity() {
+        // CLZ: count leading zeros. value=0 returns 64.
+        let instr = Instruction::Clz {
+            rd: Register::X0,
+            rn: Register::X1,
+        };
+        let values: &[u64] = &[
+            0,
+            1,
+            0x8000_0000_0000_0000,
+            0x0000_0000_0000_0080,
+            0x0000_0000_FFFF_FFFF,
+            0xFFFF_FFFF_FFFF_FFFF,
+        ];
+        for &v1 in values {
+            assert_concrete_smt_parity(&instr, &[(Register::X1, v1)], Register::X0);
+        }
+    }
+
+    #[test]
+    fn test_cls_concrete_smt_parity() {
+        // CLS: count leading bits that match the sign bit, excluding the sign
+        // itself. Returns 63 for 0 or all-ones.
+        let instr = Instruction::Cls {
+            rd: Register::X0,
+            rn: Register::X1,
+        };
+        let values: &[u64] = &[
+            0,                     // all zero -> 63
+            0xFFFF_FFFF_FFFF_FFFF, // all one -> 63
+            0x8000_0000_0000_0000, // sign-bit only -> 0
+            0x4000_0000_0000_0000, // alternate sign -> 0
+            0x0000_0000_FFFF_FFFF, // mid run -> 31
+        ];
+        for &v1 in values {
+            assert_concrete_smt_parity(&instr, &[(Register::X1, v1)], Register::X0);
+        }
+    }
+
+    #[test]
+    fn test_rbit_concrete_smt_parity() {
+        let instr = Instruction::Rbit {
+            rd: Register::X0,
+            rn: Register::X1,
+        };
+        for v1 in &[
+            0_u64,
+            1,
+            0xFFFF_FFFF_FFFF_FFFF,
+            0x8000_0000_0000_0000,
+            0x1234_5678_9ABC_DEF0,
+        ] {
+            assert_concrete_smt_parity(&instr, &[(Register::X1, *v1)], Register::X0);
+        }
+    }
+
+    #[test]
+    fn test_rev_concrete_smt_parity() {
+        let instr = Instruction::Rev {
+            rd: Register::X0,
+            rn: Register::X1,
+        };
+        for v1 in &[
+            0_u64,
+            0xFFFF_FFFF_FFFF_FFFF,
+            0x1122_3344_5566_7788,
+            0x0102_0304_0506_0708,
+        ] {
+            assert_concrete_smt_parity(&instr, &[(Register::X1, *v1)], Register::X0);
+        }
+    }
+
+    #[test]
+    fn test_rev32_concrete_smt_parity() {
+        let instr = Instruction::Rev32 {
+            rd: Register::X0,
+            rn: Register::X1,
+        };
+        for v1 in &[
+            0_u64,
+            0xFFFF_FFFF_FFFF_FFFF,
+            0x1122_3344_5566_7788,
+            0xDEAD_BEEF_CAFE_BABE,
+        ] {
+            assert_concrete_smt_parity(&instr, &[(Register::X1, *v1)], Register::X0);
+        }
+    }
+
+    #[test]
+    fn test_rev16_concrete_smt_parity() {
+        let instr = Instruction::Rev16 {
+            rd: Register::X0,
+            rn: Register::X1,
+        };
+        for v1 in &[
+            0_u64,
+            0xFFFF_FFFF_FFFF_FFFF,
+            0x1122_3344_5566_7788,
+            0xDEAD_BEEF_CAFE_BABE,
+        ] {
+            assert_concrete_smt_parity(&instr, &[(Register::X1, *v1)], Register::X0);
+        }
+    }
+
+    #[test]
+    fn test_uxtb_concrete_smt_parity() {
+        let instr = Instruction::Uxtb {
+            rd: Register::X0,
+            rn: Register::X1,
+        };
+        for v1 in &[0_u64, 0x7F, 0x80, 0xFF, 0x1234_5678, 0xFFFF_FFFF_FFFF_FFFF] {
+            assert_concrete_smt_parity(&instr, &[(Register::X1, *v1)], Register::X0);
+        }
+    }
+
+    #[test]
+    fn test_uxth_concrete_smt_parity() {
+        let instr = Instruction::Uxth {
+            rd: Register::X0,
+            rn: Register::X1,
+        };
+        for v1 in &[
+            0_u64,
+            0x7FFF,
+            0x8000,
+            0xFFFF,
+            0x1234_5678,
+            0xFFFF_FFFF_FFFF_FFFF,
+        ] {
+            assert_concrete_smt_parity(&instr, &[(Register::X1, *v1)], Register::X0);
+        }
+    }
+
+    #[test]
+    fn test_sxtb_concrete_smt_parity() {
+        let instr = Instruction::Sxtb {
+            rd: Register::X0,
+            rn: Register::X1,
+        };
+        // 0x7F = +127 stays positive; 0x80 = -128 sign-extends.
+        for v1 in &[0_u64, 0x7F, 0x80, 0xFF, 0x1234_5678, 0xFFFF_FFFF_FFFF_FFFF] {
+            assert_concrete_smt_parity(&instr, &[(Register::X1, *v1)], Register::X0);
+        }
+    }
+
+    #[test]
+    fn test_sxth_concrete_smt_parity() {
+        let instr = Instruction::Sxth {
+            rd: Register::X0,
+            rn: Register::X1,
+        };
+        for v1 in &[
+            0_u64,
+            0x7FFF,
+            0x8000,
+            0xFFFF,
+            0x1234_5678,
+            0xFFFF_FFFF_FFFF_FFFF,
+        ] {
+            assert_concrete_smt_parity(&instr, &[(Register::X1, *v1)], Register::X0);
+        }
+    }
+
+    #[test]
+    fn test_sxtw_concrete_smt_parity() {
+        let instr = Instruction::Sxtw {
+            rd: Register::X0,
+            rn: Register::X1,
+        };
+        for v1 in &[
+            0_u64,
+            0x7FFF_FFFF,
+            0x8000_0000,
+            0xFFFF_FFFF,
+            0x1234_5678_9ABC_DEF0,
+            0xFFFF_FFFF_FFFF_FFFF,
+        ] {
+            assert_concrete_smt_parity(&instr, &[(Register::X1, *v1)], Register::X0);
+        }
+    }
+
+    #[test]
+    fn test_sdiv_concrete_smt_parity() {
+        // SDIV with div-by-zero (concrete returns 0; SMT ite-guards on rhs==0)
+        // and the i64::MIN / -1 overflow case (concrete returns i64::MIN via
+        // checked_div().unwrap_or; SMT bvsdiv wraps the same way).
+        let instr = Instruction::Sdiv {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+        };
+        let samples: &[(u64, u64)] = &[
+            (10, 3),
+            (10, 0),                                        // div-by-zero
+            (0x8000_0000_0000_0000, 0xFFFF_FFFF_FFFF_FFFF), // MIN / -1
+            (0xFFFF_FFFF_FFFF_FFFF, 1),                     // -1 / 1
+            (100, 0xFFFF_FFFF_FFFF_FFFE),                   // pos / -2
+        ];
+        for &(v1, v2) in samples {
+            assert_concrete_smt_parity(
+                &instr,
+                &[(Register::X1, v1), (Register::X2, v2)],
+                Register::X0,
+            );
+        }
+    }
+
+    #[test]
+    fn test_udiv_concrete_smt_parity() {
+        let instr = Instruction::Udiv {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+        };
+        let samples: &[(u64, u64)] = &[
+            (10, 3),
+            (10, 0), // div-by-zero
+            (0xFFFF_FFFF_FFFF_FFFF, 1),
+            (0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF),
+        ];
+        for &(v1, v2) in samples {
+            assert_concrete_smt_parity(
+                &instr,
+                &[(Register::X1, v1), (Register::X2, v2)],
+                Register::X0,
+            );
+        }
+    }
+
+    #[test]
+    fn test_madd_concrete_smt_parity() {
+        let instr = Instruction::Madd {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+            ra: Register::X3,
+        };
+        let samples: &[(u64, u64, u64)] = &[
+            (0, 0, 0),
+            (2, 3, 5),
+            (0xFFFF_FFFF_FFFF_FFFF, 1, 1), // -1*1 + 1 = 0
+            (
+                0x1234_5678_9ABC_DEF0,
+                0x0FED_CBA9_8765_4321,
+                0xDEAD_BEEF_CAFE_BABE,
+            ),
+        ];
+        for &(v1, v2, v3) in samples {
+            assert_concrete_smt_parity(
+                &instr,
+                &[(Register::X1, v1), (Register::X2, v2), (Register::X3, v3)],
+                Register::X0,
+            );
+        }
+    }
+
+    #[test]
+    fn test_msub_concrete_smt_parity() {
+        let instr = Instruction::Msub {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+            ra: Register::X3,
+        };
+        let samples: &[(u64, u64, u64)] = &[
+            (0, 0, 0),
+            (2, 3, 10),
+            (1, 1, 0),
+            (0x1234, 0x5678, 0x9ABC_DEF0),
+        ];
+        for &(v1, v2, v3) in samples {
+            assert_concrete_smt_parity(
+                &instr,
+                &[(Register::X1, v1), (Register::X2, v2), (Register::X3, v3)],
+                Register::X0,
+            );
+        }
+    }
+
+    #[test]
+    fn test_mneg_concrete_smt_parity() {
+        let instr = Instruction::Mneg {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+        };
+        let samples: &[(u64, u64)] = &[
+            (0, 0xFFFF),
+            (2, 3),
+            (0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF),
+            (0x1234, 0x5678),
+        ];
+        for &(v1, v2) in samples {
+            assert_concrete_smt_parity(
+                &instr,
+                &[(Register::X1, v1), (Register::X2, v2)],
+                Register::X0,
+            );
+        }
+    }
+
+    #[test]
+    fn test_smulh_concrete_smt_parity() {
+        // SMULH: high 64 bits of signed 128-bit product.
+        let instr = Instruction::Smulh {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+        };
+        let samples: &[(u64, u64)] = &[
+            (0, 0xFFFF),
+            (1, 1),
+            (0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), // (-1)*(-1) high = 0
+            (0x8000_0000_0000_0000, 0x8000_0000_0000_0000), // MIN*MIN
+            (0x1234_5678_9ABC_DEF0, 0x0FED_CBA9_8765_4321),
+        ];
+        for &(v1, v2) in samples {
+            assert_concrete_smt_parity(
+                &instr,
+                &[(Register::X1, v1), (Register::X2, v2)],
+                Register::X0,
+            );
+        }
+    }
+
+    #[test]
+    fn test_umulh_concrete_smt_parity() {
+        // UMULH: high 64 bits of unsigned 128-bit product.
+        let instr = Instruction::Umulh {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+        };
+        let samples: &[(u64, u64)] = &[
+            (0, 0xFFFF),
+            (1, 1),
+            (0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF),
+            (0x8000_0000_0000_0000, 2),
+            (0x1234_5678_9ABC_DEF0, 0x0FED_CBA9_8765_4321),
+        ];
+        for &(v1, v2) in samples {
+            assert_concrete_smt_parity(
+                &instr,
+                &[(Register::X1, v1), (Register::X2, v2)],
+                Register::X0,
+            );
+        }
+    }
+
+    #[test]
     fn test_asr_imm_concrete_smt_parity() {
         // ASR is sign-sensitive: concrete (concrete.rs:96-101) routes through
         // `as_i64() >> shift` then back to u64; SMT uses Z3 `bvashr` which

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -1886,4 +1886,124 @@ mod tests {
         solver.assert(&neq);
         assert_eq!(solver.check(), SatResult::Unsat);
     }
+
+    // Issue #77 Stage 1 / Step 2 safety nets:
+    // per-opcode concrete-vs-SMT parity tests. Each test pins symbolic pre-state
+    // values to sampled concrete inputs, runs both interpreters, and asserts
+    // Z3 forces the symbolic post-state to agree with the concrete result.
+    // The width-aware refactor in Stage 1 Step 6 must keep these passing.
+
+    /// Pin every (register, value) in `pre_values` on both the concrete and
+    /// symbolic pre-state, run each interpreter on `instr`, and assert Z3 is
+    /// forced to agree with the concrete result for `dest`.
+    fn assert_concrete_smt_parity(
+        instr: &Instruction,
+        pre_values: &[(Register, u64)],
+        dest: Register,
+    ) {
+        use crate::semantics::concrete::apply_instruction_concrete;
+        use crate::semantics::state::{ConcreteMachineState, ConcreteValue};
+
+        let mut concrete_pre = ConcreteMachineState::new_zeroed();
+        for &(reg, val) in pre_values {
+            concrete_pre.set_register(reg, ConcreteValue::new(val));
+        }
+        let concrete_post = apply_instruction_concrete(concrete_pre, instr);
+        let concrete_dest = concrete_post.get_register(dest).as_u64();
+
+        let symbolic_pre = MachineState::new_symbolic("pre");
+        let solver = Solver::new();
+        for &(reg, val) in pre_values {
+            solver.assert(&symbolic_pre.get_register(reg).eq(&BV::from_u64(val, 64)));
+        }
+        let symbolic_post = apply_instruction(symbolic_pre, instr);
+        solver.assert(
+            &symbolic_post
+                .get_register(dest)
+                .eq(&BV::from_u64(concrete_dest, 64))
+                .not(),
+        );
+
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "concrete/SMT parity violation: {:?} with pre={:x?} yields concrete \
+             {}={:#018x}, but SMT permits a different value",
+            instr,
+            pre_values,
+            dest,
+            concrete_dest,
+        );
+    }
+
+    #[test]
+    fn test_mov_reg_concrete_smt_parity() {
+        let instr = Instruction::MovReg {
+            rd: Register::X0,
+            rn: Register::X1,
+        };
+        let samples: &[u64] = &[
+            0,
+            1,
+            0xFFFF_FFFF_FFFF_FFFF,
+            0x8000_0000_0000_0000,
+            0x1234_5678_9ABC_DEF0,
+        ];
+        for &v1 in samples {
+            assert_concrete_smt_parity(&instr, &[(Register::X1, v1)], Register::X0);
+        }
+    }
+
+    #[test]
+    fn test_add_reg_concrete_smt_parity() {
+        let instr = Instruction::Add {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        };
+        // Pairs chosen to exercise: zero, wraparound across 2^64, sign-flip,
+        // and a generic non-canonical pair.
+        let samples: &[(u64, u64)] = &[
+            (0, 0),
+            (1, 0xFFFF_FFFF_FFFF_FFFF),
+            (0x8000_0000_0000_0000, 0x8000_0000_0000_0000),
+            (0xDEAD_BEEF_CAFE_BABE, 0x0123_4567_89AB_CDEF),
+        ];
+        for &(v1, v2) in samples {
+            assert_concrete_smt_parity(
+                &instr,
+                &[(Register::X1, v1), (Register::X2, v2)],
+                Register::X0,
+            );
+        }
+    }
+
+    #[test]
+    fn test_lsl_imm_concrete_smt_parity() {
+        // LSL is width-sensitive: concrete (concrete.rs:84-88) masks the shift
+        // amount with `& 63` before applying. SMT relies on Z3 bvshl with a
+        // 64-bit shift operand. For shift in [0, 63] the two paths agree; the
+        // width-aware refactor in Step 6 must preserve that. Shift values >= 64
+        // are a known latent divergence in the SMT lowering (Z3 bvshl returns 0
+        // while AArch64 architecturally shifts by `shift & 63`) and are NOT
+        // tested here; addressing it is out of scope for the NFC stage.
+        let values: &[u64] = &[
+            0,
+            1,
+            0xFFFF_FFFF_FFFF_FFFF,
+            0x8000_0000_0000_0000,
+            0x1234_5678_9ABC_DEF0,
+        ];
+        let shifts: &[i64] = &[0, 1, 5, 16, 32, 63];
+        for &v1 in values {
+            for &shift in shifts {
+                let instr = Instruction::Lsl {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    shift: Operand::Immediate(shift),
+                };
+                assert_concrete_smt_parity(&instr, &[(Register::X1, v1)], Register::X0);
+            }
+        }
+    }
 }

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -1979,6 +1979,95 @@ mod tests {
     }
 
     #[test]
+    fn test_sub_reg_concrete_smt_parity() {
+        let instr = Instruction::Sub {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        };
+        // Underflow, equal-args (zero result), sign-flip, and a generic pair.
+        let samples: &[(u64, u64)] = &[
+            (0, 1),
+            (0x1234_5678_9ABC_DEF0, 0x1234_5678_9ABC_DEF0),
+            (0x8000_0000_0000_0000, 0xFFFF_FFFF_FFFF_FFFF),
+            (0xDEAD_BEEF_CAFE_BABE, 0x0123_4567_89AB_CDEF),
+        ];
+        for &(v1, v2) in samples {
+            assert_concrete_smt_parity(
+                &instr,
+                &[(Register::X1, v1), (Register::X2, v2)],
+                Register::X0,
+            );
+        }
+    }
+
+    #[test]
+    fn test_and_reg_concrete_smt_parity() {
+        let instr = Instruction::And {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        };
+        let samples: &[(u64, u64)] = &[
+            (0, 0xFFFF_FFFF_FFFF_FFFF),
+            (0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF),
+            (0xAAAA_AAAA_AAAA_AAAA, 0x5555_5555_5555_5555),
+            (0xDEAD_BEEF_CAFE_BABE, 0x0123_4567_89AB_CDEF),
+        ];
+        for &(v1, v2) in samples {
+            assert_concrete_smt_parity(
+                &instr,
+                &[(Register::X1, v1), (Register::X2, v2)],
+                Register::X0,
+            );
+        }
+    }
+
+    #[test]
+    fn test_orr_reg_concrete_smt_parity() {
+        let instr = Instruction::Orr {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        };
+        let samples: &[(u64, u64)] = &[
+            (0, 0),
+            (0xAAAA_AAAA_AAAA_AAAA, 0x5555_5555_5555_5555),
+            (0x8000_0000_0000_0000, 0x0000_0000_0000_0001),
+            (0xDEAD_BEEF_CAFE_BABE, 0x0123_4567_89AB_CDEF),
+        ];
+        for &(v1, v2) in samples {
+            assert_concrete_smt_parity(
+                &instr,
+                &[(Register::X1, v1), (Register::X2, v2)],
+                Register::X0,
+            );
+        }
+    }
+
+    #[test]
+    fn test_eor_reg_concrete_smt_parity() {
+        let instr = Instruction::Eor {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        };
+        let samples: &[(u64, u64)] = &[
+            (0, 0),
+            (0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF),
+            (0xAAAA_AAAA_AAAA_AAAA, 0x5555_5555_5555_5555),
+            (0xDEAD_BEEF_CAFE_BABE, 0x0123_4567_89AB_CDEF),
+        ];
+        for &(v1, v2) in samples {
+            assert_concrete_smt_parity(
+                &instr,
+                &[(Register::X1, v1), (Register::X2, v2)],
+                Register::X0,
+            );
+        }
+    }
+
+    #[test]
     fn test_lsl_imm_concrete_smt_parity() {
         // LSL is width-sensitive: concrete (concrete.rs:84-88) masks the shift
         // amount with `& 63` before applying. SMT relies on Z3 bvshl with a
@@ -1998,6 +2087,137 @@ mod tests {
         for &v1 in values {
             for &shift in shifts {
                 let instr = Instruction::Lsl {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    shift: Operand::Immediate(shift),
+                };
+                assert_concrete_smt_parity(&instr, &[(Register::X1, v1)], Register::X0);
+            }
+        }
+    }
+
+    #[test]
+    fn test_lsr_imm_concrete_smt_parity() {
+        // Mirror of LSL but logical right shift (no sign extension).
+        let values: &[u64] = &[
+            0,
+            1,
+            0xFFFF_FFFF_FFFF_FFFF,
+            0x8000_0000_0000_0000,
+            0x1234_5678_9ABC_DEF0,
+        ];
+        let shifts: &[i64] = &[0, 1, 5, 16, 32, 63];
+        for &v1 in values {
+            for &shift in shifts {
+                let instr = Instruction::Lsr {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    shift: Operand::Immediate(shift),
+                };
+                assert_concrete_smt_parity(&instr, &[(Register::X1, v1)], Register::X0);
+            }
+        }
+    }
+
+    #[test]
+    fn test_mul_reg_concrete_smt_parity() {
+        // wrapping_mul on the concrete side, Z3 bvmul on the symbolic side.
+        // Samples include zero-mul, identity, MSB sign-bit, and overflow pair.
+        let instr = Instruction::Mul {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+        };
+        let samples: &[(u64, u64)] = &[
+            (0, 0xDEAD_BEEF_CAFE_BABE),
+            (1, 0xDEAD_BEEF_CAFE_BABE),
+            (0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF), // (-1) * (-1) = 1 in wrapping
+            (0x8000_0000_0000_0000, 0x0000_0000_0000_0002), // overflow
+            (0x1234_5678_9ABC_DEF0, 0x0FED_CBA9_8765_4321),
+        ];
+        for &(v1, v2) in samples {
+            assert_concrete_smt_parity(
+                &instr,
+                &[(Register::X1, v1), (Register::X2, v2)],
+                Register::X0,
+            );
+        }
+    }
+
+    #[test]
+    fn test_movz_imm_concrete_smt_parity() {
+        // MOVZ: rd = (imm as u64) << shift, all other lanes zero.
+        // Shift legality is parser-enforced as {0, 16, 32, 48}; we exercise
+        // each lane to catch any width-related lowering bug.
+        let imms: &[u16] = &[0, 1, 0x1234, 0xFFFF];
+        let shifts: &[u8] = &[0, 16, 32, 48];
+        for &imm in imms {
+            for &shift in shifts {
+                let instr = Instruction::MovZ {
+                    rd: Register::X0,
+                    imm,
+                    shift,
+                };
+                assert_concrete_smt_parity(&instr, &[], Register::X0);
+            }
+        }
+    }
+
+    #[test]
+    fn test_movn_imm_concrete_smt_parity() {
+        // MOVN: rd = !((imm as u64) << shift).
+        let imms: &[u16] = &[0, 1, 0x1234, 0xFFFF];
+        let shifts: &[u8] = &[0, 16, 32, 48];
+        for &imm in imms {
+            for &shift in shifts {
+                let instr = Instruction::MovN {
+                    rd: Register::X0,
+                    imm,
+                    shift,
+                };
+                assert_concrete_smt_parity(&instr, &[], Register::X0);
+            }
+        }
+    }
+
+    #[test]
+    fn test_movk_imm_concrete_smt_parity() {
+        // MOVK reads rd before writing one 16-bit chunk. We need to pin a
+        // pre-value on X0 so concrete and SMT agree on the kept lanes.
+        let pre_values: &[u64] = &[0, 0xFFFF_FFFF_FFFF_FFFF, 0xAAAA_BBBB_CCCC_DDDD];
+        let imms: &[u16] = &[0, 0x1234, 0xFFFF];
+        let shifts: &[u8] = &[0, 16, 32, 48];
+        for &pre in pre_values {
+            for &imm in imms {
+                for &shift in shifts {
+                    let instr = Instruction::MovK {
+                        rd: Register::X0,
+                        imm,
+                        shift,
+                    };
+                    assert_concrete_smt_parity(&instr, &[(Register::X0, pre)], Register::X0);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_asr_imm_concrete_smt_parity() {
+        // ASR is sign-sensitive: concrete (concrete.rs:96-101) routes through
+        // `as_i64() >> shift` then back to u64; SMT uses Z3 `bvashr` which
+        // sign-preserves. Negative inputs (MSB set) must keep the sign bit.
+        let values: &[u64] = &[
+            0,
+            1,
+            0xFFFF_FFFF_FFFF_FFFF, // -1 signed
+            0x8000_0000_0000_0000, // i64::MIN
+            0x4000_0000_0000_0000, // positive, MSB-1 set
+            0x1234_5678_9ABC_DEF0,
+        ];
+        let shifts: &[i64] = &[0, 1, 5, 16, 32, 63];
+        for &v1 in values {
+            for &shift in shifts {
+                let instr = Instruction::Asr {
                     rd: Register::X0,
                     rn: Register::X1,
                     shift: Operand::Immediate(shift),

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -11,11 +11,14 @@ use z3::{Params, Solver};
 
 /// Reverse the byte order of a 64-bit BV by concatenating its 8 byte slices
 /// with byte 0 placed in the most-significant position.
-fn bv_swap_bytes_64(value: &BV) -> BV {
-    // Place byte 0 (originally at bits [7:0]) at the new top, byte 7
-    // (originally at bits [63:56]) at the new bottom.
+/// Reverse the byte order of a `width`-bit BV by concatenating its byte
+/// slices with byte 0 placed in the most-significant position. `width` must
+/// be a multiple of 8.
+fn bv_swap_bytes(value: &BV, width: u32) -> BV {
+    debug_assert!(width % 8 == 0, "bv_swap_bytes requires byte-multiple width");
+    let num_bytes = width / 8;
     let mut result = value.extract(7, 0);
-    for i in 1..8u32 {
+    for i in 1..num_bytes {
         let lo = i * 8;
         let hi = lo + 7;
         result = result.concat(&value.extract(hi, lo));
@@ -23,48 +26,49 @@ fn bv_swap_bytes_64(value: &BV) -> BV {
     result
 }
 
-/// 64-bit ROR composed as `(value lshr n) | (value shl (64 - n))`.
-/// Caller is responsible for masking `n` to 6 bits when needed (immediate
-/// callers with `n` already in 0..=63 may skip the mask).
+/// `width`-bit ROR composed as `(value lshr n) | (value shl (width - n))`.
+/// Caller is responsible for masking `n` to `log2(width)` bits when needed
+/// (immediate callers with `n` already in `0..width` may skip the mask).
 ///
-/// Edge case at n == 0: `complement` evaluates to 64, and SMTLIB2 bit-vector
-/// semantics define `bvshl(x, 64) = 0` (any shift ≥ the bit-width zeroes the
-/// value). So `hi = 0` and the result is just `value lshr 0 = value`.
-fn bv_ror_64(value: &BV, n: &BV) -> BV {
-    let mask = BV::from_u64(63, 64);
+/// Edge case at n == 0: `complement` evaluates to `width`, and SMTLIB2
+/// bit-vector semantics define `bvshl(x, width) = 0` (any shift ≥ the
+/// bit-width zeroes the value). So `hi = 0` and the result is just
+/// `value lshr 0 = value`.
+fn bv_ror(value: &BV, n: &BV, width: u32) -> BV {
+    let mask = BV::from_u64((width - 1) as u64, width);
     let n_masked = n.bvand(&mask);
-    let sixty_four = BV::from_u64(64, 64);
-    let complement = sixty_four.bvsub(&n_masked);
+    let width_const = BV::from_u64(width as u64, width);
+    let complement = width_const.bvsub(&n_masked);
     let lo = value.bvlshr(&n_masked);
     let hi = value.bvshl(&complement);
     lo.bvor(&hi)
 }
 
-/// Reverse the bit order of a 64-bit BV via 64 single-bit extracts.
-fn bv_reverse_bits_64(value: &BV) -> BV {
-    // Bit 0 of `value` becomes the new MSB; bit 63 becomes the new LSB.
+/// Reverse the bit order of a `width`-bit BV via single-bit extracts.
+fn bv_reverse_bits(value: &BV, width: u32) -> BV {
+    // Bit 0 of `value` becomes the new MSB; bit width-1 becomes the new LSB.
     let mut result = value.extract(0, 0);
-    for i in 1..64u32 {
+    for i in 1..width {
         result = result.concat(&value.extract(i, i));
     }
     result
 }
 
-/// Count leading zeros of a 64-bit BV using a nested ITE chain.
+/// Count leading zeros of a `width`-bit BV using a nested ITE chain.
 /// Iterates bit positions from LSB upward; later iterations overwrite the
 /// result when their bit is set, so the final result is the CLZ of the
 /// input — the number of leading zeros — derived from the highest-set-bit
-/// position found (or 64 if no bit is set).
+/// position found (or `width` if no bit is set).
 //
-// TODO(#112): replace this 64-deep ITE chain with an O(log n) binary-search
-// decomposition (top-32 / top-16 / … / top-1) to reduce Z3 formula depth.
-fn bv_clz_64(value: &BV) -> BV {
-    let mut result = BV::from_u64(64, 64);
+// TODO(#112): replace this width-deep ITE chain with an O(log n) binary-search
+// decomposition (top-W/2 / top-W/4 / … / top-1) to reduce Z3 formula depth.
+fn bv_clz(value: &BV, width: u32) -> BV {
+    let mut result = BV::from_u64(width as u64, width);
     let one_bit = BV::from_u64(1, 1);
-    for pos in 0..64u32 {
+    for pos in 0..width {
         let bit = value.extract(pos, pos);
         let is_set = bit.eq(&one_bit);
-        let clz_if_top = BV::from_u64(63 - pos as u64, 64);
+        let clz_if_top = BV::from_u64((width - 1 - pos) as u64, width);
         result = is_set.ite(&clz_if_top, &result);
     }
     result
@@ -117,36 +121,41 @@ pub fn create_solver_with_config(cfg: &SolverConfig) -> Solver {
     solver
 }
 
-/// Machine state representation for SMT solving
+/// Machine state representation for SMT solving.
+///
+/// Carries a `width` field per ADR-0004 decision 1; AArch64 is always
+/// width=64. All register BVs in `registers` are `width` bits wide.
 #[derive(Clone)]
 pub struct MachineState {
-    /// Register values as 64-bit bitvectors
+    /// Register values as `width`-bit bitvectors
     pub registers: HashMap<Register, BV>,
     /// NZCV condition flags as 1-bit bitvectors
     pub n: BV,
     pub z: BV,
     pub c: BV,
     pub v: BV,
+    width: u32,
 }
 
 impl MachineState {
-    /// Create a new symbolic machine state
+    /// Create a new symbolic AArch64 machine state (width=64).
     pub fn new_symbolic(prefix: &str) -> Self {
+        Self::new_symbolic_for_width(prefix, 64)
+    }
+
+    /// Create a new symbolic machine state with the given register width.
+    pub fn new_symbolic_for_width(prefix: &str, width: u32) -> Self {
         let mut registers = HashMap::new();
 
-        // Create symbolic variables for all registers
         for i in 0..=30 {
             if let Some(reg) = Register::from_index(i) {
                 let name = format!("{}_x{}", prefix, i);
-                registers.insert(reg, BV::new_const(name, 64));
+                registers.insert(reg, BV::new_const(name, width));
             }
         }
 
-        // XZR is always zero
-        registers.insert(Register::XZR, BV::from_i64(0, 64));
-
-        // SP is also symbolic
-        registers.insert(Register::SP, BV::new_const(format!("{}_sp", prefix), 64));
+        registers.insert(Register::XZR, BV::from_i64(0, width));
+        registers.insert(Register::SP, BV::new_const(format!("{}_sp", prefix), width));
 
         let n = BV::new_const(format!("{}_n", prefix), 1);
         let z = BV::new_const(format!("{}_z", prefix), 1);
@@ -159,7 +168,13 @@ impl MachineState {
             z,
             c,
             v,
+            width,
         }
+    }
+
+    /// Register bit width this state was constructed with.
+    pub fn width(&self) -> u32 {
+        self.width
     }
 
     /// Get the value of a register
@@ -192,15 +207,15 @@ impl MachineState {
     pub fn eval_operand(&self, operand: &Operand) -> BV {
         match operand {
             Operand::Register(reg) => self.get_register(*reg).clone(),
-            Operand::Immediate(imm) => BV::from_i64(*imm, 64),
+            Operand::Immediate(imm) => BV::from_i64(*imm, self.width),
             Operand::ShiftedRegister { reg, kind, amount } => {
                 let value = self.get_register(*reg).clone();
-                let amt = BV::from_u64(*amount as u64, 64);
+                let amt = BV::from_u64(*amount as u64, self.width);
                 match kind {
                     crate::ir::ShiftKind::Lsl => value.bvshl(&amt),
                     crate::ir::ShiftKind::Lsr => value.bvlshr(&amt),
                     crate::ir::ShiftKind::Asr => value.bvashr(&amt),
-                    crate::ir::ShiftKind::Ror => bv_ror_64(&value, &amt),
+                    crate::ir::ShiftKind::Ror => bv_ror(&value, &amt, self.width),
                 }
             }
             // Issue #60: ExtendedRegister extracts the low N bits, then
@@ -220,7 +235,7 @@ impl MachineState {
                 if *shift == 0 {
                     extended
                 } else {
-                    extended.bvshl(BV::from_u64(*shift as u64, 64))
+                    extended.bvshl(BV::from_u64(*shift as u64, self.width))
                 }
             }
         }
@@ -238,37 +253,39 @@ fn bv_zero() -> BV {
     BV::from_u64(0, 1)
 }
 
-/// Compute symbolic NZCV for the subtraction `lhs - rhs`. Mirrors
-/// `ConditionFlags::from_sub` in `state.rs` bit-for-bit.
-pub fn compute_flags_sub(lhs: &BV, rhs: &BV) -> Nzcv {
+/// Compute symbolic NZCV for the subtraction `lhs - rhs` at width `width`.
+/// Mirrors `ConditionFlags::from_sub` in `state.rs` bit-for-bit.
+pub fn compute_flags_sub(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
     let result = lhs.bvsub(rhs);
-    let zero64 = BV::from_u64(0, 64);
-    let n = result.extract(63, 63);
-    let z = result.eq(&zero64).ite(&bv_one(), &bv_zero());
+    let zero = BV::from_u64(0, width);
+    let msb = width - 1;
+    let n = result.extract(msb, msb);
+    let z = result.eq(&zero).ite(&bv_one(), &bv_zero());
     let c = lhs.bvuge(rhs).ite(&bv_one(), &bv_zero());
     // Signed overflow on subtraction: (lhs and rhs differ in sign) AND
     // (lhs and result differ in sign).
-    let lhs_sign = lhs.extract(63, 63);
-    let rhs_sign = rhs.extract(63, 63);
-    let res_sign = result.extract(63, 63);
+    let lhs_sign = lhs.extract(msb, msb);
+    let rhs_sign = rhs.extract(msb, msb);
+    let res_sign = result.extract(msb, msb);
     let v = lhs_sign.bvxor(&rhs_sign).bvand(&lhs_sign.bvxor(&res_sign));
     (n, z, c, v)
 }
 
-/// Compute symbolic NZCV for the addition `lhs + rhs`. Mirrors
-/// `ConditionFlags::from_add` in `state.rs`.
-pub fn compute_flags_add(lhs: &BV, rhs: &BV) -> Nzcv {
+/// Compute symbolic NZCV for the addition `lhs + rhs` at width `width`.
+/// Mirrors `ConditionFlags::from_add` in `state.rs`.
+pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
     let result = lhs.bvadd(rhs);
-    let zero64 = BV::from_u64(0, 64);
-    let n = result.extract(63, 63);
-    let z = result.eq(&zero64).ite(&bv_one(), &bv_zero());
+    let zero = BV::from_u64(0, width);
+    let msb = width - 1;
+    let n = result.extract(msb, msb);
+    let z = result.eq(&zero).ite(&bv_one(), &bv_zero());
     // Carry on add: result < lhs (unsigned).
     let c = result.bvult(lhs).ite(&bv_one(), &bv_zero());
     // Signed overflow on add: (lhs and rhs share sign) AND (lhs and result
     // differ in sign).
-    let lhs_sign = lhs.extract(63, 63);
-    let rhs_sign = rhs.extract(63, 63);
-    let res_sign = result.extract(63, 63);
+    let lhs_sign = lhs.extract(msb, msb);
+    let rhs_sign = rhs.extract(msb, msb);
+    let res_sign = result.extract(msb, msb);
     let one_bit = bv_one();
     let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&one_bit); // 1 when signs match
     let signs_flip = lhs_sign.bvxor(&res_sign); // 1 when lhs and result differ
@@ -287,12 +304,13 @@ pub fn nzcv_to_bvs(byte: u8) -> Nzcv {
     )
 }
 
-/// Compute symbolic NZCV for a logical (AND/ORR/EOR/TST) result. C and V are
-/// always cleared per the AArch64 ARM.
-pub fn compute_flags_logical(result: &BV) -> Nzcv {
-    let zero64 = BV::from_u64(0, 64);
-    let n = result.extract(63, 63);
-    let z = result.eq(&zero64).ite(&bv_one(), &bv_zero());
+/// Compute symbolic NZCV for a logical (AND/ORR/EOR/TST) result at width
+/// `width`. C and V are always cleared per the AArch64 ARM.
+pub fn compute_flags_logical(result: &BV, width: u32) -> Nzcv {
+    let zero = BV::from_u64(0, width);
+    let msb = width - 1;
+    let n = result.extract(msb, msb);
+    let z = result.eq(&zero).ite(&bv_one(), &bv_zero());
     (n, z, bv_zero(), bv_zero())
 }
 
@@ -335,13 +353,14 @@ pub fn condition_to_smt(cond: crate::ir::types::Condition, n: &BV, z: &BV, c: &B
 
 /// Apply an instruction to a machine state, returning the new state
 pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> MachineState {
+    let width = state.width();
     match instruction {
         Instruction::MovReg { rd, rn } => {
             let value = state.get_register(*rn).clone();
             state.set_register(*rd, value);
         }
         Instruction::MovImm { rd, imm } => {
-            let value = BV::from_i64(*imm, 64);
+            let value = BV::from_i64(*imm, width);
             state.set_register(*rd, value);
         }
         Instruction::Add { rd, rn, rm } => {
@@ -404,7 +423,7 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
         Instruction::Sdiv { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
-            let zero = BV::from_i64(0, 64);
+            let zero = BV::from_i64(0, width);
             let is_zero = rhs.eq(&zero);
             // AArch64: division by zero returns 0
             // For overflow case (MIN / -1), we handle it with bvsdiv which wraps correctly
@@ -415,7 +434,7 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
         Instruction::Udiv { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
-            let zero = BV::from_u64(0, 64);
+            let zero = BV::from_u64(0, width);
             let is_zero = rhs.eq(&zero);
             // AArch64: division by zero returns 0
             let div_result = lhs.bvudiv(&rhs);
@@ -440,37 +459,37 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             state.set_register(*rd, a.bvmul(&b).bvneg());
         }
         Instruction::Smulh { rd, rn, rm } => {
-            // 64-bit sign-extend to 128, multiply, extract upper 64 bits.
-            let a = state.get_register(*rn).sign_ext(64);
-            let b = state.get_register(*rm).sign_ext(64);
+            // `width`-bit sign-extend to 2*width, multiply, extract upper width bits.
+            let a = state.get_register(*rn).sign_ext(width);
+            let b = state.get_register(*rm).sign_ext(width);
             let prod = a.bvmul(&b);
-            state.set_register(*rd, prod.extract(127, 64));
+            state.set_register(*rd, prod.extract(2 * width - 1, width));
         }
         Instruction::Umulh { rd, rn, rm } => {
-            // 64-bit zero-extend to 128, multiply, extract upper 64 bits.
-            let a = state.get_register(*rn).zero_ext(64);
-            let b = state.get_register(*rm).zero_ext(64);
+            // `width`-bit zero-extend to 2*width, multiply, extract upper width bits.
+            let a = state.get_register(*rn).zero_ext(width);
+            let b = state.get_register(*rm).zero_ext(width);
             let prod = a.bvmul(&b);
-            state.set_register(*rd, prod.extract(127, 64));
+            state.set_register(*rd, prod.extract(2 * width - 1, width));
         }
         // Comparison instructions set flags and don't modify registers.
         Instruction::Cmp { rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.eval_operand(rm);
-            let (n, z, c, v) = compute_flags_sub(&lhs, &rhs);
+            let (n, z, c, v) = compute_flags_sub(&lhs, &rhs, width);
             state.set_flags(n, z, c, v);
         }
         Instruction::Cmn { rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.eval_operand(rm);
-            let (n, z, c, v) = compute_flags_add(&lhs, &rhs);
+            let (n, z, c, v) = compute_flags_add(&lhs, &rhs, width);
             state.set_flags(n, z, c, v);
         }
         Instruction::Tst { rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.eval_operand(rm);
             let result = lhs.bvand(&rhs);
-            let (n, z, c, v) = compute_flags_logical(&result);
+            let (n, z, c, v) = compute_flags_logical(&result, width);
             state.set_flags(n, z, c, v);
         }
         // CCMP / CCMN: ITE between freshly-computed sub/add NZCV (true branch)
@@ -479,7 +498,7 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
         Instruction::Ccmp { rn, rm, nzcv, cond } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.eval_operand(rm);
-            let (n_t, z_t, c_t, v_t) = compute_flags_sub(&lhs, &rhs);
+            let (n_t, z_t, c_t, v_t) = compute_flags_sub(&lhs, &rhs, width);
             let pred =
                 condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
             let (n_f, z_f, c_f, v_f) = nzcv_to_bvs(*nzcv);
@@ -493,7 +512,7 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
         Instruction::Ccmn { rn, rm, nzcv, cond } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.eval_operand(rm);
-            let (n_t, z_t, c_t, v_t) = compute_flags_add(&lhs, &rhs);
+            let (n_t, z_t, c_t, v_t) = compute_flags_add(&lhs, &rhs, width);
             let pred =
                 condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
             let (n_f, z_f, c_f, v_f) = nzcv_to_bvs(*nzcv);
@@ -515,7 +534,7 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
         }
         Instruction::Csinc { rd, rn, rm, cond } => {
             let rn_v = state.get_register(*rn).clone();
-            let rm_plus_one = state.get_register(*rm).bvadd(&BV::from_u64(1, 64));
+            let rm_plus_one = state.get_register(*rm).bvadd(&BV::from_u64(1, width));
             let pred =
                 condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
             state.set_register(*rd, pred.ite(&rn_v, &rm_plus_one));
@@ -545,27 +564,27 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
         // NEGS = SUBS rd, XZR, rm — write rd and the resulting NZCV.
         Instruction::Negs { rd, rm } => {
             let rhs = state.get_register(*rm).clone();
-            let zero = BV::from_u64(0, 64);
+            let zero = BV::from_u64(0, width);
             let value = zero.bvsub(&rhs);
-            let (n, z, c, v) = compute_flags_sub(&zero, &rhs);
+            let (n, z, c, v) = compute_flags_sub(&zero, &rhs, width);
             state.set_register(*rd, value);
             state.set_flags(n, z, c, v);
         }
         Instruction::MovN { rd, imm, shift } => {
             let value = !((*imm as u64) << (*shift as u32));
-            state.set_register(*rd, BV::from_u64(value, 64));
+            state.set_register(*rd, BV::from_u64(value, width));
         }
         Instruction::MovZ { rd, imm, shift } => {
             let value = (*imm as u64) << (*shift as u32);
-            state.set_register(*rd, BV::from_u64(value, 64));
+            state.set_register(*rd, BV::from_u64(value, width));
         }
         // MOVK keeps the 48 unwritten bits of rd. Encode as
         // `(rd_old & ~mask) | new_chunk` so the solver sees the data-flow
         // dependence on the prior rd value.
         Instruction::MovK { rd, imm, shift } => {
             let prev = state.get_register(*rd).clone();
-            let mask = BV::from_u64(!(0xFFFF_u64 << (*shift as u32)), 64);
-            let new_chunk = BV::from_u64((*imm as u64) << (*shift as u32), 64);
+            let mask = BV::from_u64(!(0xFFFF_u64 << (*shift as u32)), width);
+            let new_chunk = BV::from_u64((*imm as u64) << (*shift as u32), width);
             let result = prev.bvand(&mask).bvor(&new_chunk);
             state.set_register(*rd, result);
         }
@@ -581,7 +600,7 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.eval_operand(rm);
             let result = lhs.bvand(rhs.bvnot());
-            let (n, z, c, v) = compute_flags_logical(&result);
+            let (n, z, c, v) = compute_flags_logical(&result, width);
             state.set_register(*rd, result);
             state.set_flags(n, z, c, v);
         }
@@ -602,14 +621,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
         Instruction::Adds { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.eval_operand(rm);
-            let (n, z, c, v) = compute_flags_add(&lhs, &rhs);
+            let (n, z, c, v) = compute_flags_add(&lhs, &rhs, width);
             state.set_register(*rd, lhs.bvadd(&rhs));
             state.set_flags(n, z, c, v);
         }
         Instruction::Subs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.eval_operand(rm);
-            let (n, z, c, v) = compute_flags_sub(&lhs, &rhs);
+            let (n, z, c, v) = compute_flags_sub(&lhs, &rhs, width);
             state.set_register(*rd, lhs.bvsub(&rhs));
             state.set_flags(n, z, c, v);
         }
@@ -617,7 +636,7 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.eval_operand(rm);
             let result = lhs.bvand(&rhs);
-            let (n, z, c, v) = compute_flags_logical(&result);
+            let (n, z, c, v) = compute_flags_logical(&result, width);
             state.set_register(*rd, result);
             state.set_flags(n, z, c, v);
         }
@@ -625,53 +644,51 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
         Instruction::Cset { rd, cond } => {
             let pred =
                 condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
-            let one64 = BV::from_u64(1, 64);
-            let zero64 = BV::from_u64(0, 64);
-            state.set_register(*rd, pred.ite(&one64, &zero64));
+            let one = BV::from_u64(1, width);
+            let zero = BV::from_u64(0, width);
+            state.set_register(*rd, pred.ite(&one, &zero));
         }
         Instruction::Csetm { rd, cond } => {
             let pred =
                 condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
-            let ones = BV::from_u64(u64::MAX, 64);
-            let zero64 = BV::from_u64(0, 64);
-            state.set_register(*rd, pred.ite(&ones, &zero64));
+            let ones = BV::from_i64(-1, width); // all-ones at any width
+            let zero = BV::from_u64(0, width);
+            state.set_register(*rd, pred.ite(&ones, &zero));
         }
-        // ROR: composed via bv_ror_64 (see helper at top of file for the
-        // edge-case discussion at n == 0).
+        // ROR: composed via the width-aware bv_ror helper.
         Instruction::Ror { rd, rn, shift } => {
             let value = state.get_register(*rn).clone();
             let n = state.eval_operand(shift);
-            state.set_register(*rd, bv_ror_64(&value, &n));
+            state.set_register(*rd, bv_ror(&value, &n, width));
         }
-        // CLZ: count leading zero bits; returns 64 when the value is zero.
+        // CLZ: count leading zero bits; returns `width` when the value is zero.
         Instruction::Clz { rd, rn } => {
             let value = state.get_register(*rn).clone();
-            state.set_register(*rd, bv_clz_64(&value));
+            state.set_register(*rd, bv_clz(&value, width));
         }
         // CLS: count leading sign-bit replicas (excluding the sign bit).
-        // Fold the sign bit out via `x XOR (x ASR 63)` so the answer reduces
-        // to `clz(folded) - 1`. Bit 63 of `folded` is always 0 (a positive
-        // sign cancels its own top bit; a negative sign inverts it to 0),
-        // so `bv_clz_64(folded) ∈ [1, 64]` and the subtraction lands in
-        // `[0, 63]` — `bvsub` never wraps. For all-sign inputs (0 or -1)
-        // folded is zero, clz is 64, and the result is 63.
+        // Fold the sign bit out via `x XOR (x ASR (width-1))` so the answer
+        // reduces to `clz(folded) - 1`. Bit width-1 of `folded` is always 0,
+        // so `bv_clz(folded) ∈ [1, width]` and the subtraction lands in
+        // `[0, width-1]` — `bvsub` never wraps. For all-sign inputs (0 or -1)
+        // folded is zero, clz is `width`, and the result is `width - 1`.
         Instruction::Cls { rd, rn } => {
             let value = state.get_register(*rn).clone();
-            let asr = value.bvashr(&BV::from_u64(63, 64));
+            let asr = value.bvashr(&BV::from_u64((width - 1) as u64, width));
             let folded = value.bvxor(&asr);
-            let clz = bv_clz_64(&folded);
-            let result = clz.bvsub(&BV::from_u64(1, 64));
+            let clz = bv_clz(&folded, width);
+            let result = clz.bvsub(&BV::from_u64(1, width));
             state.set_register(*rd, result);
         }
-        // RBIT: reverse the 64 bits.
+        // RBIT: reverse the bits of the value.
         Instruction::Rbit { rd, rn } => {
             let value = state.get_register(*rn).clone();
-            state.set_register(*rd, bv_reverse_bits_64(&value));
+            state.set_register(*rd, bv_reverse_bits(&value, width));
         }
-        // REV: byte-reverse the 64-bit value.
+        // REV: byte-reverse the value.
         Instruction::Rev { rd, rn } => {
             let value = state.get_register(*rn).clone();
-            state.set_register(*rd, bv_swap_bytes_64(&value));
+            state.set_register(*rd, bv_swap_bytes(&value, width));
         }
         // REV32: byte-reverse within each 32-bit half independently.
         Instruction::Rev32 { rd, rn } => {
@@ -1396,7 +1413,7 @@ mod tests {
         let state = MachineState::new_symbolic("pre");
         let x0 = state.get_register(Register::X0).clone();
         let x1 = state.get_register(Register::X1).clone();
-        let expected = compute_flags_sub(&x0, &x1);
+        let expected = compute_flags_sub(&x0, &x1, 64);
         let after = apply_instruction(
             state,
             &Instruction::Cmp {
@@ -1605,7 +1622,7 @@ mod tests {
         force_flags(&mut state, 0, 1, 0, 0);
         let x1 = state.get_register(Register::X1).clone();
         let x2 = state.get_register(Register::X2).clone();
-        let expected = compute_flags_sub(&x1, &x2);
+        let expected = compute_flags_sub(&x1, &x2, 64);
         let after = apply_instruction(
             state,
             &Instruction::Ccmp {
@@ -1643,7 +1660,7 @@ mod tests {
         force_flags(&mut state, 0, 1, 0, 0);
         let x1 = state.get_register(Register::X1).clone();
         let x2 = state.get_register(Register::X2).clone();
-        let expected = compute_flags_add(&x1, &x2);
+        let expected = compute_flags_add(&x1, &x2, 64);
         let after = apply_instruction(
             state,
             &Instruction::Ccmn {
@@ -1673,7 +1690,7 @@ mod tests {
                     rn: Register::X0,
                     rm: rm_reg.clone(),
                 },
-                compute_flags_add(&x0, &x1),
+                compute_flags_add(&x0, &x1, 64),
                 "CMN x0, x1",
             ),
             (
@@ -1681,7 +1698,7 @@ mod tests {
                     rn: Register::X0,
                     rm: rm_reg.clone(),
                 },
-                compute_flags_logical(&x0.bvand(&x1)),
+                compute_flags_logical(&x0.bvand(&x1), 64),
                 "TST x0, x1",
             ),
             (
@@ -1690,7 +1707,7 @@ mod tests {
                     rn: Register::X0,
                     rm: rm_reg.clone(),
                 },
-                compute_flags_add(&x0, &x1),
+                compute_flags_add(&x0, &x1, 64),
                 "ADDS x2, x0, x1",
             ),
             (
@@ -1699,7 +1716,7 @@ mod tests {
                     rn: Register::X0,
                     rm: rm_reg.clone(),
                 },
-                compute_flags_sub(&x0, &x1),
+                compute_flags_sub(&x0, &x1, 64),
                 "SUBS x2, x0, x1",
             ),
             (
@@ -1708,7 +1725,7 @@ mod tests {
                     rn: Register::X0,
                     rm: rm_reg.clone(),
                 },
-                compute_flags_logical(&x0.bvand(&x1)),
+                compute_flags_logical(&x0.bvand(&x1), 64),
                 "ANDS x2, x0, x1",
             ),
             (
@@ -1716,7 +1733,7 @@ mod tests {
                     rd: Register::X2,
                     rm: Register::X1,
                 },
-                compute_flags_sub(&BV::from_u64(0, 64), &x1),
+                compute_flags_sub(&BV::from_u64(0, 64), &x1, 64),
                 "NEGS x2, x1",
             ),
             (
@@ -1725,7 +1742,7 @@ mod tests {
                     rn: Register::X0,
                     rm: rm_reg.clone(),
                 },
-                compute_flags_logical(&x0.bvand(&x1.bvnot())),
+                compute_flags_logical(&x0.bvand(&x1.bvnot()), 64),
                 "BICS x2, x0, x1",
             ),
         ];
@@ -1772,7 +1789,7 @@ mod tests {
             let rhs = BV::from_u64(b, 64);
             let expected = ConditionFlags::from_sub(a, b, a.wrapping_sub(b));
             assert_flags_match(
-                compute_flags_sub(&lhs, &rhs),
+                compute_flags_sub(&lhs, &rhs, 64),
                 expected,
                 &format!("compute_flags_sub({a}, {b}) vs ConditionFlags::from_sub"),
             );
@@ -1794,7 +1811,7 @@ mod tests {
             let rhs = BV::from_u64(b, 64);
             let expected = ConditionFlags::from_add(a, b, a.wrapping_add(b));
             assert_flags_match(
-                compute_flags_add(&lhs, &rhs),
+                compute_flags_add(&lhs, &rhs, 64),
                 expected,
                 &format!("compute_flags_add({a}, {b}) vs ConditionFlags::from_add"),
             );
@@ -1809,7 +1826,7 @@ mod tests {
             let result = BV::from_u64(r, 64);
             let expected = ConditionFlags::from_logical(r);
             assert_flags_match(
-                compute_flags_logical(&result),
+                compute_flags_logical(&result, 64),
                 expected,
                 &format!("compute_flags_logical({r}) vs ConditionFlags::from_logical"),
             );

--- a/src/semantics/state.rs
+++ b/src/semantics/state.rs
@@ -186,7 +186,7 @@ impl Eflags {
     }
 }
 
-fn mask_to_width(value: u64, width: u32) -> u64 {
+pub(crate) fn mask_to_width(value: u64, width: u32) -> u64 {
     match width {
         64 => value,
         32 => value & 0xffff_ffff,
@@ -247,16 +247,27 @@ impl fmt::Display for ConcreteValue {
     }
 }
 
-/// Concrete machine state for fast validation
+/// Concrete machine state for fast validation.
+///
+/// Per ADR-0004 decision 6, the state carries a width tag and masks writes
+/// before storing (mask-on-write). AArch64 is always width=64, which makes
+/// the mask a no-op; the field is there so stages 1+ can parameterise this
+/// type and reuse the same struct for narrower widths.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConcreteMachineState {
     registers: HashMap<Register, ConcreteValue>,
     flags: ConditionFlags,
+    width: u32,
 }
 
 impl ConcreteMachineState {
-    /// Create a new state with all registers set to zero
+    /// Create a new AArch64 (width=64) state with all registers set to zero.
     pub fn new_zeroed() -> Self {
+        Self::new_zeroed_for_width(64)
+    }
+
+    /// Create a new state with the given register width, all registers zero.
+    pub fn new_zeroed_for_width(width: u32) -> Self {
         let mut registers = HashMap::new();
 
         for i in 0..=30 {
@@ -271,7 +282,13 @@ impl ConcreteMachineState {
         ConcreteMachineState {
             registers,
             flags: ConditionFlags::new(),
+            width,
         }
+    }
+
+    /// Register width this state was constructed with.
+    pub fn width(&self) -> u32 {
+        self.width
     }
 
     /// Create state from a map of register values
@@ -292,10 +309,12 @@ impl ConcreteMachineState {
         }
     }
 
-    /// Set the value of a register (XZR writes are ignored)
+    /// Set the value of a register (XZR writes are ignored). Masks the value
+    /// to the state's width per ADR-0004 decision 6.
     pub fn set_register(&mut self, reg: Register, value: ConcreteValue) {
         if reg != Register::XZR {
-            self.registers.insert(reg, value);
+            let masked = mask_to_width(value.0, self.width);
+            self.registers.insert(reg, ConcreteValue::new(masked));
         }
     }
 

--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -93,8 +93,16 @@ pub fn compute_written_registers(instructions: &[Instruction]) -> LiveOutRegiste
 /// flag-side-effect — SMT semantics for ADDS/SUBS/ANDS/NEGS/BICS/CMP/CMN/TST
 /// model the register write but not the flag effect. A tighter "flag-writer
 /// AND later read" form is tracked as a separate follow-up.
+///
+/// Issue #77 stage 1 step 14: routes through `FlagsAnalysis<I>` (ADR-0004
+/// decision 7) instead of the inherent `Instruction::modifies_flags`. The
+/// AArch64 impl delegates to the inherent method, so behaviour is identical;
+/// the same shape works unchanged for x86 in stage 2.
 pub fn flags_live_out(instructions: &[Instruction]) -> bool {
-    instructions.iter().any(|i| i.modifies_flags())
+    use crate::isa::{AArch64, FlagsAnalysis};
+    instructions
+        .iter()
+        .any(<AArch64 as FlagsAnalysis<Instruction>>::modifies_flags)
 }
 
 /// Returns true if any instruction reads NZCV flags before any instruction writes them.
@@ -103,13 +111,17 @@ pub fn flags_live_out(instructions: &[Instruction]) -> bool {
 /// Used by the prompt builder when flags-live-in support is added (ADR-0001
 /// defines the helper; ADR-0003 omits flags from the prompt for the MVP, so
 /// the function has no consumer yet).
+///
+/// Issue #77 stage 1 step 14: same FlagsAnalysis routing as `flags_live_out`
+/// above, for parity with the upcoming x86 wire-up.
 #[allow(dead_code)]
 pub fn reads_flags_before_writing(instructions: &[Instruction]) -> bool {
+    use crate::isa::{AArch64, FlagsAnalysis};
     for instr in instructions {
-        if instr.reads_flags() {
+        if <AArch64 as FlagsAnalysis<Instruction>>::reads_flags(instr) {
             return true;
         }
-        if instr.modifies_flags() {
+        if <AArch64 as FlagsAnalysis<Instruction>>::modifies_flags(instr) {
             return false;
         }
     }

--- a/test_all.sh
+++ b/test_all.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-# Test script for s11
+# Test script for s11.
+#
+# Issue #77 stage 2 step 21 will extend this script with x86-via-trait
+# integration tests once stage 2 steps 18-20 land (parallel-pipeline
+# deletion + optimize_elf_binary merge). Today the AArch64 integration
+# suite is the only one that runs; x86 tests live in the unit tests
+# inside concrete_x86.rs / smt_x86.rs / cost_x86.rs / the x86 trait
+# impls in src/isa/x86.rs.
 set -e
 
 echo "=== s11 Test Suite ==="


### PR DESCRIPTION
## Summary
Issue #77 — collapse the parallel AArch64 / x86 / RISC-V pipelines onto the `ISA` trait surface in `src/isa/traits.rs`. **30 commits** across three stages.

## What this PR lands substantively

### Stage 0 (1 commit)
- **ADR-0004** documenting eight cross-cutting design decisions for the refactor.

### Stage 1 — AArch64 lift (21 commits)
- **5 commits of safety-net tests** (54 concrete-vs-SMT parity tests covering every supported AArch64 mnemonic, parallel coordinator clean-shutdown test, mutation encodability invariant proptest).
- **`type Width: BVWidth`** on `ISA` plus `U32` / `U64` marker types; every backend impl populated.
- **`ConcreteMachineState` width-tagged** (mask-on-write per ADR-0004 decision 6).
- **`type Flags` + `FlagsAnalysis<I>` trait** — the principled hook for `flag_writers_diverge` and `flags_live_out`, replacing the over-broad `InstructionType::has_side_effects` path.
- **`MachineState` (SMT) width-aware** — `apply_instruction` threads `state.width()` through every BV constructor, helper, and flag computation; the four `bv_*_64` helpers drop their `_64` suffix and take a `width` parameter; `compute_flags_*` take `width`; `build_smt_solver` debug-asserts both states' widths match. NFC for AArch64 (all 54 parity tests pass).
- **`LiveOutMask<R: RegisterType>`** generic type added in `src/semantics/live_out.rs` with `flags_live` on the mask itself.
- **AArch64 trait impl blocks** for the four trait gaps (`ConcreteExecutor`, `SymbolicExecutor`, `CostModel`, `Assembler`). `Assembler::can_assemble` bridges `Instruction::is_encodable_aarch64()`.
- **`AArch64Mutator`** newtype exposing the existing stochastic `Mutator` through `<AArch64 as ISA>::Mutator`. `X86Mutator` and `RiscVMutator` stubs added.
- **`is_sequence_encodable_for<I, A>`** generic encodability helper; AArch64 path routes through it.
- **`flag_writers_diverge` + `flags_live_out`** routed through `FlagsAnalysis` instead of inherent methods.

### Stage 2 — x86 (1 substantive + 4 doc-defer commits)
- **X86_64 + X86_32 trait impls** — `ConcreteExecutor`, `SymbolicExecutor`, `CostModel`, `Assembler` for both width variants. Each delegates to the existing free function (no behaviour change). `<X86_32 as Assembler>::can_assemble` reproduces the 32-bit-mode `R8..R15`-illegal filter.
- Deletion of parallel `*_x86.rs` files + `optimize_elf_binary*` merge: **deferred** with doc notes at each gate. Blocked on the `SearchAlgorithm<I>` follow-up.

### Stage 3 — RISC-V (1 ADR + 1 substantive + 4 doc-defer commits)
- **ADR-0005** records the assembler decision: ship without machine-code emission first. `<RiscV32/64 as Assembler>::assemble` returns `Err`; `can_assemble` returns `false`. A follow-up can swap in a real encoder without consumer migration.
- RISC-V `ConcreteExecutor` / `SymbolicExecutor` / `CostModel` impls, Capstone wire-up, `convert_to_riscv_ir`, build infra: **deferred**. RISC-V has no pre-existing semantics free functions to delegate to (unlike AArch64 and x86); writing them is multi-hundred-line from-scratch work tracked as a follow-up RISC-V implementation issue.

## What this PR does NOT land
- Full `SearchAlgorithm<I>` genericisation of `StochasticSearch` / `SymbolicSearch` / parallel coordinator / channels. The trait surface and the per-ISA impls exist; the consumer-side migration (~3000 lines across mcmc.rs / synthesis.rs / coordinator.rs) is the follow-up that unblocks stage 2 step 18-20 and stage 3 step 24-26.
- RISC-V concrete + SMT executor bodies (from-scratch implementations of all 16 RV mnemonics).
- The x86 parallel-pipeline file deletions and `optimize_elf_binary_x86` merge. Doc-deferred with gates pointing at the SearchAlgorithm<I> dependency.

## Test plan
- [x] `./ci_check.sh` clean after every commit
- [x] 54 per-opcode concrete/SMT parity tests cover every supported AArch64 mnemonic
- [x] No-dropped-Finished-messages test for `run_parallel_search`
- [x] Mutator output classifiability proptest (proptest dependency activated)
- [x] All 645+ pre-existing tests still pass
- [ ] Full CI suite passes in GitHub Actions

## Reading order for review
1. ADR-0004 → ADR-0005 (cross-cutting decisions).
2. Stage 1 step 2 commits (safety nets).
3. Stage 1 substantive commits (steps 3-10 + 14): the trait surface build-out.
4. Stage 1 doc-defer commits (steps 11-13, 15): trait surface ready, consumer-side migration follow-up.
5. Stage 2 step 17 (x86 trait impls) plus stage 2 doc-defers.
6. Stage 3 ADR + step 23 stub + stage 3 doc-defers.