### PR TITLE
x86: CMOVcc + Jcc + symbolic EFLAGS (closes #74)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"b6dedad3-874e-4cda-b252-4787c6d8685c","pid":105931,"procStart":"121413","acquiredAt":1779129742487}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"b6dedad3-874e-4cda-b252-4787c6d8685c","pid":105931,"procStart":"121413","acquiredAt":1779129742487}

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ mutants.out.old/
 
 .ultraplan/
 .clawpatch/
+.claude/
 
 # criterion benchmark output and JSONL accumulator (issue #70)
 benches/results/

--- a/src/assembler/x86.rs
+++ b/src/assembler/x86.rs
@@ -793,7 +793,7 @@ mod tests {
         assert!(err.contains("does not fit in 32 bits"));
     }
 
-    // --- issue #74: CMOV encoding round-trips through Capstone ---
+    // --- CMOV encoding round-trips through Capstone ---
 
     #[test]
     fn cmove_x86_64_round_trips() {
@@ -857,7 +857,7 @@ mod tests {
         );
     }
 
-    // --- issue #74: Jcc short-form encoding ---
+    // --- Jcc short-form encoding ---
 
     #[test]
     fn je_x86_64_encodes_to_short_form_je() {

--- a/src/assembler/x86.rs
+++ b/src/assembler/x86.rs
@@ -17,7 +17,7 @@
 // disfiguring the macro invocations. Allow at module scope.
 #![allow(clippy::useless_conversion)]
 
-use crate::isa::x86::{X86Instruction, X86Register};
+use crate::isa::x86::{X86Condition, X86Instruction, X86Register};
 use dynasm::dynasm;
 use dynasmrt::DynasmApi;
 
@@ -189,7 +189,6 @@ fn encode_64(ops: &mut dynasmrt::x64::Assembler, instr: &X86Instruction) -> Resu
         X86Instruction::Cmov { rd, rs, cond } => {
             let rd = reg_index(*rd)?;
             let rs = reg_index(*rs)?;
-            use crate::isa::x86::X86Condition;
             match cond {
                 X86Condition::E => dynasm!(ops ; .arch x64 ; cmove Rq(rd), Rq(rs)),
                 X86Condition::NE => dynasm!(ops ; .arch x64 ; cmovne Rq(rd), Rq(rs)),
@@ -215,7 +214,6 @@ fn encode_64(ops: &mut dynasmrt::x64::Assembler, instr: &X86Instruction) -> Resu
             // never patches Jcc bytes into the binary (terminators are
             // pinned), so the placeholder is only exercised by the
             // encoder round-trip tests.
-            use crate::isa::x86::X86Condition;
             match cond {
                 X86Condition::E => dynasm!(ops ; .arch x64 ; je BYTE 0),
                 X86Condition::NE => dynasm!(ops ; .arch x64 ; jne BYTE 0),
@@ -335,7 +333,6 @@ fn encode_32(ops: &mut dynasmrt::x86::Assembler, instr: &X86Instruction) -> Resu
         X86Instruction::Cmov { rd, rs, cond } => {
             let rd = reg_index_32(*rd)?;
             let rs = reg_index_32(*rs)?;
-            use crate::isa::x86::X86Condition;
             match cond {
                 X86Condition::E => dynasm!(ops ; .arch x86 ; cmove Rd(rd), Rd(rs)),
                 X86Condition::NE => dynasm!(ops ; .arch x86 ; cmovne Rd(rd), Rd(rs)),
@@ -357,7 +354,6 @@ fn encode_32(ops: &mut dynasmrt::x86::Assembler, instr: &X86Instruction) -> Resu
             Ok(())
         }
         X86Instruction::Jcc { cond } => {
-            use crate::isa::x86::X86Condition;
             match cond {
                 X86Condition::E => dynasm!(ops ; .arch x86 ; je BYTE 0),
                 X86Condition::NE => dynasm!(ops ; .arch x86 ; jne BYTE 0),
@@ -797,7 +793,6 @@ mod tests {
 
     #[test]
     fn cmove_x86_64_round_trips() {
-        use crate::isa::x86::X86Condition;
         check_x86_64(
             X86Instruction::Cmov {
                 rd: X86Register::RAX,
@@ -811,7 +806,6 @@ mod tests {
 
     #[test]
     fn all_cmov_suffixes_round_trip_x86_64() {
-        use crate::isa::x86::X86Condition;
         let cases = [
             (X86Condition::E, "cmove"),
             (X86Condition::NE, "cmovne"),
@@ -845,7 +839,6 @@ mod tests {
 
     #[test]
     fn cmove_x86_32_round_trips() {
-        use crate::isa::x86::X86Condition;
         check_x86_32(
             X86Instruction::Cmov {
                 rd: X86Register::RAX,
@@ -862,7 +855,6 @@ mod tests {
     #[test]
     fn je_x86_64_encodes_to_short_form_je() {
         // Short je with rel8=0 is bytes 0x74 0x00.
-        use crate::isa::x86::X86Condition;
         let mut asm = X86Assembler::new_64();
         let bytes = asm
             .assemble_instructions(&[X86Instruction::Jcc {
@@ -876,7 +868,6 @@ mod tests {
 
     #[test]
     fn all_jcc_suffixes_round_trip_x86_64() {
-        use crate::isa::x86::X86Condition;
         let cases = [
             (X86Condition::E, "je"),
             (X86Condition::NE, "jne"),
@@ -908,7 +899,6 @@ mod tests {
 
     #[test]
     fn je_x86_32_round_trips() {
-        use crate::isa::x86::X86Condition;
         let mut asm = X86Assembler::new_32();
         let bytes = asm
             .assemble_instructions(&[X86Instruction::Jcc {

--- a/src/assembler/x86.rs
+++ b/src/assembler/x86.rs
@@ -190,6 +190,10 @@ fn encode_64(ops: &mut dynasmrt::x64::Assembler, instr: &X86Instruction) -> Resu
             // Cycle 13 wires the dynasm cmovCC dispatch. Reject until then.
             Err("Cmov encoding not wired yet (issue #74 cycle 13)".to_string())
         }
+        X86Instruction::Jcc { .. } => {
+            // Cycle 14 wires the short-form Jcc dispatch. Reject until then.
+            Err("Jcc encoding not wired yet (issue #74 cycle 14)".to_string())
+        }
     }
 }
 
@@ -289,6 +293,10 @@ fn encode_32(ops: &mut dynasmrt::x86::Assembler, instr: &X86Instruction) -> Resu
         X86Instruction::Cmov { .. } => {
             // Cycle 13 wires the dynasm cmovCC dispatch. Reject until then.
             Err("Cmov encoding not wired yet (issue #74 cycle 13)".to_string())
+        }
+        X86Instruction::Jcc { .. } => {
+            // Cycle 14 wires the short-form Jcc dispatch. Reject until then.
+            Err("Jcc encoding not wired yet (issue #74 cycle 14)".to_string())
         }
     }
 }

--- a/src/assembler/x86.rs
+++ b/src/assembler/x86.rs
@@ -186,13 +186,55 @@ fn encode_64(ops: &mut dynasmrt::x64::Assembler, instr: &X86Instruction) -> Resu
             dynasm!(ops ; .arch x64 ; cmp Rq(rn), imm);
             Ok(())
         }
-        X86Instruction::Cmov { .. } => {
-            // Cycle 13 wires the dynasm cmovCC dispatch. Reject until then.
-            Err("Cmov encoding not wired yet (issue #74 cycle 13)".to_string())
+        X86Instruction::Cmov { rd, rs, cond } => {
+            let rd = reg_index(*rd)?;
+            let rs = reg_index(*rs)?;
+            use crate::isa::x86::X86Condition;
+            match cond {
+                X86Condition::E => dynasm!(ops ; .arch x64 ; cmove Rq(rd), Rq(rs)),
+                X86Condition::NE => dynasm!(ops ; .arch x64 ; cmovne Rq(rd), Rq(rs)),
+                X86Condition::B => dynasm!(ops ; .arch x64 ; cmovb Rq(rd), Rq(rs)),
+                X86Condition::AE => dynasm!(ops ; .arch x64 ; cmovae Rq(rd), Rq(rs)),
+                X86Condition::BE => dynasm!(ops ; .arch x64 ; cmovbe Rq(rd), Rq(rs)),
+                X86Condition::A => dynasm!(ops ; .arch x64 ; cmova Rq(rd), Rq(rs)),
+                X86Condition::L => dynasm!(ops ; .arch x64 ; cmovl Rq(rd), Rq(rs)),
+                X86Condition::GE => dynasm!(ops ; .arch x64 ; cmovge Rq(rd), Rq(rs)),
+                X86Condition::LE => dynasm!(ops ; .arch x64 ; cmovle Rq(rd), Rq(rs)),
+                X86Condition::G => dynasm!(ops ; .arch x64 ; cmovg Rq(rd), Rq(rs)),
+                X86Condition::S => dynasm!(ops ; .arch x64 ; cmovs Rq(rd), Rq(rs)),
+                X86Condition::NS => dynasm!(ops ; .arch x64 ; cmovns Rq(rd), Rq(rs)),
+                X86Condition::O => dynasm!(ops ; .arch x64 ; cmovo Rq(rd), Rq(rs)),
+                X86Condition::NO => dynasm!(ops ; .arch x64 ; cmovno Rq(rd), Rq(rs)),
+                X86Condition::P => dynasm!(ops ; .arch x64 ; cmovp Rq(rd), Rq(rs)),
+                X86Condition::NP => dynasm!(ops ; .arch x64 ; cmovnp Rq(rd), Rq(rs)),
+            }
+            Ok(())
         }
-        X86Instruction::Jcc { .. } => {
-            // Cycle 14 wires the short-form Jcc dispatch. Reject until then.
-            Err("Jcc encoding not wired yet (issue #74 cycle 14)".to_string())
+        X86Instruction::Jcc { cond } => {
+            // Short-form Jcc to a 0-byte displacement. The optimizer
+            // never patches Jcc bytes into the binary (terminators are
+            // pinned), so the placeholder is only exercised by the
+            // encoder round-trip tests.
+            use crate::isa::x86::X86Condition;
+            match cond {
+                X86Condition::E => dynasm!(ops ; .arch x64 ; je BYTE 0),
+                X86Condition::NE => dynasm!(ops ; .arch x64 ; jne BYTE 0),
+                X86Condition::B => dynasm!(ops ; .arch x64 ; jb BYTE 0),
+                X86Condition::AE => dynasm!(ops ; .arch x64 ; jae BYTE 0),
+                X86Condition::BE => dynasm!(ops ; .arch x64 ; jbe BYTE 0),
+                X86Condition::A => dynasm!(ops ; .arch x64 ; ja BYTE 0),
+                X86Condition::L => dynasm!(ops ; .arch x64 ; jl BYTE 0),
+                X86Condition::GE => dynasm!(ops ; .arch x64 ; jge BYTE 0),
+                X86Condition::LE => dynasm!(ops ; .arch x64 ; jle BYTE 0),
+                X86Condition::G => dynasm!(ops ; .arch x64 ; jg BYTE 0),
+                X86Condition::S => dynasm!(ops ; .arch x64 ; js BYTE 0),
+                X86Condition::NS => dynasm!(ops ; .arch x64 ; jns BYTE 0),
+                X86Condition::O => dynasm!(ops ; .arch x64 ; jo BYTE 0),
+                X86Condition::NO => dynasm!(ops ; .arch x64 ; jno BYTE 0),
+                X86Condition::P => dynasm!(ops ; .arch x64 ; jp BYTE 0),
+                X86Condition::NP => dynasm!(ops ; .arch x64 ; jnp BYTE 0),
+            }
+            Ok(())
         }
     }
 }
@@ -290,13 +332,51 @@ fn encode_32(ops: &mut dynasmrt::x86::Assembler, instr: &X86Instruction) -> Resu
             dynasm!(ops ; .arch x86 ; cmp Rd(rn), imm);
             Ok(())
         }
-        X86Instruction::Cmov { .. } => {
-            // Cycle 13 wires the dynasm cmovCC dispatch. Reject until then.
-            Err("Cmov encoding not wired yet (issue #74 cycle 13)".to_string())
+        X86Instruction::Cmov { rd, rs, cond } => {
+            let rd = reg_index_32(*rd)?;
+            let rs = reg_index_32(*rs)?;
+            use crate::isa::x86::X86Condition;
+            match cond {
+                X86Condition::E => dynasm!(ops ; .arch x86 ; cmove Rd(rd), Rd(rs)),
+                X86Condition::NE => dynasm!(ops ; .arch x86 ; cmovne Rd(rd), Rd(rs)),
+                X86Condition::B => dynasm!(ops ; .arch x86 ; cmovb Rd(rd), Rd(rs)),
+                X86Condition::AE => dynasm!(ops ; .arch x86 ; cmovae Rd(rd), Rd(rs)),
+                X86Condition::BE => dynasm!(ops ; .arch x86 ; cmovbe Rd(rd), Rd(rs)),
+                X86Condition::A => dynasm!(ops ; .arch x86 ; cmova Rd(rd), Rd(rs)),
+                X86Condition::L => dynasm!(ops ; .arch x86 ; cmovl Rd(rd), Rd(rs)),
+                X86Condition::GE => dynasm!(ops ; .arch x86 ; cmovge Rd(rd), Rd(rs)),
+                X86Condition::LE => dynasm!(ops ; .arch x86 ; cmovle Rd(rd), Rd(rs)),
+                X86Condition::G => dynasm!(ops ; .arch x86 ; cmovg Rd(rd), Rd(rs)),
+                X86Condition::S => dynasm!(ops ; .arch x86 ; cmovs Rd(rd), Rd(rs)),
+                X86Condition::NS => dynasm!(ops ; .arch x86 ; cmovns Rd(rd), Rd(rs)),
+                X86Condition::O => dynasm!(ops ; .arch x86 ; cmovo Rd(rd), Rd(rs)),
+                X86Condition::NO => dynasm!(ops ; .arch x86 ; cmovno Rd(rd), Rd(rs)),
+                X86Condition::P => dynasm!(ops ; .arch x86 ; cmovp Rd(rd), Rd(rs)),
+                X86Condition::NP => dynasm!(ops ; .arch x86 ; cmovnp Rd(rd), Rd(rs)),
+            }
+            Ok(())
         }
-        X86Instruction::Jcc { .. } => {
-            // Cycle 14 wires the short-form Jcc dispatch. Reject until then.
-            Err("Jcc encoding not wired yet (issue #74 cycle 14)".to_string())
+        X86Instruction::Jcc { cond } => {
+            use crate::isa::x86::X86Condition;
+            match cond {
+                X86Condition::E => dynasm!(ops ; .arch x86 ; je BYTE 0),
+                X86Condition::NE => dynasm!(ops ; .arch x86 ; jne BYTE 0),
+                X86Condition::B => dynasm!(ops ; .arch x86 ; jb BYTE 0),
+                X86Condition::AE => dynasm!(ops ; .arch x86 ; jae BYTE 0),
+                X86Condition::BE => dynasm!(ops ; .arch x86 ; jbe BYTE 0),
+                X86Condition::A => dynasm!(ops ; .arch x86 ; ja BYTE 0),
+                X86Condition::L => dynasm!(ops ; .arch x86 ; jl BYTE 0),
+                X86Condition::GE => dynasm!(ops ; .arch x86 ; jge BYTE 0),
+                X86Condition::LE => dynasm!(ops ; .arch x86 ; jle BYTE 0),
+                X86Condition::G => dynasm!(ops ; .arch x86 ; jg BYTE 0),
+                X86Condition::S => dynasm!(ops ; .arch x86 ; js BYTE 0),
+                X86Condition::NS => dynasm!(ops ; .arch x86 ; jns BYTE 0),
+                X86Condition::O => dynasm!(ops ; .arch x86 ; jo BYTE 0),
+                X86Condition::NO => dynasm!(ops ; .arch x86 ; jno BYTE 0),
+                X86Condition::P => dynasm!(ops ; .arch x86 ; jp BYTE 0),
+                X86Condition::NP => dynasm!(ops ; .arch x86 ; jnp BYTE 0),
+            }
+            Ok(())
         }
     }
 }
@@ -711,5 +791,132 @@ mod tests {
             }])
             .expect_err("x86-32 mov imm requires imm32");
         assert!(err.contains("does not fit in 32 bits"));
+    }
+
+    // --- issue #74: CMOV encoding round-trips through Capstone ---
+
+    #[test]
+    fn cmove_x86_64_round_trips() {
+        use crate::isa::x86::X86Condition;
+        check_x86_64(
+            X86Instruction::Cmov {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+                cond: X86Condition::E,
+            },
+            "cmove",
+            &["rax", "rbx"],
+        );
+    }
+
+    #[test]
+    fn all_cmov_suffixes_round_trip_x86_64() {
+        use crate::isa::x86::X86Condition;
+        let cases = [
+            (X86Condition::E, "cmove"),
+            (X86Condition::NE, "cmovne"),
+            (X86Condition::B, "cmovb"),
+            (X86Condition::AE, "cmovae"),
+            (X86Condition::BE, "cmovbe"),
+            (X86Condition::A, "cmova"),
+            (X86Condition::L, "cmovl"),
+            (X86Condition::GE, "cmovge"),
+            (X86Condition::LE, "cmovle"),
+            (X86Condition::G, "cmovg"),
+            (X86Condition::S, "cmovs"),
+            (X86Condition::NS, "cmovns"),
+            (X86Condition::O, "cmovo"),
+            (X86Condition::NO, "cmovno"),
+            (X86Condition::P, "cmovp"),
+            (X86Condition::NP, "cmovnp"),
+        ];
+        for (cond, mn) in cases {
+            check_x86_64(
+                X86Instruction::Cmov {
+                    rd: X86Register::RAX,
+                    rs: X86Register::RBX,
+                    cond,
+                },
+                mn,
+                &["rax", "rbx"],
+            );
+        }
+    }
+
+    #[test]
+    fn cmove_x86_32_round_trips() {
+        use crate::isa::x86::X86Condition;
+        check_x86_32(
+            X86Instruction::Cmov {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+                cond: X86Condition::E,
+            },
+            "cmove",
+            &["eax", "ebx"],
+        );
+    }
+
+    // --- issue #74: Jcc short-form encoding ---
+
+    #[test]
+    fn je_x86_64_encodes_to_short_form_je() {
+        // Short je with rel8=0 is bytes 0x74 0x00.
+        use crate::isa::x86::X86Condition;
+        let mut asm = X86Assembler::new_64();
+        let bytes = asm
+            .assemble_instructions(&[X86Instruction::Jcc {
+                cond: X86Condition::E,
+            }])
+            .expect("encode je");
+        let disasm = disasm_x86_64(&bytes);
+        assert_eq!(disasm.len(), 1);
+        assert_eq!(disasm[0].0, "je", "got {} {}", disasm[0].0, disasm[0].1);
+    }
+
+    #[test]
+    fn all_jcc_suffixes_round_trip_x86_64() {
+        use crate::isa::x86::X86Condition;
+        let cases = [
+            (X86Condition::E, "je"),
+            (X86Condition::NE, "jne"),
+            (X86Condition::B, "jb"),
+            (X86Condition::AE, "jae"),
+            (X86Condition::BE, "jbe"),
+            (X86Condition::A, "ja"),
+            (X86Condition::L, "jl"),
+            (X86Condition::GE, "jge"),
+            (X86Condition::LE, "jle"),
+            (X86Condition::G, "jg"),
+            (X86Condition::S, "js"),
+            (X86Condition::NS, "jns"),
+            (X86Condition::O, "jo"),
+            (X86Condition::NO, "jno"),
+            (X86Condition::P, "jp"),
+            (X86Condition::NP, "jnp"),
+        ];
+        for (cond, mn) in cases {
+            let mut asm = X86Assembler::new_64();
+            let bytes = asm
+                .assemble_instructions(&[X86Instruction::Jcc { cond }])
+                .unwrap_or_else(|e| panic!("encode {}: {}", mn, e));
+            let disasm = disasm_x86_64(&bytes);
+            assert_eq!(disasm.len(), 1, "expected one instr for {}", mn);
+            assert_eq!(disasm[0].0, mn);
+        }
+    }
+
+    #[test]
+    fn je_x86_32_round_trips() {
+        use crate::isa::x86::X86Condition;
+        let mut asm = X86Assembler::new_32();
+        let bytes = asm
+            .assemble_instructions(&[X86Instruction::Jcc {
+                cond: X86Condition::E,
+            }])
+            .expect("encode je 32-bit");
+        let disasm = disasm_x86_32(&bytes);
+        assert_eq!(disasm.len(), 1);
+        assert_eq!(disasm[0].0, "je");
     }
 }

--- a/src/assembler/x86.rs
+++ b/src/assembler/x86.rs
@@ -186,6 +186,10 @@ fn encode_64(ops: &mut dynasmrt::x64::Assembler, instr: &X86Instruction) -> Resu
             dynasm!(ops ; .arch x64 ; cmp Rq(rn), imm);
             Ok(())
         }
+        X86Instruction::Cmov { .. } => {
+            // Cycle 13 wires the dynasm cmovCC dispatch. Reject until then.
+            Err("Cmov encoding not wired yet (issue #74 cycle 13)".to_string())
+        }
     }
 }
 
@@ -281,6 +285,10 @@ fn encode_32(ops: &mut dynasmrt::x86::Assembler, instr: &X86Instruction) -> Resu
             let imm = imm_i32(*imm)?;
             dynasm!(ops ; .arch x86 ; cmp Rd(rn), imm);
             Ok(())
+        }
+        X86Instruction::Cmov { .. } => {
+            // Cycle 13 wires the dynasm cmovCC dispatch. Reject until then.
+            Err("Cmov encoding not wired yet (issue #74 cycle 13)".to_string())
         }
     }
 }

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -3700,7 +3700,7 @@ mod tests {
         );
     }
 
-    // --- issue #74: split_terminator_x86 ---
+    // --- split_terminator_x86 ---
 
     #[test]
     fn split_terminator_x86_peels_trailing_jcc() {

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -644,6 +644,21 @@ pub fn split_terminator(seq: &[Instruction]) -> (&[Instruction], Option<&Instruc
     }
 }
 
+/// Issue #74: x86 mirror of `split_terminator`. Peels a trailing Jcc
+/// off the sequence so the optimizer can reason about the straight-line
+/// prefix while leaving the branch terminator pinned in the binary.
+pub fn split_terminator_x86(
+    seq: &[crate::isa::x86::X86Instruction],
+) -> (
+    &[crate::isa::x86::X86Instruction],
+    Option<&crate::isa::x86::X86Instruction>,
+) {
+    match seq.last() {
+        Some(last) if last.is_terminator() => (&seq[..seq.len() - 1], Some(last)),
+        _ => (seq, None),
+    }
+}
+
 impl Instruction {
     /// Returns true if this instruction modifies NZCV flags.
     ///
@@ -3683,5 +3698,44 @@ mod tests {
             }
             .is_encodable_aarch64()
         );
+    }
+
+    // --- issue #74: split_terminator_x86 ---
+
+    #[test]
+    fn split_terminator_x86_peels_trailing_jcc() {
+        use crate::isa::x86::{X86Condition, X86Instruction, X86Register};
+        let seq = vec![
+            X86Instruction::CmpReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            X86Instruction::Jcc {
+                cond: X86Condition::E,
+            },
+        ];
+        let (prefix, term) = split_terminator_x86(&seq);
+        assert_eq!(prefix.len(), 1);
+        assert!(matches!(prefix[0], X86Instruction::CmpReg { .. }));
+        assert!(matches!(term, Some(X86Instruction::Jcc { .. })));
+    }
+
+    #[test]
+    fn split_terminator_x86_returns_none_when_no_terminator() {
+        use crate::isa::x86::{X86Instruction, X86Register};
+        let seq = vec![X86Instruction::MovReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+        }];
+        let (prefix, term) = split_terminator_x86(&seq);
+        assert_eq!(prefix.len(), 1);
+        assert!(term.is_none());
+    }
+
+    #[test]
+    fn split_terminator_x86_handles_empty_sequence() {
+        let (prefix, term) = split_terminator_x86(&[]);
+        assert!(prefix.is_empty());
+        assert!(term.is_none());
     }
 }

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -644,7 +644,7 @@ pub fn split_terminator(seq: &[Instruction]) -> (&[Instruction], Option<&Instruc
     }
 }
 
-/// Issue #74: x86 mirror of `split_terminator`. Peels a trailing Jcc
+/// x86 mirror of `split_terminator`. Peels a trailing Jcc
 /// off the sequence so the optimizer can reason about the straight-line
 /// prefix while leaving the branch terminator pinned in the binary.
 pub fn split_terminator_x86(

--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -490,9 +490,12 @@ fn x86_modifies_flags(instr: &X86Instruction) -> bool {
     )
 }
 
-/// Issue #74: CMOV and Jcc read EFLAGS; every other variant in the
-/// current set is flag-agnostic on the read side.
-fn x86_reads_flags(instr: &X86Instruction) -> bool {
+/// CMOV and Jcc read EFLAGS; every other variant in the current set
+/// is flag-agnostic on the read side. Crate-visible so external
+/// callers (e.g. `find_shorter_equivalent_x86`) can route through one
+/// authoritative match arm — adding a future flag-reader like SETcc
+/// then updates exactly one place.
+pub(crate) fn x86_reads_flags(instr: &X86Instruction) -> bool {
     matches!(
         instr,
         X86Instruction::Cmov { .. } | X86Instruction::Jcc { .. }

--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -495,7 +495,7 @@ fn x86_modifies_flags(instr: &X86Instruction) -> bool {
 /// callers (e.g. `find_shorter_equivalent_x86`) can route through one
 /// authoritative match arm — adding a future flag-reader like SETcc
 /// then updates exactly one place.
-pub(crate) fn x86_reads_flags(instr: &X86Instruction) -> bool {
+pub fn x86_reads_flags(instr: &X86Instruction) -> bool {
     matches!(
         instr,
         X86Instruction::Cmov { .. } | X86Instruction::Jcc { .. }

--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -247,6 +247,11 @@ pub enum X86Instruction {
         rs: X86Register,
         cond: X86Condition,
     },
+    /// `jCC <target>` — conditional branch (issue #74). Reads EFLAGS;
+    /// modelled as an opaque terminator. The branch target is recovered
+    /// from the surrounding ELF disassembly and is not carried in the IR
+    /// — search holds terminators fixed (see `split_terminator_x86`).
+    Jcc { cond: X86Condition },
 }
 
 impl X86Instruction {
@@ -265,7 +270,9 @@ impl X86Instruction {
             | X86Instruction::XorReg { rd, .. }
             | X86Instruction::XorImm { rd, .. }
             | X86Instruction::Cmov { rd, .. } => Some(*rd),
-            X86Instruction::CmpReg { .. } | X86Instruction::CmpImm { .. } => None,
+            X86Instruction::CmpReg { .. }
+            | X86Instruction::CmpImm { .. }
+            | X86Instruction::Jcc { .. } => None,
         }
     }
 
@@ -279,6 +286,7 @@ impl X86Instruction {
             X86Instruction::XorReg { .. } | X86Instruction::XorImm { .. } => "xor",
             X86Instruction::CmpReg { .. } | X86Instruction::CmpImm { .. } => "cmp",
             X86Instruction::Cmov { .. } => "cmov",
+            X86Instruction::Jcc { .. } => "jcc",
         }
     }
 
@@ -306,7 +314,15 @@ impl X86Instruction {
             X86Instruction::CmpImm { rn, .. } => vec![*rn],
             // Cmov reads both rd (kept on false branch) and rs.
             X86Instruction::Cmov { rd, rs, .. } => vec![*rd, *rs],
+            X86Instruction::Jcc { .. } => vec![],
         }
+    }
+
+    /// Whether this instruction transfers control out of the
+    /// optimization window. Jcc terminators are held fixed by
+    /// `split_terminator_x86`; the search never synthesizes them.
+    pub fn is_terminator(&self) -> bool {
+        matches!(self, X86Instruction::Jcc { .. })
     }
 }
 
@@ -339,6 +355,7 @@ impl InstructionType for X86Instruction {
             X86Instruction::CmpReg { .. } => 12,
             X86Instruction::CmpImm { .. } => 13,
             X86Instruction::Cmov { .. } => 14,
+            X86Instruction::Jcc { .. } => 15,
         }
     }
 
@@ -347,7 +364,7 @@ impl InstructionType for X86Instruction {
     }
 
     fn has_side_effects(&self) -> bool {
-        // x86 MOV and CMOV do not touch EFLAGS. Every other variant in
+        // MOV / CMOV / Jcc do not touch EFLAGS. Every other variant in
         // the current set sets or clobbers flag bits, which is observable
         // state beyond the destination register.
         !matches!(
@@ -355,6 +372,7 @@ impl InstructionType for X86Instruction {
             X86Instruction::MovReg { .. }
                 | X86Instruction::MovImm { .. }
                 | X86Instruction::Cmov { .. }
+                | X86Instruction::Jcc { .. }
         )
     }
 }
@@ -379,6 +397,8 @@ impl fmt::Display for X86Instruction {
             X86Instruction::CmpImm { rn, imm } => write!(f, "{} {}, {}", mn, rn, imm),
             // Render as e.g. `cmove rax, rbx` (mnemonic + condition suffix).
             X86Instruction::Cmov { rd, rs, cond } => write!(f, "cmov{} {}, {}", cond, rd, rs),
+            // Target is opaque to the IR; render with a placeholder.
+            X86Instruction::Jcc { cond } => write!(f, "j{} <target>", cond),
         }
     }
 }
@@ -456,13 +476,16 @@ impl ISA for X86_32 {
 }
 
 /// Helper used by both `FlagsAnalysis<X86Instruction> for X86_64` and
-/// `for X86_32`: every x86 mnemonic in the current set writes EFLAGS
-/// except for `Mov*` and `Cmov` (the latter reads but does not write
-/// EFLAGS — issue #74).
+/// `for X86_32`. MOV / CMOV / Jcc do not write EFLAGS (the latter two
+/// read EFLAGS — issue #74); every other variant in the current set
+/// does.
 fn x86_modifies_flags(instr: &X86Instruction) -> bool {
     !matches!(
         instr,
-        X86Instruction::MovReg { .. } | X86Instruction::MovImm { .. } | X86Instruction::Cmov { .. }
+        X86Instruction::MovReg { .. }
+            | X86Instruction::MovImm { .. }
+            | X86Instruction::Cmov { .. }
+            | X86Instruction::Jcc { .. }
     )
 }
 
@@ -641,6 +664,7 @@ impl crate::isa::traits::Assembler<X86Instruction> for X86_32 {
             X86Instruction::CmpReg { rn, rs } => reg_ok_32(*rn) && reg_ok_32(*rs),
             X86Instruction::CmpImm { rn, .. } => reg_ok_32(*rn),
             X86Instruction::Cmov { rd, rs, .. } => reg_ok_32(*rd) && reg_ok_32(*rs),
+            X86Instruction::Jcc { .. } => true,
         }
     }
 }
@@ -794,6 +818,10 @@ impl X86Mutator {
                     *rs = self.pick_register(rng);
                 }
             }
+            // Jcc is a terminator; mutation never reaches it because the
+            // search pool excludes terminators. Keep the arm as a no-op
+            // so an accidental call doesn't panic.
+            X86Instruction::Jcc { .. } => {}
         }
     }
 
@@ -837,6 +865,8 @@ impl X86Mutator {
             // Cmov has a unique shape (rd, rs, cond) with no opcode-shape
             // siblings; keep it unchanged in the opcode-bridge mutator.
             X86Instruction::Cmov { .. } => current,
+            // Jcc is a terminator and should never reach mutation; preserve it.
+            X86Instruction::Jcc { .. } => current,
         };
     }
 
@@ -1019,6 +1049,8 @@ fn with_destination(instr: X86Instruction, new_rd: X86Register) -> X86Instructio
             rs,
             cond,
         },
+        // Jcc has no register operand; ignore the requested rd swap.
+        X86Instruction::Jcc { cond } => X86Instruction::Jcc { cond },
     }
 }
 
@@ -1044,6 +1076,7 @@ fn with_sources(instr: X86Instruction, new_rs: X86Register, new_imm: i64) -> X86
             rs: new_rs,
             cond,
         },
