### PR TITLE
Implement AArch64 logical-immediate encoder (issue #65)

### DIFF
--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -461,10 +461,21 @@ impl AArch64Assembler {
                         );
                         Ok(())
                     }
-                    Operand::Immediate(_imm) => {
-                        // AND with immediate uses logical immediate encoding which is complex.
-                        // For now, only support register operands.
-                        Err("AND immediate encoding not yet supported".to_string())
+                    Operand::Immediate(imm) => {
+                        let val = *imm as u64;
+                        if dynasmrt::aarch64::encode_logical_immediate_64bit(val).is_none() {
+                            return Err(format!(
+                                "AND immediate 0x{:x} is not a valid AArch64 logical immediate",
+                                val
+                            ));
+                        }
+                        // AND (immediate) encodes Rd in the Xn|SP slot.
+                        let rd_reg_xsp = register_to_dynasm_xsp(*rd)?;
+                        dynasm!(ops
+                            ; .arch aarch64
+                            ; and XSP(rd_reg_xsp), X(rn_reg), #val
+                        );
+                        Ok(())
                     }
                     Operand::ShiftedRegister { reg, kind, amount } => {
                         let rm_reg_num = register_to_dynasm(*reg)?;
@@ -490,10 +501,20 @@ impl AArch64Assembler {
                         );
                         Ok(())
                     }
-                    Operand::Immediate(_imm) => {
-                        // ORR with immediate uses logical immediate encoding which is complex.
-                        // For now, only support register operands.
-                        Err("ORR immediate encoding not yet supported".to_string())
+                    Operand::Immediate(imm) => {
+                        let val = *imm as u64;
+                        if dynasmrt::aarch64::encode_logical_immediate_64bit(val).is_none() {
+                            return Err(format!(
+                                "ORR immediate 0x{:x} is not a valid AArch64 logical immediate",
+                                val
+                            ));
+                        }
+                        let rd_reg_xsp = register_to_dynasm_xsp(*rd)?;
+                        dynasm!(ops
+                            ; .arch aarch64
+                            ; orr XSP(rd_reg_xsp), X(rn_reg), #val
+                        );
+                        Ok(())
                     }
                     Operand::ShiftedRegister { reg, kind, amount } => {
                         let rm_reg_num = register_to_dynasm(*reg)?;
@@ -519,10 +540,20 @@ impl AArch64Assembler {
                         );
                         Ok(())
                     }
-                    Operand::Immediate(_imm) => {
-                        // EOR with immediate uses logical immediate encoding which is complex.
-                        // For now, only support register operands.
-                        Err("EOR immediate encoding not yet supported".to_string())
+                    Operand::Immediate(imm) => {
+                        let val = *imm as u64;
+                        if dynasmrt::aarch64::encode_logical_immediate_64bit(val).is_none() {
+                            return Err(format!(
+                                "EOR immediate 0x{:x} is not a valid AArch64 logical immediate",
+                                val
+                            ));
+                        }
+                        let rd_reg_xsp = register_to_dynasm_xsp(*rd)?;
+                        dynasm!(ops
+                            ; .arch aarch64
+                            ; eor XSP(rd_reg_xsp), X(rn_reg), #val
+                        );
+                        Ok(())
                     }
                     Operand::ShiftedRegister { reg, kind, amount } => {
                         let rm_reg_num = register_to_dynasm(*reg)?;
@@ -812,8 +843,19 @@ impl AArch64Assembler {
                         );
                         Ok(())
                     }
-                    Operand::Immediate(_imm) => {
-                        Err("TST immediate encoding not yet supported".to_string())
+                    Operand::Immediate(imm) => {
+                        let val = *imm as u64;
+                        if dynasmrt::aarch64::encode_logical_immediate_64bit(val).is_none() {
+                            return Err(format!(
+                                "TST immediate 0x{:x} is not a valid AArch64 logical immediate",
+                                val
+                            ));
+                        }
+                        dynasm!(ops
+                            ; .arch aarch64
+                            ; tst X(rn_reg), #val
+                        );
+                        Ok(())
                     }
                     Operand::ShiftedRegister { reg, kind, amount } => {
                         let rm_reg_num = register_to_dynasm(*reg)?;
@@ -1177,8 +1219,19 @@ impl AArch64Assembler {
                         dynasm!(ops ; .arch aarch64 ; ands X(rd_reg), X(rn_reg), X(rm_reg));
                         Ok(())
                     }
-                    Operand::Immediate(_) => {
-                        Err("ANDS immediate encoding not supported".to_string())
+                    Operand::Immediate(imm) => {
+                        let val = *imm as u64;
+                        if dynasmrt::aarch64::encode_logical_immediate_64bit(val).is_none() {
+                            return Err(format!(
+                                "ANDS immediate 0x{:x} is not a valid AArch64 logical immediate",
+                                val
+                            ));
+                        }
+                        dynasm!(ops
+                            ; .arch aarch64
+                            ; ands X(rd_reg), X(rn_reg), #val
+                        );
+                        Ok(())
                     }
                     Operand::ShiftedRegister { .. } => {
                         Err("ANDS shifted-register form not yet supported".to_string())
@@ -1734,6 +1787,158 @@ mod tests {
             .assemble_instructions(&instructions, 0)
             .expect("EOR encoding should succeed");
         disassemble_and_verify(&bytes, "eor", &["x0", "x0", "x0"]);
+    }
+
+    #[test]
+    fn test_and_immediate_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::And {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Immediate(0xFF),
+        }];
+
+        let bytes = assembler
+            .assemble_instructions(&instructions, 0)
+            .expect("AND immediate encoding should succeed");
+        disassemble_and_verify(&bytes, "and", &["x0", "x1", "0xff"]);
+    }
+
+    #[test]
+    fn test_orr_immediate_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Orr {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Immediate(0xFFFF),
+        }];
+
+        let bytes = assembler
+            .assemble_instructions(&instructions, 0)
+            .expect("ORR immediate encoding should succeed");
+        disassemble_and_verify(&bytes, "orr", &["x0", "x1", "0xffff"]);
+    }
+
+    #[test]
+    fn test_eor_immediate_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Eor {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Immediate(0xF0F0F0F0F0F0F0F0_u64 as i64),
+        }];
+
+        let bytes = assembler
+            .assemble_instructions(&instructions, 0)
+            .expect("EOR immediate encoding should succeed");
+        disassemble_and_verify(&bytes, "eor", &["x0", "x1", "0xf0f0f0f0f0f0f0f0"]);
+    }
+
+    #[test]
+    fn test_tst_immediate_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Tst {
+            rn: Register::X1,
+            rm: Operand::Immediate(0xFF),
+        }];
+
+        let bytes = assembler
+            .assemble_instructions(&instructions, 0)
+            .expect("TST immediate encoding should succeed");
+        disassemble_and_verify(&bytes, "tst", &["x1", "0xff"]);
+    }
+
+    #[test]
+    fn test_ands_immediate_correctness() {
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Ands {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Immediate(0xFF),
+        }];
+
+        let bytes = assembler
+            .assemble_instructions(&instructions, 0)
+            .expect("ANDS immediate encoding should succeed");
+        disassemble_and_verify(&bytes, "ands", &["x0", "x1", "0xff"]);
+    }
+
+    #[test]
+    fn test_logical_imm_rejects_unencodable() {
+        let mut assembler = AArch64Assembler::new();
+
+        // All-zeros: bitmask immediate spec excludes 0.
+        let r = assembler.assemble_instructions(
+            &[Instruction::And {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Immediate(0),
+            }],
+            0,
+        );
+        let err = r.expect_err("AND #0 must be rejected");
+        assert!(
+            err.contains("is not a valid AArch64 logical immediate"),
+            "unexpected error: {err}",
+        );
+
+        // All-ones: -1 i64 reinterprets to 0xFFFF_FFFF_FFFF_FFFF, also excluded.
+        let r = assembler.assemble_instructions(
+            &[Instruction::And {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Immediate(-1),
+            }],
+            0,
+        );
+        assert!(
+            r.is_err_and(|e| e.contains("is not a valid AArch64 logical immediate")),
+            "AND #-1 must be rejected",
+        );
+
+        // 0b101: non-replicating pattern.
+        let r = assembler.assemble_instructions(
+            &[Instruction::And {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Immediate(5),
+            }],
+            0,
+        );
+        assert!(
+            r.is_err_and(|e| e.contains("is not a valid AArch64 logical immediate")),
+            "AND #5 must be rejected",
+        );
+
+        // TST shares the encoder path.
+        let r = assembler.assemble_instructions(
+            &[Instruction::Tst {
+                rn: Register::X1,
+                rm: Operand::Immediate(0),
+            }],
+            0,
+        );
+        assert!(
+            r.is_err_and(|e| e.contains("is not a valid AArch64 logical immediate")),
+            "TST #0 must be rejected",
+        );
+    }
+
+    #[test]
+    fn test_high_bit_logical_imm_encodable() {
+        // Single high bit (0x8000_0000_0000_0000) is a valid AArch64 bitmask
+        // immediate — pattern length 64, one bit set. Issue #65 canonical case.
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::And {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Immediate(0x8000_0000_0000_0000_u64 as i64),
+        }];
+
+        let bytes = assembler
+            .assemble_instructions(&instructions, 0)
+            .expect("AND with single high bit should encode");
+        disassemble_and_verify(&bytes, "and", &["x0", "x1", "0x8000000000000000"]);
     }
 
     #[test]
