### PR TITLE
opt: reject --arch values that do not match the ELF e_machine

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1513,15 +1513,23 @@ fn main() {
             llm_max_calls,
             llm_model,
         } => {
-            // Architecture selection — when --arch is omitted, auto-detect
-            // from the ELF e_machine so x86 binaries route through the
-            // x86 pipeline instead of falling into the AArch64 default.
+            // Architecture selection — always read the ELF e_machine first so
+            // a stale or wrong --arch value cannot route bytes through the
+            // wrong optimization pipeline.
+            let detected_arch = detect_cli_arch_from_elf(&binary).unwrap_or_else(|e| {
+                eprintln!("Error reading ELF: {}", e);
+                std::process::exit(1);
+            });
             let cli_arch = match arch {
-                Some(a) => a,
-                None => detect_cli_arch_from_elf(&binary).unwrap_or_else(|e| {
-                    eprintln!("Error auto-detecting architecture: {}", e);
+                Some(a) if a == detected_arch => a,
+                Some(a) => {
+                    eprintln!(
+                        "Architecture mismatch: --arch {:?} but ELF reports {:?}",
+                        a, detected_arch
+                    );
                     std::process::exit(1);
-                }),
+                }
+                None => detected_arch,
             };
             match cli_arch {
                 CliArch::Aarch64 | CliArch::X86_64 | CliArch::X86_32 => {}

--- a/tests/integration/opt_test.rs
+++ b/tests/integration/opt_test.rs
@@ -45,6 +45,39 @@ fn executable_window(path: &Path, width: u64) -> (u64, u64) {
     panic!("no executable window of {width} bytes found in {path:?}");
 }
 
+fn assert_opt_arch_mismatch_rejected(test_elf: &Path, arch: &str) {
+    let output = Command::new(get_binary_path())
+        .arg("opt")
+        .arg(test_elf)
+        .arg("--arch")
+        .arg(arch)
+        .arg("--start-addr")
+        .arg("0x0")
+        .arg("--end-addr")
+        .arg("0x4")
+        .output()
+        .expect("Failed to execute s11");
+
+    assert!(
+        !output.status.success(),
+        "Command should fail with mismatched --arch"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Architecture mismatch"),
+        "Should reject before optimization, stderr: {}",
+        stderr
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("Optimizing ELF binary") && !stdout.contains("Optimizing x86 ELF binary"),
+        "Should reject before starting optimization, stdout: {}",
+        stdout
+    );
+}
+
 #[test]
 fn test_opt_basic_functionality() {
     let binary = get_binary_path();
@@ -221,6 +254,29 @@ fn test_opt_invalid_address_format() {
         stderr.contains("Error parsing"),
         "Should show parsing error"
     );
+}
+
+#[test]
+fn test_opt_rejects_arch_mismatch_before_optimization() {
+    let aarch64_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("binaries")
+        .join("simple_debug");
+
+    check_test_binary(&aarch64_elf);
+    assert_opt_arch_mismatch_rejected(&aarch64_elf, "x86-64");
+
+    let x86_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("binaries")
+        .join("x86_64")
+        .join("simple_debug");
+    if x86_elf.exists() {
+        assert_opt_arch_mismatch_rejected(&x86_elf, "aarch64");
+    } else {
+        eprintln!(
+            "Skipping x86-64 opt mismatch case: {:?} not present (run build_tests.sh)",
+            x86_elf
+        );
+    }
 }
 
 #[test]

--- a/tests/integration/opt_test.rs
+++ b/tests/integration/opt_test.rs
@@ -264,6 +264,7 @@ fn test_opt_rejects_arch_mismatch_before_optimization() {
 
     check_test_binary(&aarch64_elf);
     assert_opt_arch_mismatch_rejected(&aarch64_elf, "x86-64");
+    assert_opt_arch_mismatch_rejected(&aarch64_elf, "x86-32");
 
     let x86_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("binaries")


### PR DESCRIPTION
## Summary
- When `--arch` was supplied to `opt`, the CLI used it verbatim and skipped ELF detection entirely. Passing `--arch aarch64` for an x86 ELF routed x86 bytes through the AArch64 optimization pipeline; passing the wrong x86 width was equally accepted. `disasm` already cross-checks `--arch` against `e_machine` — `opt` had a mismatched and potentially corrupting contract.
- Always detect the ELF architecture first, then accept `--arch` only when it equals the detected value. Mismatches abort with `Architecture mismatch: --arch X but ELF reports Y` before any optimization starts.

Fixes clawpatch finding `fnd_sig-feat-cli-command-763d3af7d0-_cd5637d901` (medium, api-contract).

## Test plan
- [x] `test_opt_rejects_arch_mismatch_before_optimization`: drives `s11 opt` with mismatched `--arch` on an AArch64 fixture (and the x86-64 fixture when present), asserts non-zero exit with the mismatch error and no optimization output.
- [x] `./ci_check.sh` passes locally.
- [ ] CI green.