### PR TITLE
Cargo.toml: drop misleading optional z3 feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["compilers", "development-tools::testing", "science"]
 elf = "0.8"
 capstone = "0.14"
 clap = { version = "4.5", features = ["derive"] }
-z3 = { version = "0.20", optional = true }
+z3 = "0.20"
 dynasmrt = "5.0.0"
 dynasm = "5.0.0"
 rand = "0.10"
@@ -24,10 +24,6 @@ crossbeam-channel = "0.5"
 num_cpus = "1.16"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-
-[features]
-default = ["z3"]
-z3 = ["dep:z3"]
 
 [dev-dependencies]
 proptest = "1.10"


### PR DESCRIPTION
## Summary
- `z3` was declared `optional = true` behind a default-enabled `z3` feature, but `src/semantics/{smt,smt_x86,equivalence}.rs` and `src/search/symbolic/sketch.rs` use `z3::...` unconditionally — `cargo check --no-default-features` was broken.
- Make `z3` a plain required dependency and remove the `[features]` section so Cargo metadata matches the actual code.
- Pure metadata cleanup; no behavior change.

## Test plan
- [x] `cargo check` passes on the branch
- [ ] CI green