### PR TITLE
opt: abort AArch64 optimization on unsupported instructions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -465,16 +465,7 @@ fn optimize_elf_binary(
     }
 
     let decoded_bytes: usize = instructions.iter().map(|i| i.bytes().len()).sum();
-    if decoded_bytes != original_bytes.len() {
-        return Err(format!(
-            "AArch64 window 0x{:x}-0x{:x} ({} bytes) was not fully decoded by Capstone; decoded only {} bytes",
-            start_addr,
-            end_addr,
-            original_bytes.len(),
-            decoded_bytes
-        )
-        .into());
-    }
+    ensure_window_fully_decoded(decoded_bytes, original_bytes.len(), start_addr, end_addr)?;
 
     // Convert to IR
     let ir_instructions = convert_to_ir(&instructions)?;
@@ -884,6 +875,22 @@ fn convert_capstone_op(mnemonic: &str, op_str: &str) -> ConvertOutcome {
         Err(parser::ParseLineError::Other(err)) => {
             ConvertOutcome::Unsupported(format!("{} ({})", line, err))
         }
+    }
+}
+
+fn ensure_window_fully_decoded(
+    decoded_bytes: usize,
+    window_bytes: usize,
+    start_addr: u64,
+    end_addr: u64,
+) -> Result<(), String> {
+    if decoded_bytes == window_bytes {
+        Ok(())
+    } else {
+        Err(format!(
+            "AArch64 window 0x{:x}-0x{:x} ({} bytes) was not fully decoded by Capstone; decoded only {} bytes",
+            start_addr, end_addr, window_bytes, decoded_bytes
+        ))
     }
 }
 
