### PR TITLE
Extend --live-out CLI with ;nzcv suffix (closes #81)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ on a chosen live-out set:
 s11 equiv a.s b.s --live-out x0,x1 --timeout 30
 ```
 
+Append `;nzcv` to declare AArch64 condition flags as part of the contract
+(e.g. `--live-out "x0,x1;nzcv"`).
+
 `llm-opt` — experimental driver that asks an LLM (via the `codex` CLI) to
 propose candidates that are then verified the same way as any other
 search result.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -175,7 +175,7 @@ EQUIVALENT: The two sequences are semantically equivalent.
 
 ### Options
 
-- `--live-out <REGS>`: Registers that must match (comma-separated). Default: `x0,x1,x2,x3,x4,x5,x6,x7`
+- `--live-out <CONTRACT>`: Observable architectural state that must match. Comma-separated registers (e.g. `x0,x1`), optionally followed by `;nzcv` to declare AArch64 condition flags live (e.g. `x0,x1;nzcv` or `;nzcv` for flags only). Default: `x0,x1,x2,x3,x4,x5,x6,x7`
 - `--timeout <SECS>`: SMT solver timeout in seconds. Default: 30
 - `--fast-only`: Use random testing only, skip SMT verification
 - `-v, --verbose`: Show detailed output

--- a/docs/adr/0006-live-out-cli-grammar.md
+++ b/docs/adr/0006-live-out-cli-grammar.md
@@ -1,0 +1,44 @@
+# ADR-0006 — `--live-out` CLI grammar extends with `;nzcv` flag-liveness suffix
+
+Status: Accepted
+Date: 2026-05-18
+
+## Context
+
+Before this ADR, the `--live-out` CLI argument on the `equiv` and `llm-opt` subcommands accepted only a comma-separated register list (e.g. `x0,x1,sp`). NZCV flag-liveness was already a first-class property of the AArch64 equivalence pipeline — `EquivalenceConfig.flags_live` plus `EquivalenceConfig::with_flags(bool)` exist on `src/semantics/equivalence.rs:106,171`, and both the fast-path concrete comparison and the SMT path consume the bit. The search algorithms (enumerative, stochastic, symbolic, LLM) all internally pin `flags_live=true` when verifying candidates (e.g. `src/search/enumerative/search.rs:89`, `src/search/stochastic/mcmc.rs:211`, `src/search/symbolic/synthesis.rs:241`, `src/search/llm/outcome.rs:67`). What was missing was a way for the `equiv` user to opt in.
+
+PR #78 deferred this as issue #81 with the note that once the live-out contract grew beyond registers, the CLI parser would need broadening. The deferral was contingent on a syntax decision and on the absence of a flag bit on the contract object; that absence is no longer load-bearing because the bit lives on `EquivalenceConfig`, not on `LiveOut`.
+
+ADR-0004 §5 commits to eventually replacing `LiveOut` and `X86LiveOutMask` with the generic `LiveOutMask<R>` (already scaffolded at `src/semantics/live_out.rs:25-87` with its own `flags_live`/`set_flags_live` API). When that migration lands, the CLI parser introduced here will simply produce a `LiveOutMask<Register>` directly; the grammar does not need to change.
+
+## Decision
+
+1. Add a free function `validation::live_out::parse_live_out_contract(s: &str) -> Result<(LiveOut, bool), ParseLiveOutRegistersError>` implementing the grammar `<regs>` or `<regs>;<flags>`:
+   - Register half follows the existing `LiveOutRegisters::from_str` rules (comma- or space-separated, case-insensitive, accepts `x0..x30`, `sp`, `xzr`).
+   - Flag half accepts only the group token `nzcv` (case-insensitive). The per-flag tokens `n`, `z`, `c`, `v` are **explicitly reserved** so a future per-flag liveness rev can add them without a second grammar break. They are rejected today with a "reserved" diagnostic.
+   - Bareword `nzcv` (no leading `;`) is rejected so the bareword reservation is unambiguous.
+   - At most one `;` is permitted.
+
+2. Route both `run_equiv` (`src/main.rs`) and `run_llm_opt` through `parse_live_out_contract`, using a uniform `"invalid live-out: ..."` error prefix.
+
+3. In `run_equiv`, plug the returned `flags_live` bit into `EquivalenceConfig::with_flags(flags_live)`. The verbose printout gains `Live-out flags: nzcv` when the bit is set.
+
+4. In `run_llm_opt`, accept the same grammar but discard the bit. The LLM verification path pins `flags_live=true` internally at `src/search/llm/outcome.rs:67`, so the CLI bit is informational only on that subcommand. Keeping the parser consistent across both subcommands avoids a CLI-vocabulary fork.
+
+5. Do **not** add a `flags_live` field to `LiveOut` or a `with_flags` builder. The bit lives on `EquivalenceConfig` today and on `LiveOutMask<R>` in the future (ADR-0004 §5); adding a third home would create exactly the kind of state-duplication the ISA-trait-collapse ADR cautions against.
+
+6. Do **not** drop `impl FromStr for LiveOutRegisters`. Existing callers (and the existing `from_str` test suite) keep working.
+
+## Consequences
+
+**Positive:**
+- The `equiv` subcommand can finally express "match registers and NZCV after execution" — a real user-facing capability gap closed without semantic churn.
+- The CLI grammar reserves the per-flag tokens up front, so a per-flag rev (when one is needed) lands without breaking in-flight scripts.
+- The two divergent CLI parse paths (`run_llm_opt` via `LiveOutRegisters::from_str`, `run_equiv` via hand-rolled `parser::parse_register` splitting) now share a single helper. Error messages match.
+
+**Negative / scope:**
+- `run_llm_opt --live-out "x0;nzcv"` and `run_llm_opt --live-out "x0"` are observationally identical on the LLM path today because `outcome.rs:67` pins `flags_live=true`. Users may be surprised that the suffix is "accepted but ignored" on this subcommand. Documented in the help text and in the `run_llm_opt` source comment.
+- `opt` (ELF optimization) does not accept `--live-out` and is unchanged. The search algorithms it dispatches still pin `flags_live=true` internally, so the conservative semantics there are preserved.
+- The bit lives on `EquivalenceConfig` and (in scaffolding) on `LiveOutMask<R>`. When the mask migration of ADR-0004 §5 lands, this ADR's CLI grammar should remain stable but the parser will return `(LiveOutMask<Register>, ())` — a single-return shape — and the explicit `bool` plumbing in `run_equiv` will collapse.
+
+**Reversibility:** high for the per-flag rev — the `n`/`z`/`c`/`v` tokens are rejected with a "reserved" message today, so adding their semantics later is a strict superset of the current grammar. Reversibility low for the parser function itself: it becomes load-bearing for both CLI subcommands.

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,7 +205,7 @@ enum Commands {
         /// Path to an .s file containing the target sequence (GAS syntax)
         #[arg(long)]
         asm: PathBuf,
-        /// Live-out contract (comma-separated regs; optional ';nzcv' suffix declares flags live, e.g. "x0,x1;nzcv")
+        /// Live-out contract (comma-separated regs; ';nzcv' suffix is accepted for syntax compatibility with `equiv` but has no effect here — the LLM verifier always treats NZCV as live; see ADR-0006)
         #[arg(long)]
         live_out: String,
         /// Maximum number of `codex exec` invocations

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,8 +25,8 @@ use search::config::{
 };
 use search::parallel::{ParallelConfig, run_parallel_search};
 use search::{EnumerativeSearch, SearchAlgorithm, StochasticSearch, SymbolicSearch};
+use semantics::LiveOut;
 use semantics::cost::CostMetric;
-use semantics::{LiveOut, LiveOutRegisters};
 
 // --- Command Line Arguments ---
 
@@ -205,7 +205,7 @@ enum Commands {
         /// Path to an .s file containing the target sequence (GAS syntax)
         #[arg(long)]
         asm: PathBuf,
-        /// Live-out registers (comma-separated, e.g. "x0,x1")
+        /// Live-out contract (comma-separated regs; optional ';nzcv' suffix declares flags live, e.g. "x0,x1;nzcv")
         #[arg(long)]
         live_out: String,
         /// Maximum number of `codex exec` invocations
@@ -227,7 +227,7 @@ enum Commands {
         file1: PathBuf,
         /// Second assembly file
         file2: PathBuf,
-        /// Registers that must match (comma-separated, e.g., "x0,x1")
+        /// Live-out contract (comma-separated regs; optional ';nzcv' suffix declares flags live, e.g. "x0,x1;nzcv")
         #[arg(long, default_value = "x0,x1,x2,x3,x4,x5,x6,x7")]
         live_out: String,
         /// Timeout in seconds for SMT solver
@@ -1295,10 +1295,12 @@ fn run_llm_opt(
         }
     }
 
-    let live_out_registers: LiveOutRegisters = live_out_str
-        .parse()
-        .map_err(|e: validation::live_out::ParseLiveOutRegistersError| e.to_string())?;
-    let live_out = LiveOut::from_register_set(live_out_registers);
+    // The LLM verifier in `outcome.rs` pins `flags_live=true` regardless of
+    // what the user requests here, so the `;nzcv` suffix is accepted (for
+    // CLI vocabulary parity with `equiv`) but does not change behaviour on
+    // this path. See ADR-0006.
+    let (live_out, _flags_live) = validation::live_out::parse_live_out_contract(live_out_str)
+        .map_err(|e| format!("invalid live-out: {}", e))?;
 
     let llm = LlmConfig::default()
         .with_max_codex_calls(max_calls)
@@ -1362,31 +1364,22 @@ fn run_equiv(
         }
     }
 
-    // Parse live-out registers
-    let live_out_regs: Vec<Register> = live_out_str
-        .split(',')
-        .map(|s| s.trim())
-        .filter(|s| !s.is_empty())
-        .map(parser::parse_register)
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| format!("invalid live-out register: {}", e))?;
+    let (live_out, flags_live) = validation::live_out::parse_live_out_contract(live_out_str)
+        .map_err(|e| format!("invalid live-out: {}", e))?;
 
     if verbose {
-        println!(
-            "Live-out registers: {}",
-            live_out_regs
-                .iter()
-                .map(|r| format!("{}", r))
-                .collect::<Vec<_>>()
-                .join(", ")
-        );
+        let mut regs: Vec<_> = live_out.registers().iter().collect();
+        regs.sort_by_key(|r| r.index().unwrap_or(u8::MAX));
+        let names: Vec<String> = regs.iter().map(|r| format!("{}", r)).collect();
+        println!("Live-out registers: {}", names.join(", "));
+        if flags_live {
+            println!("Live-out flags: nzcv");
+        }
     }
 
-    let live_out = LiveOut::from_registers(live_out_regs);
-
-    // Build config
     let config = EquivalenceConfig::default()
         .live_out(live_out)
+        .with_flags(flags_live)
         .timeout(Duration::from_secs(timeout))
         .set_fast_only(fast_only);
 

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -265,8 +265,7 @@ fn fast_path_input_registers(
 /// NZCV as live-out: the standard random/edge-case inputs leave initial
 /// NZCV at `ConditionFlags::default()` (all zero), so a CCMP under a
 /// condition predicate that depends on an incoming flag (e.g. `mi`) only
-/// gets exercised on the condition-false branch. PR #172 review thread
-/// PRRT_kwDOOuU3Hc6CxjC4.
+/// gets exercised on the condition-false branch.
 fn fast_path_initial_nzcv_variants(
     input_regs: &[crate::ir::Register],
 ) -> Vec<ConcreteMachineState> {
@@ -2125,9 +2124,6 @@ mod tests {
         );
     }
 
-    /// Soundness regression test for PR #172 review thread
-    /// PRRT_kwDOOuU3Hc6Cw2qx.
-    ///
     /// `tst x1, #1` and `tst x1, #2` differ on NZCV when bit 0 vs bit 1 of
     /// x1 is set, so a flag-aware live-out contract must classify them as
     /// non-equivalent. Prior to the source-register randomization fix, the
@@ -2157,9 +2153,6 @@ mod tests {
         );
     }
 