+        X86Instruction::Jcc { cond } => X86Instruction::Jcc { cond },
     }
 }
 
@@ -1669,5 +1702,59 @@ mod tests {
                 }
             }
         }
+    }
+
+    // --- issue #74: Jcc IR + is_terminator ---
+
+    #[test]
+    fn jcc_is_terminator() {
+        let jcc = X86Instruction::Jcc {
+            cond: X86Condition::E,
+        };
+        assert!(jcc.is_terminator());
+    }
+
+    #[test]
+    fn non_jcc_x86_instructions_are_not_terminators() {
+        assert!(
+            !X86Instruction::MovImm {
+                rd: X86Register::RAX,
+                imm: 0
+            }
+            .is_terminator()
+        );
+        assert!(
+            !X86Instruction::CmpReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX
+            }
+            .is_terminator()
+        );
+        assert!(
+            !X86Instruction::Cmov {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+                cond: X86Condition::E
+            }
+            .is_terminator()
+        );
+    }
+
+    #[test]
+    fn jcc_has_no_destination_and_no_source_registers() {
+        let jcc = X86Instruction::Jcc {
+            cond: X86Condition::NE,
+        };
+        assert_eq!(jcc.destination(), None);
+        assert!(jcc.source_registers().is_empty());
+    }
+
+    #[test]
+    fn jcc_does_not_modify_flags_and_has_no_side_effects() {
+        let jcc = X86Instruction::Jcc {
+            cond: X86Condition::B,
+        };
+        assert!(!x86_modifies_flags(&jcc));
+        assert!(!jcc.has_side_effects());
     }
 }

--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -18,6 +18,60 @@ use crate::isa::traits::{ISA, InstructionGenerator, InstructionType, OperandType
 use rand::{Rng, RngExt};
 use std::fmt;
 
+/// x86 condition codes consumed by CMOVcc / Jcc (issue #74).
+///
+/// The 16 canonical codes here cover every short-form jump / cmov GAS
+/// emits. Aliases (`NB` for `AE`, `Z` for `E`, etc.) are normalized to
+/// the canonical variant by the parser, not represented here.
+///
+/// Kept distinct from AArch64's `Condition` because (a) x86's CF on
+/// subtraction has inverted polarity vs AArch64's C, and (b) the
+/// mnemonics differ (`e`/`ne` vs `eq`/`ne`), so a shared enum would
+/// invite cross-arch bugs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum X86Condition {
+    E,  // equal / zero            (ZF=1)
+    NE, // not equal / not zero    (ZF=0)
+    B,  // below   (unsigned <)    (CF=1)
+    AE, // above-or-equal          (CF=0)
+    BE, // below-or-equal          (CF=1 | ZF=1)
+    A,  // above                   (CF=0 & ZF=0)
+    L,  // less    (signed <)      (SF!=OF)
+    GE, // greater-or-equal        (SF==OF)
+    LE, // less-or-equal           (ZF=1 | SF!=OF)
+    G,  // greater                 (ZF=0 & SF==OF)
+    S,  // sign (negative)         (SF=1)
+    NS, // not sign                (SF=0)
+    O,  // overflow                (OF=1)
+    NO, // not overflow            (OF=0)
+    P,  // parity-even             (PF=1)
+    NP, // parity-odd              (PF=0)
+}
+
+impl fmt::Display for X86Condition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            X86Condition::E => "e",
+            X86Condition::NE => "ne",
+            X86Condition::B => "b",
+            X86Condition::AE => "ae",
+            X86Condition::BE => "be",
+            X86Condition::A => "a",
+            X86Condition::L => "l",
+            X86Condition::GE => "ge",
+            X86Condition::LE => "le",
+            X86Condition::G => "g",
+            X86Condition::S => "s",
+            X86Condition::NS => "ns",
+            X86Condition::O => "o",
+            X86Condition::NO => "no",
+            X86Condition::P => "p",
+            X86Condition::NP => "np",
+        };
+        f.write_str(s)
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum X86Register {
     RAX,
@@ -185,6 +239,14 @@ pub enum X86Instruction {
     CmpReg { rn: X86Register, rs: X86Register },
     /// `cmp rn, imm` — `rn - imm` discarding the result; sets EFLAGS.
     CmpImm { rn: X86Register, imm: i64 },
+    /// `cmovCC rd, rs` — conditional move (issue #74). Reads EFLAGS;
+    /// when `cond` holds, writes `rd = rs`; otherwise `rd` is unchanged.
+    /// Does not modify EFLAGS.
+    Cmov {
+        rd: X86Register,
+        rs: X86Register,
+        cond: X86Condition,
+    },
 }
 
 impl X86Instruction {
@@ -201,7 +263,8 @@ impl X86Instruction {
             | X86Instruction::OrReg { rd, .. }
             | X86Instruction::OrImm { rd, .. }
             | X86Instruction::XorReg { rd, .. }
-            | X86Instruction::XorImm { rd, .. } => Some(*rd),
+            | X86Instruction::XorImm { rd, .. }
+            | X86Instruction::Cmov { rd, .. } => Some(*rd),
             X86Instruction::CmpReg { .. } | X86Instruction::CmpImm { .. } => None,
         }
     }
@@ -215,6 +278,7 @@ impl X86Instruction {
             X86Instruction::OrReg { .. } | X86Instruction::OrImm { .. } => "or",
             X86Instruction::XorReg { .. } | X86Instruction::XorImm { .. } => "xor",
             X86Instruction::CmpReg { .. } | X86Instruction::CmpImm { .. } => "cmp",
+            X86Instruction::Cmov { .. } => "cmov",
         }
     }
 
@@ -240,6 +304,8 @@ impl X86Instruction {
             | X86Instruction::XorImm { rd, .. } => vec![*rd],
             X86Instruction::CmpReg { rn, rs } => vec![*rn, *rs],
             X86Instruction::CmpImm { rn, .. } => vec![*rn],
+            // Cmov reads both rd (kept on false branch) and rs.
+            X86Instruction::Cmov { rd, rs, .. } => vec![*rd, *rs],
         }
     }
 }
@@ -272,6 +338,7 @@ impl InstructionType for X86Instruction {
             X86Instruction::XorImm { .. } => 11,
             X86Instruction::CmpReg { .. } => 12,
             X86Instruction::CmpImm { .. } => 13,
+            X86Instruction::Cmov { .. } => 14,
         }
     }
 
@@ -280,12 +347,14 @@ impl InstructionType for X86Instruction {
     }
 
     fn has_side_effects(&self) -> bool {
-        // x86 MOV does not touch EFLAGS. Every other variant in the minimal
-        // core set sets or clobbers flag bits, which is observable state
-        // beyond the destination register.
+        // x86 MOV and CMOV do not touch EFLAGS. Every other variant in
+        // the current set sets or clobbers flag bits, which is observable
+        // state beyond the destination register.
         !matches!(
             self,
-            X86Instruction::MovReg { .. } | X86Instruction::MovImm { .. }
+            X86Instruction::MovReg { .. }
+                | X86Instruction::MovImm { .. }
+                | X86Instruction::Cmov { .. }
         )
     }
 }
@@ -308,6 +377,8 @@ impl fmt::Display for X86Instruction {
             | X86Instruction::XorImm { rd, imm } => write!(f, "{} {}, {}", mn, rd, imm),
             X86Instruction::CmpReg { rn, rs } => write!(f, "{} {}, {}", mn, rn, rs),
             X86Instruction::CmpImm { rn, imm } => write!(f, "{} {}, {}", mn, rn, imm),
+            // Render as e.g. `cmove rax, rbx` (mnemonic + condition suffix).
+            X86Instruction::Cmov { rd, rs, cond } => write!(f, "cmov{} {}, {}", cond, rd, rs),
         }
     }
 }
@@ -385,11 +456,13 @@ impl ISA for X86_32 {
 }
 
 /// Helper used by both `FlagsAnalysis<X86Instruction> for X86_64` and
-/// `for X86_32`: every x86 mnemonic except `Mov*` writes EFLAGS.
+/// `for X86_32`: every x86 mnemonic in the current set writes EFLAGS
+/// except for `Mov*` and `Cmov` (the latter reads but does not write
+/// EFLAGS — issue #74).
 fn x86_modifies_flags(instr: &X86Instruction) -> bool {
     !matches!(
         instr,
-        X86Instruction::MovReg { .. } | X86Instruction::MovImm { .. }
+        X86Instruction::MovReg { .. } | X86Instruction::MovImm { .. } | X86Instruction::Cmov { .. }
     )
 }
 
@@ -567,6 +640,7 @@ impl crate::isa::traits::Assembler<X86Instruction> for X86_32 {
             | X86Instruction::XorImm { rd, .. } => reg_ok_32(*rd),
             X86Instruction::CmpReg { rn, rs } => reg_ok_32(*rn) && reg_ok_32(*rs),
             X86Instruction::CmpImm { rn, .. } => reg_ok_32(*rn),
+            X86Instruction::Cmov { rd, rs, .. } => reg_ok_32(*rd) && reg_ok_32(*rs),
         }
     }
 }
@@ -711,6 +785,15 @@ impl X86Mutator {
                     *imm = self.pick_immediate(rng);
                 }
             }
+            X86Instruction::Cmov { rd, rs, .. } => {
+                // Cond stays fixed — stochastic mutation only swaps registers
+                // for now; cycle 16+ may add condition-bridging.
+                if rng.random_bool(0.5) {
+                    *rd = self.pick_register(rng);
+                } else {
+                    *rs = self.pick_register(rng);
+                }
+            }
         }
     }
 
@@ -751,6 +834,9 @@ impl X86Mutator {
                 _ => X86Instruction::XorImm { rd, imm },
             },
             X86Instruction::CmpReg { .. } | X86Instruction::CmpImm { .. } => current,
+            // Cmov has a unique shape (rd, rs, cond) with no opcode-shape
+            // siblings; keep it unchanged in the opcode-bridge mutator.
+            X86Instruction::Cmov { .. } => current,
         };
     }
 
@@ -928,6 +1014,11 @@ fn with_destination(instr: X86Instruction, new_rd: X86Register) -> X86Instructio
         // CMP variants have rn instead of rd; mutate rn for symmetry.
         X86Instruction::CmpReg { rs, .. } => X86Instruction::CmpReg { rn: new_rd, rs },
         X86Instruction::CmpImm { imm, .. } => X86Instruction::CmpImm { rn: new_rd, imm },
+        X86Instruction::Cmov { rs, cond, .. } => X86Instruction::Cmov {
+            rd: new_rd,
+            rs,
+            cond,
+        },
     }
 }
 
@@ -947,6 +1038,12 @@ fn with_sources(instr: X86Instruction, new_rs: X86Register, new_imm: i64) -> X86
         X86Instruction::XorImm { rd, .. } => X86Instruction::XorImm { rd, imm: new_imm },
         X86Instruction::CmpReg { rn, .. } => X86Instruction::CmpReg { rn, rs: new_rs },
         X86Instruction::CmpImm { rn, .. } => X86Instruction::CmpImm { rn, imm: new_imm },
+        // Cmov's `rs` is mutated; `cond` and `rd` carry through unchanged.
+        X86Instruction::Cmov { rd, cond, .. } => X86Instruction::Cmov {
+            rd,
+            rs: new_rs,
+            cond,
+        },
     }
 }
 

--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -364,8 +364,9 @@ impl InstructionType for X86Instruction {
     }
 
     fn has_side_effects(&self) -> bool {
-        // MOV / CMOV / Jcc do not touch EFLAGS. Every other variant in
-        // the current set sets or clobbers flag bits, which is observable
+        // MOV / CMOV / Jcc do not write EFLAGS (CMOV and Jcc read them,
+        // but reading is not a side effect on observable state). Every
+        // other variant sets or clobbers flag bits, which is observable
         // state beyond the destination register.
         !matches!(
             self,
@@ -476,9 +477,9 @@ impl ISA for X86_32 {
 }
 
 /// Helper used by both `FlagsAnalysis<X86Instruction> for X86_64` and
-/// `for X86_32`. MOV / CMOV / Jcc do not write EFLAGS (the latter two
-/// read EFLAGS — ); every other variant in the current set
-/// does.
+/// `for X86_32`. MOV / CMOV / Jcc do not write EFLAGS — CMOV and Jcc
+/// read them via `x86_reads_flags` but do not modify any flag bit.
+/// Every other variant in the current set writes EFLAGS.
 fn x86_modifies_flags(instr: &X86Instruction) -> bool {
     !matches!(
         instr,

--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -489,14 +489,22 @@ fn x86_modifies_flags(instr: &X86Instruction) -> bool {
     )
 }
 
+/// Issue #74: CMOV and Jcc read EFLAGS; every other variant in the
+/// current set is flag-agnostic on the read side.
+fn x86_reads_flags(instr: &X86Instruction) -> bool {
+    matches!(
+        instr,
+        X86Instruction::Cmov { .. } | X86Instruction::Jcc { .. }
+    )
+}
+
 impl crate::isa::traits::FlagsAnalysis<X86Instruction> for X86_64 {
     fn modifies_flags(instr: &X86Instruction) -> bool {
         x86_modifies_flags(instr)
     }
 
-    fn reads_flags(_instr: &X86Instruction) -> bool {
-        // No conditional ops in the current x86 mnemonic set.
-        false
+    fn reads_flags(instr: &X86Instruction) -> bool {
+        x86_reads_flags(instr)
     }
 }
 
@@ -505,8 +513,8 @@ impl crate::isa::traits::FlagsAnalysis<X86Instruction> for X86_32 {
         x86_modifies_flags(instr)
     }
 
-    fn reads_flags(_instr: &X86Instruction) -> bool {
-        false
+    fn reads_flags(instr: &X86Instruction) -> bool {
+        x86_reads_flags(instr)
     }
 }
 
@@ -1756,5 +1764,60 @@ mod tests {
         };
         assert!(!x86_modifies_flags(&jcc));
         assert!(!jcc.has_side_effects());
+    }
+
+    // --- issue #74: FlagsAnalysis::reads_flags wired for Cmov / Jcc ---
+
+    #[test]
+    fn x86_64_reads_flags_returns_true_for_cmov_and_jcc() {
+        use crate::isa::traits::FlagsAnalysis;
+        let cmov = X86Instruction::Cmov {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+            cond: X86Condition::E,
+        };
+        let jcc = X86Instruction::Jcc {
+            cond: X86Condition::NE,
+        };
+        assert!(<X86_64 as FlagsAnalysis<X86Instruction>>::reads_flags(
+            &cmov
+        ));
+        assert!(<X86_64 as FlagsAnalysis<X86Instruction>>::reads_flags(&jcc));
+    }
+
+    #[test]
+    fn x86_32_reads_flags_returns_true_for_cmov_and_jcc() {
+        use crate::isa::traits::FlagsAnalysis;
+        let cmov = X86Instruction::Cmov {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+            cond: X86Condition::E,
+        };
+        let jcc = X86Instruction::Jcc {
+            cond: X86Condition::NE,
+        };
+        assert!(<X86_32 as FlagsAnalysis<X86Instruction>>::reads_flags(
+            &cmov
+        ));
+        assert!(<X86_32 as FlagsAnalysis<X86Instruction>>::reads_flags(&jcc));
+    }
+
+    #[test]
+    fn x86_reads_flags_returns_false_for_non_condition_ops() {
+        use crate::isa::traits::FlagsAnalysis;
+        let mov = X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: 0,
+        };
+        let add = X86Instruction::AddReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+        };
+        assert!(!<X86_64 as FlagsAnalysis<X86Instruction>>::reads_flags(
+            &mov
+        ));
+        assert!(!<X86_64 as FlagsAnalysis<X86Instruction>>::reads_flags(
+            &add
+        ));
     }
 }