@@ -2015,6 +2022,23 @@ mod cli_helper_tests {
         assert!(err.contains("ldr x0, [x1]"));
         assert!(err.contains("0x1234"));
         assert!(err.contains("cannot optimize"));
+    }
+
+    #[test]
+    fn ensure_window_fully_decoded_accepts_exact_match() {
+        ensure_window_fully_decoded(8, 8, 0x1000, 0x1008)
+            .expect("equal decoded and window byte counts must pass");
+    }
+
+    #[test]
+    fn ensure_window_fully_decoded_rejects_partial_decode() {
+        let err = ensure_window_fully_decoded(4, 8, 0x1000, 0x1008)
+            .expect_err("a window Capstone only partially decoded must be rejected");
+
+        assert!(err.contains("0x1000"));
+        assert!(err.contains("0x1008"));
+        assert!(err.contains("8 bytes"));
+        assert!(err.contains("decoded only 4 bytes"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -891,6 +891,8 @@ fn ensure_window_fully_decoded(
             "AArch64 window 0x{:x}-0x{:x} ({} bytes) was not fully decoded by Capstone; decoded only {} bytes",
             start_addr, end_addr, window_bytes, decoded_bytes
         )),
+        // Defensive: cs.disasm_all only emits bytes it was given, so this
+        // branch is an internal-invariant guard, not a user-facing condition.
         Ordering::Greater => Err(format!(
             "AArch64 window 0x{:x}-0x{:x} ({} bytes) decoded {} bytes by Capstone — more than the window holds",
             start_addr, end_addr, window_bytes, decoded_bytes

--- a/src/main.rs
+++ b/src/main.rs
@@ -884,13 +884,17 @@ fn ensure_window_fully_decoded(
     start_addr: u64,
     end_addr: u64,
 ) -> Result<(), String> {
-    if decoded_bytes == window_bytes {
-        Ok(())
-    } else {
-        Err(format!(
+    use std::cmp::Ordering;
+    match decoded_bytes.cmp(&window_bytes) {
+        Ordering::Equal => Ok(()),
+        Ordering::Less => Err(format!(
             "AArch64 window 0x{:x}-0x{:x} ({} bytes) was not fully decoded by Capstone; decoded only {} bytes",
             start_addr, end_addr, window_bytes, decoded_bytes
-        ))
+        )),
+        Ordering::Greater => Err(format!(
+            "AArch64 window 0x{:x}-0x{:x} ({} bytes) decoded {} bytes by Capstone — more than the window holds",
+            start_addr, end_addr, window_bytes, decoded_bytes
+        )),
     }
 }
 
@@ -2039,6 +2043,17 @@ mod cli_helper_tests {
         assert!(err.contains("0x1008"));
         assert!(err.contains("8 bytes"));
         assert!(err.contains("decoded only 4 bytes"));
+    }
+
+    #[test]
+    fn ensure_window_fully_decoded_rejects_over_count() {
+        let err = ensure_window_fully_decoded(12, 8, 0x1000, 0x1008)
+            .expect_err("a window Capstone reported more bytes than holds must be rejected");
+
+        assert!(err.contains("0x1000"));
+        assert!(err.contains("0x1008"));
+        assert!(err.contains("decoded 12 bytes"));
+        assert!(err.contains("more than the window holds"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -464,8 +464,20 @@ fn optimize_elf_binary(
         );
     }
 
+    let decoded_bytes: usize = instructions.iter().map(|i| i.bytes().len()).sum();
+    if decoded_bytes != original_bytes.len() {
+        return Err(format!(
+            "AArch64 window 0x{:x}-0x{:x} ({} bytes) was not fully decoded by Capstone; decoded only {} bytes",
+            start_addr,
+            end_addr,
+            original_bytes.len(),
+            decoded_bytes
+        )
+        .into());
+    }
+
     // Convert to IR
-    let ir_instructions = convert_to_ir(&instructions);
+    let ir_instructions = convert_to_ir(&instructions)?;
     println!("Converted {} instructions to IR:", ir_instructions.len());
 
     for instr in &ir_instructions {
@@ -875,23 +887,38 @@ fn convert_capstone_op(mnemonic: &str, op_str: &str) -> ConvertOutcome {
     }
 }
 
-fn convert_to_ir(instructions: &capstone::Instructions) -> Vec<Instruction> {
+fn convert_capstone_op_for_optimization(
+    mnemonic: &str,
+    op_str: &str,
+    address: u64,
+) -> Result<Option<Instruction>, String> {
+    match convert_capstone_op(mnemonic, op_str) {
+        ConvertOutcome::Instruction(instr) => Ok(Some(instr)),
+        ConvertOutcome::Skip => Ok(None),
+        ConvertOutcome::Unsupported(line) => Err(format!(
+            "AArch64 window contains unsupported instruction '{}' at 0x{:x}; \
+             cannot optimize. Narrow the --start-addr/--end-addr range to \
+             exclude it, or add the mnemonic to the supported set.",
+            line, address
+        )),
+    }
+}
+
+fn convert_to_ir(instructions: &capstone::Instructions) -> Result<Vec<Instruction>, String> {
     let mut ir_instructions = Vec::new();
 
     for instruction in instructions.iter() {
         let mnemonic = instruction.mnemonic().unwrap_or("");
         let op_str = instruction.op_str().unwrap_or("");
 
-        match convert_capstone_op(mnemonic, op_str) {
-            ConvertOutcome::Instruction(instr) => ir_instructions.push(instr),
-            ConvertOutcome::Skip => {}
-            ConvertOutcome::Unsupported(line) => {
-                eprintln!("Warning: Skipping unsupported instruction: {}", line);
-            }
+        if let Some(instr) =
+            convert_capstone_op_for_optimization(mnemonic, op_str, instruction.address())?
+        {
+            ir_instructions.push(instr);
         }
     }
 
-    ir_instructions
+    Ok(ir_instructions)
 }
 
 /// Validate that an IR sequence forms a single basic block: at most one
@@ -1981,10 +2008,20 @@ mod cli_helper_tests {
     }
 
     #[test]
+    fn convert_capstone_op_for_optimization_rejects_unsupported_instruction() {
+        let err = convert_capstone_op_for_optimization("ldr", "x0, [x1]", 0x1234)
+            .expect_err("optimization conversion must reject unsupported non-NOP instructions");
+
+        assert!(err.contains("ldr x0, [x1]"));
+        assert!(err.contains("0x1234"));
+        assert!(err.contains("cannot optimize"));
+    }
+
+    #[test]
     fn convert_capstone_op_reports_operand_errors_against_supported_mnemonic() {
-        // Mnemonic recognised, but operand fails to parse — should be reported
-        // as Unsupported (warn + skip) with the parser's error appended so the
-        // user can see why.
+        // Mnemonic recognised, but operand fails to parse — should be
+        // classified as Unsupported with the parser's error appended so the
+        // optimization path can reject the window with useful context.
         match convert_capstone_op("add", "x0, x1, #wat") {
             ConvertOutcome::Unsupported(line) => {
                 assert!(line.contains("add"));

--- a/tests/integration/opt_test.rs
+++ b/tests/integration/opt_test.rs
@@ -54,12 +54,9 @@ fn test_opt_basic_functionality() {
 
     check_test_binary(&test_elf);
 
-    // Target `add x16, x16, #0xff8` at 0x5cc — a single ADD-immediate with
-    // general-purpose registers, fully supported by the parser, assembler and
-    // optimizer. We do not use executable_window here because the start of
-    // .init in arrays_debug is `paciasp` (an unsupported HINT), which the
-    // AArch64 optimization path now correctly rejects rather than silently
-    // dropping.
+    // We do not use executable_window here because the start of .init in
+    // arrays_debug is `paciasp` (an unsupported HINT), which the AArch64
+    // optimization path now correctly rejects rather than silently dropping.
     let start_addr: u64 = 0x5cc;
     let end_addr: u64 = 0x5d0;
 

--- a/tests/integration/opt_test.rs
+++ b/tests/integration/opt_test.rs
@@ -24,34 +24,33 @@ fn get_binary_path() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_s11"))
 }
 
-fn assert_bytes_at_addr(elf_path: &Path, addr: u64, expected: &[u8], label: &str) {
-    let data = std::fs::read(elf_path).expect("read ELF for byte-pattern check");
+// Scan every executable, instruction-aligned slot in `elf_path` for the
+// 4-byte little-endian encoding `pattern` and return the virtual address of
+// the first match. Used by opt tests to dynamically resolve a window onto a
+// known supported (or known unsupported) AArch64 instruction without
+// hardcoding addresses against a specific build of the fixture binary.
+fn find_encoding(elf_path: &Path, pattern: &[u8], label: &str) -> u64 {
+    let data = std::fs::read(elf_path).expect("read ELF for pattern scan");
     let elf = elf::ElfBytes::<elf::endian::AnyEndian>::minimal_parse(&data)
-        .expect("parse ELF for byte-pattern check");
+        .expect("parse ELF for pattern scan");
     let section_headers = elf.section_headers().expect("ELF section headers");
 
     for section in section_headers.iter() {
         if section.sh_flags & elf::abi::SHF_EXECINSTR as u64 == 0 {
             continue;
         }
-        let sec_start = section.sh_addr;
-        let sec_end = sec_start + section.sh_size;
-        if addr < sec_start || addr + expected.len() as u64 > sec_end {
-            continue;
+        let file_start = section.sh_offset as usize;
+        let size = section.sh_size as usize;
+        let bytes = &data[file_start..file_start + size];
+        for off in (0..size.saturating_sub(pattern.len()) + 1).step_by(4) {
+            if &bytes[off..off + pattern.len()] == pattern {
+                return section.sh_addr + off as u64;
+            }
         }
-        let offset_in_section = (addr - sec_start) as usize;
-        let file_offset = section.sh_offset as usize + offset_in_section;
-        let actual = &data[file_offset..file_offset + expected.len()];
-        assert_eq!(
-            actual, expected,
-            "fixture {:?} drifted: bytes at 0x{:x} no longer match {} encoding {:02x?}; got {:02x?}",
-            elf_path, addr, label, expected, actual
-        );
-        return;
     }
     panic!(
-        "address 0x{:x} not in any executable section of {:?}",
-        addr, elf_path
+        "encoding {:02x?} ({}) not found in any executable section of {:?}",
+        pattern, label, elf_path
     );
 }
 
@@ -85,17 +84,13 @@ fn test_opt_basic_functionality() {
 
     check_test_binary(&test_elf);
 
-    // We do not use executable_window here because the start of .init in
-    // arrays_debug is `paciasp` (an unsupported HINT), which the AArch64
-    // optimization path now correctly rejects rather than silently dropping.
-    let start_addr: u64 = 0x5cc;
-    let end_addr: u64 = 0x5d0;
-    assert_bytes_at_addr(
-        &test_elf,
-        start_addr,
-        &[0x10, 0xe2, 0x3f, 0x91],
-        "add x16, x16, #0xff8",
-    );
+    // executable_window starts at the first executable section, which is .init
+    // and begins with `paciasp` (an unsupported HINT); the AArch64 optimization
+    // path now correctly rejects that window. Scan instead for the PLT's
+    // `add x16, x16, #0xff8` trampoline slot — a supported AArch64 instruction
+    // that always exists in the fixture regardless of build environment drift.
+    let start_addr = find_encoding(&test_elf, &[0x10, 0xe2, 0x3f, 0x91], "add x16, x16, #0xff8");
+    let end_addr = start_addr + 4;
 
     let output = Command::new(binary)
         .arg("opt")
@@ -334,16 +329,18 @@ fn test_opt_rejects_unsupported_instruction_window() {
         .join("binaries")
         .join("loops_debug");
     check_test_binary(&test_elf);
-    assert_bytes_at_addr(
+
+    // Scan loops_debug for the first `stp x29, x30, [sp, #-0x10]!` — an
+    // unsupported mnemonic for the AArch64 optimization path. Targeting a
+    // 4-byte window on that instruction must abort before any output file
+    // is written.
+    let start_addr = find_encoding(
         &test_elf,
-        0x59c,
         &[0xfd, 0x7b, 0xbf, 0xa9],
         "stp x29, x30, [sp, #-0x10]!",
     );
+    let end_addr = start_addr + 4;
 
-    // 0x59c in loops_debug is a `stp x29, x30, [sp, #-0x10]!` — an unsupported
-    // mnemonic for the AArch64 optimization path. Targeting a 4-byte window on
-    // this single instruction should abort before any output file is written.
     let optimized_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("binaries")
         .join("loops_debug_optimized");
@@ -353,9 +350,9 @@ fn test_opt_rejects_unsupported_instruction_window() {
         .arg("opt")
         .arg(&test_elf)
         .arg("--start-addr")
-        .arg("0x59c")
+        .arg(format!("0x{start_addr:x}"))
         .arg("--end-addr")
-        .arg("0x5a0")
+        .arg(format!("0x{end_addr:x}"))
         .output()
         .expect("Failed to execute s11");
 
@@ -372,8 +369,8 @@ fn test_opt_rejects_unsupported_instruction_window() {
         "stderr should identify the offending mnemonic; got: {stderr}",
     );
     assert!(
-        stderr.contains("0x59c"),
-        "stderr should report the offending address; got: {stderr}",
+        stderr.contains(&format!("0x{start_addr:x}")),
+        "stderr should report the offending address 0x{start_addr:x}; got: {stderr}",
     );
 
     assert!(

--- a/tests/integration/opt_test.rs
+++ b/tests/integration/opt_test.rs
@@ -53,7 +53,15 @@ fn test_opt_basic_functionality() {
         .join("arrays_debug");
 
     check_test_binary(&test_elf);
-    let (start_addr, end_addr) = executable_window(&test_elf, 4);
+
+    // Target `add x16, x16, #0xff8` at 0x5cc — a single ADD-immediate with
+    // general-purpose registers, fully supported by the parser, assembler and
+    // optimizer. We do not use executable_window here because the start of
+    // .init in arrays_debug is `paciasp` (an unsupported HINT), which the
+    // AArch64 optimization path now correctly rejects rather than silently
+    // dropping.
+    let start_addr: u64 = 0x5cc;
+    let end_addr: u64 = 0x5d0;
 
     let output = Command::new(binary)
         .arg("opt")
@@ -282,6 +290,56 @@ fn test_opt_address_alignment() {
     assert!(
         stderr.contains("4-byte aligned"),
         "Should show alignment error"
+    );
+}
+
+#[test]
+fn test_opt_rejects_unsupported_instruction_window() {
+    let binary = get_binary_path();
+    let test_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("binaries")
+        .join("loops_debug");
+    check_test_binary(&test_elf);
+
+    // 0x59c in loops_debug is a `stp x29, x30, [sp, #-0x10]!` — an unsupported
+    // mnemonic for the AArch64 optimization path. Targeting a 4-byte window on
+    // this single instruction should abort before any output file is written.
+    let optimized_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("binaries")
+        .join("loops_debug_optimized");
+    let _ = fs::remove_file(&optimized_path);
+
+    let output = Command::new(binary)
+        .arg("opt")
+        .arg(&test_elf)
+        .arg("--start-addr")
+        .arg("0x59c")
+        .arg("--end-addr")
+        .arg("0x5a0")
+        .output()
+        .expect("Failed to execute s11");
+
+    assert!(
+        !output.status.success(),
+        "opt must reject an AArch64 window containing an unsupported instruction.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unsupported instruction") && stderr.contains("stp"),
+        "stderr should identify the offending mnemonic; got: {stderr}",
+    );
+    assert!(
+        stderr.contains("0x59c"),
+        "stderr should report the offending address; got: {stderr}",
+    );
+
+    assert!(
+        !optimized_path.exists(),
+        "no optimized binary should be written when conversion fails: {:?}",
+        optimized_path,
     );
 }
 

--- a/tests/integration/opt_test.rs
+++ b/tests/integration/opt_test.rs
@@ -24,12 +24,13 @@ fn get_binary_path() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_s11"))
 }
 
-// Scan every executable, instruction-aligned slot in `elf_path` for the
-// 4-byte little-endian encoding `pattern` and return the virtual address of
-// the first match. Used by opt tests to dynamically resolve a window onto a
-// known supported (or known unsupported) AArch64 instruction without
-// hardcoding addresses against a specific build of the fixture binary.
-fn find_encoding(elf_path: &Path, pattern: &[u8], label: &str) -> u64 {
+// Scan every executable, instruction-aligned slot in `elf_path` for a 4-byte
+// little-endian AArch64 encoding matching `expected` under `mask` (i.e.
+// `bytes[i] & mask[i] == expected[i] & mask[i]` for each of the 4 bytes).
+// A `mask` of all 0xff means exact match; a partial mask lets opt tests
+// match any `add x16, x16, #N` PLT trampoline regardless of the build's GOT
+// layout, etc.
+fn find_encoding_masked(elf_path: &Path, expected: &[u8; 4], mask: &[u8; 4], label: &str) -> u64 {
     let data = std::fs::read(elf_path).expect("read ELF for pattern scan");
     let elf = elf::ElfBytes::<elf::endian::AnyEndian>::minimal_parse(&data)
         .expect("parse ELF for pattern scan");
@@ -41,19 +42,19 @@ fn find_encoding(elf_path: &Path, pattern: &[u8], label: &str) -> u64 {
         }
         let file_start = section.sh_offset as usize;
         let size = section.sh_size as usize;
-        if size < pattern.len() {
+        if size < expected.len() {
             continue;
         }
         let bytes = &data[file_start..file_start + size];
-        for off in (0..size.saturating_sub(pattern.len()) + 1).step_by(4) {
-            if &bytes[off..off + pattern.len()] == pattern {
+        for off in (0..size - expected.len() + 1).step_by(4) {
+            if (0..4).all(|i| bytes[off + i] & mask[i] == expected[i] & mask[i]) {
                 return section.sh_addr + off as u64;
             }
         }
     }
     panic!(
-        "encoding {:02x?} ({}) not found in any executable section of {:?}",
-        pattern, label, elf_path
+        "encoding matching {:02x?} (mask {:02x?}, {}) not found in any executable section of {:?}",
+        expected, mask, label, elf_path
     );
 }
 
@@ -89,10 +90,16 @@ fn test_opt_basic_functionality() {
 
     // executable_window starts at the first executable section, which is .init
     // and begins with `paciasp` (an unsupported HINT); the AArch64 optimization
-    // path now correctly rejects that window. Scan instead for the PLT's
-    // `add x16, x16, #0xff8` trampoline slot — a supported AArch64 instruction
-    // that always exists in the fixture regardless of build environment drift.
-    let start_addr = find_encoding(&test_elf, &[0x10, 0xe2, 0x3f, 0x91], "add x16, x16, #0xff8");
+    // path now correctly rejects that window. Scan instead for any PLT
+    // trampoline slot `add x16, x16, #N` — encoding constraints sf=1, sh=0,
+    // Rd=Rn=16, immediate N free. Mask leaves the 12 imm bits as wildcards
+    // so we match every build's GOT-offset variation.
+    let start_addr = find_encoding_masked(
+        &test_elf,
+        &[0x10, 0x02, 0x00, 0x91],
+        &[0xff, 0x03, 0xc0, 0xff],
+        "add x16, x16, #N (PLT trampoline)",
+    );
     let end_addr = start_addr + 4;
 
     let output = Command::new(binary)
@@ -337,9 +344,10 @@ fn test_opt_rejects_unsupported_instruction_window() {
     // unsupported mnemonic for the AArch64 optimization path. Targeting a
     // 4-byte window on that instruction must abort before any output file
     // is written.
-    let start_addr = find_encoding(
+    let start_addr = find_encoding_masked(
         &test_elf,
         &[0xfd, 0x7b, 0xbf, 0xa9],
+        &[0xff, 0xff, 0xff, 0xff],
         "stp x29, x30, [sp, #-0x10]!",
     );
     let end_addr = start_addr + 4;

--- a/tests/integration/opt_test.rs
+++ b/tests/integration/opt_test.rs
@@ -24,12 +24,12 @@ fn get_binary_path() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_s11"))
 }
 
-// Scan every executable, instruction-aligned slot in `elf_path` for a 4-byte
-// little-endian AArch64 encoding matching `expected` under `mask` (i.e.
-// `bytes[i] & mask[i] == expected[i] & mask[i]` for each of the 4 bytes).
-// A `mask` of all 0xff means exact match; a partial mask lets opt tests
-// match any `add x16, x16, #N` PLT trampoline regardless of the build's GOT
-// layout, etc.
+// AArch64 only: scans at 4-byte-aligned offsets in every executable section
+// of `elf_path` for a little-endian AArch64 encoding matching `expected`
+// under `mask` (i.e. `bytes[i] & mask[i] == expected[i] & mask[i]` for each
+// of the 4 bytes). A `mask` of all 0xff means exact match; a partial mask
+// lets opt tests match any `add x16, x16, #N` PLT trampoline regardless of
+// the build's GOT layout, etc.
 fn find_encoding_masked(elf_path: &Path, expected: &[u8; 4], mask: &[u8; 4], label: &str) -> u64 {
     let data = std::fs::read(elf_path).expect("read ELF for pattern scan");
     let elf = elf::ElfBytes::<elf::endian::AnyEndian>::minimal_parse(&data)

--- a/tests/integration/opt_test.rs
+++ b/tests/integration/opt_test.rs
@@ -24,6 +24,37 @@ fn get_binary_path() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_s11"))
 }
 
+fn assert_bytes_at_addr(elf_path: &Path, addr: u64, expected: &[u8], label: &str) {
+    let data = std::fs::read(elf_path).expect("read ELF for byte-pattern check");
+    let elf = elf::ElfBytes::<elf::endian::AnyEndian>::minimal_parse(&data)
+        .expect("parse ELF for byte-pattern check");
+    let section_headers = elf.section_headers().expect("ELF section headers");
+
+    for section in section_headers.iter() {
+        if section.sh_flags & elf::abi::SHF_EXECINSTR as u64 == 0 {
+            continue;
+        }
+        let sec_start = section.sh_addr;
+        let sec_end = sec_start + section.sh_size;
+        if addr < sec_start || addr + expected.len() as u64 > sec_end {
+            continue;
+        }
+        let offset_in_section = (addr - sec_start) as usize;
+        let file_offset = section.sh_offset as usize + offset_in_section;
+        let actual = &data[file_offset..file_offset + expected.len()];
+        assert_eq!(
+            actual, expected,
+            "fixture {:?} drifted: bytes at 0x{:x} no longer match {} encoding {:02x?}; got {:02x?}",
+            elf_path, addr, label, expected, actual
+        );
+        return;
+    }
+    panic!(
+        "address 0x{:x} not in any executable section of {:?}",
+        addr, elf_path
+    );
+}
+
 fn executable_window(path: &Path, width: u64) -> (u64, u64) {
     let data = std::fs::read(path).expect("read test ELF");
     let elf =
@@ -59,6 +90,12 @@ fn test_opt_basic_functionality() {
     // optimization path now correctly rejects rather than silently dropping.
     let start_addr: u64 = 0x5cc;
     let end_addr: u64 = 0x5d0;
+    assert_bytes_at_addr(
+        &test_elf,
+        start_addr,
+        &[0x10, 0xe2, 0x3f, 0x91],
+        "add x16, x16, #0xff8",
+    );
 
     let output = Command::new(binary)
         .arg("opt")
@@ -297,6 +334,12 @@ fn test_opt_rejects_unsupported_instruction_window() {
         .join("binaries")
         .join("loops_debug");
     check_test_binary(&test_elf);
+    assert_bytes_at_addr(
+        &test_elf,
+        0x59c,
+        &[0xfd, 0x7b, 0xbf, 0xa9],
+        "stp x29, x30, [sp, #-0x10]!",
+    );
 
     // 0x59c in loops_debug is a `stp x29, x30, [sp, #-0x10]!` — an unsupported
     // mnemonic for the AArch64 optimization path. Targeting a 4-byte window on

--- a/tests/integration/opt_test.rs
+++ b/tests/integration/opt_test.rs
@@ -41,6 +41,9 @@ fn find_encoding(elf_path: &Path, pattern: &[u8], label: &str) -> u64 {
         }
         let file_start = section.sh_offset as usize;
         let size = section.sh_size as usize;
+        if size < pattern.len() {
+            continue;
+        }
         let bytes = &data[file_start..file_start + size];
         for off in (0..size.saturating_sub(pattern.len()) + 1).step_by(4) {
             if &bytes[off..off + pattern.len()] == pattern {


### PR DESCRIPTION
## Summary
- Previously, AArch64 `opt` warned and silently dropped instructions Capstone decoded but the parser/IR didn't support, then reassembled the shortened IR over the entire requested window. A window containing an unsupported side-effecting insn (e.g. `ldr`/`str`/`stp`) could therefore produce an "optimized" binary with that instruction removed.
- `convert_to_ir` now returns `Result`; `ConvertOutcome::Unsupported` aborts with a message naming the offending mnemonic + address before any patch is written.
- Added a byte-coverage guard so a window Capstone fails to fully decode is rejected the same way.
- Adjusted `test_opt_basic_functionality`: it had been targeting `paciasp` at `.init[0]` of `arrays_debug`, which was silently dropped under the old behaviour — the test was passing on an effectively empty IR. Repointed at `add x16, x16, #0xff8` at `0x5cc`, which is fully supported end-to-end.

Fixes clawpatch finding `fnd_sig-feat-cli-command-763d3af7d0-_5b7c01d4a2` (high, data-loss).

## Test plan
- [x] Unit test `convert_capstone_op_for_optimization_rejects_unsupported_instruction`
- [x] Integration test `test_opt_rejects_unsupported_instruction_window` drives `s11 opt` against a `stp` window in `loops_debug` and asserts non-zero exit + no `_optimized` file
- [x] `./ci_check.sh` passes locally
- [ ] CI green