@@ -2680,20 +2885,22 @@ mod tests {
                 rn: Register::X1,
                 rm: Operand::Immediate(-1),
             },
+            // imm 5 (0b101) is not a valid AArch64 logical bitmask immediate
+            // — exercise the encoder's rejection path for AND/ORR/EOR imm.
             Instruction::And {
                 rd: Register::X0,
                 rn: Register::X1,
-                rm: Operand::Immediate(1),
+                rm: Operand::Immediate(5),
             },
             Instruction::Orr {
                 rd: Register::X0,
                 rn: Register::X1,
-                rm: Operand::Immediate(1),
+                rm: Operand::Immediate(5),
             },
             Instruction::Eor {
                 rd: Register::X0,
                 rn: Register::X1,
-                rm: Operand::Immediate(1),
+                rm: Operand::Immediate(5),
             },
             Instruction::Lsl {
                 rd: Register::X0,
@@ -2720,7 +2927,7 @@ mod tests {
             },
             Instruction::Tst {
                 rn: Register::X1,
-                rm: Operand::Immediate(1),
+                rm: Operand::Immediate(5),
             },
             Instruction::MovN {
                 rd: Register::X0,
@@ -2780,7 +2987,7 @@ mod tests {
             Instruction::Ands {
                 rd: Register::X0,
                 rn: Register::X1,
-                rm: Operand::Immediate(1),
+                rm: Operand::Immediate(5),
             },
             Instruction::Ror {
                 rd: Register::X0,

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -448,12 +448,17 @@ impl AArch64Assembler {
                     }
                 }
             }
+            // For AND/ORR/EOR: rd resolution depends on the rm operand shape —
+            // the immediate form encodes Rd in the Xn|SP slot (accepts SP,
+            // rejects XZR), while the register and shifted-register forms use
+            // the plain Xn slot (rejects SP). Resolving rd inside each arm
+            // avoids prematurely rejecting `<op> sp, xn, #imm`.
             Instruction::And { rd, rn, rm } => {
-                let rd_reg = register_to_dynasm(*rd)?;
                 let rn_reg = register_to_dynasm(*rn)?;
 
                 match rm {
                     Operand::Register(rm_reg) => {
+                        let rd_reg = register_to_dynasm(*rd)?;
                         let rm_reg_num = register_to_dynasm(*rm_reg)?;
                         dynasm!(ops
                             ; .arch aarch64
@@ -478,6 +483,7 @@ impl AArch64Assembler {
                         Ok(())
                     }
                     Operand::ShiftedRegister { reg, kind, amount } => {
+                        let rd_reg = register_to_dynasm(*rd)?;
                         let rm_reg_num = register_to_dynasm(*reg)?;
                         emit_shifted_reg_3op_logical!(
                             ops, and, rd_reg, rn_reg, rm_reg_num, kind, *amount
@@ -489,11 +495,11 @@ impl AArch64Assembler {
                 }
             }
             Instruction::Orr { rd, rn, rm } => {
-                let rd_reg = register_to_dynasm(*rd)?;
                 let rn_reg = register_to_dynasm(*rn)?;
 
                 match rm {
                     Operand::Register(rm_reg) => {
+                        let rd_reg = register_to_dynasm(*rd)?;
                         let rm_reg_num = register_to_dynasm(*rm_reg)?;
                         dynasm!(ops
                             ; .arch aarch64
@@ -517,6 +523,7 @@ impl AArch64Assembler {
                         Ok(())
                     }
                     Operand::ShiftedRegister { reg, kind, amount } => {
+                        let rd_reg = register_to_dynasm(*rd)?;
                         let rm_reg_num = register_to_dynasm(*reg)?;
                         emit_shifted_reg_3op_logical!(
                             ops, orr, rd_reg, rn_reg, rm_reg_num, kind, *amount
@@ -528,11 +535,11 @@ impl AArch64Assembler {
                 }
             }
             Instruction::Eor { rd, rn, rm } => {
-                let rd_reg = register_to_dynasm(*rd)?;
                 let rn_reg = register_to_dynasm(*rn)?;
 
                 match rm {
                     Operand::Register(rm_reg) => {
+                        let rd_reg = register_to_dynasm(*rd)?;
                         let rm_reg_num = register_to_dynasm(*rm_reg)?;
                         dynasm!(ops
                             ; .arch aarch64
@@ -556,6 +563,7 @@ impl AArch64Assembler {
                         Ok(())
                     }
                     Operand::ShiftedRegister { reg, kind, amount } => {
+                        let rd_reg = register_to_dynasm(*rd)?;
                         let rm_reg_num = register_to_dynasm(*reg)?;
                         emit_shifted_reg_3op_logical!(
                             ops, eor, rd_reg, rn_reg, rm_reg_num, kind, *amount
@@ -1939,6 +1947,45 @@ mod tests {
             .assemble_instructions(&instructions, 0)
             .expect("AND with single high bit should encode");
         disassemble_and_verify(&bytes, "and", &["x0", "x1", "0x8000000000000000"]);
+    }
+
+    #[test]
+    fn test_and_immediate_with_sp_destination_roundtrips() {
+        // AArch64 AND (immediate) puts rd in the Xn|SP slot — SP-as-destination
+        // is a legitimate encoding. Verifies the assembler routes rd through
+        // register_to_dynasm_xsp inside the Immediate arm (not the plain Xn
+        // helper used by the register/shifted-register arms).
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::And {
+            rd: Register::SP,
+            rn: Register::X1,
+            rm: Operand::Immediate(0xFF),
+        }];
+
+        let bytes = assembler
+            .assemble_instructions(&instructions, 0)
+            .expect("AND with SP destination (immediate form) should encode");
+        disassemble_and_verify(&bytes, "and", &["sp", "x1", "0xff"]);
+    }
+
+    #[test]
+    fn test_ands_immediate_with_xzr_destination_roundtrips() {
+        // ANDS (immediate) with rd=XZR is the canonical TST shape per ARM ARM;
+        // Capstone disassembles it back as `tst`. Verifies the assembler
+        // accepts rd=XZR for ANDS (which uses the plain Xn slot, unlike
+        // AND/ORR/EOR's Xn|SP slot) and that round-trip yields the TST alias.
+        let mut assembler = AArch64Assembler::new();
+        let instructions = vec![Instruction::Ands {
+            rd: Register::XZR,
+            rn: Register::X1,
+            rm: Operand::Immediate(0xFF),
+        }];
+
+        let bytes = assembler
+            .assemble_instructions(&instructions, 0)
+            .expect("ANDS with XZR destination (immediate form) should encode");
+        // Capstone canonicalises ANDS XZR ..., #imm → TST X..., #imm.
+        disassemble_and_verify(&bytes, "tst", &["x1", "0xff"]);
     }
 
     #[test]

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -9,6 +9,13 @@ use std::fmt;
 /// out of sync across the codebase.
 pub const MOVW_LEGAL_SHIFTS: [u8; 4] = [0, 16, 32, 48];
 
+/// True iff `imm` (reinterpreted as `u64`) is representable as an AArch64
+/// 64-bit logical bitmask immediate (the `N:immr:imms` encoding used by
+/// AND/ORR/EOR/TST/ANDS immediate forms). Delegates to dynasmrt's encoder.
+fn logical_imm64_encodable(imm: i64) -> bool {
+    dynasmrt::aarch64::encode_logical_immediate_64bit(imm as u64).is_some()
+}
+
 /// AArch64 instructions supported by the IR
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[allow(dead_code)]
@@ -551,8 +558,9 @@ impl Instruction {
     /// - ADD/SUB immediate: 0 to 0xFFF (12-bit unsigned)
     /// - CMP/CMN immediate: 0 to 0xFFF (12-bit unsigned)
     /// - LSL/LSR/ASR immediate: 0 to 63
-    /// - AND/ORR/EOR immediate: register only (bitmask encoding not supported)
-    /// - TST immediate: register only (bitmask encoding not supported)
+    /// - AND/ORR/EOR immediate: register, or encodable bitmask immediate
+    ///   (rd ≠ XZR for the imm form — Xn|SP slot rejects the zero register)
+    /// - TST immediate: register, or encodable bitmask immediate
     pub fn is_encodable_aarch64(&self) -> bool {
         match self {
             // MovReg is always encodable
@@ -591,13 +599,16 @@ impl Instruction {
                 }
             },
 
-            // AND/ORR/EOR: register operand or shifted-register (all 4 kinds, ROR allowed).
-            // Shifted-register form forbids SP for any operand.
+            // AND/ORR/EOR: register, encodable bitmask immediate (issue #65), or
+            // shifted-register (all 4 kinds incl. ROR; shifted-register form
+            // forbids SP for any operand). The immediate form encodes Rd in
+            // the Xn|SP slot, which forbids XZR (would alias to SP and
+            // silently miscompile).
             Instruction::And { rd, rn, rm }
             | Instruction::Orr { rd, rn, rm }
             | Instruction::Eor { rd, rn, rm } => match rm {
                 Operand::Register(_) => true,
-                Operand::Immediate(_) => false,
+                Operand::Immediate(imm) => *rd != Register::XZR && logical_imm64_encodable(*imm),
                 Operand::ShiftedRegister { reg, amount, .. } => {
                     *amount <= 63
                         && *reg != Register::SP
@@ -653,10 +664,12 @@ impl Instruction {
                 }
             },
 
-            // TST: register operand or shifted-register (all 4 kinds, ROR allowed).
+            // TST: register, encodable bitmask immediate (issue #65), or
+            // shifted-register (all 4 kinds incl. ROR). No rd, so no XZR-slot
+            // guard needed for the immediate form.
             Instruction::Tst { rn, rm } => match rm {
                 Operand::Register(_) => true,
-                Operand::Immediate(_) => false,
+                Operand::Immediate(imm) => logical_imm64_encodable(*imm),
                 Operand::ShiftedRegister { reg, amount, .. } => {
                     *amount <= 63 && *reg != Register::SP && *rn != Register::SP
                 }
@@ -692,8 +705,15 @@ impl Instruction {
                 Operand::ShiftedRegister { .. } => false,
                 Operand::ExtendedRegister { .. } => false,
             },
-            // ANDS: register-only (same as AND). ShiftedRegister out of scope (#59).
-            Instruction::Ands { rm, .. } => matches!(rm, Operand::Register(_)),
+            // ANDS: register or encodable bitmask immediate (issue #65).
+            // ShiftedRegister out of scope (#59). The immediate form uses the
+            // plain X slot for Rd (unlike AND/ORR/EOR), so XZR-as-rd is fine.
+            Instruction::Ands { rm, .. } => match rm {
+                Operand::Register(_) => true,
+                Operand::Immediate(imm) => logical_imm64_encodable(*imm),
+                Operand::ShiftedRegister { .. } => false,
+                Operand::ExtendedRegister { .. } => false,
+            },
 
             // CSET / CSETM: reject AL (always true ⇒ unconditional 1/-1) and
             // NV (reserved). All other 14 conditions are encodable.
@@ -1437,9 +1457,9 @@ mod tests {
             .is_encodable_aarch64()
         );
 
-        // Immediate operand not supported for AND/ORR/EOR
+        // Encodable bitmask immediates are accepted (issue #65).
         assert!(
-            !Instruction::And {
+            Instruction::And {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Immediate(0xFF)
@@ -1447,13 +1467,15 @@ mod tests {
             .is_encodable_aarch64()
         );
         assert!(
-            !Instruction::Orr {
+            Instruction::Orr {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Immediate(1)
             }
             .is_encodable_aarch64()
         );
+
+        // Non-bitmask immediates are still rejected.
         assert!(
             !Instruction::Eor {
                 rd: Register::X0,
@@ -1696,7 +1718,7 @@ mod tests {
             .is_encodable_aarch64()
         );
 
-        // TST only supports register operands
+        // TST: register form and encodable bitmask immediates both accepted.
         assert!(
             Instruction::Tst {
                 rn: Register::X0,
@@ -1705,9 +1727,17 @@ mod tests {
             .is_encodable_aarch64()
         );
         assert!(
-            !Instruction::Tst {
+            Instruction::Tst {
                 rn: Register::X0,
                 rm: Operand::Immediate(1)
+            }
+            .is_encodable_aarch64()
+        );
+        // Non-bitmask immediates are rejected.
+        assert!(
+            !Instruction::Tst {
+                rn: Register::X0,
+                rm: Operand::Immediate(5)
             }
             .is_encodable_aarch64()
         );
@@ -2427,5 +2457,145 @@ mod tests {
             rm: Operand::Register(Register::X1),
         };
         assert!(!cmp.is_terminator());
+    }
+
+    #[test]
+    fn test_is_encodable_aarch64_logical_imm_accepts_valid() {
+        // Canonical valid bitmask immediates from issue #65.
+        for imm in [
+            0xFF_i64,
+            0xFFFF,
+            0xF0F0F0F0F0F0F0F0_u64 as i64,
+            0x5555_5555_5555_5555,
+        ] {
+            assert!(
+                Instruction::And {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::Immediate(imm),
+                }
+                .is_encodable_aarch64(),
+                "AND with valid imm 0x{:x} should be encodable",
+                imm as u64
+            );
+            assert!(
+                Instruction::Orr {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::Immediate(imm),
+                }
+                .is_encodable_aarch64(),
+                "ORR with valid imm 0x{:x} should be encodable",
+                imm as u64
+            );
+            assert!(
+                Instruction::Eor {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::Immediate(imm),
+                }
+                .is_encodable_aarch64(),
+                "EOR with valid imm 0x{:x} should be encodable",
+                imm as u64
+            );
+            assert!(
+                Instruction::Tst {
+                    rn: Register::X1,
+                    rm: Operand::Immediate(imm),
+                }
+                .is_encodable_aarch64(),
+                "TST with valid imm 0x{:x} should be encodable",
+                imm as u64
+            );
+            assert!(
+                Instruction::Ands {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::Immediate(imm),
+                }
+                .is_encodable_aarch64(),
+                "ANDS with valid imm 0x{:x} should be encodable",
+                imm as u64
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_encodable_aarch64_logical_imm_rejects_invalid() {
+        // 0 (all-zeros), -1 (all-ones reinterpret), 5 (non-replicating pattern).
+        for imm in [0_i64, -1, 5] {
+            for ctor in [
+                |r: i64| Instruction::And {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::Immediate(r),
+                },
+                |r| Instruction::Orr {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::Immediate(r),
+                },
+                |r| Instruction::Eor {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::Immediate(r),
+                },
+                |r| Instruction::Tst {
+                    rn: Register::X1,
+                    rm: Operand::Immediate(r),
+                },
+                |r| Instruction::Ands {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::Immediate(r),
+                },
+            ] {
+                let instr = ctor(imm);
+                assert!(
+                    !instr.is_encodable_aarch64(),
+                    "{} with non-bitmask imm 0x{:x} must NOT be encodable",
+                    instr,
+                    imm as u64,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_is_encodable_aarch64_rejects_xzr_dest_for_and_orr_eor_imm() {
+        // AND/ORR/EOR (immediate) put Rd in the Xn|SP slot — XZR aliases to SP
+        // there, so the assembler will reject it. is_encodable must agree.
+        for ctor in [
+            |rd, imm| Instruction::And {
+                rd,
+                rn: Register::X1,
+                rm: Operand::Immediate(imm),
+            },
+            |rd, imm| Instruction::Orr {
+                rd,
+                rn: Register::X1,
+                rm: Operand::Immediate(imm),
+            },
+            |rd, imm| Instruction::Eor {
+                rd,
+                rn: Register::X1,
+                rm: Operand::Immediate(imm),
+            },
+        ] {
+            // Same encoder accepts 0xFF for X0…
+            assert!(ctor(Register::X0, 0xFF).is_encodable_aarch64());
+            // …but XZR-as-dest is rejected even with the otherwise-valid imm.
+            assert!(!ctor(Register::XZR, 0xFF).is_encodable_aarch64());
+        }
+
+        // ANDS uses the plain X slot for Rd, so XZR is fine there.
+        assert!(
+            Instruction::Ands {
+                rd: Register::XZR,
+                rn: Register::X1,
+                rm: Operand::Immediate(0xFF),
+            }
+            .is_encodable_aarch64()
+        );
     }
 }

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -608,7 +608,11 @@ impl Instruction {
             | Instruction::Orr { rd, rn, rm }
             | Instruction::Eor { rd, rn, rm } => match rm {
                 Operand::Register(_) => true,
-                Operand::Immediate(imm) => *rd != Register::XZR && logical_imm64_encodable(*imm),
+                // rd in the Xn|SP slot (SP allowed, XZR forbidden); rn in the
+                // plain Xn slot (XZR allowed via reg 31, SP forbidden).
+                Operand::Immediate(imm) => {
+                    *rd != Register::XZR && *rn != Register::SP && logical_imm64_encodable(*imm)
+                }
                 Operand::ShiftedRegister { reg, amount, .. } => {
                     *amount <= 63
                         && *reg != Register::SP
@@ -666,10 +670,11 @@ impl Instruction {
 
             // TST: register, encodable bitmask immediate (issue #65), or
             // shifted-register (all 4 kinds incl. ROR). No rd, so no XZR-slot
-            // guard needed for the immediate form.
+            // guard needed for the immediate form — but rn is the plain Xn slot
+            // (rejects SP).
             Instruction::Tst { rn, rm } => match rm {
                 Operand::Register(_) => true,
-                Operand::Immediate(imm) => logical_imm64_encodable(*imm),
+                Operand::Immediate(imm) => *rn != Register::SP && logical_imm64_encodable(*imm),
                 Operand::ShiftedRegister { reg, amount, .. } => {
                     *amount <= 63 && *reg != Register::SP && *rn != Register::SP
                 }
@@ -707,10 +712,13 @@ impl Instruction {
             },
             // ANDS: register or encodable bitmask immediate (issue #65).
             // ShiftedRegister out of scope (#59). The immediate form uses the
-            // plain X slot for Rd (unlike AND/ORR/EOR), so XZR-as-rd is fine.
-            Instruction::Ands { rm, .. } => match rm {
+            // plain X slot for both rd and rn (rejects SP); XZR is fine for rd
+            // (encodes as the TST shape).
+            Instruction::Ands { rd, rn, rm } => match rm {
                 Operand::Register(_) => true,
-                Operand::Immediate(imm) => logical_imm64_encodable(*imm),
+                Operand::Immediate(imm) => {
+                    *rd != Register::SP && *rn != Register::SP && logical_imm64_encodable(*imm)
+                }
                 Operand::ShiftedRegister { .. } => false,
                 Operand::ExtendedRegister { .. } => false,
             },
@@ -2593,6 +2601,75 @@ mod tests {
             Instruction::Ands {
                 rd: Register::XZR,
                 rn: Register::X1,
+                rm: Operand::Immediate(0xFF),
+            }
+            .is_encodable_aarch64()
+        );
+    }
+
+    #[test]
+    fn test_is_encodable_aarch64_rejects_sp_in_xn_slot_for_logical_imm() {
+        // AND/ORR/EOR (immediate): rn is the plain Xn slot — rejects SP. rd in
+        // Xn|SP slot accepts SP per ARM spec.
+        for ctor in [
+            |rn| Instruction::And {
+                rd: Register::X0,
+                rn,
+                rm: Operand::Immediate(0xFF),
+            },
+            |rn| Instruction::Orr {
+                rd: Register::X0,
+                rn,
+                rm: Operand::Immediate(0xFF),
+            },
+            |rn| Instruction::Eor {
+                rd: Register::X0,
+                rn,
+                rm: Operand::Immediate(0xFF),
+            },
+        ] {
+            assert!(
+                !ctor(Register::SP).is_encodable_aarch64(),
+                "rn=SP must be rejected for logical-imm (Xn slot)"
+            );
+            assert!(
+                ctor(Register::X1).is_encodable_aarch64(),
+                "rn=X1 must remain encodable"
+            );
+        }
+
+        // AND/ORR/EOR with rd=SP is legitimate (Xn|SP slot encodes SP).
+        assert!(
+            Instruction::And {
+                rd: Register::SP,
+                rn: Register::X1,
+                rm: Operand::Immediate(0xFF),
+            }
+            .is_encodable_aarch64()
+        );
+
+        // TST: rn in the plain Xn slot — SP rejected.
+        assert!(
+            !Instruction::Tst {
+                rn: Register::SP,
+                rm: Operand::Immediate(0xFF),
+            }
+            .is_encodable_aarch64()
+        );
+
+        // ANDS: both rd and rn in plain Xn slots — SP rejected for either.
+        assert!(
+            !Instruction::Ands {
+                rd: Register::SP,
+                rn: Register::X1,
+                rm: Operand::Immediate(0xFF),
+            }
+            .is_encodable_aarch64()
+        );
+        assert!(
+            !Instruction::Ands {
+                rd: Register::X0,
+                rn: Register::SP,
                 rm: Operand::Immediate(0xFF),
             }
             .is_encodable_aarch64()

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1722,8 +1722,10 @@ mod tests {
         // Invalid ADD immediate (out of range)
         assert!(parse_line("add x0, x1, #4096").is_err());
 
-        // AND with immediate not encodable (we don't support bitmask encoding)
-        assert!(parse_line("and x0, x1, #1").is_err());
+        // AND with a non-bitmask immediate (e.g., #5 = 0b101) is rejected by
+        // the encodability check. Valid bitmask values (e.g., #1) are accepted.
+        assert!(parse_line("and x0, x1, #1").is_ok());
+        assert!(parse_line("and x0, x1, #5").is_err());
     }
 
     // Full assembly parsing tests

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -489,12 +489,9 @@ fn parse_subs(operands: &[&str]) -> Result<Instruction, String> {
 
 /// Parse ANDS instruction (register-only rm)
 fn parse_ands(operands: &[&str]) -> Result<Instruction, String> {
-    if operands.len() != 3 {
-        return Err(format!("ands requires 3 operands, got {}", operands.len()));
-    }
+    let rm = parse_rm_3op("ands", operands)?;
     let rd = parse_register(operands[0])?;
     let rn = parse_register(operands[1])?;
-    let rm = Operand::Register(parse_register(operands[2])?);
     Ok(Instruction::Ands { rd, rn, rm })
 }
 
@@ -1726,6 +1723,11 @@ mod tests {
         // the encodability check. Valid bitmask values (e.g., #1) are accepted.
         assert!(parse_line("and x0, x1, #1").is_ok());
         assert!(parse_line("and x0, x1, #5").is_err());
+
+        // ANDS immediate must reach the encoder via the parser so Capstone
+        // disassembly of an ELF region containing `ands x?, x?, #imm` round-trips.
+        assert!(parse_line("ands x0, x1, #0xff").is_ok());
+        assert!(parse_line("ands x0, x1, #5").is_err());
     }
 
     // Full assembly parsing tests

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -205,9 +205,14 @@ pub fn parse_immediate(s: &str) -> Result<i64, String> {
         return Err("empty immediate value".to_string());
     }
 
-    // Handle hex
+    // Handle hex. Positive hex parses as u64 then reinterprets as i64 so that
+    // high-bit logical-immediate masks (e.g., 0x8000_0000_0000_0000) round-trip
+    // from Capstone text into the IR — i64::from_str_radix would reject them as
+    // overflow.
     if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
-        i64::from_str_radix(hex, 16).map_err(|e| format!("invalid hex immediate '{}': {}", s, e))
+        u64::from_str_radix(hex, 16)
+            .map(|v| v as i64)
+            .map_err(|e| format!("invalid hex immediate '{}': {}", s, e))
     } else if let Some(hex) = s.strip_prefix("-0x").or_else(|| s.strip_prefix("-0X")) {
         i64::from_str_radix(hex, 16)
             .map(|v| -v)
@@ -1728,6 +1733,11 @@ mod tests {
         // disassembly of an ELF region containing `ands x?, x?, #imm` round-trips.
         assert!(parse_line("ands x0, x1, #0xff").is_ok());
         assert!(parse_line("ands x0, x1, #5").is_err());
+
+        // High-bit logical immediates (>= 2^63) must parse from positive hex.
+        // i64::from_str_radix would overflow; we wrap through u64.
+        assert!(parse_line("and x0, x1, #0x8000000000000000").is_ok());
+        assert!(parse_line("tst x1, #0x8000000000000000").is_ok());
     }
 
     // Full assembly parsing tests

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -203,7 +203,9 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
                 instrs.push(Instruction::Ands { rd, rn, rm: rm_op });
             }
             // ADDS / SUBS also accept the same 12-bit-class immediate table
-            // ADD / SUB does — keep them in sync. ANDS is register-only.
+            // ADD / SUB does — keep them in sync. ANDS accepts bitmask
+            // immediates, but the curated 12-bit table here would mostly
+            // miss-encode, so we omit it for enumerative parity with AND.
             for &imm in immediates {
                 let imm_op = Operand::Immediate(imm);
                 instrs.push(Instruction::Adds { rd, rn, rm: imm_op });
@@ -426,15 +428,14 @@ pub fn generate_random_instruction<R: rand::RngExt>(
             let rm = random_operand(rng, registers, immediates);
             Instruction::Sub { rd, rn, rm }
         }
-        // AND / ORR / EOR are deliberately register-only here. AArch64's
-        // bitmask-immediate encoding for these is not supported by the
-        // assembler — the `Instruction::And { rm: Operand::Immediate(_) }`
-        // arm in `src/assembler/mod.rs` returns
-        // `Err("AND immediate encoding not yet supported")` (and likewise
-        // for ORR/EOR), so any `Operand::Immediate` candidate would be
-        // silently rejected at encoding time. Picking only register-form
-        // here keeps the stochastic search emitting candidates the encoder
-        // actually accepts.
+        // AND / ORR / EOR are deliberately register-only here. The assembler
+        // now accepts encodable AArch64 bitmask immediates (issue #65), but
+        // the generic `immediates` table passed in is a 12-bit-class set tuned
+        // for ADD/SUB and would mostly miss the bitmask form — most picks
+        // would round-trip through `is_encodable_aarch64` as `false` and burn
+        // iterations. Wiring a curated bitmask-immediate table for these
+        // opcodes is left to a follow-up; for now stochastic search keeps
+        // emitting register-only AND/ORR/EOR candidates.
         4 => {
             let rn = pick_reg(rng);
             let rm = Operand::Register(pick_reg(rng));

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -321,7 +321,9 @@ impl Mutator {
                     _ => *rm = Operand::Register(self.random_register(rng)),
                 }
             }
-            // Flag-setting arith/logical: ADDS/SUBS allow imm; ANDS register-only
+            // Flag-setting arith/logical: ADDS/SUBS allow 12-bit imm; ANDS
+            // also accepts bitmask imms but we keep the mutator's `rm` table
+            // tuned to the 12-bit form (see candidate.rs notes).
             Instruction::Adds { rd, rn, rm } | Instruction::Subs { rd, rn, rm } => {
                 let choice = rng.random_range(0..3);
                 match choice {
@@ -726,13 +728,12 @@ impl Mutator {
             },
             // Flag-setting cluster: ADDS↔SUBS↔ANDS, and into/out of ADD/SUB/AND.
             //
-            // Note: ADDS/SUBS accept `Operand::Immediate` (12-bit), but ANDS
-            // and AND are register-only (bitmask-immediate encoding is not
-            // supported). Forwarding an Immediate `rm` directly into ANDS
-            // would produce an un-encodable instruction that is_encodable
-            // silently rejects, burning search iterations. When mutating
-            // into ANDS, clamp `rm` to a register; the same logic applies
-            // when mutating into AND.
+            // Note: ADDS/SUBS accept `Operand::Immediate` (12-bit). ANDS and
+            // AND now accept *bitmask* immediates (issue #65), but the table
+            // the mutator draws from is 12-bit-tuned — forwarding such an imm
+            // into ANDS/AND would almost always fail `is_encodable_aarch64`
+            // and burn iterations. When mutating into ANDS/AND, clamp `rm`
+            // to a register until a curated bitmask-immediate table lands.
             Instruction::Adds { rd, rn, rm } => match rng.random_range(0..4) {
                 0 => Instruction::Add { rd, rn, rm },
                 1 => Instruction::Subs { rd, rn, rm },


### PR DESCRIPTION
## Summary
- Wire AND/ORR/EOR/TST/ANDS immediate forms through the AArch64 assembler. The implementation uses `dynasmrt::aarch64::encode_logical_immediate_64bit` to pre-validate the immediate and then emits via `dynasm!` with the correct register class per opmap (`XSP(rd)` for AND/ORR/EOR, plain `X(rd)` for ANDS, no `rd` for TST).
- Non-encodable bitmask immediates (0, all-ones, non-replicating patterns like `0b101`) return a descriptive `Err`.
- `is_encodable_aarch64` accepts encodable bitmask immediates for AND/ORR/EOR/TST/ANDS, with an `rd != XZR` guard for AND/ORR/EOR (the Xn|SP destination slot rejects the zero register).

Closes #65.

## Test plan
- [x] `test_and_immediate_correctness`, `test_orr_immediate_correctness`, `test_eor_immediate_correctness`, `test_tst_immediate_correctness`, `test_ands_immediate_correctness` — assemble each with a canonical bitmask immediate and Capstone-roundtrip via `disassemble_and_verify`.
- [x] `test_high_bit_logical_imm_encodable` — covers the `0x8000_0000_0000_0000` canonical case from the issue.
- [x] `test_logical_imm_rejects_unencodable` — exercises rejection for `0`, `-1` (all-ones), `5` (non-replicating), and TST `0`; asserts error message contains `"is not a valid AArch64 logical immediate"`.
- [x] `test_is_encodable_aarch64_logical_imm_accepts_valid` / `_rejects_invalid` / `_rejects_xzr_dest_for_and_orr_eor_imm` — IR-level predicate tests covering valid imms, invalid imms, and the XZR-destination guard (and confirming ANDS allows XZR-as-rd).
- [x] Stale tests updated: `reject_remaining_invalid_forms` now exercises a *real* non-bitmask value (`5`) instead of the previously-rejected-but-now-valid `1`; `test_is_encodable_logical` / `test_is_encodable_cmp` / `test_parse_line_encoding_validation` updated to reflect the new accept/reject split.
- [x] `./ci_check.sh` passes (fmt-check, build, unit tests, test-binary builds, full integration suite).

## Implementation notes
- `dynasmrt` 5.0.0 already ships the bitmask-immediate encoder publicly (`encode_logical_immediate_64bit`). No bespoke `N:immr:imms` encoder needed.
- IR `is_encodable_aarch64` now imports `dynasmrt::aarch64` — this is a single-line dependency from `src/ir/` into a backend crate (already a workspace dep). If layering hygiene matters later, the helper can move into a dedicated module.
- Search-side candidate generators (`src/search/candidate.rs`, `src/search/stochastic/mutation.rs`) continue to emit register-only AND/ORR/EOR forms — the existing 12-bit `immediates` table is tuned for ADD/SUB and would mostly miss the bitmask form. Wiring a curated bitmask-immediate table is a follow-up. Comments refreshed to reflect this is now a candidate-generator scope choice, not an assembler limitation.