--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -18,7 +18,7 @@ use crate::isa::traits::{ISA, InstructionGenerator, InstructionType, OperandType
 use rand::{Rng, RngExt};
 use std::fmt;
 
-/// x86 condition codes consumed by CMOVcc / Jcc (issue #74).
+/// x86 condition codes consumed by CMOVcc / Jcc.
 ///
 /// The 16 canonical codes here cover every short-form jump / cmov GAS
 /// emits. Aliases (`NB` for `AE`, `Z` for `E`, etc.) are normalized to
@@ -239,7 +239,7 @@ pub enum X86Instruction {
     CmpReg { rn: X86Register, rs: X86Register },
     /// `cmp rn, imm` — `rn - imm` discarding the result; sets EFLAGS.
     CmpImm { rn: X86Register, imm: i64 },
-    /// `cmovCC rd, rs` — conditional move (issue #74). Reads EFLAGS;
+    /// `cmovCC rd, rs` — conditional move. Reads EFLAGS;
     /// when `cond` holds, writes `rd = rs`; otherwise `rd` is unchanged.
     /// Does not modify EFLAGS.
     Cmov {
@@ -247,7 +247,7 @@ pub enum X86Instruction {
         rs: X86Register,
         cond: X86Condition,
     },
-    /// `jCC <target>` — conditional branch (issue #74). Reads EFLAGS;
+    /// `jCC <target>` — conditional branch. Reads EFLAGS;
     /// modelled as an opaque terminator. The branch target is recovered
     /// from the surrounding ELF disassembly and is not carried in the IR
     /// — search holds terminators fixed (see `split_terminator_x86`).
@@ -477,7 +477,7 @@ impl ISA for X86_32 {
 
 /// Helper used by both `FlagsAnalysis<X86Instruction> for X86_64` and
 /// `for X86_32`. MOV / CMOV / Jcc do not write EFLAGS (the latter two
-/// read EFLAGS — issue #74); every other variant in the current set
+/// read EFLAGS — ); every other variant in the current set
 /// does.
 fn x86_modifies_flags(instr: &X86Instruction) -> bool {
     !matches!(
@@ -1712,7 +1712,7 @@ mod tests {
         }
     }
 
-    // --- issue #74: Jcc IR + is_terminator ---
+    // --- Jcc IR + is_terminator ---
 
     #[test]
     fn jcc_is_terminator() {
@@ -1766,7 +1766,7 @@ mod tests {
         assert!(!jcc.has_side_effects());
     }
 
-    // --- issue #74: FlagsAnalysis::reads_flags wired for Cmov / Jcc ---
+    // --- FlagsAnalysis::reads_flags wired for Cmov / Jcc ---
 
     #[test]
     fn x86_64_reads_flags_returns_true_for_cmov_and_jcc() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1062,9 +1062,21 @@ fn find_shorter_equivalent_x86(
     let imms = vec![0i64, 1, -1];
 
     let candidates = generate_all_x86_instructions(&pool, &imms);
-    let cfg = X86EquivalenceConfig::new(width)
-        .live_out(live_out.clone())
-        .fast_only();
+    // Defense-in-depth: when the target reads EFLAGS (any CMOV/Jcc),
+    // the fast-path's 10 random trials might not cover every flag
+    // combination the reader actually depends on. Drop `.fast_only()` so
+    // the SMT path also runs for those targets. Combined with the
+    // run_fast_path_x86 input-flag randomization fix, this closes the
+    // soundness gap where a flag-clobbering proposal could pass.
+    let target_reads_flags = target.iter().any(|i| {
+        use crate::isa::x86::X86Instruction::*;
+        matches!(i, Cmov { .. } | Jcc { .. })
+    });
+    let mut cfg_builder = X86EquivalenceConfig::new(width).live_out(live_out.clone());
+    if !target_reads_flags {
+        cfg_builder = cfg_builder.fast_only();
+    }
+    let cfg = cfg_builder;
     for cand in candidates {
         let seq = vec![cand];
         let cand_cost =

--- a/src/main.rs
+++ b/src/main.rs
@@ -1232,12 +1232,20 @@ fn reassemble_x86_prefix_with_pinned_terminator(
 
     // Pad NOPs so the Jcc lands at the same offset as in the original
     // window. `nop_sequence` may return fewer than the requested bytes;
-    // loop until the gap is filled.
+    // loop until the gap is filled. Return Err on an empty NOP slice
+    // (debug-assert alone would let release builds spin forever).
     let gap = original_prefix_byte_size - out.len();
     let mut padded = 0;
     while padded < gap {
         let nop = arch.nop_sequence(gap - padded);
-        debug_assert!(!nop.is_empty(), "nop_sequence returned empty slice");
+        if nop.is_empty() {
+            return Err(format!(
+                "nop_sequence returned an empty slice while padding {} bytes \
+                 for arch {:?}; refusing to spin forever",
+                gap - padded,
+                arch
+            ));
+        }
         out.extend_from_slice(nop);
         padded += nop.len();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1036,6 +1036,14 @@ fn find_shorter_equivalent_x86(
     let target_cost =
         cost_x86::sequence_cost(target, &semantics::cost::CostMetric::CodeSize, width);
 
+    // Peel any trailing Jcc terminator. Candidates never include Jcc, so
+    // a non-Jcc proposal against a Jcc-terminated target would otherwise
+    // be immediately rejected by `check_equivalence_x86`'s terminator-
+    // equality precheck. We append the original terminator to each
+    // proposal so the equivalence check sees matching terminators and
+    // its flag-observability guard fires correctly.
+    let (_, target_terminator) = crate::ir::instructions::split_terminator_x86(target);
+
     // Live-out registers = everything the target writes.
     let live_regs: Vec<X86Register> = target.iter().filter_map(|i| i.destination()).collect();
     // Flags are live whenever the target contains any instruction with
@@ -1081,7 +1089,15 @@ fn find_shorter_equivalent_x86(
         .fast_only();
     let cfg_smt = X86EquivalenceConfig::new(width).live_out(live_out.clone());
     for cand in candidates {
-        let seq = vec![cand];
+        // Build the proposal as [candidate] + original_terminator so
+        // both sides share the same trailing Jcc (if any). The
+        // equivalence check peels them in lockstep and runs the prefix
+        // comparison under forced flags_live (since the terminator
+        // reads flags).
+        let mut seq = vec![cand];
+        if let Some(t) = target_terminator {
+            seq.push(*t);
+        }
         let cand_cost =
             cost_x86::sequence_cost(&seq, &semantics::cost::CostMetric::CodeSize, width);
         if cand_cost >= target_cost {
@@ -2217,6 +2233,45 @@ mod cli_helper_tests {
     /// pool-narrowing change (issue #84 item 8) so any future
     /// reintroduction of unconditional scratch-register inflation is
     /// caught.
+    #[test]
+    fn find_shorter_equivalent_x86_can_optimize_jcc_terminated_window() {
+        use isa::x86::X86Condition;
+        // Two redundant MovImms followed by a Jcc terminator. Search
+        // should collapse the prefix and re-attach the original Jcc.
+        let optimized = find_shorter_equivalent_x86(
+            &[
+                X86Instruction::MovImm {
+                    rd: X86Register::RBX,
+                    imm: 1,
+                },
+                X86Instruction::MovImm {
+                    rd: X86Register::RBX,
+                    imm: 1,
+                },
+                X86Instruction::Jcc {
+                    cond: X86Condition::E,
+                },
+            ],
+            64,
+        )
+        .expect("redundant prefix + Jcc must be optimizable");
+        // Expect: [MovImm RBX, 1, Jcc E].
+        assert_eq!(optimized.len(), 2);
+        match optimized[0] {
+            X86Instruction::MovImm { rd, imm } => {
+                assert_eq!(rd, X86Register::RBX);
+                assert_eq!(imm, 1);
+            }
+            ref other => panic!("expected MovImm RBX, 1, got {:?}", other),
+        }
+        assert!(matches!(
+            optimized[1],
+            X86Instruction::Jcc {
+                cond: X86Condition::E
+            }
+        ));
+    }
+
     #[test]
     fn find_shorter_equivalent_x86_collapses_without_rax_or_rdi_in_target() {
         let optimized = find_shorter_equivalent_x86(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1075,14 +1075,10 @@ fn find_shorter_equivalent_x86(
     // the reader depends on. Drop `.fast_only()` for those iterations so
     // the SMT path also runs. The two configs differ only in fast_only;
     // building them once outside the loop avoids per-iteration churn.
-    let reads_flags = |seq: &[isa::x86::X86Instruction]| -> bool {
-        seq.iter().any(|i| {
-            matches!(
-                i,
-                isa::x86::X86Instruction::Cmov { .. } | isa::x86::X86Instruction::Jcc { .. }
-            )
-        })
-    };
+    // Route through `isa::x86::x86_reads_flags` so a future flag-reader
+    // (e.g. SETcc) only needs the predicate updated in one place.
+    let reads_flags =
+        |seq: &[isa::x86::X86Instruction]| -> bool { seq.iter().any(isa::x86::x86_reads_flags) };
     let target_reads_flags = reads_flags(target);
     let cfg_fast = X86EquivalenceConfig::new(width)
         .live_out(live_out.clone())

--- a/src/main.rs
+++ b/src/main.rs
@@ -2475,4 +2475,141 @@ mod cli_helper_tests {
             err
         );
     }
+
+    // --- issue #74: end-to-end CMP + CMOV / Jcc pipeline ---
+
+    #[test]
+    fn issue_74_cmp_cmov_round_trips_through_asm_disasm_parse() {
+        use assembler::x86::X86Assembler;
+        use capstone::prelude::*;
+        use isa::x86::{X86Condition, X86Instruction, X86Register};
+        use parser::x86::x86_ir_from_mnemonic;
+
+        let original = vec![
+            X86Instruction::CmpReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            X86Instruction::Cmov {
+                rd: X86Register::RAX,
+                rs: X86Register::RCX,
+                cond: X86Condition::E,
+            },
+        ];
+        let mut asm = X86Assembler::new_64();
+        let bytes = asm
+            .assemble_instructions(&original)
+            .expect("encode cmp + cmove");
+        let cs = capstone::Capstone::new()
+            .x86()
+            .mode(capstone::arch::x86::ArchMode::Mode64)
+            .syntax(capstone::arch::x86::ArchSyntax::Intel)
+            .build()
+            .expect("capstone init");
+        let insns = cs.disasm_all(&bytes, 0x0).expect("disassemble");
+        let recovered: Vec<X86Instruction> = insns
+            .iter()
+            .map(|i| {
+                let mn = i.mnemonic().unwrap_or("");
+                let op = i.op_str().unwrap_or("");
+                x86_ir_from_mnemonic(mn, op)
+                    .expect("parse succeeds")
+                    .expect("parse yields IR")
+            })
+            .collect();
+        assert_eq!(recovered, original);
+    }
+
+    #[test]
+    fn issue_74_jcc_round_trips_through_asm_disasm_parse() {
+        use assembler::x86::X86Assembler;
+        use capstone::prelude::*;
+        use isa::x86::{X86Condition, X86Instruction};
+        use parser::x86::x86_ir_from_mnemonic;
+
+        let original = vec![X86Instruction::Jcc {
+            cond: X86Condition::NE,
+        }];
+        let mut asm = X86Assembler::new_64();
+        let bytes = asm.assemble_instructions(&original).expect("encode jne");
+        let cs = capstone::Capstone::new()
+            .x86()
+            .mode(capstone::arch::x86::ArchMode::Mode64)
+            .syntax(capstone::arch::x86::ArchSyntax::Intel)
+            .build()
+            .expect("capstone init");
+        let insns = cs.disasm_all(&bytes, 0x0).expect("disassemble");
+        assert_eq!(insns.len(), 1);
+        let mn = insns.iter().next().unwrap().mnemonic().unwrap_or("");
+        let op = insns.iter().next().unwrap().op_str().unwrap_or("");
+        let parsed = x86_ir_from_mnemonic(mn, op)
+            .expect("parse succeeds")
+            .expect("parse yields IR");
+        assert_eq!(parsed, original[0]);
+    }
+
+    #[test]
+    fn issue_74_cmp_cmov_pipeline_distinguishes_different_cmov_sources_when_flags_live() {
+        use isa::x86::{X86Condition, X86Instruction, X86Register};
+        use semantics::equivalence::{
+            EquivalenceResult, X86EquivalenceConfig, check_equivalence_x86,
+        };
+        use semantics::state::X86LiveOutMask;
+
+        let target = vec![
+            X86Instruction::CmpReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            X86Instruction::Cmov {
+                rd: X86Register::RAX,
+                rs: X86Register::RCX,
+                cond: X86Condition::E,
+            },
+        ];
+        let proposal = vec![
+            X86Instruction::CmpReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            X86Instruction::Cmov {
+                rd: X86Register::RAX,
+                rs: X86Register::RDX,
+                cond: X86Condition::E,
+            },
+        ];
+        let cfg = X86EquivalenceConfig::new_for_64()
+            .live_out(X86LiveOutMask::from_registers(vec![X86Register::RAX]).with_flags(true));
+        assert!(matches!(
+            check_equivalence_x86(&target, &proposal, &cfg),
+            EquivalenceResult::NotEquivalent
+        ));
+    }
+
+    #[test]
+    fn issue_74_cmp_cmov_pipeline_self_equivalent_under_flags_live() {
+        use isa::x86::{X86Condition, X86Instruction, X86Register};
+        use semantics::equivalence::{
+            EquivalenceResult, X86EquivalenceConfig, check_equivalence_x86,
+        };
+        use semantics::state::X86LiveOutMask;
+
+        let seq = vec![
+            X86Instruction::CmpReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            X86Instruction::Cmov {
+                rd: X86Register::RAX,
+                rs: X86Register::RCX,
+                cond: X86Condition::NE,
+            },
+        ];
+        let cfg = X86EquivalenceConfig::new_for_64()
+            .live_out(X86LiveOutMask::from_registers(vec![X86Register::RAX]).with_flags(true));
+        assert_eq!(
+            check_equivalence_x86(&seq.clone(), &seq, &cfg),
+            EquivalenceResult::Equivalent
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1356,7 +1356,7 @@ fn optimize_elf_binary_x86(
     // zero displacement and overwrite the real branch target. Peel the
     // Jcc from `final_ir` and splice the ORIGINAL Jcc bytes back at the
     // same offset they had in the source window so the displacement
-    // stays valid (reviewer-flagged P1 on PR #268).
+    // stays valid.
     let (final_prefix_ir, final_terminator) =
         crate::ir::instructions::split_terminator_x86(&final_ir);
     let (_, original_terminator) = crate::ir::instructions::split_terminator_x86(&ir);
@@ -2564,7 +2564,7 @@ mod cli_helper_tests {
         );
     }
 
-    // --- issue #74: end-to-end CMP + CMOV / Jcc pipeline ---
+    // --- end-to-end CMP + CMOV / Jcc pipeline ---
 
     #[test]
     fn issue_74_cmp_cmov_round_trips_through_asm_disasm_parse() {
@@ -2701,7 +2701,7 @@ mod cli_helper_tests {
         );
     }
 
-    // --- x86 Jcc-byte preservation across reassembly (PR #268 review) ---
+    // --- x86 Jcc-byte preservation across reassembly ---
 
     #[test]
     fn reassemble_x86_no_terminator_returns_assembled_bytes_unchanged() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2931,6 +2931,33 @@ mod cli_helper_tests {
     }
 
     #[test]
+    fn reassemble_x86_32_splices_and_pads_correctly() {
+        // Mirrors the x86-64 pad-with-NOPs test for the x86-32 mode.
+        // The x86-32 nop_sequence returns single-byte 0x90 NOPs, so the
+        // padding loop must iterate `gap` times rather than once.
+        use isa::x86::{X86Instruction, X86Register};
+        let original_jcc_bytes = [0x74u8, 0x05]; // je rel8=5
+        let final_ir = [X86Instruction::MovReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+        }];
+        // Original prefix was 5 bytes; optimized prefix encodes to 2
+        // bytes (`mov eax, ebx` on x86-32). NOP-pad 3 bytes then the
+        // 2-byte je at offset 5 — total 7 bytes.
+        let out = reassemble_x86_prefix_with_pinned_terminator(
+            &final_ir,
+            DetectedArch::X86_32,
+            Some(&original_jcc_bytes),
+            5,
+        )
+        .expect("x86-32 reassemble succeeds");
+        assert_eq!(out.len(), 7);
+        assert_eq!(&out[5..7], &original_jcc_bytes);
+        // Bytes [2..5] are NOP-padding; x86-32 nop_sequence emits 0x90.
+        assert_eq!(&out[2..5], &[0x90u8; 3]);
+    }
+
+    #[test]
     fn reassemble_x86_rejects_optimized_prefix_larger_than_original() {
         // Pathological case: optimized prefix is LARGER than the original
         // prefix room. Cannot pad backwards. Must surface as an error

--- a/src/main.rs
+++ b/src/main.rs
@@ -979,6 +979,29 @@ fn validate_basic_block(ir: &[Instruction]) -> Result<(), String> {
 
 use parser::x86::x86_ir_from_mnemonic;
 
+/// Reject any non-terminal Jcc in an x86 optimization window. The
+/// optimizer only special-cases a trailing Jcc (peeled by
+/// `split_terminator_x86`, displacement preserved by
+/// `reassemble_x86_prefix_with_pinned_terminator`). A Jcc anywhere
+/// else in the window would be modelled as a data-state no-op by
+/// both the concrete and SMT executors, so the equivalence check
+/// could accept a rewrite that silently drops or rewrites the branch.
+fn validate_x86_window_terminator_placement(ir: &[isa::x86::X86Instruction]) -> Result<(), String> {
+    for (idx, instr) in ir.iter().enumerate() {
+        if matches!(instr, isa::x86::X86Instruction::Jcc { .. }) && idx != ir.len() - 1 {
+            return Err(format!(
+                "x86 window contains a non-terminal conditional branch at position {} \
+                 (last position is {}). The optimizer only supports Jcc as the trailing \
+                 terminator of a window. Narrow --start-addr/--end-addr to exclude the \
+                 mid-window branch.",
+                idx,
+                ir.len() - 1
+            ));
+        }
+    }
+    Ok(())
+}
+
 fn convert_to_x86_ir(
     instructions: &capstone::Instructions,
 ) -> Result<Vec<isa::x86::X86Instruction>, String> {
@@ -1365,6 +1388,14 @@ fn optimize_elf_binary_x86(
     for instr in &ir {
         println!("  {}", instr);
     }
+
+    // Reject any non-terminal Jcc. The optimizer only special-cases a
+    // trailing Jcc (peeled by `split_terminator_x86`, displacement
+    // preserved by the reassemble helper); a mid-window Jcc would be a
+    // data-state no-op in both the concrete executor and the SMT path,
+    // letting the equivalence check accept rewrites that silently
+    // corrupt control flow in the patched binary.
+    validate_x86_window_terminator_placement(&ir)?;
 
     let optimized = match options.algorithm {
         Algorithm::Enumerative => find_shorter_equivalent_x86(&ir, width),
@@ -2229,6 +2260,56 @@ mod cli_helper_tests {
     /// pool-narrowing change (issue #84 item 8) so any future
     /// reintroduction of unconditional scratch-register inflation is
     /// caught.
+    #[test]
+    fn validate_x86_window_rejects_mid_window_jcc() {
+        use isa::x86::{X86Condition, X86Instruction, X86Register};
+        let ir = vec![
+            X86Instruction::CmpReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            X86Instruction::Jcc {
+                cond: X86Condition::E,
+            },
+            X86Instruction::MovImm {
+                rd: X86Register::RAX,
+                imm: 0,
+            },
+        ];
+        let err = validate_x86_window_terminator_placement(&ir)
+            .expect_err("mid-window Jcc must be rejected");
+        assert!(
+            err.contains("non-terminal conditional branch") && err.contains("position 1"),
+            "unhelpful error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn validate_x86_window_accepts_trailing_jcc() {
+        use isa::x86::{X86Condition, X86Instruction, X86Register};
+        let ir = vec![
+            X86Instruction::CmpReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            X86Instruction::Jcc {
+                cond: X86Condition::E,
+            },
+        ];
+        validate_x86_window_terminator_placement(&ir).expect("trailing Jcc must be accepted");
+    }
+
+    #[test]
+    fn validate_x86_window_accepts_no_jcc() {
+        use isa::x86::{X86Instruction, X86Register};
+        let ir = vec![X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: 0,
+        }];
+        validate_x86_window_terminator_placement(&ir).expect("Jcc-free window must be accepted");
+    }
+
     #[test]
     fn find_shorter_equivalent_x86_can_optimize_jcc_terminated_window() {
         use isa::x86::X86Condition;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1062,21 +1062,24 @@ fn find_shorter_equivalent_x86(
     let imms = vec![0i64, 1, -1];
 
     let candidates = generate_all_x86_instructions(&pool, &imms);
-    // Defense-in-depth: when the target reads EFLAGS (any CMOV/Jcc),
-    // the fast-path's 10 random trials might not cover every flag
-    // combination the reader actually depends on. Drop `.fast_only()` so
-    // the SMT path also runs for those targets. Combined with the
-    // run_fast_path_x86 input-flag randomization fix, this closes the
-    // soundness gap where a flag-clobbering proposal could pass.
-    let target_reads_flags = target.iter().any(|i| {
-        use crate::isa::x86::X86Instruction::*;
-        matches!(i, Cmov { .. } | Jcc { .. })
-    });
-    let mut cfg_builder = X86EquivalenceConfig::new(width).live_out(live_out.clone());
-    if !target_reads_flags {
-        cfg_builder = cfg_builder.fast_only();
-    }
-    let cfg = cfg_builder;
+    // Defense-in-depth: when EITHER side reads EFLAGS (CMOV/Jcc), the
+    // fast-path's 10 random trials may not cover every flag combination
+    // the reader depends on. Drop `.fast_only()` for those iterations so
+    // the SMT path also runs. The two configs differ only in fast_only;
+    // building them once outside the loop avoids per-iteration churn.
+    let reads_flags = |seq: &[isa::x86::X86Instruction]| -> bool {
+        seq.iter().any(|i| {
+            matches!(
+                i,
+                isa::x86::X86Instruction::Cmov { .. } | isa::x86::X86Instruction::Jcc { .. }
+            )
+        })
+    };
+    let target_reads_flags = reads_flags(target);
+    let cfg_fast = X86EquivalenceConfig::new(width)
+        .live_out(live_out.clone())
+        .fast_only();
+    let cfg_smt = X86EquivalenceConfig::new(width).live_out(live_out.clone());
     for cand in candidates {
         let seq = vec![cand];
         let cand_cost =
@@ -1084,7 +1087,12 @@ fn find_shorter_equivalent_x86(
         if cand_cost >= target_cost {
             continue;
         }
-        match check_equivalence_x86(target, &seq, &cfg) {
+        let cfg = if target_reads_flags || reads_flags(&seq) {
+            &cfg_smt
+        } else {
+            &cfg_fast
+        };
+        match check_equivalence_x86(target, &seq, cfg) {
             semantics::equivalence::EquivalenceResult::Equivalent => return Some(seq),
             _ => continue,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2416,7 +2416,7 @@ mod cli_helper_tests {
                 rd: Register::X2,
                 imm: 5,
             },
-            terminator.clone(),
+            terminator,
         ];
         let candidate_clobbers_x0 = vec![
             Instruction::MovImm {
@@ -2578,7 +2578,7 @@ mod cli_helper_tests {
                 cond: X86Condition::E,
             },
         ];
-        let cfg = X86EquivalenceConfig::new_for_64()
+        let cfg = X86EquivalenceConfig::new(64)
             .live_out(X86LiveOutMask::from_registers(vec![X86Register::RAX]).with_flags(true));
         assert!(matches!(
             check_equivalence_x86(&target, &proposal, &cfg),
@@ -2605,7 +2605,7 @@ mod cli_helper_tests {
                 cond: X86Condition::NE,
             },
         ];
-        let cfg = X86EquivalenceConfig::new_for_64()
+        let cfg = X86EquivalenceConfig::new(64)
             .live_out(X86LiveOutMask::from_registers(vec![X86Register::RAX]).with_flags(true));
         assert_eq!(
             check_equivalence_x86(&seq.clone(), &seq, &cfg),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1186,6 +1186,65 @@ fn run_x86_symbolic(
     optimized
 }
 
+/// Reassemble an x86 prefix and splice an ORIGINAL pinned Jcc
+/// terminator back at its original byte offset. Re-encoding the Jcc via
+/// dynasm would emit a placeholder zero displacement and overwrite the
+/// real branch target.
+///
+/// `pinned_terminator` is `None` when the source window had no trailing
+/// Jcc; in that case the function returns the assembled prefix verbatim.
+/// When `Some(jcc_bytes)`, the returned vector is exactly
+/// `original_prefix_byte_size + jcc_bytes.len()` long, with NOP padding
+/// inserted between the new prefix and the Jcc so the Jcc lands at its
+/// original offset (preserving its rel8 / rel32 displacement).
+///
+/// Returns `Err` if the optimized prefix encodes to more bytes than the
+/// original prefix occupied — shifting the Jcc earlier would change the
+/// branch target.
+fn reassemble_x86_prefix_with_pinned_terminator(
+    final_prefix_ir: &[isa::x86::X86Instruction],
+    arch: DetectedArch,
+    pinned_terminator: Option<&[u8]>,
+    original_prefix_byte_size: usize,
+) -> Result<Vec<u8>, String> {
+    let mut asm = match arch {
+        DetectedArch::X86_64 => assembler::x86::X86Assembler::new_64(),
+        DetectedArch::X86_32 => assembler::x86::X86Assembler::new_32(),
+        DetectedArch::Aarch64 => {
+            return Err("reassemble helper is x86-only".to_string());
+        }
+    };
+    let mut out = asm.assemble_instructions(final_prefix_ir)?;
+
+    let Some(jcc_bytes) = pinned_terminator else {
+        return Ok(out);
+    };
+
+    if out.len() > original_prefix_byte_size {
+        return Err(format!(
+            "optimized prefix ({} bytes) is larger than original prefix \
+             ({} bytes); cannot preserve the pinned Jcc terminator's \
+             displacement",
+            out.len(),
+            original_prefix_byte_size
+        ));
+    }
+
+    // Pad NOPs so the Jcc lands at the same offset as in the original
+    // window. `nop_sequence` may return fewer than the requested bytes;
+    // loop until the gap is filled.
+    let gap = original_prefix_byte_size - out.len();
+    let mut padded = 0;
+    while padded < gap {
+        let nop = arch.nop_sequence(gap - padded);
+        debug_assert!(!nop.is_empty(), "nop_sequence returned empty slice");
+        out.extend_from_slice(nop);
+        padded += nop.len();
+    }
+    out.extend_from_slice(jcc_bytes);
+    Ok(out)
+}
+
 fn optimize_elf_binary_x86(
     patcher: &ElfPatcher,
     path: &Path,
@@ -1292,12 +1351,41 @@ fn optimize_elf_binary_x86(
         println!("  {}", i);
     }
 
-    let mut asm = match arch {
-        DetectedArch::X86_64 => assembler::x86::X86Assembler::new_64(),
-        DetectedArch::X86_32 => assembler::x86::X86Assembler::new_32(),
-        DetectedArch::Aarch64 => unreachable!(),
+    // If the original window ended in a Jcc, the search holds that
+    // terminator fixed. Re-encoding it via dynasm would emit a placeholder
+    // zero displacement and overwrite the real branch target. Peel the
+    // Jcc from `final_ir` and splice the ORIGINAL Jcc bytes back at the
+    // same offset they had in the source window so the displacement
+    // stays valid (reviewer-flagged P1 on PR #268).
+    let (final_prefix_ir, final_terminator) =
+        crate::ir::instructions::split_terminator_x86(&final_ir);
+    let (_, original_terminator) = crate::ir::instructions::split_terminator_x86(&ir);
+    if final_terminator != original_terminator {
+        return Err(format!(
+            "search returned a terminator ({:?}) that does not match the \
+             original window's terminator ({:?}); refusing to patch",
+            final_terminator, original_terminator
+        )
+        .into());
+    }
+    let pinned_terminator_bytes: Option<Vec<u8>> = if original_terminator.is_some() {
+        let last = cs_instrs
+            .iter()
+            .last()
+            .ok_or("expected non-empty disassembly when peeling terminator")?;
+        Some(last.bytes().to_vec())
+    } else {
+        None
     };
-    let new_bytes = asm.assemble_instructions(&final_ir)?;
+    let original_prefix_byte_size =
+        bytes.len() - pinned_terminator_bytes.as_ref().map_or(0, |b| b.len());
+
+    let new_bytes = reassemble_x86_prefix_with_pinned_terminator(
+        final_prefix_ir,
+        arch,
+        pinned_terminator_bytes.as_deref(),
+        original_prefix_byte_size,
+    )?;
     println!("Reassembled to {} bytes", new_bytes.len());
 
     let output_path = {
@@ -2610,6 +2698,101 @@ mod cli_helper_tests {
         assert_eq!(
             check_equivalence_x86(&seq.clone(), &seq, &cfg),
             EquivalenceResult::Equivalent
+        );
+    }
+
+    // --- x86 Jcc-byte preservation across reassembly (PR #268 review) ---
+
+    #[test]
+    fn reassemble_x86_no_terminator_returns_assembled_bytes_unchanged() {
+        use isa::x86::{X86Instruction, X86Register};
+        let final_ir = [X86Instruction::MovReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+        }];
+        let bytes =
+            reassemble_x86_prefix_with_pinned_terminator(&final_ir, DetectedArch::X86_64, None, 3)
+                .expect("reassemble succeeds");
+        // No splice, no padding: just the assembled prefix.
+        assert_eq!(bytes.len(), 3);
+    }
+
+    #[test]
+    fn reassemble_x86_splices_original_terminator_bytes_at_original_offset() {
+        // Original window: [3-byte mov rax,rbx] [2-byte je 0x10] = 5 bytes total,
+        // jcc at offset 3.
+        // Optimized prefix: same 3-byte mov. Should produce: [mov, je] = 5 bytes,
+        // jcc still at offset 3 (no NOP padding needed since prefix didn't shrink).
+        use isa::x86::{X86Instruction, X86Register};
+        let original_jcc_bytes = [0x74u8, 0x10]; // je rel8=0x10
+        let final_ir = [X86Instruction::MovReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+        }];
+        let out = reassemble_x86_prefix_with_pinned_terminator(
+            &final_ir,
+            DetectedArch::X86_64,
+            Some(&original_jcc_bytes),
+            3,
+        )
+        .expect("reassemble succeeds");
+        // Original Jcc bytes must be the LAST 2 bytes, unchanged.
+        assert_eq!(&out[out.len() - 2..], &original_jcc_bytes);
+        assert_eq!(out.len(), 5);
+    }
+
+    #[test]
+    fn reassemble_x86_pads_with_nops_when_optimized_prefix_shrinks() {
+        // Original window: 7-byte prefix + 2-byte jcc = 9 bytes, jcc at offset 7.
+        // Optimized prefix shrinks to 3 bytes. We must NOP-pad 4 bytes so the
+        // Jcc still lands at offset 7 (preserving its rel8 displacement).
+        use isa::x86::{X86Instruction, X86Register};
+        let original_jcc_bytes = [0x75u8, 0x20]; // jne rel8=0x20
+        let final_ir = [X86Instruction::MovReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+        }];
+        let out = reassemble_x86_prefix_with_pinned_terminator(
+            &final_ir,
+            DetectedArch::X86_64,
+            Some(&original_jcc_bytes),
+            7,
+        )
+        .expect("reassemble succeeds");
+        // Total length matches the original window.
+        assert_eq!(out.len(), 9);
+        // Jcc bytes are at the original offset (7).
+        assert_eq!(&out[7..9], &original_jcc_bytes);
+        // First 3 bytes are the new prefix; bytes [3..7] are NOP padding.
+        // We don't assert specific NOP encodings here — `nop_sequence` is
+        // covered separately. We just assert they aren't zero (which would
+        // be the buggy `je BYTE 0` overwrite the reviewer flagged).
+        assert_ne!(&out[3..7], &[0u8; 4]);
+    }
+
+    #[test]
+    fn reassemble_x86_rejects_optimized_prefix_larger_than_original() {
+        // Pathological case: optimized prefix is LARGER than the original
+        // prefix room. Cannot pad backwards. Must surface as an error
+        // instead of silently corrupting the Jcc displacement.
+        use isa::x86::{X86Instruction, X86Register};
+        let original_jcc_bytes = [0x74u8, 0x10];
+        // 3-byte assembled prefix — but we claim original prefix room was 1.
+        let final_ir = [X86Instruction::MovReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+        }];
+        let err = reassemble_x86_prefix_with_pinned_terminator(
+            &final_ir,
+            DetectedArch::X86_64,
+            Some(&original_jcc_bytes),
+            1,
+        )
+        .expect_err("should reject");
+        assert!(
+            err.contains("larger") || err.contains("preserve"),
+            "expected explanatory error, got: {}",
+            err
         );
     }
 }

--- a/src/parser/x86.rs
+++ b/src/parser/x86.rs
@@ -218,9 +218,10 @@ pub fn x86_ir_from_mnemonic(
 /// for the AArch64 path.
 ///
 /// Recognised lines: empty, comments (`;`, `//`, `#`), labels
-/// (`name:`), directives (`.foo`), and 2-operand instructions whose
-/// mnemonic is one of the seven the minimal-core IR supports
-/// (mov, add, sub, and, or, xor, cmp). Anything else is a parse error.
+/// (`name:`), directives (`.foo`), and instructions whose mnemonic is
+/// one of the nine supported families (mov, add, sub, and, or, xor,
+/// cmp plus the conditional cmovCC and jCC variants). Anything else is
+/// a parse error.
 pub fn parse_x86_assembly_string(
     content: &str,
     source_name: String,

--- a/src/parser/x86.rs
+++ b/src/parser/x86.rs
@@ -10,8 +10,35 @@
 
 #![allow(dead_code)]
 
-use crate::isa::x86::{X86Instruction, X86Operand, X86Register};
+use crate::isa::x86::{X86Condition, X86Instruction, X86Operand, X86Register};
 use crate::parser::ParseError;
+
+/// Parse a condition-code suffix from a CMOVcc / Jcc mnemonic. Accepts
+/// the canonical 16 codes plus the most common GAS aliases
+/// (`z`/`nz`/`nae`/`nb`/`nc`/`pe`/`po`/`nge`/`nl`/`ng`/`nle`).
+/// Returns `Err` on anything unrecognised so callers surface bad input
+/// instead of silently dropping the instruction.
+pub fn parse_x86_condition(suffix: &str) -> Result<X86Condition, String> {
+    match suffix.trim().to_lowercase().as_str() {
+        "e" | "z" => Ok(X86Condition::E),
+        "ne" | "nz" => Ok(X86Condition::NE),
+        "b" | "c" | "nae" => Ok(X86Condition::B),
+        "ae" | "nb" | "nc" => Ok(X86Condition::AE),
+        "be" | "na" => Ok(X86Condition::BE),
+        "a" | "nbe" => Ok(X86Condition::A),
+        "l" | "nge" => Ok(X86Condition::L),
+        "ge" | "nl" => Ok(X86Condition::GE),
+        "le" | "ng" => Ok(X86Condition::LE),
+        "g" | "nle" => Ok(X86Condition::G),
+        "s" => Ok(X86Condition::S),
+        "ns" => Ok(X86Condition::NS),
+        "o" => Ok(X86Condition::O),
+        "no" => Ok(X86Condition::NO),
+        "p" | "pe" => Ok(X86Condition::P),
+        "np" | "po" => Ok(X86Condition::NP),
+        other => Err(format!("unknown x86 condition suffix: '{}'", other)),
+    }
+}
 
 /// Parse a single x86 register name (case-insensitive).
 ///
@@ -88,6 +115,43 @@ pub fn x86_ir_from_mnemonic(
     op_str: &str,
 ) -> Result<Option<X86Instruction>, String> {
     let mnemonic = mnemonic.trim().to_lowercase();
+
+    // Issue #74: CMOVcc — strip "cmov" prefix, parse suffix, expect
+    // two register operands. Unknown suffixes are errors, not Ok(None).
+    if let Some(suffix) = mnemonic.strip_prefix("cmov") {
+        let cond = parse_x86_condition(suffix)?;
+        let parts: Vec<&str> = op_str.split(',').map(|s| s.trim()).collect();
+        if parts.len() != 2 {
+            return Err(format!(
+                "cmov{} expects 2 operands, got {}",
+                suffix,
+                parts.len()
+            ));
+        }
+        let rd = parse_x86_register(parts[0])?;
+        let rs = parse_x86_register(parts[1])?;
+        return Ok(Some(X86Instruction::Cmov { rd, rs, cond }));
+    }
+
+    // Issue #74: Jcc — strip "j" prefix (excluding "jmp"), parse suffix,
+    // validate the operand is a numeric target then discard it.
+    if mnemonic != "jmp"
+        && let Some(suffix) = mnemonic.strip_prefix('j')
+    {
+        let cond = parse_x86_condition(suffix)?;
+        let op = op_str.trim();
+        if op.is_empty() {
+            return Err(format!("j{} expects a target operand", suffix));
+        }
+        // Capstone renders Jcc targets as absolute addresses. Validate
+        // the operand parses as an immediate; if Capstone ever switches
+        // to labels we want the failure to surface here rather than
+        // silently producing a Jcc with a corrupted target reading.
+        parse_x86_immediate(op)
+            .map_err(|e| format!("j{} target must be numeric: {}", suffix, e))?;
+        return Ok(Some(X86Instruction::Jcc { cond }));
+    }
+
     // Reject unsupported mnemonics before attempting operand parsing so
     // shapes outside the minimal core (e.g. LEA `rax, [rbx+1]`) surface
     // as "unsupported mnemonic" rather than a confusing downstream
@@ -464,5 +528,120 @@ mod tests {
                 },
             ]
         );
+    }
+
+    // --- issue #74: CMOV / Jcc mnemonic parsing ---
+
+    #[test]
+    fn parses_cmove_rax_rbx() {
+        use crate::isa::x86::X86Condition;
+        let r = x86_ir_from_mnemonic("cmove", "rax, rbx").unwrap();
+        assert_eq!(
+            r,
+            Some(X86Instruction::Cmov {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+                cond: X86Condition::E
+            })
+        );
+    }
+
+    #[test]
+    fn parses_all_canonical_cmov_suffixes() {
+        use crate::isa::x86::X86Condition;
+        let cases = [
+            ("cmove", X86Condition::E),
+            ("cmovne", X86Condition::NE),
+            ("cmovb", X86Condition::B),
+            ("cmovae", X86Condition::AE),
+            ("cmovbe", X86Condition::BE),
+            ("cmova", X86Condition::A),
+            ("cmovl", X86Condition::L),
+            ("cmovge", X86Condition::GE),
+            ("cmovle", X86Condition::LE),
+            ("cmovg", X86Condition::G),
+            ("cmovs", X86Condition::S),
+            ("cmovns", X86Condition::NS),
+            ("cmovo", X86Condition::O),
+            ("cmovno", X86Condition::NO),
+            ("cmovp", X86Condition::P),
+            ("cmovnp", X86Condition::NP),
+        ];
+        for (mn, cond) in cases {
+            let r = x86_ir_from_mnemonic(mn, "rax, rbx").unwrap().unwrap();
+            assert_eq!(
+                r,
+                X86Instruction::Cmov {
+                    rd: X86Register::RAX,
+                    rs: X86Register::RBX,
+                    cond
+                },
+                "parsing {} failed",
+                mn
+            );
+        }
+    }
+
+    #[test]
+    fn cmov_with_unknown_suffix_errors() {
+        // `cmovxx` is not a real x86 mnemonic; parser must surface the
+        // failure instead of silently producing Ok(None).
+        let r = x86_ir_from_mnemonic("cmovxx", "rax, rbx");
+        assert!(r.is_err(), "expected Err, got {:?}", r);
+    }
+
+    #[test]
+    fn parses_je_as_jcc_e() {
+        use crate::isa::x86::X86Condition;
+        let r = x86_ir_from_mnemonic("je", "0x1234").unwrap();
+        assert_eq!(
+            r,
+            Some(X86Instruction::Jcc {
+                cond: X86Condition::E
+            })
+        );
+    }
+
+    #[test]
+    fn parses_all_canonical_jcc_suffixes() {
+        use crate::isa::x86::X86Condition;
+        let cases = [
+            ("je", X86Condition::E),
+            ("jne", X86Condition::NE),
+            ("jb", X86Condition::B),
+            ("jae", X86Condition::AE),
+            ("jbe", X86Condition::BE),
+            ("ja", X86Condition::A),
+            ("jl", X86Condition::L),
+            ("jge", X86Condition::GE),
+            ("jle", X86Condition::LE),
+            ("jg", X86Condition::G),
+            ("js", X86Condition::S),
+            ("jns", X86Condition::NS),
+            ("jo", X86Condition::O),
+            ("jno", X86Condition::NO),
+            ("jp", X86Condition::P),
+            ("jnp", X86Condition::NP),
+        ];
+        for (mn, cond) in cases {
+            let r = x86_ir_from_mnemonic(mn, "0x4242").unwrap().unwrap();
+            assert_eq!(r, X86Instruction::Jcc { cond }, "parsing {} failed", mn);
+        }
+    }
+
+    #[test]
+    fn jmp_is_not_parsed_as_jcc() {
+        // The unconditional JMP is not in scope; must not be claimed.
+        let r = x86_ir_from_mnemonic("jmp", "0x100").unwrap();
+        assert_eq!(r, None);
+    }
+
+    #[test]
+    fn jcc_with_non_numeric_operand_errors() {
+        // Capstone always renders Jcc targets as numeric addresses.
+        // Anything else is a sign the disassembly format changed —
+        // surface it loudly.
+        let r = x86_ir_from_mnemonic("je", "label");
+        assert!(r.is_err(), "expected Err, got {:?}", r);
     }
 }

--- a/src/parser/x86.rs
+++ b/src/parser/x86.rs
@@ -135,10 +135,18 @@ pub fn x86_ir_from_mnemonic(
 
     // Jcc — strip "j" prefix (excluding "jmp"), parse suffix,
     // validate the operand is a numeric target then discard it.
+    // Mnemonics like `jrcxz`/`jecxz` start with 'j' but aren't
+    // flag-based conditional branches — `parse_x86_condition` rejects
+    // their suffixes. Fall back to `Ok(None)` for those (same shape
+    // unsupported mnemonics like `lea` get) instead of erroring; that
+    // way `convert_to_x86_ir`'s unified "unsupported mnemonic" branch
+    // produces an actionable window-rejection error.
     if mnemonic != "jmp"
         && let Some(suffix) = mnemonic.strip_prefix('j')
     {
-        let cond = parse_x86_condition(suffix)?;
+        let Ok(cond) = parse_x86_condition(suffix) else {
+            return Ok(None);
+        };
         let op = op_str.trim();
         if op.is_empty() {
             return Err(format!("j{} expects a target operand", suffix));
@@ -635,6 +643,25 @@ mod tests {
         // The unconditional JMP is not in scope; must not be claimed.
         let r = x86_ir_from_mnemonic("jmp", "0x100").unwrap();
         assert_eq!(r, None);
+    }
+
+    #[test]
+    fn jrcxz_and_jecxz_fall_through_to_ok_none() {
+        // jrcxz / jecxz appear in real compiled binaries. They start
+        // with 'j' but aren't conditional branches with a flag-based
+        // condition code, so they fall outside the Jcc IR. Returning
+        // Err here would propagate through convert_to_x86_ir and refuse
+        // the whole window; Ok(None) lets convert_to_x86_ir reject the
+        // window with a clean "unsupported mnemonic" error instead.
+        for mn in ["jrcxz", "jecxz", "jcxz"] {
+            let r = x86_ir_from_mnemonic(mn, "0x100");
+            assert_eq!(
+                r,
+                Ok(None),
+                "{} should be Ok(None), not propagate an unknown-suffix Err",
+                mn
+            );
+        }
     }
 
     #[test]

--- a/src/parser/x86.rs
+++ b/src/parser/x86.rs
@@ -116,7 +116,7 @@ pub fn x86_ir_from_mnemonic(
 ) -> Result<Option<X86Instruction>, String> {
     let mnemonic = mnemonic.trim().to_lowercase();
 
-    // Issue #74: CMOVcc — strip "cmov" prefix, parse suffix, expect
+    // CMOVcc — strip "cmov" prefix, parse suffix, expect
     // two register operands. Unknown suffixes are errors, not Ok(None).
     if let Some(suffix) = mnemonic.strip_prefix("cmov") {
         let cond = parse_x86_condition(suffix)?;
@@ -133,7 +133,7 @@ pub fn x86_ir_from_mnemonic(
         return Ok(Some(X86Instruction::Cmov { rd, rs, cond }));
     }
 
-    // Issue #74: Jcc — strip "j" prefix (excluding "jmp"), parse suffix,
+    // Jcc — strip "j" prefix (excluding "jmp"), parse suffix,
     // validate the operand is a numeric target then discard it.
     if mnemonic != "jmp"
         && let Some(suffix) = mnemonic.strip_prefix('j')
@@ -644,5 +644,43 @@ mod tests {
         // surface it loudly.
         let r = x86_ir_from_mnemonic("je", "label");
         assert!(r.is_err(), "expected Err, got {:?}", r);
+    }
+
+    #[test]
+    fn jcc_gas_aliases_normalize_to_canonical_conditions() {
+        // GAS aliases (jc → jb, jz → je, jnae → jb, jnle → jg, etc.)
+        // must produce the same Jcc IR as their canonical spelling so
+        // the optimizer sees identical sequences regardless of which
+        // form the upstream toolchain emitted.
+        use crate::isa::x86::X86Condition;
+        let alias_cases = [
+            ("jc", X86Condition::B),
+            ("jz", X86Condition::E),
+            ("jnz", X86Condition::NE),
+            ("jnae", X86Condition::B),
+            ("jnb", X86Condition::AE),
+            ("jnc", X86Condition::AE),
+            ("jna", X86Condition::BE),
+            ("jnbe", X86Condition::A),
+            ("jnge", X86Condition::L),
+            ("jnl", X86Condition::GE),
+            ("jng", X86Condition::LE),
+            ("jnle", X86Condition::G),
+            ("jpe", X86Condition::P),
+            ("jpo", X86Condition::NP),
+        ];
+        for (mn, expected_cond) in alias_cases {
+            let r = x86_ir_from_mnemonic(mn, "0x100")
+                .unwrap_or_else(|e| panic!("parse {}: {}", mn, e))
+                .unwrap_or_else(|| panic!("parse {} produced None", mn));
+            assert_eq!(
+                r,
+                X86Instruction::Jcc {
+                    cond: expected_cond
+                },
+                "alias {} should normalize to canonical cond",
+                mn
+            );
+        }
     }
 }

--- a/src/parser/x86.rs
+++ b/src/parser/x86.rs
@@ -530,7 +530,7 @@ mod tests {
         );
     }
 
-    // --- issue #74: CMOV / Jcc mnemonic parsing ---
+    // --- CMOV / Jcc mnemonic parsing ---
 
     #[test]
     fn parses_cmove_rax_rbx() {

--- a/src/search/candidate_x86.rs
+++ b/src/search/candidate_x86.rs
@@ -257,33 +257,16 @@ mod tests {
 
     #[test]
     fn enumerator_includes_cmov_per_condition_and_register_pair() {
-        use crate::isa::x86::X86Condition;
         let regs = [X86Register::RAX, X86Register::RBX];
         let imms = [0i64];
         let all = generate_all_x86_instructions(&regs, &imms);
 
         // For every (rd, rs, cond) triple expected, find a matching Cmov.
-        let conds = [
-            X86Condition::E,
-            X86Condition::NE,
-            X86Condition::B,
-            X86Condition::AE,
-            X86Condition::BE,
-            X86Condition::A,
-            X86Condition::L,
-            X86Condition::GE,
-            X86Condition::LE,
-            X86Condition::G,
-            X86Condition::S,
-            X86Condition::NS,
-            X86Condition::O,
-            X86Condition::NO,
-            X86Condition::P,
-            X86Condition::NP,
-        ];
+        // Reuse the module-level constant so a future condition added to
+        // CMOV_CONDITIONS automatically extends the test's coverage.
         for &rd in &regs {
             for &rs in &regs {
-                for &cond in &conds {
+                for &cond in &CMOV_CONDITIONS {
                     let needle = X86Instruction::Cmov { rd, rs, cond };
                     assert!(all.contains(&needle), "candidate pool missing {:?}", needle);
                 }

--- a/src/search/candidate_x86.rs
+++ b/src/search/candidate_x86.rs
@@ -222,7 +222,7 @@ mod tests {
         let all = generate_all_x86_instructions(&regs, &imms);
         // 7 reg-reg variants × N×N register pairs
         // + 7 reg-imm variants × N × M
-        // + 16 CMOV conditions × N×N register pairs (issue #74)
+        // + 16 CMOV conditions × N×N register pairs
         let expected = 7 * regs.len() * regs.len()
             + 7 * regs.len() * imms.len()
             + 16 * regs.len() * regs.len();
@@ -253,7 +253,7 @@ mod tests {
         }
     }
 
-    // --- issue #74: CMOV enumeration + Jcc exclusion ---
+    // --- CMOV enumeration + Jcc exclusion ---
 
     #[test]
     fn enumerator_includes_cmov_per_condition_and_register_pair() {

--- a/src/search/candidate_x86.rs
+++ b/src/search/candidate_x86.rs
@@ -7,17 +7,42 @@
 //! as encoder errors at use-site.
 
 use crate::assembler::x86::{X86Assembler, X86Mode};
-use crate::isa::x86::{X86Instruction, X86Register};
+use crate::isa::x86::{X86Condition, X86Instruction, X86Register};
 use rand::RngExt;
 
-/// Enumerate every reg/reg and reg/imm form of the 14 minimal-core
-/// variants for the given register and immediate pools.
+/// The 16 canonical x86 condition codes enumerated for CMOV candidates.
+/// Jcc is intentionally *not* enumerated here — it is a terminator
+/// (see `X86Instruction::is_terminator`) and the search pool must
+/// exclude terminators, mirroring the AArch64 branch precedent.
+const CMOV_CONDITIONS: [X86Condition; 16] = [
+    X86Condition::E,
+    X86Condition::NE,
+    X86Condition::B,
+    X86Condition::AE,
+    X86Condition::BE,
+    X86Condition::A,
+    X86Condition::L,
+    X86Condition::GE,
+    X86Condition::LE,
+    X86Condition::G,
+    X86Condition::S,
+    X86Condition::NS,
+    X86Condition::O,
+    X86Condition::NO,
+    X86Condition::P,
+    X86Condition::NP,
+];
+
+/// Enumerate every reg/reg and reg/imm form of the minimal-core
+/// variants plus CMOV (per condition × register pair) for the given
+/// register and immediate pools.
 pub fn generate_all_x86_instructions(
     registers: &[X86Register],
     immediates: &[i64],
 ) -> Vec<X86Instruction> {
+    let r2 = registers.len() * registers.len();
     let mut out = Vec::with_capacity(
-        registers.len() * registers.len() * 7 + registers.len() * immediates.len() * 7,
+        r2 * 7 + registers.len() * immediates.len() * 7 + r2 * CMOV_CONDITIONS.len(),
     );
 
     for &rd in registers {
@@ -41,6 +66,17 @@ pub fn generate_all_x86_instructions(
             out.push(X86Instruction::OrImm { rd, imm });
             out.push(X86Instruction::XorImm { rd, imm });
             out.push(X86Instruction::CmpImm { rn: rd, imm });
+        }
+    }
+
+    // Issue #74: CMOV per (rd, rs, cond). `rd == rs` is a legal but
+    // wasteful no-op variant; left in for symmetry with the other
+    // reg/reg loops above.
+    for &rd in registers {
+        for &rs in registers {
+            for &cond in &CMOV_CONDITIONS {
+                out.push(X86Instruction::Cmov { rd, rs, cond });
+            }
         }
     }
 
@@ -186,25 +222,23 @@ mod tests {
         let all = generate_all_x86_instructions(&regs, &imms);
         // 7 reg-reg variants × N×N register pairs
         // + 7 reg-imm variants × N × M
-        let expected = 7 * regs.len() * regs.len() + 7 * regs.len() * imms.len();
+        // + 16 CMOV conditions × N×N register pairs (issue #74)
+        let expected = 7 * regs.len() * regs.len()
+            + 7 * regs.len() * imms.len()
+            + 16 * regs.len() * regs.len();
         assert_eq!(all.len(), expected);
     }
 
     #[test]
-    fn covers_all_seven_mnemonics() {
+    fn covers_all_minimal_mnemonics() {
         let regs = [X86Register::RAX];
         let imms = [0i64];
         let all = generate_all_x86_instructions(&regs, &imms);
 
         let mnemonics: std::collections::HashSet<&str> = all.iter().map(|i| i.mnemonic()).collect();
-        assert!(mnemonics.contains("mov"));
-        assert!(mnemonics.contains("add"));
-        assert!(mnemonics.contains("sub"));
-        assert!(mnemonics.contains("and"));
-        assert!(mnemonics.contains("or"));
-        assert!(mnemonics.contains("xor"));
-        assert!(mnemonics.contains("cmp"));
-        assert_eq!(mnemonics.len(), 7);
+        for required in ["mov", "add", "sub", "and", "or", "xor", "cmp", "cmov"] {
+            assert!(mnemonics.contains(required), "missing {}", required);
+        }
     }
 
     #[test]
@@ -217,5 +251,73 @@ mod tests {
                 assert!(regs.contains(&dst), "{:?} dest not in pool", instr);
             }
         }
+    }
+
+    // --- issue #74: CMOV enumeration + Jcc exclusion ---
+
+    #[test]
+    fn enumerator_includes_cmov_per_condition_and_register_pair() {
+        use crate::isa::x86::X86Condition;
+        let regs = [X86Register::RAX, X86Register::RBX];
+        let imms = [0i64];
+        let all = generate_all_x86_instructions(&regs, &imms);
+
+        // For every (rd, rs, cond) triple expected, find a matching Cmov.
+        let conds = [
+            X86Condition::E,
+            X86Condition::NE,
+            X86Condition::B,
+            X86Condition::AE,
+            X86Condition::BE,
+            X86Condition::A,
+            X86Condition::L,
+            X86Condition::GE,
+            X86Condition::LE,
+            X86Condition::G,
+            X86Condition::S,
+            X86Condition::NS,
+            X86Condition::O,
+            X86Condition::NO,
+            X86Condition::P,
+            X86Condition::NP,
+        ];
+        for &rd in &regs {
+            for &rs in &regs {
+                for &cond in &conds {
+                    let needle = X86Instruction::Cmov { rd, rs, cond };
+                    assert!(all.contains(&needle), "candidate pool missing {:?}", needle);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn enumerator_excludes_jcc_terminator() {
+        let regs = [X86Register::RAX];
+        let imms = [0i64];
+        let all = generate_all_x86_instructions(&regs, &imms);
+        for instr in &all {
+            assert!(
+                !matches!(instr, X86Instruction::Jcc { .. }),
+                "Jcc must never appear in the candidate pool: {:?}",
+                instr
+            );
+        }
+    }
+
+    #[test]
+    fn covers_eight_mnemonics_after_cmov_added() {
+        let regs = [X86Register::RAX];
+        let imms = [0i64];
+        let all = generate_all_x86_instructions(&regs, &imms);
+        let mnemonics: std::collections::HashSet<&str> = all.iter().map(|i| i.mnemonic()).collect();
+        assert!(mnemonics.contains("cmov"));
+        assert!(!mnemonics.contains("jcc"));
+        assert_eq!(
+            mnemonics.len(),
+            8,
+            "expected 7 minimal-core + cmov mnemonics, got {:?}",
+            mnemonics
+        );
     }
 }

--- a/src/search/stochastic/backend.rs
+++ b/src/search/stochastic/backend.rs
@@ -99,6 +99,15 @@ pub trait StochasticBackend<I: ISA>: Sized {
         config: &SearchConfig,
     ) -> Vec<I::Instruction>;
 
+    /// Return the target's trailing terminator if any. MCMC appends it
+    /// to every `random_sequence` result so the equivalence check's
+    /// terminator-equality precheck doesn't reject every random
+    /// proposal against a Jcc-terminated target. Default returns
+    /// `None`; x86 overrides to peel its `Jcc` terminator.
+    fn target_terminator(_target: &[I::Instruction]) -> Option<I::Instruction> {
+        None
+    }
+
     /// Width parameter for cost + state masking. AArch64 returns 64;
     /// x86 reads `SearchConfig::x86_width` (32 or 64).
     fn width(config: &SearchConfig) -> u32;
@@ -316,6 +325,14 @@ impl StochasticBackend<crate::isa::X86_64> for crate::isa::X86_64 {
         x86_random_sequence(rng, len, regs, imms, crate::assembler::x86::X86Mode::Mode64)
     }
 
+    fn target_terminator(
+        target: &[crate::isa::x86::X86Instruction],
+    ) -> Option<crate::isa::x86::X86Instruction> {
+        crate::ir::instructions::split_terminator_x86(target)
+            .1
+            .copied()
+    }
+
     fn width(_config: &SearchConfig) -> u32 {
         64
     }
@@ -393,6 +410,14 @@ impl StochasticBackend<crate::isa::X86_32> for crate::isa::X86_32 {
         _config: &SearchConfig,
     ) -> Vec<crate::isa::x86::X86Instruction> {
         x86_random_sequence(rng, len, regs, imms, crate::assembler::x86::X86Mode::Mode32)
+    }
+
+    fn target_terminator(
+        target: &[crate::isa::x86::X86Instruction],
+    ) -> Option<crate::isa::x86::X86Instruction> {
+        crate::ir::instructions::split_terminator_x86(target)
+            .1
+            .copied()
     }
 
     fn width(config: &SearchConfig) -> u32 {

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -117,18 +117,28 @@ where
         let mutator = <I as StochasticBackend<I>>::make_mutator(config);
         let acceptance = AcceptanceCriterion::new(config.stochastic.beta);
 
+        // If the target ends in a terminator (x86 Jcc, AArch64 branch),
+        // every random_sequence proposal must end in the same terminator
+        // — the equivalence check's terminator-equality precheck rejects
+        // any candidate that lacks it. Peel once and append below.
+        let target_terminator = <I as StochasticBackend<I>>::target_terminator(target);
+        let terminator_len = if target_terminator.is_some() { 1 } else { 0 };
+        let with_term = |mut seq: Vec<I::Instruction>| -> Vec<I::Instruction> {
+            if let Some(t) = target_terminator {
+                seq.push(t);
+            }
+            seq
+        };
+
         // Start with target sequence or random sequence of same length
         let mut current = if rng.random_bool(0.5) {
             target.to_vec()
         } else {
             loop {
-                let seq = <I as StochasticBackend<I>>::random_sequence(
-                    &mut rng,
-                    target.len(),
-                    &regs,
-                    &imms,
-                    config,
-                );
+                let prefix_len = target.len().saturating_sub(terminator_len);
+                let seq = with_term(<I as StochasticBackend<I>>::random_sequence(
+                    &mut rng, prefix_len, &regs, &imms, config,
+                ));
                 if <I as StochasticBackend<I>>::is_encodable(&seq) {
                     break seq;
                 }
@@ -140,7 +150,9 @@ where
         let mut best_equivalent: Option<Vec<I::Instruction>> = None;
         let mut best_cost = original_cost;
 
-        let min_length = 1;
+        // Length bounds: the terminator (if any) is always pinned at the
+        // tail, so length-change proposals only vary the prefix length.
+        let min_length = 1 + terminator_len;
         let max_length = target.len();
         let smt_timeout = Duration::from_secs(5);
 
@@ -159,9 +171,10 @@ where
                 let new_len = rng.random_range(min_length..=max_length);
                 if new_len != current.len() {
                     loop {
-                        let seq = <I as StochasticBackend<I>>::random_sequence(
-                            &mut rng, new_len, &regs, &imms, config,
-                        );
+                        let prefix_len = new_len.saturating_sub(terminator_len);
+                        let seq = with_term(<I as StochasticBackend<I>>::random_sequence(
+                            &mut rng, prefix_len, &regs, &imms, config,
+                        ));
                         if <I as StochasticBackend<I>>::is_encodable(&seq) {
                             current = seq;
                             break;

--- a/src/search/symbolic/backend.rs
+++ b/src/search/symbolic/backend.rs
@@ -29,6 +29,15 @@ pub trait SymbolicBackend<I: ISA>: Sized {
     /// the supplied register and immediate pools.
     fn enumerate_all(regs: &[I::Register], imms: &[i64]) -> Vec<I::Instruction>;
 
+    /// Return the target's trailing terminator if any. The synthesis
+    /// loop appends it to each candidate proposal so the equivalence
+    /// check's terminator-equality precheck doesn't reject every
+    /// candidate against a Jcc-terminated target. Default returns
+    /// `None`; x86 overrides to peel its `Jcc` terminator.
+    fn target_terminator(_target: &[I::Instruction]) -> Option<I::Instruction> {
+        None
+    }
+
     /// Sum the cost of every instruction in the sequence.
     fn sequence_cost(seq: &[I::Instruction], metric: &CostMetric, width: u32) -> u64;
 
@@ -113,6 +122,14 @@ impl SymbolicBackend<crate::isa::X86_64> for crate::isa::X86_64 {
         crate::search::candidate_x86::generate_all_x86_instructions(regs, imms)
     }
 
+    fn target_terminator(
+        target: &[crate::isa::x86::X86Instruction],
+    ) -> Option<crate::isa::x86::X86Instruction> {
+        crate::ir::instructions::split_terminator_x86(target)
+            .1
+            .copied()
+    }
+
     fn sequence_cost(
         seq: &[crate::isa::x86::X86Instruction],
         metric: &CostMetric,
@@ -166,6 +183,14 @@ impl SymbolicBackend<crate::isa::X86_32> for crate::isa::X86_32 {
         imms: &[i64],
     ) -> Vec<crate::isa::x86::X86Instruction> {
         crate::search::candidate_x86::generate_all_x86_instructions(regs, imms)
+    }
+
+    fn target_terminator(
+        target: &[crate::isa::x86::X86Instruction],
+    ) -> Option<crate::isa::x86::X86Instruction> {
+        crate::ir::instructions::split_terminator_x86(target)
+            .1
+            .copied()
     }
 
     fn sequence_cost(

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -109,6 +109,17 @@ where
     ) -> Option<Vec<I::Instruction>> {
         let width = <I as SymbolicBackend<I>>::width(config);
         let mut best_at_length: Option<Vec<I::Instruction>> = None;
+        // If the target ends in a terminator (x86 Jcc, AArch64 branch),
+        // candidate proposals must end in the same terminator for the
+        // equivalence check's peel-and-compare precheck to admit them.
+        // Compute once and append below.
+        let target_terminator = <I as SymbolicBackend<I>>::target_terminator(target);
+        let with_term = |mut seq: Vec<I::Instruction>| -> Vec<I::Instruction> {
+            if let Some(t) = target_terminator {
+                seq.push(t);
+            }
+            seq
+        };
 
         if length == 1 {
             // Single instruction search
@@ -118,7 +129,7 @@ where
                     return best_at_length;
                 }
 
-                let candidate = vec![*instr];
+                let candidate = with_term(vec![*instr]);
                 let candidate_cost = <I as SymbolicBackend<I>>::sequence_cost(
                     &candidate,
                     &config.cost_metric,
@@ -150,7 +161,7 @@ where
                 }
 
                 for instr2 in all_instructions {
-                    let candidate = vec![*instr1, *instr2];
+                    let candidate = with_term(vec![*instr1, *instr2]);
                     let candidate_cost = <I as SymbolicBackend<I>>::sequence_cost(
                         &candidate,
                         &config.cost_metric,
@@ -202,14 +213,14 @@ where
                         }
 
                         let candidate = if length == 3 {
-                            vec![*instr1, *instr2, *instr3]
+                            with_term(vec![*instr1, *instr2, *instr3])
                         } else {
                             // For longer sequences, fill with first instruction
                             let mut seq = vec![*instr1, *instr2, *instr3];
                             while seq.len() < length {
                                 seq.push(all_instructions[0]);
                             }
-                            seq
+                            with_term(seq)
                         };
 
                         let candidate_cost = <I as SymbolicBackend<I>>::sequence_cost(

--- a/src/semantics/concrete_x86.rs
+++ b/src/semantics/concrete_x86.rs
@@ -49,6 +49,10 @@ pub fn apply_instruction_concrete_x86(
             }
             // CMOV does not write EFLAGS regardless of the branch taken.
         }
+        // Jcc transfers control; PC is unmodelled and the search peels
+        // it off via `split_terminator_x86`. Treat as a no-op for
+        // safety if a stray Jcc reaches the concrete executor.
+        X86Instruction::Jcc { .. } => {}
     }
     state
 }

--- a/src/semantics/concrete_x86.rs
+++ b/src/semantics/concrete_x86.rs
@@ -449,7 +449,7 @@ mod tests {
         assert!(!states_equal_for_live_out_x86(&a, &b, &with_flags));
     }
 
-    // --- issue #74: CMOVcc concrete semantics ---
+    // --- CMOVcc concrete semantics ---
 
     #[test]
     fn cmov_when_condition_true_writes_source() {

--- a/src/semantics/concrete_x86.rs
+++ b/src/semantics/concrete_x86.rs
@@ -42,6 +42,13 @@ pub fn apply_instruction_concrete_x86(
         X86Instruction::XorImm { rd, imm } => apply_binop_imm(&mut state, *rd, *imm, Binop::Xor),
         X86Instruction::CmpReg { rn, rs } => apply_cmp_reg(&mut state, *rn, *rs),
         X86Instruction::CmpImm { rn, imm } => apply_cmp_imm(&mut state, *rn, *imm),
+        X86Instruction::Cmov { rd, rs, cond } => {
+            if state.get_flags().evaluate(*cond) {
+                let v = state.get_register(*rs);
+                state.set_register(*rd, v);
+            }
+            // CMOV does not write EFLAGS regardless of the branch taken.
+        }
     }
     state
 }
@@ -436,5 +443,51 @@ mod tests {
 
         let with_flags = no_flags.with_flags(true);
         assert!(!states_equal_for_live_out_x86(&a, &b, &with_flags));
+    }
+
+    // --- issue #74: CMOVcc concrete semantics ---
+
+    #[test]
+    fn cmov_when_condition_true_writes_source() {
+        use crate::isa::x86::X86Condition;
+        // ZF=1, so CMOVE rax, rbx should copy rbx into rax.
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(0xaa));
+        state.set_register(X86Register::RBX, ConcreteValue::new(0xbb));
+        let mut flags = Eflags::new();
+        flags.zf = true;
+        state.set_flags(flags);
+
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::Cmov {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+                cond: X86Condition::E,
+            },
+        );
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 0xbb);
+        // CMOV does not modify flags.
+        assert!(after.get_flags().zf);
+    }
+
+    #[test]
+    fn cmov_when_condition_false_preserves_dest() {
+        use crate::isa::x86::X86Condition;
+        // ZF=0, so CMOVE rax, rbx must NOT update rax.
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(0xaa));
+        state.set_register(X86Register::RBX, ConcreteValue::new(0xbb));
+        // zf stays false.
+
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::Cmov {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+                cond: X86Condition::E,
+            },
+        );
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 0xaa);
     }
 }

--- a/src/semantics/cost_x86.rs
+++ b/src/semantics/cost_x86.rs
@@ -53,6 +53,8 @@ fn instruction_code_size(instr: &X86Instruction, width: u32) -> u64 {
         | X86Instruction::OrImm { .. }
         | X86Instruction::XorImm { .. }
         | X86Instruction::CmpImm { .. } => 6 + rex,
+        // CMOV is `0F 4x ModR/M` = 3 bytes plus REX.W on 64-bit.
+        X86Instruction::Cmov { .. } => 3 + rex,
     }
 }
 

--- a/src/semantics/cost_x86.rs
+++ b/src/semantics/cost_x86.rs
@@ -150,7 +150,7 @@ mod tests {
         assert_eq!(sequence_cost(&seq, &CostMetric::CodeSize, 32), 4);
     }
 
-    // --- issue #74: CMOV / Jcc cost ---
+    // --- CMOV / Jcc cost ---
 
     #[test]
     fn cmov_code_size_includes_rex_on_64_bit() {

--- a/src/semantics/cost_x86.rs
+++ b/src/semantics/cost_x86.rs
@@ -149,4 +149,30 @@ mod tests {
         // 2 + 2 = 4 bytes on x86-32.
         assert_eq!(sequence_cost(&seq, &CostMetric::CodeSize, 32), 4);
     }
+
+    // --- issue #74: CMOV / Jcc cost ---
+
+    #[test]
+    fn cmov_code_size_includes_rex_on_64_bit() {
+        use crate::isa::x86::X86Condition;
+        let cmov = X86Instruction::Cmov {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+            cond: X86Condition::E,
+        };
+        // CMOV is `0F 4x ModR/M` = 3 bytes, +1 for REX.W on x86-64.
+        assert_eq!(instruction_cost(&cmov, &CostMetric::CodeSize, 64), 4);
+        assert_eq!(instruction_cost(&cmov, &CostMetric::CodeSize, 32), 3);
+    }
+
+    #[test]
+    fn jcc_short_form_costs_two_bytes() {
+        use crate::isa::x86::X86Condition;
+        let jcc = X86Instruction::Jcc {
+            cond: X86Condition::NE,
+        };
+        // 0x7x + rel8 = 2 bytes regardless of mode.
+        assert_eq!(instruction_cost(&jcc, &CostMetric::CodeSize, 64), 2);
+        assert_eq!(instruction_cost(&jcc, &CostMetric::CodeSize, 32), 2);
+    }
 }

--- a/src/semantics/cost_x86.rs
+++ b/src/semantics/cost_x86.rs
@@ -55,6 +55,11 @@ fn instruction_code_size(instr: &X86Instruction, width: u32) -> u64 {
         | X86Instruction::CmpImm { .. } => 6 + rex,
         // CMOV is `0F 4x ModR/M` = 3 bytes plus REX.W on 64-bit.
         X86Instruction::Cmov { .. } => 3 + rex,
+        // Short-form Jcc is `7x rel8` = 2 bytes (no REX). Long-form
+        // `0F 8x rel32` = 6 bytes is used when the displacement doesn't
+        // fit. The optimizer never emits Jcc bytes (terminators stay
+        // pinned in the binary), so 2 is the conservative baseline.
+        X86Instruction::Jcc { .. } => 2,
     }
 }
 

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -721,7 +721,8 @@ pub fn check_equivalence_x86_for_search(
 /// for the AArch64 backend: fast path uses the concrete interpreter over
 /// random inputs (and EFLAGS comparison when CMP is present or the mask
 /// declares flags live); slow path lowers to Z3 BVs and checks UNSAT of the
-/// not-equal assertion over live-out registers.
+/// not-equal assertion over live-out registers, plus the five tracked
+/// EFLAGS bits when `flags_live` is set (issue #74).
 pub fn check_equivalence_x86(
     seq1: &[crate::isa::x86::X86Instruction],
     seq2: &[crate::isa::x86::X86Instruction],

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -722,7 +722,7 @@ pub fn check_equivalence_x86_for_search(
 /// random inputs (and EFLAGS comparison when CMP is present or the mask
 /// declares flags live); slow path lowers to Z3 BVs and checks UNSAT of the
 /// not-equal assertion over live-out registers, plus the five tracked
-/// EFLAGS bits when `flags_live` is set (issue #74).
+/// EFLAGS bits when `flags_live` is set.
 pub fn check_equivalence_x86(
     seq1: &[crate::isa::x86::X86Instruction],
     seq2: &[crate::isa::x86::X86Instruction],
@@ -985,7 +985,7 @@ mod tests {
         );
     }
 
-    // --- issue #74: SMT path catches flag-only divergence when flags_live ---
+    // --- SMT path catches flag-only divergence when flags_live ---
 
     #[test]
     fn x86_smt_path_distinguishes_cmps_with_different_operands_when_flags_live() {

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -727,8 +727,17 @@ pub fn check_equivalence_x86(
     seq2: &[crate::isa::x86::X86Instruction],
     config: &X86EquivalenceConfig,
 ) -> EquivalenceResult {
-    // Fast path: 10 random inputs.
-    if let Some(refutation) = run_fast_path_x86(seq1, seq2, config) {
+    // Issue #74: peel Jcc terminators and require both sides to share
+    // the exact same terminator (struct equality on the condition code).
+    // Mirrors the AArch64 precheck in `check_equivalence`.
+    let (prefix1, terminator1) = crate::ir::instructions::split_terminator_x86(seq1);
+    let (prefix2, terminator2) = crate::ir::instructions::split_terminator_x86(seq2);
+    if terminator1 != terminator2 {
+        return EquivalenceResult::NotEquivalent;
+    }
+
+    // Fast path: 10 random inputs over the prefixes only.
+    if let Some(refutation) = run_fast_path_x86(prefix1, prefix2, config) {
         return refutation;
     }
     if config.fast_only {
@@ -741,8 +750,8 @@ pub fn check_equivalence_x86(
     };
     let solver = create_solver_with_config(&solver_config);
     let initial = crate::semantics::smt_x86::MachineStateX86::new_symbolic("init", config.width);
-    let final1 = crate::semantics::smt_x86::apply_sequence(initial.clone(), seq1);
-    let final2 = crate::semantics::smt_x86::apply_sequence(initial, seq2);
+    let final1 = crate::semantics::smt_x86::apply_sequence(initial.clone(), prefix1);
+    let final2 = crate::semantics::smt_x86::apply_sequence(initial, prefix2);
 
     let mut disjuncts: Vec<z3::ast::Bool> = Vec::new();
     for reg in config.live_out.iter() {
@@ -979,6 +988,73 @@ mod tests {
         cfg.random_test_count = 0;
         assert!(matches!(
             check_equivalence_x86(&seq1, &seq2, &cfg),
+            EquivalenceResult::NotEquivalent
+        ));
+    }
+
+    #[test]
+    fn x86_rejects_sequences_with_differing_jcc_terminators() {
+        use crate::isa::x86::X86Condition;
+        // Same prefix, different Jcc conditions => not equivalent.
+        let prefix = X86Instruction::CmpReg {
+            rn: X86Register::RAX,
+            rs: X86Register::RBX,
+        };
+        let seq_je = vec![
+            prefix.clone(),
+            X86Instruction::Jcc {
+                cond: X86Condition::E,
+            },
+        ];
+        let seq_jne = vec![
+            prefix,
+            X86Instruction::Jcc {
+                cond: X86Condition::NE,
+            },
+        ];
+        let cfg = X86EquivalenceConfig::new_for_64().live_out(X86LiveOutMask::empty());
+        assert!(matches!(
+            check_equivalence_x86(&seq_je, &seq_jne, &cfg),
+            EquivalenceResult::NotEquivalent
+        ));
+    }
+
+    #[test]
+    fn x86_accepts_sequences_with_matching_jcc_terminators() {
+        use crate::isa::x86::X86Condition;
+        let prefix = X86Instruction::CmpReg {
+            rn: X86Register::RAX,
+            rs: X86Register::RBX,
+        };
+        let jcc = X86Instruction::Jcc {
+            cond: X86Condition::E,
+        };
+        let seq1 = vec![prefix.clone(), jcc.clone()];
+        let seq2 = vec![prefix, jcc];
+        let cfg = X86EquivalenceConfig::new_for_64().live_out(X86LiveOutMask::empty());
+        assert_eq!(
+            check_equivalence_x86(&seq1, &seq2, &cfg),
+            EquivalenceResult::Equivalent
+        );
+    }
+
+    #[test]
+    fn x86_rejects_terminator_present_on_only_one_side() {
+        use crate::isa::x86::X86Condition;
+        let prefix = X86Instruction::CmpReg {
+            rn: X86Register::RAX,
+            rs: X86Register::RBX,
+        };
+        let seq_with_jcc = vec![
+            prefix.clone(),
+            X86Instruction::Jcc {
+                cond: X86Condition::E,
+            },
+        ];
+        let seq_without = vec![prefix];
+        let cfg = X86EquivalenceConfig::new_for_64().live_out(X86LiveOutMask::empty());
+        assert!(matches!(
+            check_equivalence_x86(&seq_with_jcc, &seq_without, &cfg),
             EquivalenceResult::NotEquivalent
         ));
     }

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -728,14 +728,34 @@ pub fn check_equivalence_x86(
     seq2: &[crate::isa::x86::X86Instruction],
     config: &X86EquivalenceConfig,
 ) -> EquivalenceResult {
-    // Issue #74: peel Jcc terminators and require both sides to share
-    // the exact same terminator (struct equality on the condition code).
+    // Peel matching Jcc terminators and require both sides to share the
+    // exact same terminator (struct equality on the condition code).
     // Mirrors the AArch64 precheck in `check_equivalence`.
     let (prefix1, terminator1) = crate::ir::instructions::split_terminator_x86(seq1);
     let (prefix2, terminator2) = crate::ir::instructions::split_terminator_x86(seq2);
     if terminator1 != terminator2 {
         return EquivalenceResult::NotEquivalent;
     }
+
+    // When a Jcc terminator is held fixed across both sides, its branch
+    // outcome consumes the prefix's final EFLAGS. The caller-supplied
+    // live-out mask may not declare flags live (e.g. when the target
+    // contains only MOV/CMOV which `has_side_effects` reports as
+    // flag-clean), so force `flags_live=true` for the prefix comparison
+    // whenever a Jcc was peeled — otherwise a proposal that clobbers
+    // EFLAGS before the branch would be accepted unsoundly.
+    let effective_config = if matches!(
+        terminator1,
+        Some(crate::isa::x86::X86Instruction::Jcc { .. })
+    ) && !config.live_out.flags_live()
+    {
+        let mut c = config.clone();
+        c.live_out = c.live_out.with_flags(true);
+        std::borrow::Cow::Owned(c)
+    } else {
+        std::borrow::Cow::Borrowed(config)
+    };
+    let config = effective_config.as_ref();
 
     // Fast path: 10 random inputs over the prefixes only.
     if let Some(refutation) = run_fast_path_x86(prefix1, prefix2, config) {
@@ -760,8 +780,8 @@ pub fn check_equivalence_x86(
         let v2 = final2.get_register(*reg);
         disjuncts.push(v1.eq(v2).not());
     }
-    // Issue #74: when the caller declares flags live, any of the five
-    // tracked EFLAGS bits diverging is enough to refute equivalence.
+    // When flags are live (caller-declared or forced by a peeled Jcc),
+    // any of the five tracked EFLAGS bits diverging refutes equivalence.
     if config.live_out.flags_live() {
         disjuncts.push(crate::semantics::smt_x86::flags_not_equal_x86(
             &final1, &final2,
@@ -1037,6 +1057,42 @@ mod tests {
             check_equivalence_x86(&seq1, &seq2, &cfg),
             EquivalenceResult::Equivalent
         );
+    }
+
+    #[test]
+    fn x86_jcc_terminator_forces_flag_observability_on_prefix() {
+        // Reviewer-supplied counterexample: a no-op `cmove rax, rax` prefix
+        // versus `xor rcx, rcx` prefix, with a fixed `je` terminator on both
+        // sides. Live-out is rax only (no caller-declared flags_live). The
+        // prefixes leave rax untouched, but XOR clobbers ZF — which the
+        // trailing `je` reads. Equivalence must reject; the Jcc terminator
+        // forces the prefix's EFLAGS effect to be observable.
+        use crate::isa::x86::X86Condition;
+        let target = vec![
+            X86Instruction::Cmov {
+                rd: X86Register::RAX,
+                rs: X86Register::RAX,
+                cond: X86Condition::E,
+            },
+            X86Instruction::Jcc {
+                cond: X86Condition::E,
+            },
+        ];
+        let proposal = vec![
+            X86Instruction::XorReg {
+                rd: X86Register::RCX,
+                rs: X86Register::RCX,
+            },
+            X86Instruction::Jcc {
+                cond: X86Condition::E,
+            },
+        ];
+        let cfg = X86EquivalenceConfig::new(64)
+            .live_out(X86LiveOutMask::from_registers(vec![X86Register::RAX]));
+        assert!(matches!(
+            check_equivalence_x86(&target, &proposal, &cfg),
+            EquivalenceResult::NotEquivalent
+        ));
     }
 
     #[test]

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -985,7 +985,7 @@ mod tests {
             rs: X86Register::RCX,
         }];
         let mut cfg =
-            X86EquivalenceConfig::new_for_64().live_out(X86LiveOutMask::empty().with_flags(true));
+            X86EquivalenceConfig::new(64).live_out(X86LiveOutMask::empty().with_flags(true));
         cfg.random_test_count = 0;
         assert!(matches!(
             check_equivalence_x86(&seq1, &seq2, &cfg),
@@ -1002,7 +1002,7 @@ mod tests {
             rs: X86Register::RBX,
         };
         let seq_je = vec![
-            prefix.clone(),
+            prefix,
             X86Instruction::Jcc {
                 cond: X86Condition::E,
             },
@@ -1013,7 +1013,7 @@ mod tests {
                 cond: X86Condition::NE,
             },
         ];
-        let cfg = X86EquivalenceConfig::new_for_64().live_out(X86LiveOutMask::empty());
+        let cfg = X86EquivalenceConfig::new(64).live_out(X86LiveOutMask::empty());
         assert!(matches!(
             check_equivalence_x86(&seq_je, &seq_jne, &cfg),
             EquivalenceResult::NotEquivalent
@@ -1030,9 +1030,9 @@ mod tests {
         let jcc = X86Instruction::Jcc {
             cond: X86Condition::E,
         };
-        let seq1 = vec![prefix.clone(), jcc.clone()];
+        let seq1 = vec![prefix, jcc];
         let seq2 = vec![prefix, jcc];
-        let cfg = X86EquivalenceConfig::new_for_64().live_out(X86LiveOutMask::empty());
+        let cfg = X86EquivalenceConfig::new(64).live_out(X86LiveOutMask::empty());
         assert_eq!(
             check_equivalence_x86(&seq1, &seq2, &cfg),
             EquivalenceResult::Equivalent
@@ -1047,13 +1047,13 @@ mod tests {
             rs: X86Register::RBX,
         };
         let seq_with_jcc = vec![
-            prefix.clone(),
+            prefix,
             X86Instruction::Jcc {
                 cond: X86Condition::E,
             },
         ];
         let seq_without = vec![prefix];
-        let cfg = X86EquivalenceConfig::new_for_64().live_out(X86LiveOutMask::empty());
+        let cfg = X86EquivalenceConfig::new(64).live_out(X86LiveOutMask::empty());
         assert!(matches!(
             check_equivalence_x86(&seq_with_jcc, &seq_without, &cfg),
             EquivalenceResult::NotEquivalent
@@ -1074,7 +1074,7 @@ mod tests {
             rn: X86Register::RAX,
             rs: X86Register::RCX,
         }];
-        let mut cfg = X86EquivalenceConfig::new_for_64().live_out(X86LiveOutMask::empty());
+        let mut cfg = X86EquivalenceConfig::new(64).live_out(X86LiveOutMask::empty());
         cfg.random_test_count = 0;
         assert_eq!(
             check_equivalence_x86(&seq1, &seq2, &cfg),
@@ -1091,7 +1091,7 @@ mod tests {
             rs: X86Register::RBX,
         }];
         let mut cfg =
-            X86EquivalenceConfig::new_for_64().live_out(X86LiveOutMask::empty().with_flags(true));
+            X86EquivalenceConfig::new(64).live_out(X86LiveOutMask::empty().with_flags(true));
         cfg.random_test_count = 0;
         assert_eq!(
             check_equivalence_x86(&cmp.clone(), &cmp, &cfg),

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -750,6 +750,13 @@ pub fn check_equivalence_x86(
         let v2 = final2.get_register(*reg);
         disjuncts.push(v1.eq(v2).not());
     }
+    // Issue #74: when the caller declares flags live, any of the five
+    // tracked EFLAGS bits diverging is enough to refute equivalence.
+    if config.live_out.flags_live() {
+        disjuncts.push(crate::semantics::smt_x86::flags_not_equal_x86(
+            &final1, &final2,
+        ));
+    }
     let any_diff = if disjuncts.is_empty() {
         z3::ast::Bool::from_bool(false)
     } else {
@@ -944,6 +951,73 @@ mod tests {
             .live_out(X86LiveOutMask::from_registers(vec![X86Register::RAX]));
         assert_eq!(
             check_equivalence_x86(&seq1, &seq2, &cfg),
+            EquivalenceResult::Equivalent
+        );
+    }
+
+    // --- issue #74: SMT path catches flag-only divergence when flags_live ---
+
+    #[test]
+    fn x86_smt_path_distinguishes_cmps_with_different_operands_when_flags_live() {
+        // `cmp rax, rbx` and `cmp rax, rcx` both write EFLAGS symbolically
+        // (cycle 3) but their flag effects diverge whenever rbx != rcx.
+        // The SMT flag disjunct (cycle 4) must let Z3 find that model and
+        // refute equivalence under flags_live=true.
+        //
+        // Zero `random_test_count` to force-skip the fast path so the
+        // assertion lands squarely on the SMT solver path.
+        let seq1 = vec![X86Instruction::CmpReg {
+            rn: X86Register::RAX,
+            rs: X86Register::RBX,
+        }];
+        let seq2 = vec![X86Instruction::CmpReg {
+            rn: X86Register::RAX,
+            rs: X86Register::RCX,
+        }];
+        let mut cfg =
+            X86EquivalenceConfig::new_for_64().live_out(X86LiveOutMask::empty().with_flags(true));
+        cfg.random_test_count = 0;
+        assert!(matches!(
+            check_equivalence_x86(&seq1, &seq2, &cfg),
+            EquivalenceResult::NotEquivalent
+        ));
+    }
+
+    #[test]
+    fn x86_smt_path_treats_cmps_with_different_operands_as_equivalent_without_flags_live() {
+        // Without flags_live=true, the same CMP pair must still pass on
+        // the SMT path — the disjunct is gated on `flags_live`, and the
+        // register-disjunct list is empty (no live-out registers), so
+        // equivalence is vacuously true.
+        let seq1 = vec![X86Instruction::CmpReg {
+            rn: X86Register::RAX,
+            rs: X86Register::RBX,
+        }];
+        let seq2 = vec![X86Instruction::CmpReg {
+            rn: X86Register::RAX,
+            rs: X86Register::RCX,
+        }];
+        let mut cfg = X86EquivalenceConfig::new_for_64().live_out(X86LiveOutMask::empty());
+        cfg.random_test_count = 0;
+        assert_eq!(
+            check_equivalence_x86(&seq1, &seq2, &cfg),
+            EquivalenceResult::Equivalent
+        );
+    }
+
+    #[test]
+    fn x86_smt_path_equates_two_cmps_with_same_operands_under_flags_live() {
+        // Identical CMPs must remain equivalent on the SMT path even with
+        // flags_live=true — the flag-disjunct should be UNSAT.
+        let cmp = vec![X86Instruction::CmpReg {
+            rn: X86Register::RAX,
+            rs: X86Register::RBX,
+        }];
+        let mut cfg =
+            X86EquivalenceConfig::new_for_64().live_out(X86LiveOutMask::empty().with_flags(true));
+        cfg.random_test_count = 0;
+        assert_eq!(
+            check_equivalence_x86(&cmp.clone(), &cmp, &cfg),
             EquivalenceResult::Equivalent
         );
     }

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -839,6 +839,18 @@ fn run_fast_path_x86(
                 );
             }
         }
+        // Also randomize the five tracked input EFLAGS bits from the
+        // same seed. Otherwise CMOV/Jcc-flag-reading instructions would
+        // see ZF=CF=SF=OF=PF=0 across every trial and a proposal that
+        // ignores incoming flags could pass the fast path (e.g.
+        // `cmovne rax, rbx` accepted as equivalent to `mov rax, rbx`).
+        let mut flags = crate::semantics::state::Eflags::new();
+        flags.cf = (seed & 1) != 0;
+        flags.pf = (seed & 2) != 0;
+        flags.zf = (seed & 4) != 0;
+        flags.sf = (seed & 8) != 0;
+        flags.of = (seed & 16) != 0;
+        state.set_flags(flags);
         let mut s1 = state.clone();
         for instr in seq1 {
             s1 = apply_instruction_concrete_x86(s1, instr);
@@ -1057,6 +1069,32 @@ mod tests {
             check_equivalence_x86(&seq1, &seq2, &cfg),
             EquivalenceResult::Equivalent
         );
+    }
+
+    #[test]
+    fn x86_fast_path_distinguishes_cmov_from_unconditional_mov_under_random_flags() {
+        // Reviewer-supplied counterexample: `cmovne rax, rbx` should NOT
+        // be accepted as equivalent to `mov rax, rbx` because the
+        // original preserves rax when incoming ZF=1. The fast path must
+        // randomize incoming EFLAGS — not just registers — for any trial
+        // to hit a ZF=1 case and refute the rewrite.
+        use crate::isa::x86::X86Condition;
+        let target = vec![X86Instruction::Cmov {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+            cond: X86Condition::NE,
+        }];
+        let proposal = vec![X86Instruction::MovReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+        }];
+        let cfg = X86EquivalenceConfig::new(64)
+            .live_out(X86LiveOutMask::from_registers(vec![X86Register::RAX]))
+            .fast_only();
+        assert!(matches!(
+            check_equivalence_x86(&target, &proposal, &cfg),
+            EquivalenceResult::NotEquivalent
+        ));
     }
 
     #[test]

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -676,6 +676,11 @@ pub struct X86EquivalenceConfig {
 }
 
 impl X86EquivalenceConfig {
+    /// Construct a baseline config. **Note:** `live_out` defaults to
+    /// `X86LiveOutMask::empty()` — equivalence over an empty live-out
+    /// set is vacuously true. Callers must populate the mask (typically
+    /// via `live_out(x86_live_out_from_target(target))`) before using
+    /// the config, or any two sequences will compare as equivalent.
     pub fn new(width: u32) -> Self {
         Self {
             live_out: crate::semantics::state::X86LiveOutMask::empty(),

--- a/src/semantics/smt_x86.rs
+++ b/src/semantics/smt_x86.rs
@@ -116,15 +116,53 @@ fn is_zero_bv(value: &BV, width: u32) -> BV {
     value.eq(&BV::from_u64(0, width)).ite(&bv_one(), &bv_zero())
 }
 
+/// Translate an `X86Condition` into a symbolic `Bool` predicate over
+/// the supplied flag BVs. Mirrors `Eflags::evaluate` arm-for-arm.
+pub fn x86_condition_to_smt(
+    cond: crate::isa::x86::X86Condition,
+    flags: (&BV, &BV, &BV, &BV, &BV),
+) -> z3::ast::Bool {
+    use crate::isa::x86::X86Condition;
+    let (cf, pf, zf, sf, of) = flags;
+    let one = bv_one();
+    let cf1 = cf.eq(&one);
+    let pf1 = pf.eq(&one);
+    let zf1 = zf.eq(&one);
+    let sf1 = sf.eq(&one);
+    let of1 = of.eq(&one);
+    match cond {
+        X86Condition::E => zf1,
+        X86Condition::NE => zf1.not(),
+        X86Condition::B => cf1,
+        X86Condition::AE => cf1.not(),
+        X86Condition::BE => z3::ast::Bool::or(&[&cf1, &zf1]),
+        X86Condition::A => z3::ast::Bool::and(&[&cf1.not(), &zf1.not()]),
+        X86Condition::L => sf1.eq(&of1).not(),
+        X86Condition::GE => sf1.eq(&of1),
+        X86Condition::LE => {
+            let signed_lt = sf1.eq(&of1).not();
+            z3::ast::Bool::or(&[&zf1, &signed_lt])
+        }
+        X86Condition::G => {
+            let signed_ge = sf1.eq(&of1);
+            z3::ast::Bool::and(&[&zf1.not(), &signed_ge])
+        }
+        X86Condition::S => sf1,
+        X86Condition::NS => sf1.not(),
+        X86Condition::O => of1,
+        X86Condition::NO => of1.not(),
+        X86Condition::P => pf1,
+        X86Condition::NP => pf1.not(),
+    }
+}
+
 /// Symbolic flags from `lhs - rhs` at the operand width.
 /// Mirrors `Eflags::from_sub` bit-for-bit.
 pub fn compute_eflags_sub(lhs: &BV, rhs: &BV, width: u32) -> EflagsBvs {
     let result = lhs.bvsub(rhs);
-    // CF = (lhs <u rhs) — x86 sets CF on borrow (opposite of AArch64 C).
     let cf = lhs.bvult(rhs).ite(&bv_one(), &bv_zero());
     let zf = is_zero_bv(&result, width);
     let sf = top_bit_bv(&result, width);
-    // OF on sub: (lhs_sign != rhs_sign) && (lhs_sign != result_sign).
     let l = top_bit_bv(lhs, width);
     let r = top_bit_bv(rhs, width);
     let res_s = top_bit_bv(&result, width);
@@ -134,6 +172,35 @@ pub fn compute_eflags_sub(lhs: &BV, rhs: &BV, width: u32) -> EflagsBvs {
     let of = of_bool.ite(&bv_one(), &bv_zero());
     let pf = parity8_bv(&result);
     (cf, pf, zf, sf, of)
+}
+
+/// Symbolic flags from `lhs + rhs` at the operand width.
+/// Mirrors `Eflags::from_add` bit-for-bit.
+pub fn compute_eflags_add(lhs: &BV, rhs: &BV, width: u32) -> EflagsBvs {
+    let result = lhs.bvadd(rhs);
+    // CF = unsigned overflow: result <u lhs (equivalent to <u rhs).
+    let cf = result.bvult(lhs).ite(&bv_one(), &bv_zero());
+    let zf = is_zero_bv(&result, width);
+    let sf = top_bit_bv(&result, width);
+    // OF on add: input signs match AND result sign differs from inputs.
+    let l = top_bit_bv(lhs, width);
+    let r = top_bit_bv(rhs, width);
+    let res_s = top_bit_bv(&result, width);
+    let signs_match = l.eq(&r);
+    let lhs_vs_res = l.eq(&res_s).not();
+    let of_bool = z3::ast::Bool::and(&[&signs_match, &lhs_vs_res]);
+    let of = of_bool.ite(&bv_one(), &bv_zero());
+    let pf = parity8_bv(&result);
+    (cf, pf, zf, sf, of)
+}
+
+/// Symbolic flags from a logical op (AND/OR/XOR). CF and OF are
+/// always cleared per x86 spec; SF/ZF/PF reflect the result.
+pub fn compute_eflags_logical(result: &BV, width: u32) -> EflagsBvs {
+    let zf = is_zero_bv(result, width);
+    let sf = top_bit_bv(result, width);
+    let pf = parity8_bv(result);
+    (bv_zero(), pf, zf, sf, bv_zero())
 }
 
 /// Apply a single x86 instruction symbolically. CMP variants are no-ops
@@ -154,52 +221,82 @@ pub fn apply_instruction(
         X86Instruction::AddReg { rd, rs } => {
             let lhs = state.get_register(*rd).clone();
             let rhs = state.get_register(*rs).clone();
-            state.set_register(*rd, lhs.bvadd(&rhs));
+            let result = lhs.bvadd(&rhs);
+            let flags = compute_eflags_add(&lhs, &rhs, state.width());
+            state.set_register(*rd, result);
+            state.set_flags(flags);
         }
         X86Instruction::AddImm { rd, imm } => {
             let lhs = state.get_register(*rd).clone();
             let rhs = state.imm_bv(*imm);
-            state.set_register(*rd, lhs.bvadd(&rhs));
+            let result = lhs.bvadd(&rhs);
+            let flags = compute_eflags_add(&lhs, &rhs, state.width());
+            state.set_register(*rd, result);
+            state.set_flags(flags);
         }
         X86Instruction::SubReg { rd, rs } => {
             let lhs = state.get_register(*rd).clone();
             let rhs = state.get_register(*rs).clone();
-            state.set_register(*rd, lhs.bvsub(&rhs));
+            let result = lhs.bvsub(&rhs);
+            let flags = compute_eflags_sub(&lhs, &rhs, state.width());
+            state.set_register(*rd, result);
+            state.set_flags(flags);
         }
         X86Instruction::SubImm { rd, imm } => {
             let lhs = state.get_register(*rd).clone();
             let rhs = state.imm_bv(*imm);
-            state.set_register(*rd, lhs.bvsub(&rhs));
+            let result = lhs.bvsub(&rhs);
+            let flags = compute_eflags_sub(&lhs, &rhs, state.width());
+            state.set_register(*rd, result);
+            state.set_flags(flags);
         }
         X86Instruction::AndReg { rd, rs } => {
             let lhs = state.get_register(*rd).clone();
             let rhs = state.get_register(*rs).clone();
-            state.set_register(*rd, lhs.bvand(&rhs));
+            let result = lhs.bvand(&rhs);
+            let flags = compute_eflags_logical(&result, state.width());
+            state.set_register(*rd, result);
+            state.set_flags(flags);
         }
         X86Instruction::AndImm { rd, imm } => {
             let lhs = state.get_register(*rd).clone();
             let rhs = state.imm_bv(*imm);
-            state.set_register(*rd, lhs.bvand(&rhs));
+            let result = lhs.bvand(&rhs);
+            let flags = compute_eflags_logical(&result, state.width());
+            state.set_register(*rd, result);
+            state.set_flags(flags);
         }
         X86Instruction::OrReg { rd, rs } => {
             let lhs = state.get_register(*rd).clone();
             let rhs = state.get_register(*rs).clone();
-            state.set_register(*rd, lhs.bvor(&rhs));
+            let result = lhs.bvor(&rhs);
+            let flags = compute_eflags_logical(&result, state.width());
+            state.set_register(*rd, result);
+            state.set_flags(flags);
         }
         X86Instruction::OrImm { rd, imm } => {
             let lhs = state.get_register(*rd).clone();
             let rhs = state.imm_bv(*imm);
-            state.set_register(*rd, lhs.bvor(&rhs));
+            let result = lhs.bvor(&rhs);
+            let flags = compute_eflags_logical(&result, state.width());
+            state.set_register(*rd, result);
+            state.set_flags(flags);
         }
         X86Instruction::XorReg { rd, rs } => {
             let lhs = state.get_register(*rd).clone();
             let rhs = state.get_register(*rs).clone();
-            state.set_register(*rd, lhs.bvxor(&rhs));
+            let result = lhs.bvxor(&rhs);
+            let flags = compute_eflags_logical(&result, state.width());
+            state.set_register(*rd, result);
+            state.set_flags(flags);
         }
         X86Instruction::XorImm { rd, imm } => {
             let lhs = state.get_register(*rd).clone();
             let rhs = state.imm_bv(*imm);
-            state.set_register(*rd, lhs.bvxor(&rhs));
+            let result = lhs.bvxor(&rhs);
+            let flags = compute_eflags_logical(&result, state.width());
+            state.set_register(*rd, result);
+            state.set_flags(flags);
         }
         // CMP sets EFLAGS without writing a register (issue #74).
         X86Instruction::CmpReg { rn, rs } => {
@@ -214,10 +311,12 @@ pub fn apply_instruction(
             let flags = compute_eflags_sub(&lhs, &rhs, state.width());
             state.set_flags(flags);
         }
-        // Cmov reads EFLAGS conditionally writes rd. Symbolic ITE wiring
-        // lands in cycle 5; for now treat as a no-op so the type checker
-        // stays happy without affecting any existing test.
-        X86Instruction::Cmov { .. } => {}
+        X86Instruction::Cmov { rd, rs, cond } => {
+            let pred = x86_condition_to_smt(*cond, state.get_flags());
+            let rs_val = state.get_register(*rs).clone();
+            let rd_old = state.get_register(*rd).clone();
+            state.set_register(*rd, pred.ite(&rs_val, &rd_old));
+        }
     }
     state
 }
@@ -394,6 +493,280 @@ mod tests {
             solver.check(),
             SatResult::Unsat,
             "CF after CMP must equal (rax <u rbx)"
+        );
+    }
+
+    // --- issue #74: symbolic CMOV ---
+
+    #[test]
+    fn cmov_ites_rd_on_condition() {
+        // After `cmove rax, rbx`, rax must equal (zf_init == 1 ? rbx_init : rax_init).
+        use crate::isa::x86::X86Condition;
+        let s0 = MachineStateX86::new_symbolic("s", 64);
+        let rax_init = s0.get_register(X86Register::RAX).clone();
+        let rbx_init = s0.get_register(X86Register::RBX).clone();
+        let zf_init = s0.get_flags().2.clone();
+        let s1 = apply_instruction(
+            s0,
+            &X86Instruction::Cmov {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+                cond: X86Condition::E,
+            },
+        );
+        let rax_after = s1.get_register(X86Register::RAX);
+        // Expected: zf_init == 1 → rbx_init, else rax_init.
+        let zf_one = BV::from_u64(1, 1);
+        let expected = zf_init.eq(&zf_one).ite(&rbx_init, &rax_init);
+        let solver = Solver::new();
+        solver.assert(&rax_after.eq(&expected).not());
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "CMOV must ITE rd on condition predicate"
+        );
+    }
+
+    #[test]
+    fn xor_self_provably_clears_cf_and_of_and_sets_zf_pf() {
+        // The canonical zeroing idiom: xor rax, rax. After Cycle 6's
+        // logical-flag wiring this must be observable symbolically.
+        let s0 = MachineStateX86::new_symbolic("s", 64);
+        let s1 = apply_instruction(
+            s0,
+            &X86Instruction::XorReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RAX,
+            },
+        );
+        let (cf, pf, zf, _sf, of) = s1.get_flags();
+        let zero = BV::from_u64(0, 1);
+        let one = BV::from_u64(1, 1);
+        let solver = Solver::new();
+        solver.assert(&z3::ast::Bool::or(&[
+            &cf.eq(&zero).not(),
+            &of.eq(&zero).not(),
+            &zf.eq(&one).not(),
+            &pf.eq(&one).not(),
+        ]));
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "XOR x,x must clear CF/OF and set ZF=PF=1"
+        );
+    }
+
+    #[test]
+    fn addreg_binds_zf_to_sum_equality() {
+        // After `add rax, rbx`, ZF=1 iff rax_init + rbx_init == 0.
+        let s0 = MachineStateX86::new_symbolic("s", 64);
+        let rax_init = s0.get_register(X86Register::RAX).clone();
+        let rbx_init = s0.get_register(X86Register::RBX).clone();
+        let s1 = apply_instruction(
+            s0,
+            &X86Instruction::AddReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+        );
+        let zf = s1.get_flags().2;
+        let zero = BV::from_u64(0, 64);
+        let zf_one = BV::from_u64(1, 1);
+        let solver = Solver::new();
+        let sum_zero = rax_init.bvadd(&rbx_init).eq(&zero);
+        let iff = zf.eq(&zf_one).iff(&sum_zero);
+        solver.assert(&iff.not());
+        assert_eq!(solver.check(), SatResult::Unsat);
+    }
+
+    #[test]
+    fn subreg_binds_cf_to_unsigned_borrow() {
+        // After `sub rax, rbx`, CF=1 iff rax_init <u rbx_init (borrow).
+        let s0 = MachineStateX86::new_symbolic("s", 64);
+        let rax_init = s0.get_register(X86Register::RAX).clone();
+        let rbx_init = s0.get_register(X86Register::RBX).clone();
+        let s1 = apply_instruction(
+            s0,
+            &X86Instruction::SubReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+        );
+        let cf = s1.get_flags().0;
+        let cf_one = BV::from_u64(1, 1);
+        let solver = Solver::new();
+        let borrow = rax_init.bvult(&rbx_init);
+        let iff = cf.eq(&cf_one).iff(&borrow);
+        solver.assert(&iff.not());
+        assert_eq!(solver.check(), SatResult::Unsat);
+    }
+
+    // --- issue #74: concrete↔SMT parity for x86 flag computation ---
+
+    fn assert_x86_concrete_smt_parity(instr: &X86Instruction, lhs: u64, rhs: u64) {
+        use crate::semantics::concrete_x86::apply_instruction_concrete_x86;
+        use crate::semantics::state::{ConcreteValue, X86ConcreteMachineState};
+
+        let mut concrete_pre = X86ConcreteMachineState::new_zeroed(64);
+        concrete_pre.set_register(X86Register::RAX, ConcreteValue::new(lhs));
+        concrete_pre.set_register(X86Register::RBX, ConcreteValue::new(rhs));
+        let concrete_post = apply_instruction_concrete_x86(concrete_pre, instr);
+        let cf_post = concrete_post.get_flags();
+
+        let symbolic_pre = MachineStateX86::new_symbolic("pre", 64);
+        let solver = Solver::new();
+        solver.assert(
+            &symbolic_pre
+                .get_register(X86Register::RAX)
+                .eq(&BV::from_u64(lhs, 64)),
+        );
+        solver.assert(
+            &symbolic_pre
+                .get_register(X86Register::RBX)
+                .eq(&BV::from_u64(rhs, 64)),
+        );
+        let symbolic_post = apply_instruction(symbolic_pre, instr);
+
+        // Build inequality disjunct over all five tracked flags and rd
+        // (when the instruction has one).
+        let one_bit = |b: bool| BV::from_u64(b as u64, 1);
+        let (cf_s, pf_s, zf_s, sf_s, of_s) = symbolic_post.get_flags();
+        let mut diffs: Vec<z3::ast::Bool> = vec![
+            cf_s.eq(&one_bit(cf_post.cf)).not(),
+            pf_s.eq(&one_bit(cf_post.pf)).not(),
+            zf_s.eq(&one_bit(cf_post.zf)).not(),
+            sf_s.eq(&one_bit(cf_post.sf)).not(),
+            of_s.eq(&one_bit(cf_post.of)).not(),
+        ];
+        if let Some(rd) = instr.destination() {
+            let expected = BV::from_u64(concrete_post.get_register(rd).as_u64(), 64);
+            diffs.push(symbolic_post.get_register(rd).eq(&expected).not());
+        }
+        let refs: Vec<&z3::ast::Bool> = diffs.iter().collect();
+        solver.assert(&z3::ast::Bool::or(&refs));
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "concrete/SMT parity violation for {:?} with lhs={:#x} rhs={:#x}",
+            instr,
+            lhs,
+            rhs
+        );
+    }
+
+    const PARITY_SAMPLES: &[(u64, u64)] = &[
+        (0, 0),
+        (0, 1),
+        (1, 1),
+        (5, 5),
+        (5, 7),
+        (7, 5),
+        (u64::MAX, 1),
+        (1, u64::MAX),
+        (i64::MIN as u64, 1),
+        (i64::MAX as u64, 1),
+        (0x8000_0000_0000_0000, 0x8000_0000_0000_0000),
+        (0xDEAD_BEEF_CAFE_BABE, 0x1234_5678_9ABC_DEF0),
+    ];
+
+    #[test]
+    fn parity_add_reg() {
+        let instr = X86Instruction::AddReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+        };
+        for &(a, b) in PARITY_SAMPLES {
+            assert_x86_concrete_smt_parity(&instr, a, b);
+        }
+    }
+
+    #[test]
+    fn parity_sub_reg() {
+        let instr = X86Instruction::SubReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+        };
+        for &(a, b) in PARITY_SAMPLES {
+            assert_x86_concrete_smt_parity(&instr, a, b);
+        }
+    }
+
+    #[test]
+    fn parity_cmp_reg() {
+        let instr = X86Instruction::CmpReg {
+            rn: X86Register::RAX,
+            rs: X86Register::RBX,
+        };
+        for &(a, b) in PARITY_SAMPLES {
+            assert_x86_concrete_smt_parity(&instr, a, b);
+        }
+    }
+
+    #[test]
+    fn parity_and_reg() {
+        let instr = X86Instruction::AndReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+        };
+        for &(a, b) in PARITY_SAMPLES {
+            assert_x86_concrete_smt_parity(&instr, a, b);
+        }
+    }
+
+    #[test]
+    fn parity_or_reg() {
+        let instr = X86Instruction::OrReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+        };
+        for &(a, b) in PARITY_SAMPLES {
+            assert_x86_concrete_smt_parity(&instr, a, b);
+        }
+    }
+
+    #[test]
+    fn parity_xor_reg() {
+        let instr = X86Instruction::XorReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+        };
+        for &(a, b) in PARITY_SAMPLES {
+            assert_x86_concrete_smt_parity(&instr, a, b);
+        }
+    }
+
+    #[test]
+    fn cmov_does_not_modify_flags() {
+        // Cmov must leave the five tracked flag BVs symbolically untouched.
+        use crate::isa::x86::X86Condition;
+        let s0 = MachineStateX86::new_symbolic("s", 64);
+        let (cf0, pf0, zf0, sf0, of0) = {
+            let (cf, pf, zf, sf, of) = s0.get_flags();
+            (cf.clone(), pf.clone(), zf.clone(), sf.clone(), of.clone())
+        };
+        let s1 = apply_instruction(
+            s0,
+            &X86Instruction::Cmov {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+                cond: X86Condition::NE,
+            },
+        );
+        let solver = Solver::new();
+        let (cf1, pf1, zf1, sf1, of1) = s1.get_flags();
+        // Any flag differing means we touched flags.
+        let diff = z3::ast::Bool::or(&[
+            &cf1.eq(&cf0).not(),
+            &pf1.eq(&pf0).not(),
+            &zf1.eq(&zf0).not(),
+            &sf1.eq(&sf0).not(),
+            &of1.eq(&of0).not(),
+        ]);
+        solver.assert(&diff);
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "CMOV must not write any flag"
         );
     }
 }

--- a/src/semantics/smt_x86.rs
+++ b/src/semantics/smt_x86.rs
@@ -100,10 +100,10 @@ fn bv_zero() -> BV {
 fn parity8_bv(result: &BV) -> BV {
     let mut acc = result.extract(0, 0);
     for i in 1..8u32 {
-        acc = acc.bvxor(&result.extract(i, i));
+        acc = acc.bvxor(result.extract(i, i));
     }
     // PF = 1 iff XOR-reduction == 0 (even number of set bits).
-    acc.eq(&bv_zero()).ite(&bv_one(), &bv_zero())
+    acc.eq(bv_zero()).ite(&bv_one(), &bv_zero())
 }
 
 /// Top bit of `value` as a 1-bit BV (SF flag).
@@ -113,7 +113,7 @@ fn top_bit_bv(value: &BV, width: u32) -> BV {
 
 /// Zero predicate of `value` as a 1-bit BV (ZF flag).
 fn is_zero_bv(value: &BV, width: u32) -> BV {
-    value.eq(&BV::from_u64(0, width)).ite(&bv_one(), &bv_zero())
+    value.eq(BV::from_u64(0, width)).ite(&bv_one(), &bv_zero())
 }
 
 /// Translate an `X86Condition` into a symbolic `Bool` predicate over
@@ -401,7 +401,7 @@ mod tests {
         // Z3 should be able to prove rax == 12.
         let solver = Solver::new();
         let actual = s1.get_register(X86Register::RAX);
-        solver.assert(&actual.eq(&BV::from_i64(12, 64)).not());
+        solver.assert(actual.eq(BV::from_i64(12, 64)).not());
         // If the negation is unsatisfiable, the original equality is a theorem.
         assert_eq!(solver.check(), SatResult::Unsat);
     }
@@ -419,7 +419,7 @@ mod tests {
         );
         let solver = Solver::new();
         let actual = s1.get_register(X86Register::RAX);
-        solver.assert(&actual.eq(&BV::from_i64(0, 64)).not());
+        solver.assert(actual.eq(BV::from_i64(0, 64)).not());
         assert_eq!(solver.check(), SatResult::Unsat);
     }
 
@@ -435,7 +435,7 @@ mod tests {
             },
         );
         let solver = Solver::new();
-        solver.assert(&s1.get_register(X86Register::RAX).eq(&rax_before).not());
+        solver.assert(s1.get_register(X86Register::RAX).eq(&rax_before).not());
         assert_eq!(
             solver.check(),
             SatResult::Unsat,
@@ -466,7 +466,7 @@ mod tests {
         let eq_regs = rax.eq(&rbx);
         let eq_zf = zf.eq(&zf_one);
         let iff = eq_zf.iff(&eq_regs);
-        solver.assert(&iff.not());
+        solver.assert(iff.not());
         assert_eq!(
             solver.check(),
             SatResult::Unsat,
@@ -493,7 +493,7 @@ mod tests {
         let unsigned_lt = rax.bvult(&rbx);
         let eq_cf = cf.eq(&cf_one);
         let iff = eq_cf.iff(&unsigned_lt);
-        solver.assert(&iff.not());
+        solver.assert(iff.not());
         assert_eq!(
             solver.check(),
             SatResult::Unsat,
@@ -524,7 +524,7 @@ mod tests {
         let zf_one = BV::from_u64(1, 1);
         let expected = zf_init.eq(&zf_one).ite(&rbx_init, &rax_init);
         let solver = Solver::new();
-        solver.assert(&rax_after.eq(&expected).not());
+        solver.assert(rax_after.eq(&expected).not());
         assert_eq!(
             solver.check(),
             SatResult::Unsat,
@@ -548,7 +548,7 @@ mod tests {
         let zero = BV::from_u64(0, 1);
         let one = BV::from_u64(1, 1);
         let solver = Solver::new();
-        solver.assert(&z3::ast::Bool::or(&[
+        solver.assert(z3::ast::Bool::or(&[
             &cf.eq(&zero).not(),
             &of.eq(&zero).not(),
             &zf.eq(&one).not(),
@@ -580,7 +580,7 @@ mod tests {
         let solver = Solver::new();
         let sum_zero = rax_init.bvadd(&rbx_init).eq(&zero);
         let iff = zf.eq(&zf_one).iff(&sum_zero);
-        solver.assert(&iff.not());
+        solver.assert(iff.not());
         assert_eq!(solver.check(), SatResult::Unsat);
     }
 
@@ -602,7 +602,7 @@ mod tests {
         let solver = Solver::new();
         let borrow = rax_init.bvult(&rbx_init);
         let iff = cf.eq(&cf_one).iff(&borrow);
-        solver.assert(&iff.not());
+        solver.assert(iff.not());
         assert_eq!(solver.check(), SatResult::Unsat);
     }
 
@@ -621,14 +621,14 @@ mod tests {
         let symbolic_pre = MachineStateX86::new_symbolic("pre", 64);
         let solver = Solver::new();
         solver.assert(
-            &symbolic_pre
+            symbolic_pre
                 .get_register(X86Register::RAX)
-                .eq(&BV::from_u64(lhs, 64)),
+                .eq(BV::from_u64(lhs, 64)),
         );
         solver.assert(
-            &symbolic_pre
+            symbolic_pre
                 .get_register(X86Register::RBX)
-                .eq(&BV::from_u64(rhs, 64)),
+                .eq(BV::from_u64(rhs, 64)),
         );
         let symbolic_post = apply_instruction(symbolic_pre, instr);
 
@@ -637,18 +637,18 @@ mod tests {
         let one_bit = |b: bool| BV::from_u64(b as u64, 1);
         let (cf_s, pf_s, zf_s, sf_s, of_s) = symbolic_post.get_flags();
         let mut diffs: Vec<z3::ast::Bool> = vec![
-            cf_s.eq(&one_bit(cf_post.cf)).not(),
-            pf_s.eq(&one_bit(cf_post.pf)).not(),
-            zf_s.eq(&one_bit(cf_post.zf)).not(),
-            sf_s.eq(&one_bit(cf_post.sf)).not(),
-            of_s.eq(&one_bit(cf_post.of)).not(),
+            cf_s.eq(one_bit(cf_post.cf)).not(),
+            pf_s.eq(one_bit(cf_post.pf)).not(),
+            zf_s.eq(one_bit(cf_post.zf)).not(),
+            sf_s.eq(one_bit(cf_post.sf)).not(),
+            of_s.eq(one_bit(cf_post.of)).not(),
         ];
         if let Some(rd) = instr.destination() {
             let expected = BV::from_u64(concrete_post.get_register(rd).as_u64(), 64);
             diffs.push(symbolic_post.get_register(rd).eq(&expected).not());
         }
         let refs: Vec<&z3::ast::Bool> = diffs.iter().collect();
-        solver.assert(&z3::ast::Bool::or(&refs));
+        solver.assert(z3::ast::Bool::or(&refs));
         assert_eq!(
             solver.check(),
             SatResult::Unsat,

--- a/src/semantics/smt_x86.rs
+++ b/src/semantics/smt_x86.rs
@@ -3,7 +3,7 @@
 //! Width-parameterised: `MachineStateX86` carries the bitvector width so
 //! the same module handles both x86-64 (width=64) and x86-32 (width=32).
 //!
-//! Symbolic EFLAGS (issue #74) tracks five 1-bit flag BVs: CF, PF, ZF,
+//! Symbolic EFLAGS tracks five 1-bit flag BVs: CF, PF, ZF,
 //! SF, OF. AF is intentionally not modelled — none of the canonical x86
 //! condition codes (see `Eflags::evaluate`) reads AF, and the concrete
 //! interpreter leaves AF as `false`. If a future feature requires AF
@@ -85,7 +85,7 @@ impl MachineStateX86 {
     }
 }
 
-// --- symbolic EFLAGS helpers (issue #74) ---
+// --- symbolic EFLAGS helpers ---
 
 fn bv_one() -> BV {
     BV::from_u64(1, 1)
@@ -205,7 +205,7 @@ pub fn compute_eflags_logical(result: &BV, width: u32) -> EflagsBvs {
 
 /// Apply a single x86 instruction symbolically. Arithmetic / logic /
 /// CMP arms bind the five tracked flag BVs via `compute_eflags_*`;
-/// CMOV reads them via `x86_condition_to_smt` (issue #74).
+/// CMOV reads them via `x86_condition_to_smt`.
 pub fn apply_instruction(
     mut state: MachineStateX86,
     instruction: &X86Instruction,
@@ -299,7 +299,7 @@ pub fn apply_instruction(
             state.set_register(*rd, result);
             state.set_flags(flags);
         }
-        // CMP sets EFLAGS without writing a register (issue #74).
+        // CMP sets EFLAGS without writing a register.
         X86Instruction::CmpReg { rn, rs } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rs).clone();
@@ -443,7 +443,7 @@ mod tests {
         );
     }
 
-    // --- issue #74: CMP writes symbolic EFLAGS ---
+    // --- CMP writes symbolic EFLAGS ---
 
     #[test]
     fn cmp_reg_binds_zf_to_subtraction_equality() {
@@ -501,7 +501,7 @@ mod tests {
         );
     }
 
-    // --- issue #74: symbolic CMOV ---
+    // --- symbolic CMOV ---
 
     #[test]
     fn cmov_ites_rd_on_condition() {
@@ -606,7 +606,7 @@ mod tests {
         assert_eq!(solver.check(), SatResult::Unsat);
     }
 
-    // --- issue #74: concrete↔SMT parity for x86 flag computation ---
+    // --- concrete↔SMT parity for x86 flag computation ---
 
     fn assert_x86_concrete_smt_parity(instr: &X86Instruction, lhs: u64, rhs: u64) {
         use crate::semantics::concrete_x86::apply_instruction_concrete_x86;

--- a/src/semantics/smt_x86.rs
+++ b/src/semantics/smt_x86.rs
@@ -317,6 +317,10 @@ pub fn apply_instruction(
             let rd_old = state.get_register(*rd).clone();
             state.set_register(*rd, pred.ite(&rs_val, &rd_old));
         }
+        // Jcc reads EFLAGS but transfers control; nothing is observable
+        // in the data-state machine modelled here. Cycle 10 peels Jccs
+        // off the sequence before applying it symbolically.
+        X86Instruction::Jcc { .. } => {}
     }
     state
 }

--- a/src/semantics/smt_x86.rs
+++ b/src/semantics/smt_x86.rs
@@ -2,8 +2,13 @@
 //!
 //! Width-parameterised: `MachineStateX86` carries the bitvector width so
 //! the same module handles both x86-64 (width=64) and x86-32 (width=32).
-//! Flags are NOT modelled symbolically yet — CMP variants are encoded as
-//! no-ops, mirroring the AArch64 SMT path's treatment of CMP/CMN/TST.
+//!
+//! Symbolic EFLAGS (issue #74) tracks five 1-bit flag BVs: CF, PF, ZF,
+//! SF, OF. AF is intentionally not modelled — none of the canonical x86
+//! condition codes (see `Eflags::evaluate`) reads AF, and the concrete
+//! interpreter leaves AF as `false`. If a future feature requires AF
+//! (e.g. BCD instructions), extend `MachineStateX86` with a sixth BV
+//! and derive AF deterministically in `compute_eflags_*`.
 
 #![allow(dead_code)]
 
@@ -11,10 +16,19 @@ use crate::isa::x86::{X86Instruction, X86Register};
 use std::collections::HashMap;
 use z3::ast::BV;
 
+/// Symbolic EFLAGS quintuple `(cf, pf, zf, sf, of)`, mirroring
+/// `Eflags` minus the unmodelled AF (see module docs).
+pub type EflagsBvs = (BV, BV, BV, BV, BV);
+
 #[derive(Clone)]
 pub struct MachineStateX86 {
     pub registers: HashMap<X86Register, BV>,
     width: u32,
+    cf: BV,
+    pf: BV,
+    zf: BV,
+    sf: BV,
+    of: BV,
 }
 
 impl MachineStateX86 {
@@ -26,7 +40,15 @@ impl MachineStateX86 {
                 registers.insert(reg, BV::new_const(name, width));
             }
         }
-        MachineStateX86 { registers, width }
+        MachineStateX86 {
+            registers,
+            width,
+            cf: BV::new_const(format!("{}_cf", prefix), 1),
+            pf: BV::new_const(format!("{}_pf", prefix), 1),
+            zf: BV::new_const(format!("{}_zf", prefix), 1),
+            sf: BV::new_const(format!("{}_sf", prefix), 1),
+            of: BV::new_const(format!("{}_of", prefix), 1),
+        }
     }
 
     pub fn width(&self) -> u32 {
@@ -43,9 +65,75 @@ impl MachineStateX86 {
         self.registers.insert(reg, value);
     }
 
+    /// Return the five flag BVs as `(cf, pf, zf, sf, of)`.
+    pub fn get_flags(&self) -> (&BV, &BV, &BV, &BV, &BV) {
+        (&self.cf, &self.pf, &self.zf, &self.sf, &self.of)
+    }
+
+    /// Replace all five flag BVs at once.
+    pub fn set_flags(&mut self, flags: EflagsBvs) {
+        let (cf, pf, zf, sf, of) = flags;
+        self.cf = cf;
+        self.pf = pf;
+        self.zf = zf;
+        self.sf = sf;
+        self.of = of;
+    }
+
     fn imm_bv(&self, imm: i64) -> BV {
         BV::from_i64(imm, self.width)
     }
+}
+
+// --- symbolic EFLAGS helpers (issue #74) ---
+
+fn bv_one() -> BV {
+    BV::from_u64(1, 1)
+}
+
+fn bv_zero() -> BV {
+    BV::from_u64(0, 1)
+}
+
+/// PF = even parity of low 8 bits of `result`. Implemented as the XOR
+/// reduction of those 8 bits, then negated.
+fn parity8_bv(result: &BV) -> BV {
+    let mut acc = result.extract(0, 0);
+    for i in 1..8u32 {
+        acc = acc.bvxor(&result.extract(i, i));
+    }
+    // PF = 1 iff XOR-reduction == 0 (even number of set bits).
+    acc.eq(&bv_zero()).ite(&bv_one(), &bv_zero())
+}
+
+/// Top bit of `value` as a 1-bit BV (SF flag).
+fn top_bit_bv(value: &BV, width: u32) -> BV {
+    value.extract(width - 1, width - 1)
+}
+
+/// Zero predicate of `value` as a 1-bit BV (ZF flag).
+fn is_zero_bv(value: &BV, width: u32) -> BV {
+    value.eq(&BV::from_u64(0, width)).ite(&bv_one(), &bv_zero())
+}
+
+/// Symbolic flags from `lhs - rhs` at the operand width.
+/// Mirrors `Eflags::from_sub` bit-for-bit.
+pub fn compute_eflags_sub(lhs: &BV, rhs: &BV, width: u32) -> EflagsBvs {
+    let result = lhs.bvsub(rhs);
+    // CF = (lhs <u rhs) — x86 sets CF on borrow (opposite of AArch64 C).
+    let cf = lhs.bvult(rhs).ite(&bv_one(), &bv_zero());
+    let zf = is_zero_bv(&result, width);
+    let sf = top_bit_bv(&result, width);
+    // OF on sub: (lhs_sign != rhs_sign) && (lhs_sign != result_sign).
+    let l = top_bit_bv(lhs, width);
+    let r = top_bit_bv(rhs, width);
+    let res_s = top_bit_bv(&result, width);
+    let signs_differ = l.eq(&r).not();
+    let lhs_vs_res = l.eq(&res_s).not();
+    let of_bool = z3::ast::Bool::and(&[&signs_differ, &lhs_vs_res]);
+    let of = of_bool.ite(&bv_one(), &bv_zero());
+    let pf = parity8_bv(&result);
+    (cf, pf, zf, sf, of)
 }
 
 /// Apply a single x86 instruction symbolically. CMP variants are no-ops
@@ -113,8 +201,23 @@ pub fn apply_instruction(
             let rhs = state.imm_bv(*imm);
             state.set_register(*rd, lhs.bvxor(&rhs));
         }
-        // CMP sets EFLAGS only — not modelled here. Mirrors AArch64 path.
-        X86Instruction::CmpReg { .. } | X86Instruction::CmpImm { .. } => {}
+        // CMP sets EFLAGS without writing a register (issue #74).
+        X86Instruction::CmpReg { rn, rs } => {
+            let lhs = state.get_register(*rn).clone();
+            let rhs = state.get_register(*rs).clone();
+            let flags = compute_eflags_sub(&lhs, &rhs, state.width());
+            state.set_flags(flags);
+        }
+        X86Instruction::CmpImm { rn, imm } => {
+            let lhs = state.get_register(*rn).clone();
+            let rhs = state.imm_bv(*imm);
+            let flags = compute_eflags_sub(&lhs, &rhs, state.width());
+            state.set_flags(flags);
+        }
+        // Cmov reads EFLAGS conditionally writes rd. Symbolic ITE wiring
+        // lands in cycle 5; for now treat as a no-op so the type checker
+        // stays happy without affecting any existing test.
+        X86Instruction::Cmov { .. } => {}
     }
     state
 }
@@ -127,6 +230,22 @@ pub fn apply_sequence(
         state = apply_instruction(state, instr);
     }
     state
+}
+
+/// Bool predicate asserting that any of the five tracked flags differs
+/// between two symbolic x86 states. Used by `check_equivalence_x86` to
+/// reject sequences whose flag effects diverge under `flags_live=true`.
+/// AF is intentionally excluded — see module docs.
+pub fn flags_not_equal_x86(a: &MachineStateX86, b: &MachineStateX86) -> z3::ast::Bool {
+    let (a_cf, a_pf, a_zf, a_sf, a_of) = a.get_flags();
+    let (b_cf, b_pf, b_zf, b_sf, b_of) = b.get_flags();
+    z3::ast::Bool::or(&[
+        &a_cf.eq(b_cf).not(),
+        &a_pf.eq(b_pf).not(),
+        &a_zf.eq(b_zf).not(),
+        &a_sf.eq(b_sf).not(),
+        &a_of.eq(b_of).not(),
+    ])
 }
 
 #[cfg(test)]
@@ -217,6 +336,64 @@ mod tests {
             solver.check(),
             SatResult::Unsat,
             "CMP must leave RAX symbolically unchanged"
+        );
+    }
+
+    // --- issue #74: CMP writes symbolic EFLAGS ---
+
+    #[test]
+    fn cmp_reg_binds_zf_to_subtraction_equality() {
+        // After `cmp rax, rbx`, ZF must be 1 iff rax == rbx.
+        // We prove this by asserting the negation is unsatisfiable.
+        let s0 = MachineStateX86::new_symbolic("s", 64);
+        let rax = s0.get_register(X86Register::RAX).clone();
+        let rbx = s0.get_register(X86Register::RBX).clone();
+        let s1 = apply_instruction(
+            s0,
+            &X86Instruction::CmpReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+        );
+        let zf = s1.get_flags().2; // (cf, pf, zf, sf, of) — zf at index 2
+        let zf_one = BV::from_u64(1, 1);
+        let solver = Solver::new();
+        // Assert: NOT (zf == 1 <=> rax == rbx). If unsat, the bi-implication holds.
+        let eq_regs = rax.eq(&rbx);
+        let eq_zf = zf.eq(&zf_one);
+        let iff = eq_zf.iff(&eq_regs);
+        solver.assert(&iff.not());
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "ZF after CMP must equal (rax == rbx)"
+        );
+    }
+
+    #[test]
+    fn cmp_reg_binds_cf_to_unsigned_borrow() {
+        // After `cmp rax, rbx`, CF must be 1 iff rax <u rbx (borrow).
+        let s0 = MachineStateX86::new_symbolic("s", 64);
+        let rax = s0.get_register(X86Register::RAX).clone();
+        let rbx = s0.get_register(X86Register::RBX).clone();
+        let s1 = apply_instruction(
+            s0,
+            &X86Instruction::CmpReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+        );
+        let cf = s1.get_flags().0;
+        let cf_one = BV::from_u64(1, 1);
+        let solver = Solver::new();
+        let unsigned_lt = rax.bvult(&rbx);
+        let eq_cf = cf.eq(&cf_one);
+        let iff = eq_cf.iff(&unsigned_lt);
+        solver.assert(&iff.not());
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "CF after CMP must equal (rax <u rbx)"
         );
     }
 }

--- a/src/semantics/smt_x86.rs
+++ b/src/semantics/smt_x86.rs
@@ -203,8 +203,9 @@ pub fn compute_eflags_logical(result: &BV, width: u32) -> EflagsBvs {
     (bv_zero(), pf, zf, sf, bv_zero())
 }
 
-/// Apply a single x86 instruction symbolically. CMP variants are no-ops
-/// because we do not (yet) model EFLAGS in Z3.
+/// Apply a single x86 instruction symbolically. Arithmetic / logic /
+/// CMP arms bind the five tracked flag BVs via `compute_eflags_*`;
+/// CMOV reads them via `x86_condition_to_smt` (issue #74).
 pub fn apply_instruction(
     mut state: MachineStateX86,
     instruction: &X86Instruction,

--- a/src/semantics/state.rs
+++ b/src/semantics/state.rs
@@ -161,6 +161,34 @@ impl Eflags {
         }
     }
 
+    /// Evaluate an x86 condition code against the current flag bits
+    /// (issue #74). Mirrors `ConditionFlags::evaluate` for AArch64.
+    ///
+    /// Intentionally does not read `self.af`; none of the 16 canonical
+    /// x86 condition codes consult AF, and `MachineStateX86` does not
+    /// model AF symbolically (see `src/semantics/smt_x86.rs`).
+    pub fn evaluate(&self, cond: crate::isa::x86::X86Condition) -> bool {
+        use crate::isa::x86::X86Condition;
+        match cond {
+            X86Condition::E => self.zf,
+            X86Condition::NE => !self.zf,
+            X86Condition::B => self.cf,
+            X86Condition::AE => !self.cf,
+            X86Condition::BE => self.cf || self.zf,
+            X86Condition::A => !self.cf && !self.zf,
+            X86Condition::L => self.sf != self.of,
+            X86Condition::GE => self.sf == self.of,
+            X86Condition::LE => self.zf || (self.sf != self.of),
+            X86Condition::G => !self.zf && (self.sf == self.of),
+            X86Condition::S => self.sf,
+            X86Condition::NS => !self.sf,
+            X86Condition::O => self.of,
+            X86Condition::NO => !self.of,
+            X86Condition::P => self.pf,
+            X86Condition::NP => !self.pf,
+        }
+    }
+
     /// Flags from `lhs - rhs == result` (CMP and SUB at width `width`).
     /// CF is set if a borrow occurred (lhs < rhs at the operand width) —
     /// opposite of AArch64.
@@ -853,5 +881,113 @@ mod tests {
         let b = ConcreteMachineState::new_zeroed();
         a.write_bytes(0x100, 0, AccessWidth::Word);
         assert_eq!(a, b, "writing zeroes must not perturb structural equality");
+    }
+
+    // ---- Eflags::evaluate(X86Condition) (issue #74) ----
+
+    #[test]
+    fn eflags_evaluate_e_reads_zf() {
+        use crate::isa::x86::X86Condition;
+        let mut f = Eflags::new();
+        f.zf = true;
+        assert!(f.evaluate(X86Condition::E));
+        assert!(!f.evaluate(X86Condition::NE));
+        f.zf = false;
+        assert!(!f.evaluate(X86Condition::E));
+        assert!(f.evaluate(X86Condition::NE));
+    }
+
+    #[test]
+    fn eflags_evaluate_b_reads_cf_unsigned_below() {
+        use crate::isa::x86::X86Condition;
+        let mut f = Eflags::new();
+        f.cf = true;
+        assert!(f.evaluate(X86Condition::B));
+        assert!(!f.evaluate(X86Condition::AE));
+        f.cf = false;
+        assert!(!f.evaluate(X86Condition::B));
+        assert!(f.evaluate(X86Condition::AE));
+    }
+
+    #[test]
+    fn eflags_evaluate_l_compares_sf_vs_of_signed_less() {
+        use crate::isa::x86::X86Condition;
+        let mut f = Eflags::new();
+        // L is true iff SF != OF.
+        f.sf = true;
+        f.of = false;
+        assert!(f.evaluate(X86Condition::L));
+        assert!(!f.evaluate(X86Condition::GE));
+        f.of = true;
+        assert!(!f.evaluate(X86Condition::L));
+        assert!(f.evaluate(X86Condition::GE));
+    }
+
+    #[test]
+    fn eflags_evaluate_ble_combines_zf_and_signed_less() {
+        use crate::isa::x86::X86Condition;
+        // BE: cf || zf; LE: zf || (sf != of).
+        let mut f = Eflags::new();
+        f.cf = true;
+        assert!(f.evaluate(X86Condition::BE));
+        f.cf = false;
+        f.zf = true;
+        assert!(f.evaluate(X86Condition::BE));
+        assert!(f.evaluate(X86Condition::LE));
+        f.zf = false;
+        f.sf = true;
+        f.of = false;
+        assert!(f.evaluate(X86Condition::LE));
+        assert!(!f.evaluate(X86Condition::G));
+    }
+
+    #[test]
+    fn eflags_evaluate_p_reads_pf_only() {
+        use crate::isa::x86::X86Condition;
+        let mut f = Eflags::new();
+        f.pf = true;
+        assert!(f.evaluate(X86Condition::P));
+        assert!(!f.evaluate(X86Condition::NP));
+        f.pf = false;
+        assert!(!f.evaluate(X86Condition::P));
+        assert!(f.evaluate(X86Condition::NP));
+    }
+
+    #[test]
+    fn eflags_evaluate_never_reads_af() {
+        // x86 condition codes do not consult AF — enforce by toggling AF
+        // across all 16 codes and asserting the result is invariant. Acts
+        // as a tripwire if a future condition arm accidentally reads af.
+        use crate::isa::x86::X86Condition;
+        let mut f = Eflags::new();
+        f.cf = true;
+        f.pf = true;
+        f.zf = true;
+        f.sf = true;
+        f.of = true;
+        for cond in [
+            X86Condition::E,
+            X86Condition::NE,
+            X86Condition::B,
+            X86Condition::AE,
+            X86Condition::BE,
+            X86Condition::A,
+            X86Condition::L,
+            X86Condition::GE,
+            X86Condition::LE,
+            X86Condition::G,
+            X86Condition::S,
+            X86Condition::NS,
+            X86Condition::O,
+            X86Condition::NO,
+            X86Condition::P,
+            X86Condition::NP,
+        ] {
+            f.af = false;
+            let v0 = f.evaluate(cond);
+            f.af = true;
+            let v1 = f.evaluate(cond);
+            assert_eq!(v0, v1, "evaluate({:?}) must not depend on AF", cond);
+        }
     }
 }

--- a/src/semantics/state.rs
+++ b/src/semantics/state.rs
@@ -162,7 +162,7 @@ impl Eflags {
     }
 
     /// Evaluate an x86 condition code against the current flag bits
-    /// (issue #74). Mirrors `ConditionFlags::evaluate` for AArch64.
+    ///. Mirrors `ConditionFlags::evaluate` for AArch64.
     ///
     /// Intentionally does not read `self.af`; none of the 16 canonical
     /// x86 condition codes consult AF, and `MachineStateX86` does not
@@ -811,7 +811,7 @@ mod tests {
         assert!(!f.zf);
     }
 
-    // ---- Memory model (issue #68 step 5) ----
+    // ---- Memory model ----
 
     #[test]
     fn read_bytes_returns_zero_on_fresh_state() {
@@ -883,7 +883,7 @@ mod tests {
         assert_eq!(a, b, "writing zeroes must not perturb structural equality");
     }
 
-    // ---- Eflags::evaluate(X86Condition) (issue #74) ----
+    // --- Eflags::evaluate(X86Condition) ---
 
     #[test]
     fn eflags_evaluate_e_reads_zf() {

--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -235,11 +235,17 @@ pub fn compute_live_in_registers(instructions: &[Instruction]) -> RegisterSet<Re
 /// Build an `X86LiveOutMask` from a target sequence by treating every
 /// written register as live-out and declaring EFLAGS live whenever the
 /// target contains any instruction with observable side effects (i.e.
-/// any non-MOV variant — see `InstructionType::has_side_effects` for
-/// the contract).
+/// any non-MOV / non-CMOV / non-Jcc variant — see
+/// `InstructionType::has_side_effects` for the contract).
 ///
-/// Mirrors the ad-hoc construction inside `find_shorter_equivalent_x86`
-/// (`src/main.rs`) so search algorithms reuse the same liveness rule.
+/// **Asymmetry:** CMOV and Jcc READ EFLAGS but report
+/// `has_side_effects=false` (they don't write flags), so a CMOV-only or
+/// Jcc-only target gets `flags_live=false` from this helper.
+/// `find_shorter_equivalent_x86` (`src/main.rs`) compensates by
+/// dropping `.fast_only()` when the target contains any flag-reader,
+/// forcing the SMT path to fully account for incoming EFLAGS. Direct
+/// callers that bypass that helper must apply their own equivalent
+/// guard if their downstream code reads flags.
 pub fn x86_live_out_from_target(
     target: &[crate::isa::x86::X86Instruction],
 ) -> crate::semantics::state::X86LiveOutMask {


### PR DESCRIPTION
## Summary
- Models x86 EFLAGS symbolically in `MachineStateX86` (5 BVs: cf/pf/zf/sf/of). CMP is no longer a no-op symbolically; ADD/SUB/AND/OR/XOR bind flags via three new `compute_eflags_*` helpers that mirror `Eflags::from_*` bit-for-bit.
- Adds `X86Instruction::Cmov { rd, rs, cond }` (concrete dispatch, symbolic ITE, dynasm encoding for all 16 conditions, parser + cost-model + candidate-enumeration wiring) and `X86Instruction::Jcc { cond }` (opaque terminator with `is_terminator()`, `split_terminator_x86`, short-form encoding for round-trip tests).
- `check_equivalence_x86` now peels Jcc terminators (rejects mismatched conditions) and appends a flag-inequality disjunct under `config.live_out.flags_live()` — closing the soundness gap the fast-path EFLAGS heuristic was previously the only safety net for.

## Design notes
- **AF is not modelled symbolically**. None of the 16 canonical x86 condition codes reads AF; a tripwire test (`eflags_evaluate_never_reads_af`) ensures any future arm that adds AF reads fails loudly so the model can be extended.
- **Jcc carries no target** in the IR — the optimizer holds terminators fixed and the original branch bytes stay pinned in the binary. The Capstone-emitted operand is parsed as a numeric immediate to surface format drift, then discarded.
- AArch64 NZCV symbolic was already implemented; the x86 side mirrors that pipeline arm-for-arm.

## Test plan
- [x] 879 unit tests pass (`cargo test --bin s11`), including 6 concrete↔SMT parity tests over 12 value samples
- [x] `./ci_check.sh` passes end-to-end (fmt, build, unit + AArch64 integration tests, test binaries)
- [x] Capstone round-trip tests cover all 16 CMOV and all 16 Jcc suffixes on both x86-64 and x86-32
- [x] End-to-end pipeline tests in `src/main.rs::cli_helper_tests` cross-module compose asm→disasm→parse→equivalence for both CMP+CMOV and Jcc