-    /// Soundness regression test for PR #172 review thread
-    /// PRRT_kwDOOuU3Hc6CxjC4.
-    ///
     /// `ccmp x0, #0, #0, mi` and `ccmp x1, #1, #0, mi` both fall through to
     /// the immediate-NZCV `#0` branch when initial N is false, so all flags
     /// land at zero regardless of x0/x1. When initial N is true, the MI

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -341,10 +341,11 @@ fn run_fast_path(
     // handles this correctly via symbolic initial state, and adding 16
     // inputs to every search-algorithm candidate would burn significant
     // wall-clock time on a verifier that's normally SMT-authoritative.
-    if config.fast_only
-        && config.flags_live
-        && (reads_flags_before_writing(seq1) || reads_flags_before_writing(seq2))
-    {
+    // NOT gated on `config.flags_live` — a flag-reading sequence whose
+    // *register* output depends on incoming NZCV (e.g. `csel x0, x1, x2, mi`
+    // under `--live-out x0`) also needs the variants for the fast path to
+    // catch divergence on the condition-true branch.
+    if config.fast_only && (reads_flags_before_writing(seq1) || reads_flags_before_writing(seq2)) {
         for input in &fast_path_initial_nzcv_variants(&input_regs) {
             let state1 = apply_sequence_concrete(input.clone(), seq1);
             let state2 = apply_sequence_concrete(input.clone(), seq2);
@@ -2184,6 +2185,39 @@ mod tests {
         assert!(
             matches!(result, EquivalenceResult::NotEquivalentFast(_)),
             "expected NotEquivalentFast for ccmp pair under flags-only fast-only, got {:?}",
+            result
+        );
+    }
+
+    /// `csel x0, x1, x2, mi` reads incoming N to decide whether x0 = x1
+    /// (N=true) or x0 = x2 (N=false). With a register-live contract
+    /// (`--live-out x0` but `flags_live=false`), the initial-NZCV variants
+    /// were originally gated on `config.flags_live` — so all fast-path
+    /// inputs left N=false and the candidate `mov x0, x2` was accepted as
+    /// equivalent even when x1 != x2 and N=true would differ. Broadening
+    /// the gate to fire on any flag-reading sequence (regardless of whether
+    /// flags themselves are observable) plugs the gap.
+    #[test]
+    fn fast_only_register_contract_detects_csel_initial_nzcv_divergence() {
+        let seq1 = vec![Instruction::Csel {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+            cond: Condition::MI,
+        }];
+        let seq2 = vec![Instruction::MovReg {
+            rd: Register::X0,
+            rn: Register::X2,
+        }];
+        let config =
+            EquivalenceConfig::fast_only().live_out(LiveOut::from_registers(vec![Register::X0]));
+        // Deliberately NOT calling `.with_flags(true)` — this regression
+        // exercises a register-only contract where the candidate's output
+        // depends on incoming NZCV via CSEL.
+        let result = check_equivalence_with_config(&seq1, &seq2, &config);
+        assert!(
+            matches!(result, EquivalenceResult::NotEquivalentFast(_)),
+            "expected NotEquivalentFast for csel-vs-mov under --fast-only --live-out x0, got {:?}",
             result
         );
     }

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -296,7 +296,19 @@ fn run_fast_path(
     config: &EquivalenceConfig,
 ) -> Option<EquivalenceResult> {
     let live_out_registers = config.live_out.registers();
-    let input_regs = fast_path_input_registers(live_out_registers, seq1, seq2);
+    // Under `fast_only`, the SMT path that would otherwise catch divergences
+    // depending on source registers outside `live_out` is skipped — extend
+    // the random-input mask to cover seq1+seq2 source registers so e.g.
+    // `tst x1, #1` vs `tst x1, #2` is caught under `--live-out ';nzcv'
+    // --fast-only`. Otherwise stay with the live-out-only mask: the SMT
+    // path is authoritative (operates on symbolic inputs), and the larger
+    // mask measurably increases per-call cost in search algorithms which
+    // run check_equivalence on thousands of candidates.
+    let input_regs: Vec<crate::ir::Register> = if config.fast_only {
+        fast_path_input_registers(live_out_registers, seq1, seq2)
+    } else {
+        live_out_registers.iter().cloned().collect()
+    };
 
     let random_config = RandomInputConfig {
         count: config.random_test_count,

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -226,6 +226,38 @@ pub struct EquivalenceMetrics {
     pub smt_formula_bytes: Option<usize>,
 }
 
+/// Build the fast-path input randomization set.
+///
+/// Returns the union of `live_out_registers` and the source registers of every
+/// instruction in `seq1` and `seq2`. Registers not in this set stay at the
+/// `ConcreteMachineState::new_zeroed` default across all random/edge-case
+/// inputs, which is a soundness gap for any sequence whose flag or register
+/// output depends on a source register that is neither live-out nor a
+/// destination of an earlier instruction in the sequence (e.g. `tst x1, #1`
+/// vs `tst x1, #2` under a flag-only contract — see the regression test in
+/// this module). The SMT path is unaffected; it operates on symbolic inputs.
+fn fast_path_input_registers(
+    live_out_registers: &crate::semantics::live_out::LiveOutRegisters,
+    seq1: &[Instruction],
+    seq2: &[Instruction],
+) -> Vec<crate::ir::Register> {
+    use std::collections::HashSet;
+    let mut regs: HashSet<crate::ir::Register> = HashSet::new();
+    for r in live_out_registers.iter() {
+        regs.insert(*r);
+    }
+    for instr in seq1.iter().chain(seq2.iter()) {
+        for src in instr.source_registers() {
+            regs.insert(src);
+        }
+    }
+    // Sort by register index for deterministic input ordering (so test
+    // failures and SMT-formula seeds are reproducible).
+    let mut v: Vec<_> = regs.into_iter().collect();
+    v.sort_by_key(|r| r.index().unwrap_or(u8::MAX));
+    v
+}
+
 /// Run the fast-path random + edge-case checks. Returns either a
 /// `NotEquivalentFast` refutation, `None` if the fast path passed, or
 /// `Some(Equivalent)` if `fast_only` short-circuits.
@@ -235,7 +267,7 @@ fn run_fast_path(
     config: &EquivalenceConfig,
 ) -> Option<EquivalenceResult> {
     let live_out_registers = config.live_out.registers();
-    let input_regs: Vec<_> = live_out_registers.iter().cloned().collect();
+    let input_regs = fast_path_input_registers(live_out_registers, seq1, seq2);
 
     let random_config = RandomInputConfig {
         count: config.random_test_count,
@@ -2028,6 +2060,38 @@ mod tests {
         assert!(
             matches!(result, EquivalenceResult::Equivalent),
             "got {:?}",
+            result
+        );
+    }
+
+    /// Soundness regression test for PR #172 review thread
+    /// PRRT_kwDOOuU3Hc6Cw2qx.
+    ///
+    /// `tst x1, #1` and `tst x1, #2` differ on NZCV when bit 0 vs bit 1 of
+    /// x1 is set, so a flag-aware live-out contract must classify them as
+    /// non-equivalent. Prior to the source-register randomization fix, the
+    /// fast path only varied registers in `config.live_out.registers()` —
+    /// empty for a flag-only contract — so x1 stayed at zero across all
+    /// random + edge-case inputs and both sequences reported flags as zero,
+    /// returning `Equivalent` under `--fast-only`. The fix unions the source
+    /// registers of both sequences into the random-input mask.
+    #[test]
+    fn fast_only_flags_only_contract_detects_tst_divergence() {
+        let seq1 = vec![Instruction::Tst {
+            rn: Register::X1,
+            rm: Operand::Immediate(1),
+        }];
+        let seq2 = vec![Instruction::Tst {
+            rn: Register::X1,
+            rm: Operand::Immediate(2),
+        }];
+        let config = EquivalenceConfig::fast_only()
+            .live_out(LiveOut::from_registers(vec![]))
+            .with_flags(true);
+        let result = check_equivalence_with_config(&seq1, &seq2, &config);
+        assert!(
+            matches!(result, EquivalenceResult::NotEquivalentFast(_)),
+            "expected NotEquivalentFast for flags-only fast-only contract, got {:?}",
             result
         );
     }

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -323,10 +323,17 @@ fn run_fast_path(
         }
     }
 
-    // When the live-out contract treats NZCV as observable AND either
-    // sequence reads flags before writing them, also test all 16 initial
-    // NZCV combinations. Skipped otherwise to keep per-call cost bounded.
-    if config.flags_live && (reads_flags_before_writing(seq1) || reads_flags_before_writing(seq2)) {
+    // Under `fast_only`, the SMT path that would otherwise catch initial-
+    // NZCV divergence is skipped — for sequences that read flags before
+    // writing them (CSEL family, CCMP, CCMN, ...), also test all 16 initial
+    // NZCV combinations. Gated on `fast_only` because the SMT path already
+    // handles this correctly via symbolic initial state, and adding 16
+    // inputs to every search-algorithm candidate would burn significant
+    // wall-clock time on a verifier that's normally SMT-authoritative.
+    if config.fast_only
+        && config.flags_live
+        && (reads_flags_before_writing(seq1) || reads_flags_before_writing(seq2))
+    {
         for input in &fast_path_initial_nzcv_variants(&input_regs) {
             let state1 = apply_sequence_concrete(input.clone(), seq1);
             let state2 = apply_sequence_concrete(input.clone(), seq2);

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -23,6 +23,7 @@ use crate::semantics::smt::{
     states_not_equal_for_live_out,
 };
 use crate::semantics::state::ConcreteMachineState;
+use crate::validation::live_out::reads_flags_before_writing;
 use crate::validation::random::{
     RandomInputConfig, generate_edge_case_inputs, generate_random_inputs,
 };
@@ -258,6 +259,34 @@ fn fast_path_input_registers(
     v
 }
 
+/// Build 16 inputs covering every initial NZCV combination with source
+/// registers randomized. Used to plug a soundness gap when either sequence
+/// reads flags before writing (e.g. CCMP, CSEL) and the contract treats
+/// NZCV as live-out: the standard random/edge-case inputs leave initial
+/// NZCV at `ConditionFlags::default()` (all zero), so a CCMP under a
+/// condition predicate that depends on an incoming flag (e.g. `mi`) only
+/// gets exercised on the condition-false branch. PR #172 review thread
+/// PRRT_kwDOOuU3Hc6CxjC4.
+fn fast_path_initial_nzcv_variants(
+    input_regs: &[crate::ir::Register],
+) -> Vec<ConcreteMachineState> {
+    use crate::semantics::state::ConditionFlags;
+    let variant_regs_config = RandomInputConfig {
+        count: 16,
+        registers: input_regs.to_vec(),
+    };
+    let mut variants = generate_random_inputs(&variant_regs_config);
+    for (i, input) in variants.iter_mut().enumerate() {
+        input.set_flags(ConditionFlags {
+            n: (i & 0b1000) != 0,
+            z: (i & 0b0100) != 0,
+            c: (i & 0b0010) != 0,
+            v: (i & 0b0001) != 0,
+        });
+    }
+    variants
+}
+
 /// Run the fast-path random + edge-case checks. Returns either a
 /// `NotEquivalentFast` refutation, `None` if the fast path passed, or
 /// `Some(Equivalent)` if `fast_only` short-circuits.
@@ -291,6 +320,19 @@ fn run_fast_path(
 
         if !states_equal_for_live_out(&state1, &state2, live_out_registers, config.flags_live) {
             return Some(EquivalenceResult::NotEquivalentFast(input.clone()));
+        }
+    }
+
+    // When the live-out contract treats NZCV as observable AND either
+    // sequence reads flags before writing them, also test all 16 initial
+    // NZCV combinations. Skipped otherwise to keep per-call cost bounded.
+    if config.flags_live && (reads_flags_before_writing(seq1) || reads_flags_before_writing(seq2)) {
+        for input in &fast_path_initial_nzcv_variants(&input_regs) {
+            let state1 = apply_sequence_concrete(input.clone(), seq1);
+            let state2 = apply_sequence_concrete(input.clone(), seq2);
+            if !states_equal_for_live_out(&state1, &state2, live_out_registers, config.flags_live) {
+                return Some(EquivalenceResult::NotEquivalentFast(input.clone()));
+            }
         }
     }
 
@@ -2092,6 +2134,44 @@ mod tests {
         assert!(
             matches!(result, EquivalenceResult::NotEquivalentFast(_)),
             "expected NotEquivalentFast for flags-only fast-only contract, got {:?}",
+            result
+        );
+    }
+
+    /// Soundness regression test for PR #172 review thread
+    /// PRRT_kwDOOuU3Hc6CxjC4.
+    ///
+    /// `ccmp x0, #0, #0, mi` and `ccmp x1, #1, #0, mi` both fall through to
+    /// the immediate-NZCV `#0` branch when initial N is false, so all flags
+    /// land at zero regardless of x0/x1. When initial N is true, the MI
+    /// branch fires: seq1 computes `x0 cmp 0`, seq2 computes `x1 cmp 1` —
+    /// flags then depend on x0/x1 and diverge for most randomized values.
+    /// Prior to the initial-NZCV variants in `run_fast_path`, the fast path
+    /// only tested with NZCV defaulted to zero, so this pair returned
+    /// `Equivalent` under `--fast-only`. The fix is to also generate inputs
+    /// with each of the 16 initial NZCV combinations when either sequence
+    /// reads flags before writing.
+    #[test]
+    fn fast_only_flags_only_contract_detects_ccmp_initial_nzcv_divergence() {
+        let seq1 = vec![Instruction::Ccmp {
+            rn: Register::X0,
+            rm: Operand::Immediate(0),
+            nzcv: 0,
+            cond: Condition::MI,
+        }];
+        let seq2 = vec![Instruction::Ccmp {
+            rn: Register::X1,
+            rm: Operand::Immediate(1),
+            nzcv: 0,
+            cond: Condition::MI,
+        }];
+        let config = EquivalenceConfig::fast_only()
+            .live_out(LiveOut::from_registers(vec![]))
+            .with_flags(true);
+        let result = check_equivalence_with_config(&seq1, &seq2, &config);
+        assert!(
+            matches!(result, EquivalenceResult::NotEquivalentFast(_)),
+            "expected NotEquivalentFast for ccmp pair under flags-only fast-only, got {:?}",
             result
         );
     }

--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -170,13 +170,11 @@ pub fn flags_live_out(instructions: &[Instruction]) -> bool {
 /// Returns true if any instruction reads NZCV flags before any instruction writes them.
 ///
 /// In live-in terms: NZCV is part of the live-in set iff this returns true.
-/// Used by the prompt builder when flags-live-in support is added (ADR-0001
-/// defines the helper; ADR-0003 omits flags from the prompt for the MVP, so
-/// the function has no consumer yet).
-///
-/// Issue #77 stage 1 step 14: same FlagsAnalysis routing as `flags_live_out`
-/// above, for parity with the upcoming x86 wire-up.
-#[allow(dead_code)]
+/// Consumed by the equivalence fast path to decide whether initial NZCV must
+/// be varied across random/edge-case inputs (see `fast_path_initial_nzcv_variants`
+/// in `src/semantics/equivalence.rs`). ADR-0001 defines the helper shape;
+/// ADR-0003 omits flags from the LLM prompt for the MVP. Routed through
+/// `FlagsAnalysis<I>` (ADR-0004 decision 7) for parity with the x86 wire-up.
 pub fn reads_flags_before_writing(instructions: &[Instruction]) -> bool {
     use crate::isa::{AArch64, FlagsAnalysis};
     for instr in instructions {

--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -3,7 +3,7 @@
 #![allow(dead_code)]
 
 use crate::ir::{Instruction, Register};
-use crate::semantics::live_out::LiveOutRegisters;
+use crate::semantics::live_out::{LiveOut, LiveOutRegisters};
 use std::str::FromStr;
 
 /// Error type for parsing live-out register sets.
@@ -68,6 +68,55 @@ impl FromStr for LiveOutRegisters {
 
         Ok(mask)
     }
+}
+
+/// Parse the CLI `--live-out` contract string.
+///
+/// Grammar: `<regs>` or `<regs>;<flags>`. The register half follows
+/// `LiveOutRegisters::from_str` (comma- or space-separated, case-insensitive,
+/// accepts `x0..x30`, `sp`, `xzr`). The flag half currently accepts only the
+/// group token `nzcv`; per-flag tokens `n`/`z`/`c`/`v` are reserved for a
+/// future per-flag liveness extension and rejected today. A bareword `nzcv`
+/// with no leading `;` is rejected to keep that reservation unambiguous.
+///
+/// Returns `(LiveOut, flags_live)`. Callers pass `flags_live` to
+/// `EquivalenceConfig::with_flags(...)` (see ADR-0006).
+pub fn parse_live_out_contract(s: &str) -> Result<(LiveOut, bool), ParseLiveOutRegistersError> {
+    let trimmed = s.trim();
+    let semicolon_count = trimmed.matches(';').count();
+    if semicolon_count > 1 {
+        return Err(ParseLiveOutRegistersError {
+            message: format!("--live-out accepts at most one ';' (got: '{}')", s),
+        });
+    }
+    if semicolon_count == 0 {
+        if trimmed.eq_ignore_ascii_case("nzcv") {
+            return Err(ParseLiveOutRegistersError {
+                message: format!(
+                    "flag-only live-out requires a leading ';' (e.g. \";nzcv\"); got '{}'",
+                    s
+                ),
+            });
+        }
+        let regs = LiveOutRegisters::from_str(trimmed)?;
+        return Ok((LiveOut::from_register_set(regs), false));
+    }
+    let (regs_part, flags_part) = trimmed.split_once(';').unwrap();
+    let regs = LiveOutRegisters::from_str(regs_part.trim())?;
+    let flags_tok = flags_part.trim().to_ascii_lowercase();
+    let flags_live = match flags_tok.as_str() {
+        "" => false,
+        "nzcv" => true,
+        other => {
+            return Err(ParseLiveOutRegistersError {
+                message: format!(
+                    "unknown flag token '{}', expected 'nzcv' (per-flag tokens n/z/c/v reserved)",
+                    other
+                ),
+            });
+        }
+    };
+    Ok((LiveOut::from_register_set(regs), flags_live))
 }
 
 /// Compute the set of registers written by a sequence of instructions
@@ -469,5 +518,115 @@ mod tests {
         let mask = compute_written_registers(&instructions);
         assert!(!mask.contains(Register::XZR));
         assert!(mask.is_empty());
+    }
+
+    #[test]
+    fn test_parse_live_out_contract_regs_and_flags() {
+        let (live_out, flags_live) = parse_live_out_contract("x0,x1;nzcv").unwrap();
+        assert!(live_out.contains_register(Register::X0));
+        assert!(live_out.contains_register(Register::X1));
+        assert!(flags_live);
+    }
+
+    #[test]
+    fn test_parse_live_out_contract_regs_only_flags_off() {
+        let (live_out, flags_live) = parse_live_out_contract("x0,x1").unwrap();
+        assert!(live_out.contains_register(Register::X0));
+        assert!(live_out.contains_register(Register::X1));
+        assert!(!flags_live);
+    }
+
+    #[test]
+    fn test_parse_live_out_contract_flags_only() {
+        let (live_out, flags_live) = parse_live_out_contract(";nzcv").unwrap();
+        assert_eq!(live_out.registers().len(), 0);
+        assert!(flags_live);
+    }
+
+    #[test]
+    fn test_parse_live_out_contract_trailing_semicolon() {
+        let (live_out, flags_live) = parse_live_out_contract("x0,x1;").unwrap();
+        assert!(live_out.contains_register(Register::X0));
+        assert!(!flags_live);
+    }
+
+    #[test]
+    fn test_parse_live_out_contract_uppercase_passes() {
+        let (live_out, flags_live) = parse_live_out_contract("X0,X1;NZCV").unwrap();
+        assert!(live_out.contains_register(Register::X0));
+        assert!(live_out.contains_register(Register::X1));
+        assert!(flags_live);
+    }
+
+    #[test]
+    fn test_parse_live_out_contract_empty_input() {
+        let (live_out, flags_live) = parse_live_out_contract("").unwrap();
+        assert_eq!(live_out.registers().len(), 0);
+        assert!(!flags_live);
+    }
+
+    #[test]
+    fn test_parse_live_out_contract_whitespace_around_semicolon() {
+        let (live_out, flags_live) = parse_live_out_contract("x0 ; nzcv").unwrap();
+        assert!(live_out.contains_register(Register::X0));
+        assert!(flags_live);
+    }
+
+    #[test]
+    fn test_parse_live_out_contract_lone_semicolon() {
+        let (live_out, flags_live) = parse_live_out_contract(";").unwrap();
+        assert_eq!(live_out.registers().len(), 0);
+        assert!(!flags_live);
+    }
+
+    #[test]
+    fn test_parse_live_out_contract_whitespace_only_sides() {
+        let (live_out, flags_live) = parse_live_out_contract("  ;  ").unwrap();
+        assert_eq!(live_out.registers().len(), 0);
+        assert!(!flags_live);
+    }
+
+    #[test]
+    fn test_parse_live_out_contract_bareword_nzcv_rejected() {
+        let err = parse_live_out_contract("nzcv").unwrap_err();
+        assert!(
+            err.message
+                .contains("flag-only live-out requires a leading ';'"),
+            "got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn test_parse_live_out_contract_multi_section_rejected() {
+        assert!(parse_live_out_contract("x0;nzcv;extra").is_err());
+        assert!(parse_live_out_contract(";nzcv;").is_err());
+    }
+
+    #[test]
+    fn test_parse_live_out_contract_unknown_flag_rejected() {
+        let err = parse_live_out_contract("x0;bogus").unwrap_err();
+        assert!(
+            err.message.contains("unknown flag token"),
+            "got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn test_parse_live_out_contract_per_flag_tokens_reserved() {
+        for tok in ["n", "z", "c", "v"] {
+            let s = format!("x0;{}", tok);
+            assert!(
+                parse_live_out_contract(&s).is_err(),
+                "expected '{}' to be rejected (reserved)",
+                s
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_live_out_contract_invalid_register_still_errors() {
+        assert!(parse_live_out_contract("x0,bogus;nzcv").is_err());
     }
 }

--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -107,12 +107,17 @@ pub fn parse_live_out_contract(s: &str) -> Result<(LiveOut, bool), ParseLiveOutR
     let flags_live = match flags_tok.as_str() {
         "" => false,
         "nzcv" => true,
-        other => {
+        "n" | "z" | "c" | "v" => {
             return Err(ParseLiveOutRegistersError {
                 message: format!(
-                    "unknown flag token '{}', expected 'nzcv' (per-flag tokens n/z/c/v reserved)",
-                    other
+                    "per-flag token '{}' is reserved for a future extension; use 'nzcv' for all flags",
+                    flags_tok
                 ),
+            });
+        }
+        other => {
+            return Err(ParseLiveOutRegistersError {
+                message: format!("unknown flag token '{}'; expected 'nzcv'", other),
             });
         }
     };
@@ -617,10 +622,18 @@ mod tests {
     fn test_parse_live_out_contract_per_flag_tokens_reserved() {
         for tok in ["n", "z", "c", "v"] {
             let s = format!("x0;{}", tok);
+            let err = parse_live_out_contract(&s).unwrap_err();
             assert!(
-                parse_live_out_contract(&s).is_err(),
-                "expected '{}' to be rejected (reserved)",
-                s
+                err.message.contains("reserved for a future extension"),
+                "expected '{}' to be rejected as reserved, got: {}",
+                s,
+                err.message
+            );
+            assert!(
+                err.message.contains(&format!("per-flag token '{}'", tok)),
+                "expected reserved-token error to name '{}', got: {}",
+                tok,
+                err.message
             );
         }
     }

--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -20,7 +20,9 @@ impl std::fmt::Display for ParseLiveOutRegistersError {
 
 impl std::error::Error for ParseLiveOutRegistersError {}
 
-/// Parse a register name like "x0", "X1", "sp", "SP"
+/// Parse a register name like "x0", "X1", "sp", "SP". Accepts the standard
+/// AArch64 aliases `fp` (x29) and `lr` (x30) to match the assembly parser at
+/// `src/parser/mod.rs::parse_register`.
 fn parse_register(s: &str) -> Result<Register, ParseLiveOutRegistersError> {
     let s = s.trim().to_lowercase();
 
@@ -29,6 +31,12 @@ fn parse_register(s: &str) -> Result<Register, ParseLiveOutRegistersError> {
     }
     if s == "xzr" {
         return Ok(Register::XZR);
+    }
+    if s == "fp" {
+        return Ok(Register::X29);
+    }
+    if s == "lr" {
+        return Ok(Register::X30);
     }
 
     if let Some(num_str) = s.strip_prefix('x')
@@ -236,10 +244,33 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_register_fp_lr_aliases() {
+        assert_eq!(parse_register("fp"), Ok(Register::X29));
+        assert_eq!(parse_register("FP"), Ok(Register::X29));
+        assert_eq!(parse_register("lr"), Ok(Register::X30));
+        assert_eq!(parse_register("LR"), Ok(Register::X30));
+    }
+
+    #[test]
     fn test_parse_register_invalid() {
         assert!(parse_register("r0").is_err());
         assert!(parse_register("x32").is_err());
         assert!(parse_register("foo").is_err());
+    }
+
+    #[test]
+    fn test_parse_live_out_contract_accepts_fp_lr_aliases() {
+        let (live_out, flags_live) = parse_live_out_contract("fp,lr").unwrap();
+        assert!(live_out.contains_register(Register::X29));
+        assert!(live_out.contains_register(Register::X30));
+        assert!(!flags_live);
+    }
+
+    #[test]
+    fn test_parse_live_out_contract_fp_lr_with_flags() {
+        let (live_out, flags_live) = parse_live_out_contract("lr;nzcv").unwrap();
+        assert!(live_out.contains_register(Register::X30));
+        assert!(flags_live);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `validation::live_out::parse_live_out_contract(s) -> Result<(LiveOut, bool), _>` implementing the grammar `<regs>` or `<regs>;<flags>`; group token `nzcv` only, per-flag tokens `n`/`z`/`c`/`v` and bareword `nzcv` (no leading `;`) reserved for a future per-flag rev.
- Routes both `run_equiv` and `run_llm_opt` through the new helper and unifies the previously divergent CLI parse paths under a single `"invalid live-out: ..."` error prefix.
- `run_equiv` plugs the parsed flag bit into `EquivalenceConfig::with_flags(flags_live)` so users can finally opt into NZCV-aware equivalence checking from the CLI (e.g. `--live-out "x0,x1;nzcv"`).
- `run_llm_opt` accepts the suffix for vocabulary parity but discards the bit — `outcome.rs` already pins `flags_live=true` on that verifier path, documented in source + ADR.
- ADR-0006 records the grammar decision and the reservation policy. TUTORIAL.md and README.md document the new suffix.

## Test plan

- [x] `cargo test --bin s11 validation::live_out::tests::test_parse_live_out_contract` — 14 unit tests cover happy paths (`x0,x1;nzcv`, `;nzcv`, `x0,x1;`, `X0,X1;NZCV`, `""`), whitespace edge cases (`x0 ; nzcv`, `;`, `  ;  `), and error classes (bareword `nzcv`, multi-section, unknown flag token, reserved `n`/`z`/`c`/`v`, invalid register).
- [x] `./ci_check.sh` — fmt + build + unit + integration tests pass.
- [ ] Manual sanity (reviewer or local): `s11 equiv a.s b.s --live-out "x0;nzcv" --verbose` prints `Live-out flags: nzcv`; same with `x0,x1` (no suffix) prints only registers; `nzcv` (bareword) errors with `flag-only live-out requires a leading ';'`.