### PR TITLE
opt: build ElfPatcher once at dispatch (#88)

### DIFF
--- a/src/elf_patcher/mod.rs
+++ b/src/elf_patcher/mod.rs
@@ -563,4 +563,47 @@ mod tests {
             "second pad should be the canonical 8-byte Intel NOP",
         );
     }
+
+    #[test]
+    fn elf_patcher_does_not_reread_file_after_construction() {
+        // Pins the invariant the issue-88 dispatch refactor relies on:
+        // once an ElfPatcher is constructed, every accessor it exposes serves
+        // data from the in-memory buffer rather than reopening the file.
+        // Callers (the `s11 opt` dispatch) can therefore construct the patcher
+        // once and thread it into the per-arch helpers without paying for a
+        // second `fs::read` + `ElfBytes::minimal_parse`.
+        use crate::test_utils::TempFile;
+
+        let text_vaddr: u64 = 0x100000;
+        let text_bytes = [0xc3u8; 8];
+        let elf_bytes = build_minimal_x86_64_elf(&text_bytes, text_vaddr);
+
+        let input = TempFile::new_bytes("s11-elf-no-reread", "elf", &elf_bytes);
+        let saved_path = input.path().to_path_buf();
+        let patcher = ElfPatcher::new(&saved_path).expect("patcher should accept minimal ELF");
+
+        std::fs::remove_file(&saved_path).expect("remove input before exercising patcher");
+        assert!(
+            !saved_path.exists(),
+            "precondition: input file removed so any disk read would fail",
+        );
+
+        assert_eq!(patcher.arch(), DetectedArch::X86_64);
+
+        let window = AddressWindow {
+            start: text_vaddr,
+            end: text_vaddr + 8,
+        };
+        let section = patcher
+            .validate_address_window(&window)
+            .expect("validate should not reopen the file");
+        assert_eq!(section.virtual_addr, text_vaddr);
+
+        let bytes = patcher
+            .get_instructions_in_window(&window)
+            .expect("get_instructions should not reopen the file");
+        assert_eq!(bytes, text_bytes.to_vec());
+
+        // TempFile::drop tolerates a missing file (test_utils.rs:33-37).
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ mod test_utils;
 mod validation;
 
 use assembler::AArch64Assembler;
-use elf_patcher::{AddressWindow, ElfPatcher, parse_hex_address};
+use elf_patcher::{AddressWindow, DetectedArch, ElfPatcher, parse_hex_address};
 use ir::instructions::split_terminator;
 use ir::{Instruction, Register};
 use search::config::{
@@ -121,6 +121,19 @@ pub enum CliArch {
     X86_64,
     /// x86-32 (i386) architecture
     X86_32,
+}
+
+impl From<DetectedArch> for CliArch {
+    fn from(arch: DetectedArch) -> Self {
+        // DetectedArch is the closed set of architectures ElfPatcher accepts
+        // (it rejects everything else at construction), so this mapping is
+        // total — there is no RISC-V case to handle here.
+        match arch {
+            DetectedArch::Aarch64 => CliArch::Aarch64,
+            DetectedArch::X86_64 => CliArch::X86_64,
+            DetectedArch::X86_32 => CliArch::X86_32,
+        }
+    }
 }
 
 #[derive(Subcommand)]
@@ -420,6 +433,7 @@ struct OptimizationOptions {
 // mechanical: `match detect_cli_arch_from_elf(...) { Aarch64 => ::<AArch64>,
 // X86_64 => ::<X86_64>, X86_32 => ::<X86_32>, Riscv* => stage 3 }`.
 fn optimize_elf_binary(
+    elf_patcher: &ElfPatcher,
     path: &Path,
     start_addr: u64,
     end_addr: u64,
@@ -435,8 +449,6 @@ fn optimize_elf_binary(
         end: end_addr,
     };
 
-    // Load and validate the ELF file
-    let elf_patcher = ElfPatcher::new(path)?;
     let section = elf_patcher.validate_address_window(&window)?;
     println!("Window is within section: {}", section.name);
 
@@ -1187,13 +1199,12 @@ fn run_x86_symbolic(
 }
 
 fn optimize_elf_binary_x86(
+    patcher: &ElfPatcher,
     path: &Path,
     start_addr: u64,
     end_addr: u64,
     options: &OptimizationOptions,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    use elf_patcher::{AddressWindow, DetectedArch};
-
     println!("Optimizing x86 ELF binary: {}", path.display());
     println!("Address window: 0x{:x} - 0x{:x}", start_addr, end_addr);
 
@@ -1201,7 +1212,6 @@ fn optimize_elf_binary_x86(
         start: start_addr,
         end: end_addr,
     };
-    let patcher = elf_patcher::ElfPatcher::new(path)?;
     let arch = patcher.arch();
     let width = match arch {
         DetectedArch::X86_64 => 64u32,
@@ -1557,11 +1567,14 @@ fn main() {
         } => {
             // Architecture selection — always read the ELF e_machine first so
             // a stale or wrong --arch value cannot route bytes through the
-            // wrong optimization pipeline.
-            let detected_arch = detect_cli_arch_from_elf(&binary).unwrap_or_else(|e| {
+            // wrong optimization pipeline. Build the ElfPatcher once here
+            // (issue #88) and thread it into both helpers so the file isn't
+            // read + parsed twice.
+            let patcher = ElfPatcher::new(&binary).unwrap_or_else(|e| {
                 eprintln!("Error reading ELF: {}", e);
                 std::process::exit(1);
             });
+            let detected_arch: CliArch = patcher.arch().into();
             let cli_arch = match arch {
                 Some(a) if a == detected_arch => a,
                 Some(a) => {
@@ -1650,9 +1663,9 @@ fn main() {
             };
 
             let opt_result = if is_x86 {
-                optimize_elf_binary_x86(&binary, start_addr, end_addr, &options)
+                optimize_elf_binary_x86(&patcher, &binary, start_addr, end_addr, &options)
             } else {
-                optimize_elf_binary(&binary, start_addr, end_addr, &options)
+                optimize_elf_binary(&patcher, &binary, start_addr, end_addr, &options)
             };
             match opt_result {
                 Ok(()) => println!("\nOptimization completed successfully."),

--- a/src/main.rs
+++ b/src/main.rs
@@ -428,7 +428,7 @@ struct OptimizationOptions {
 // `optimize_elf_binary_x86` still drives `find_shorter_equivalent_x86`
 // over `X86Instruction` directly.
 fn optimize_elf_binary(
-    elf_patcher: &ElfPatcher,
+    patcher: &ElfPatcher,
     path: &Path,
     start_addr: u64,
     end_addr: u64,
@@ -444,11 +444,11 @@ fn optimize_elf_binary(
         end: end_addr,
     };
 
-    let section = elf_patcher.validate_address_window(&window)?;
+    let section = patcher.validate_address_window(&window)?;
     println!("Window is within section: {}", section.name);
 
     // Get the original instructions in the window
-    let original_bytes = elf_patcher.get_instructions_in_window(&window)?;
+    let original_bytes = patcher.get_instructions_in_window(&window)?;
     println!("Original code: {} bytes", original_bytes.len());
 
     // Initialize Capstone disassembler
@@ -523,7 +523,7 @@ fn optimize_elf_binary(
     };
 
     // Create patched ELF file
-    elf_patcher.create_patched_copy(&output_path, &window, &assembled_bytes)?;
+    patcher.create_patched_copy(&output_path, &window, &assembled_bytes)?;
     println!("Created optimized binary: {}", output_path.display());
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -417,21 +417,16 @@ struct OptimizationOptions {
 
 // --- Optimization Function ---
 
-// Issue #77 stage 1 step 15 note: this AArch64 optimization path consumes the
-// new trait-surface scaffolding (`<AArch64 as ConcreteExecutor<Instruction>>`,
-// `<AArch64 as SymbolicExecutor<Instruction>>`, `<AArch64 as Assembler<...>>`)
-// indirectly through the existing free functions, which step 8 wired to the
-// trait impls. Stage 2 step 20 merges this function with
-// `optimize_elf_binary_x86` into a single `optimize_elf_binary_generic<I: ISA>`
-// once x86 has its own SearchAlgorithm impl. For now the AArch64-typed
-// signature is preserved so existing callers do not need turbofish.
+// AArch64 dispatch target for `s11 opt`. Receives a pre-built `ElfPatcher`
+// from the CLI arm so the file is read exactly once (issue #88).
 //
-// Step 20 status: BLOCKED on the SearchAlgorithm<I> follow-up to step 11.
-// `optimize_elf_binary_x86` uses `find_shorter_equivalent_x86` which directly
-// drives the candidate enumerator over X86Instruction — there is no x86
-// SearchAlgorithm impl to dispatch to. Once that lands, the merge is
-// mechanical: `match detect_cli_arch_from_elf(...) { Aarch64 => ::<AArch64>,
-// X86_64 => ::<X86_64>, X86_32 => ::<X86_32>, Riscv* => stage 3 }`.
+// Issue #77 stage 2 step 20 will merge this with `optimize_elf_binary_x86`
+// into a single `optimize_elf_binary_generic<I: ISA>` once x86 has its own
+// `SearchAlgorithm` impl; the merge dispatch will branch on
+// `patcher.arch()` (now that the Opt arm already has a patcher in scope).
+// Currently blocked on the `SearchAlgorithm<I>` follow-up to step 11 —
+// `optimize_elf_binary_x86` still drives `find_shorter_equivalent_x86`
+// over `X86Instruction` directly.
 fn optimize_elf_binary(
     elf_patcher: &ElfPatcher,
     path: &Path,


### PR DESCRIPTION
## Summary

Closes #88. Removes the double `fs::read` + `ElfBytes::minimal_parse` that
happened on every `s11 opt` invocation: the CLI arm called
`detect_cli_arch_from_elf`, then each per-arch helper called
`ElfPatcher::new(path)` internally.

After this PR the Opt arm builds the `ElfPatcher` once and threads `&patcher`
into both `optimize_elf_binary` (AArch64) and `optimize_elf_binary_x86`.

## Changes

- `src/main.rs`
  - New `impl From<DetectedArch> for CliArch` next to the `CliArch` enum so
    the Opt arm can derive the CLI-facing arch from the patcher without a
    second parse.
  - Opt arm replaces `detect_cli_arch_from_elf(&binary)` with
    `ElfPatcher::new(&binary)`; the existing `--arch` cross-check + RISC-V
    rejection are preserved.
  - Both `optimize_elf_binary` and `optimize_elf_binary_x86` take
    `patcher: &ElfPatcher` as the first parameter; the internal
    `ElfPatcher::new(path)?` calls are gone. `path` stays for the log lines
    and output-filename construction.
  - `detect_cli_arch_from_elf` is unchanged — the Disasm arm still uses it.
- `src/elf_patcher/mod.rs`
  - New test `elf_patcher_does_not_reread_file_after_construction` builds
    a minimal x86-64 ELF, constructs the patcher, removes the source file,
    and asserts `arch()` / `validate_address_window` /
    `get_instructions_in_window` still succeed. Pins the in-memory contract
    the refactor relies on; any regression that re-introduces a disk read
    breaks this test loudly.

The fix applies to both architectures even though the issue title called
out x86 — the same double-parse existed on the AArch64 path and a half-fix
would have forced an asymmetric dispatch.

## Test plan

- [x] `./ci_check.sh` clean (fmt + build + 821 unit tests + 20 integration
      tests + `test_all.sh`)
- [x] New `elf_patcher_does_not_reread_file_after_construction` test passes
- [x] All existing integration tests in `tests/integration/opt_test.rs`
      pass unchanged (subprocess-based, so they don't care how many times
      the ELF is parsed internally — they only assert observable CLI
      behavior, which this PR preserves)