### PR TITLE
Bootstrap criterion-based benchmark suite (closes #70)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ mutants.out.old/
 
 .ultraplan/
 .clawpatch/
+
+# criterion benchmark output and JSONL accumulator (issue #70)
+benches/results/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,30 @@ Both recipes depend on `build-tests` so that AArch64 integration-test binaries a
 
 In CI, `.github/workflows/coverage.yml` runs on PRs and pushes to `main`, collects LCOV across unit + integration tests, and uploads to [Codecov](https://codecov.io/) using the `CODECOV_TOKEN` repo secret. Project/patch thresholds live in `codecov.yml`.
 
+### Benchmark suite (issue #70)
+
+Criterion-driven benchmarks live under `benches/`. Three phases —
+Hacker's Delight micro-suite (Phase 1), LLVM AArch64 codegen sample
+(Phase 2), and an algebraic-identities catalog (Phase 3). The shared
+harness (`load_sequence`, `run_bench`, `append_json`,
+`discover_specs_in`) lives in `src/bench_support.rs` because criterion
+benchmarks built with `harness = false` cannot run `#[test]` blocks
+— the lib-test path is the only way to unit-test the helpers.
+
+Each criterion sample emits one JSON-Lines record to
+`benches/results/results.jsonl`. See `benches/README.md` for the schema
+and how to add a fixture.
+
+- `just bench` / `just bench-phase1` / `just bench-clean` are the entry
+  points.
+- Benchmarks are **not** wired into CI — full runs are tens of minutes
+  and would burn through GitHub Actions budget.
+- Reproducibility depends on a seeded `StochasticConfig`. The bench
+  harness sets `spec.seed + sample_index` per record so runs are
+  deterministic given the pair.
+- Phase 2 fixtures are not committed; run
+  `scripts/harvest_llvm_codegen.sh` to populate them.
+
 ### Mutation Testing (informational, local-only)
 
 Mutation testing runs via [cargo-mutants](https://mutants.rs/) and is **informational only** — it does not gate merges. It is **not** wired into CI to keep GitHub Actions minutes for the test/clippy/CodeQL workflows.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +101,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +130,12 @@ checksum = "a4e8087cab6731295f5a2a2bd82989ba4f41d3a428aab2e7c98d8f4db38aac05"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -135,6 +162,33 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -193,6 +247,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +315,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "dynasm"
@@ -306,6 +402,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +449,17 @@ dependencies = [
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -377,16 +508,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -465,10 +628,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -652,6 +855,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,6 +897,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +920,7 @@ version = "0.1.0"
 dependencies = [
  "capstone",
  "clap",
+ "criterion",
  "crossbeam-channel",
  "dynasm",
  "dynasmrt",
@@ -699,7 +932,17 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "tempfile",
  "z3",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -758,6 +1001,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,6 +1043,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,6 +1086,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,6 +1111,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -876,6 +1190,25 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = "1"
 
 [dev-dependencies]
 proptest = "1.10"
+criterion = { version = "0.5", features = ["html_reports"] }
 
 # Optional: Profile for release builds for better performance/smaller binary
 [profile.release]
@@ -35,3 +36,18 @@ codegen-units = 1    # Maximize optimizations
 panic = 'abort'      # Abort on panic for smaller binary (no unwinding)
 strip = true         # Strip symbols from the binary
 opt-level = 3        # Ensure highest optimization level (default for release but explicit)
+
+# Benchmark suite (issue #70). `harness = false` swaps the libtest
+# harness for criterion's custom one. See benches/README.md for the
+# JSON-Lines report schema and how to add a new benchmark.
+[[bench]]
+name = "hackers_delight"
+harness = false
+
+[[bench]]
+name = "llvm_codegen"
+harness = false
+
+[[bench]]
+name = "algebraic_fusion"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ serde_json = "1"
 [dev-dependencies]
 proptest = "1.10"
 criterion = { version = "0.5", features = ["html_reports"] }
+tempfile = "3.10"
 
 # Optional: Profile for release builds for better performance/smaller binary
 [profile.release]

--- a/Justfile
+++ b/Justfile
@@ -84,6 +84,22 @@ llm-demo: build
 mutants *ARGS:
     ./scripts/run-mutants.sh {{ARGS}}
 
+# Run every benchmark phase and append JSON Lines to benches/results/.
+# See benches/README.md for the schema and how to add a benchmark.
+bench: build
+    @mkdir -p benches/results
+    @echo "Running benchmarks (all phases)..."
+    cargo bench --bench hackers_delight --bench llvm_codegen --bench algebraic_fusion
+
+# Phase 1 only (Hacker's Delight micro-suite).
+bench-phase1: build
+    @mkdir -p benches/results
+    cargo bench --bench hackers_delight
+
+# Wipe criterion HTML reports and the JSONL accumulator.
+bench-clean:
+    rm -rf target/criterion benches/results
+
 # Generate an HTML coverage report locally (open target/llvm-cov/html/index.html).
 # Requires `cargo install cargo-llvm-cov` and the `llvm-tools-preview` rustup component.
 coverage: build-tests

--- a/README.md
+++ b/README.md
@@ -123,6 +123,24 @@ just test-all        # build + run ./test_all.sh end-to-end demo
 ./ci_check.sh        # what CI runs before push
 ```
 
+### Benchmarks
+
+```
+just bench           # all three phases
+just bench-phase1    # Hacker's Delight micro-suite only
+just bench-clean     # wipe criterion reports + JSONL accumulator
+```
+
+Each criterion sample emits one JSON-Lines record to
+`benches/results/results.jsonl`. Criterion HTML reports land under
+`target/criterion/`. Phase 2 fixtures are not committed; run
+`scripts/harvest_llvm_codegen.sh` to populate them from
+`llvm-project/llvm/test/CodeGen/AArch64/`. See `benches/README.md` for
+the layout, schema, and how to add a new fixture.
+
+Benchmarks are **not** wired into CI — full runs are tens of minutes
+and would burn through GitHub Actions minutes.
+
 ### Mutation testing (informational, local-only)
 
 s11 uses [cargo-mutants] to surface tests that are too weak to detect

--- a/benches/README.md
+++ b/benches/README.md
@@ -100,7 +100,7 @@ over `sample_index` per `benchmark_id`.
 | `cost_metric` | Cost function: `instructioncount` / `latency` / `codesize`. |
 | `original_length` / `found_length` | Target length and optimized length (or `null` if no optimization). |
 | `original_cost` / `best_cost` | Cost under the chosen metric. |
-| `search_elapsed_ms` | Wall time of the search itself. |
+| `search_elapsed_ms` | Wall time of the search itself, truncated to milliseconds for legibility. Sub-millisecond runs serialise as `0`; the bench driver uses the precise `Duration` internally so criterion's timing analysis sees real values. |
 | `smt_elapsed_ms` | Cumulative Z3 `solver.check()` time. Often zero — the pre-SMT guard rejects most flag-divergent candidates before reaching the solver. |
 | `smt_queries` / `smt_equivalent` | SMT call count (net of fast-path rollbacks) and how many proved equivalence. |
 | `candidates_evaluated` | Total candidates considered. |

--- a/benches/README.md
+++ b/benches/README.md
@@ -13,8 +13,8 @@ cargo bench --bench hackers_delight -- max --quick   # one fixture, fast smoke r
 
 Output:
 
-- `benches/results/results.jsonl` — one record per criterion sample,
-  appended across all runs. Schema below.
+- `benches/results/results.jsonl` — exactly one record per fixture
+  per `cargo bench` invocation, appended across all runs. Schema below.
 - `target/criterion/<group>/<fixture>/report/index.html` — criterion's
   per-fixture HTML report.
 
@@ -63,13 +63,16 @@ A missing `// Live-out:` header panics with a pointer to this file.
 
 ## JSON record schema
 
-Each criterion sample emits one record. Downstream tooling aggregates
-over `sample_index` per `benchmark_id`.
+One record per fixture per `cargo bench` run. Bench drivers emit the
+JSON before driving criterion's `iter_custom`, so warm-up iterations
+never appear in the file. Criterion's HTML report under
+`target/criterion/<group>/<fixture>/` owns the per-sample variance; the
+JSON record below is the canonical snapshot downstream tooling diffs
+across commits.
 
 ```json
 {
   "benchmark_id": "mov_add_fuse",
-  "sample_index": 0,
   "phase": 3,
   "algorithm": "enumerative",
   "seed": 42,
@@ -93,10 +96,9 @@ over `sample_index` per `benchmark_id`.
 | Field | Meaning |
 | --- | --- |
 | `benchmark_id` | Fixture file stem (`abs`, `mov_add_fuse`, …). |
-| `sample_index` | Criterion runs each fixture N times; index counts up. |
 | `phase` | 1 = Hacker's Delight, 2 = LLVM CodeGen, 3 = algebraic identities. |
 | `algorithm` | Search algorithm (currently always `enumerative`). |
-| `seed` | RNG seed used for this sample (`spec.seed + sample_index`). |
+| `seed` | RNG seed (passed verbatim from `spec.seed`; stochastic search uses it directly, deterministic algorithms ignore it). |
 | `cost_metric` | Cost function: `instructioncount` / `latency` / `codesize`. |
 | `original_length` / `found_length` | Target length and optimized length (or `null` if no optimization). |
 | `original_cost` / `best_cost` | Cost under the chosen metric. |

--- a/benches/README.md
+++ b/benches/README.md
@@ -86,7 +86,7 @@ across commits.
   "smt_queries": 73000,
   "smt_equivalent": 1,
   "candidates_evaluated": 85000,
-  "success": true,
+  "improved": true,
   "timeout": false,
   "git_sha": "9576937",
   "timestamp_utc": "1779000000s"
@@ -106,7 +106,7 @@ across commits.
 | `smt_elapsed_ms` | Cumulative Z3 `solver.check()` time. Often zero — the pre-SMT guard rejects most flag-divergent candidates before reaching the solver. |
 | `smt_queries` / `smt_equivalent` | SMT call count (net of fast-path rollbacks) and how many proved equivalence. |
 | `candidates_evaluated` | Total candidates considered. |
-| `success` / `timeout` | Whether an optimization was found, and whether wall time hit `spec.timeout`. |
+| `improved` / `timeout` | `improved`: whether the search returned a strictly cheaper sequence than the target — **not** "search completed without error" (a clean timeout that finds nothing also reports `improved: false`). Combine with `timeout` to distinguish "explored fully, no win" from "ran out of time." |
 | `git_sha` / `timestamp_utc` | Run provenance, stamped once per `cargo bench` invocation. |
 
 ## Phase 2 refresh procedure

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,0 +1,136 @@
+# s11 benchmark suite
+
+Criterion-driven benchmark suite for issue #70. Three phases, one
+shared JSON-Lines report.
+
+## Running
+
+```
+just bench           # all three phases
+just bench-phase1    # Hacker's Delight only
+cargo bench --bench hackers_delight -- max --quick   # one fixture, fast smoke run
+```
+
+Output:
+
+- `benches/results/results.jsonl` — one record per criterion sample,
+  appended across all runs. Schema below.
+- `target/criterion/<group>/<fixture>/report/index.html` — criterion's
+  per-fixture HTML report.
+
+The harness is **not wired into CI**. Full sweeps are tens of minutes,
+which would burn through GitHub Actions budget.
+
+## Layout
+
+```
+benches/
+├── hackers_delight.rs     # Phase 1 driver
+├── hackers_delight/*.s    # Phase 1 fixtures (~20, register-only HD idioms)
+├── llvm_codegen.rs        # Phase 2 driver
+├── llvm_codegen/          # Phase 2 fixtures — populated by the harvester
+├── algebraic_fusion.rs    # Phase 3 driver
+├── algebraic_fusion/*.s   # Phase 3 fixtures (~15, textbook identities)
+├── results/results.jsonl  # JSONL accumulator (gitignored)
+└── README.md              # you are here
+```
+
+The shared harness (`load_sequence`, `run_bench`, `append_json`,
+`discover_specs_in`, `run_provenance`, `BenchSpec`, `BenchRecord`)
+lives in `src/bench_support.rs` because criterion's `harness = false`
+mode prevents `#[test]` blocks under `benches/` from running — putting
+the helpers in the library gives them a normal unit-test path.
+
+## Adding a fixture
+
+1. Drop a `.s` file under the phase directory of your choice.
+2. Give it the required header:
+
+   ```
+   // Live-in: x0, x1
+   // Live-out: x0
+   // Reference / Identity: free-form note
+   <body — straight-line AArch64 assembly>
+   ```
+
+   Header syntax matches `validation::live_out::parse_live_out_contract`
+   (so `// Live-out: x0,x1;nzcv` declares X0, X1, and NZCV as observable).
+3. Constrain the body to instructions s11 supports — see `CLAUDE.md`.
+4. Re-run the bench; the discovery loop picks up new fixtures
+   automatically.
+
+A missing `// Live-out:` header panics with a pointer to this file.
+
+## JSON record schema
+
+Each criterion sample emits one record. Downstream tooling aggregates
+over `sample_index` per `benchmark_id`.
+
+```json
+{
+  "benchmark_id": "mov_add_fuse",
+  "sample_index": 0,
+  "phase": 3,
+  "algorithm": "enumerative",
+  "seed": 42,
+  "cost_metric": "instructioncount",
+  "original_length": 2,
+  "found_length": 1,
+  "original_cost": 2,
+  "best_cost": 1,
+  "search_elapsed_ms": 22,
+  "smt_elapsed_ms": 0,
+  "smt_queries": 73000,
+  "smt_equivalent": 1,
+  "candidates_evaluated": 85000,
+  "success": true,
+  "timeout": false,
+  "git_sha": "9576937",
+  "timestamp_utc": "1779000000s"
+}
+```
+
+| Field | Meaning |
+| --- | --- |
+| `benchmark_id` | Fixture file stem (`abs`, `mov_add_fuse`, …). |
+| `sample_index` | Criterion runs each fixture N times; index counts up. |
+| `phase` | 1 = Hacker's Delight, 2 = LLVM CodeGen, 3 = algebraic identities. |
+| `algorithm` | Search algorithm (currently always `enumerative`). |
+| `seed` | RNG seed used for this sample (`spec.seed + sample_index`). |
+| `cost_metric` | Cost function: `instructioncount` / `latency` / `codesize`. |
+| `original_length` / `found_length` | Target length and optimized length (or `null` if no optimization). |
+| `original_cost` / `best_cost` | Cost under the chosen metric. |
+| `search_elapsed_ms` | Wall time of the search itself. |
+| `smt_elapsed_ms` | Cumulative Z3 `solver.check()` time. Often zero — the pre-SMT guard rejects most flag-divergent candidates before reaching the solver. |
+| `smt_queries` / `smt_equivalent` | SMT call count (net of fast-path rollbacks) and how many proved equivalence. |
+| `candidates_evaluated` | Total candidates considered. |
+| `success` / `timeout` | Whether an optimization was found, and whether wall time hit `spec.timeout`. |
+| `git_sha` / `timestamp_utc` | Run provenance, stamped once per `cargo bench` invocation. |
+
+## Phase 2 refresh procedure
+
+```
+scripts/harvest_llvm_codegen.sh [SEED] [SAMPLE_SIZE]
+```
+
+The script shallow-clones `llvm-project`, samples `.ll` files
+deterministically, drives them through `llc -mtriple=aarch64-linux-gnu
+-O2`, filters output blocks to s11-supported mnemonics, and writes
+each survivor as `benches/llvm_codegen/<basename>.s` with `// Source:`
+provenance.
+
+Maintainer-run only. Review `git status -- benches/llvm_codegen` and
+commit fixtures you want to keep. Re-run with the same `SEED` for a
+deterministic refresh.
+
+## Caveats
+
+- **Bench wall time is noisy** — Z3 is OS-scheduler-dependent, and
+  rayon-parallel enumerative search uses every core. Pin `seed` for
+  diffable runs across commits.
+- **`smt_elapsed_ms = 0` is normal**. For most Phase 1 targets the
+  pre-SMT guard catches flag-divergence early and the solver never
+  fires. Use `smt_queries` to see how many candidates reached the
+  solver (net of fast-path rollbacks).
+- **Phase 2 emptiness is normal**. The harvester is opt-in; the bench
+  driver skips the group when the fixture directory is empty.

--- a/benches/algebraic_fusion.rs
+++ b/benches/algebraic_fusion.rs
@@ -1,7 +1,7 @@
 //! Phase 3 — algebraic identities & fusion catalog.
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use s11::bench_support::{BenchRecord, append_json, discover_specs_in, run_bench, run_provenance};
+use s11::bench_support::{append_json, discover_specs_in, run_bench, run_provenance};
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -20,22 +20,17 @@ fn phase3(c: &mut Criterion) {
     group.measurement_time(Duration::from_secs(10));
 
     for spec in &specs {
+        let mut record = run_bench(spec);
+        record.git_sha = git_sha.clone();
+        record.timestamp_utc = timestamp_utc.clone();
+        append_json(&record, &out);
+
         let spec_owned = spec.clone();
-        let sha = git_sha.clone();
-        let ts = timestamp_utc.clone();
-        let out = out.clone();
         group.bench_function(spec_owned.id.clone(), |b| {
-            let mut next_sample = 0u32;
             b.iter_custom(|iters| {
                 let mut total = Duration::ZERO;
                 for _ in 0..iters {
-                    let mut record: BenchRecord = run_bench(&spec_owned, next_sample);
-                    record.git_sha = sha.clone();
-                    record.timestamp_utc = ts.clone();
-                    let elapsed = record.search_elapsed;
-                    append_json(&record, &out);
-                    total += elapsed;
-                    next_sample = next_sample.wrapping_add(1);
+                    total += run_bench(&spec_owned).search_elapsed;
                 }
                 total
             });

--- a/benches/algebraic_fusion.rs
+++ b/benches/algebraic_fusion.rs
@@ -32,7 +32,7 @@ fn phase3(c: &mut Criterion) {
                     let mut record: BenchRecord = run_bench(&spec_owned, next_sample);
                     record.git_sha = sha.clone();
                     record.timestamp_utc = ts.clone();
-                    let elapsed = Duration::from_millis(record.search_elapsed_ms);
+                    let elapsed = record.search_elapsed;
                     append_json(&record, &out);
                     total += elapsed;
                     next_sample = next_sample.wrapping_add(1);

--- a/benches/algebraic_fusion.rs
+++ b/benches/algebraic_fusion.rs
@@ -1,82 +1,19 @@
 //! Phase 3 — algebraic identities & fusion catalog.
-//!
-//! Mirror of `benches/hackers_delight.rs` (phase=3); fixtures under
-//! `benches/algebraic_fusion/` exercise textbook identities the
-//! optimizer is expected to rediscover. The optimizer measures the
-//! search overhead of recognising each identity, recorded into the
-//! shared JSON-Lines accumulator.
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use s11::bench_support::{BenchRecord, BenchSpec, append_json, run_bench};
-use s11::search::config::Algorithm;
-use s11::semantics::cost::CostMetric;
+use s11::bench_support::{BenchRecord, append_json, discover_specs_in, run_bench, run_provenance};
 use std::path::PathBuf;
 use std::time::Duration;
 
-fn fixture_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/algebraic_fusion")
-}
-
-fn results_path() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/results/results.jsonl")
-}
-
-fn run_provenance() -> (Option<String>, Option<String>) {
-    let sha = std::process::Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .output()
-        .ok()
-        .and_then(|o| {
-            if o.status.success() {
-                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
-            } else {
-                None
-            }
-        });
-    let ts = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .ok()
-        .map(|d| format!("{}s", d.as_secs()));
-    (sha, ts)
-}
-
-fn discover_specs() -> Vec<BenchSpec> {
-    let dir = fixture_dir();
-    let mut specs: Vec<_> = std::fs::read_dir(&dir)
-        .unwrap_or_else(|e| panic!("read {}: {e}", dir.display()))
-        .filter_map(Result::ok)
-        .map(|e| e.path())
-        .filter(|p| p.extension().is_some_and(|x| x == "s"))
-        .map(|fixture| {
-            let id = fixture
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or("unknown")
-                .to_string();
-            BenchSpec {
-                id,
-                fixture,
-                phase: 3,
-                algorithm: Algorithm::Enumerative,
-                cost_metric: CostMetric::InstructionCount,
-                seed: 42,
-                timeout: Duration::from_secs(30),
-            }
-        })
-        .collect();
-    specs.sort_by(|a, b| a.id.cmp(&b.id));
-    specs
-}
-
 fn phase3(c: &mut Criterion) {
-    let specs = discover_specs();
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/algebraic_fusion");
+    let specs = discover_specs_in(&dir, 3);
     if specs.is_empty() {
-        eprintln!("no Phase 3 fixtures found; skipping");
+        eprintln!("no Phase 3 fixtures under {}; skipping", dir.display());
         return;
     }
-
     let (git_sha, timestamp_utc) = run_provenance();
-    let results = results_path();
+    let out = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/results/results.jsonl");
 
     let mut group = c.benchmark_group("algebraic_fusion");
     group.sample_size(10);
@@ -86,7 +23,7 @@ fn phase3(c: &mut Criterion) {
         let spec_owned = spec.clone();
         let sha = git_sha.clone();
         let ts = timestamp_utc.clone();
-        let out = results.clone();
+        let out = out.clone();
         group.bench_function(spec_owned.id.clone(), |b| {
             let mut next_sample = 0u32;
             b.iter_custom(|iters| {

--- a/benches/algebraic_fusion.rs
+++ b/benches/algebraic_fusion.rs
@@ -2,6 +2,7 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use s11::bench_support::{append_json, discover_specs_in, run_bench, run_provenance};
+use std::cell::Cell;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -20,17 +21,27 @@ fn phase3(c: &mut Criterion) {
     group.measurement_time(Duration::from_secs(10));
 
     for spec in &specs {
-        let mut record = run_bench(spec);
-        record.git_sha = git_sha.clone();
-        record.timestamp_utc = timestamp_utc.clone();
-        append_json(&record, &out);
-
         let spec_owned = spec.clone();
+        let sha = git_sha.clone();
+        let ts = timestamp_utc.clone();
+        let out = out.clone();
         group.bench_function(spec_owned.id.clone(), |b| {
+            // See benches/hackers_delight.rs for the rationale: JSON
+            // emission inside iter_custom so filtered runs only emit
+            // for selected fixtures; Cell<bool> dedups warm-up +
+            // measurement repeats. PR #269 review.
+            let emitted = Cell::new(false);
             b.iter_custom(|iters| {
                 let mut total = Duration::ZERO;
                 for _ in 0..iters {
-                    total += run_bench(&spec_owned).search_elapsed;
+                    let mut record = run_bench(&spec_owned);
+                    total += record.search_elapsed;
+                    if !emitted.get() {
+                        record.git_sha = sha.clone();
+                        record.timestamp_utc = ts.clone();
+                        append_json(&record, &out);
+                        emitted.set(true);
+                    }
                 }
                 total
             });

--- a/benches/algebraic_fusion.rs
+++ b/benches/algebraic_fusion.rs
@@ -1,0 +1,4 @@
+// Phase 3 — Algebraic identities & fusion catalog. Placeholder; real
+// body lands alongside the Phase 3 fixtures.
+
+fn main() {}

--- a/benches/algebraic_fusion.rs
+++ b/benches/algebraic_fusion.rs
@@ -1,4 +1,112 @@
-// Phase 3 — Algebraic identities & fusion catalog. Placeholder; real
-// body lands alongside the Phase 3 fixtures.
+//! Phase 3 — algebraic identities & fusion catalog.
+//!
+//! Mirror of `benches/hackers_delight.rs` (phase=3); fixtures under
+//! `benches/algebraic_fusion/` exercise textbook identities the
+//! optimizer is expected to rediscover. The optimizer measures the
+//! search overhead of recognising each identity, recorded into the
+//! shared JSON-Lines accumulator.
 
-fn main() {}
+use criterion::{Criterion, criterion_group, criterion_main};
+use s11::bench_support::{BenchRecord, BenchSpec, append_json, run_bench};
+use s11::search::config::Algorithm;
+use s11::semantics::cost::CostMetric;
+use std::path::PathBuf;
+use std::time::Duration;
+
+fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/algebraic_fusion")
+}
+
+fn results_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/results/results.jsonl")
+}
+
+fn run_provenance() -> (Option<String>, Option<String>) {
+    let sha = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            } else {
+                None
+            }
+        });
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .map(|d| format!("{}s", d.as_secs()));
+    (sha, ts)
+}
+
+fn discover_specs() -> Vec<BenchSpec> {
+    let dir = fixture_dir();
+    let mut specs: Vec<_> = std::fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("read {}: {e}", dir.display()))
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|x| x == "s"))
+        .map(|fixture| {
+            let id = fixture
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("unknown")
+                .to_string();
+            BenchSpec {
+                id,
+                fixture,
+                phase: 3,
+                algorithm: Algorithm::Enumerative,
+                cost_metric: CostMetric::InstructionCount,
+                seed: 42,
+                timeout: Duration::from_secs(30),
+            }
+        })
+        .collect();
+    specs.sort_by(|a, b| a.id.cmp(&b.id));
+    specs
+}
+
+fn phase3(c: &mut Criterion) {
+    let specs = discover_specs();
+    if specs.is_empty() {
+        eprintln!("no Phase 3 fixtures found; skipping");
+        return;
+    }
+
+    let (git_sha, timestamp_utc) = run_provenance();
+    let results = results_path();
+
+    let mut group = c.benchmark_group("algebraic_fusion");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(10));
+
+    for spec in &specs {
+        let spec_owned = spec.clone();
+        let sha = git_sha.clone();
+        let ts = timestamp_utc.clone();
+        let out = results.clone();
+        group.bench_function(spec_owned.id.clone(), |b| {
+            let mut next_sample = 0u32;
+            b.iter_custom(|iters| {
+                let mut total = Duration::ZERO;
+                for _ in 0..iters {
+                    let mut record: BenchRecord = run_bench(&spec_owned, next_sample);
+                    record.git_sha = sha.clone();
+                    record.timestamp_utc = ts.clone();
+                    let elapsed = Duration::from_millis(record.search_elapsed_ms);
+                    append_json(&record, &out);
+                    total += elapsed;
+                    next_sample = next_sample.wrapping_add(1);
+                }
+                total
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, phase3);
+criterion_main!(benches);

--- a/benches/algebraic_fusion/add_commute.s
+++ b/benches/algebraic_fusion/add_commute.s
@@ -1,0 +1,5 @@
+// Live-in: x1, x2
+// Live-out: x0
+// Identity: ADD is commutative — ADD x0,x1,x2 ≡ ADD x0,x2,x1.
+// Already minimum length; bench measures search overhead.
+add x0, x1, x2

--- a/benches/algebraic_fusion/and_redundant.s
+++ b/benches/algebraic_fusion/and_redundant.s
@@ -1,0 +1,4 @@
+// Live-in: x1
+// Live-out: x0
+// Identity: x AND x ≡ x — single MOV is the canonical short form.
+and x0, x1, x1

--- a/benches/algebraic_fusion/csel_constant.s
+++ b/benches/algebraic_fusion/csel_constant.s
@@ -1,0 +1,5 @@
+// Live-in: x1, x2
+// Live-out: x0
+// Identity: CSEL between equal sources is always the source.
+cmp x1, x2
+csel x0, x1, x1, eq

--- a/benches/algebraic_fusion/csinc_inc.s
+++ b/benches/algebraic_fusion/csinc_inc.s
@@ -1,0 +1,8 @@
+// Live-in: x1
+// Live-out: x0
+// Identity: CSINC of (x, x, cond) equals x+1 when cond is false; the
+// optimizer can rediscover the single-instruction CSINC form from
+// CMP+ADD+CSEL patterns.
+cmp x1, #0
+add x2, x1, #1
+csel x0, x1, x2, eq

--- a/benches/algebraic_fusion/div_pow2_asr.s
+++ b/benches/algebraic_fusion/div_pow2_asr.s
@@ -1,0 +1,7 @@
+// Live-in: x1
+// Live-out: x0
+// Identity: signed x / 4 ≡ x >> 2 for non-negative x (caveat: rounding
+// differs for negatives — bench measures whether the optimizer notices
+// the signed-division input contract via SMT).
+mov x0, #4
+sdiv x0, x1, x0

--- a/benches/algebraic_fusion/double_neg.s
+++ b/benches/algebraic_fusion/double_neg.s
@@ -1,0 +1,7 @@
+// Live-in: x1
+// Live-out: x0
+// Identity: -(-x) ≡ x — two SUB-from-zero ops cancel back to MOV.
+mov x0, #0
+sub x0, x0, x1
+mov x2, #0
+sub x0, x2, x0

--- a/benches/algebraic_fusion/mov_add_fuse.s
+++ b/benches/algebraic_fusion/mov_add_fuse.s
@@ -1,0 +1,5 @@
+// Live-in: x1
+// Live-out: x0
+// Identity: MOV+ADD imm fuses into a single ADD imm.
+mov x0, x1
+add x0, x0, #1

--- a/benches/algebraic_fusion/mul_add_madd.s
+++ b/benches/algebraic_fusion/mul_add_madd.s
@@ -1,0 +1,5 @@
+// Live-in: x1, x2, x3
+// Live-out: x0
+// Identity: MUL+ADD fuses into MADD.
+mul x0, x1, x2
+add x0, x0, x3

--- a/benches/algebraic_fusion/mul_pow2_lsl.s
+++ b/benches/algebraic_fusion/mul_pow2_lsl.s
@@ -1,0 +1,5 @@
+// Live-in: x1
+// Live-out: x0
+// Identity: x * 8 ≡ x << 3 — strength reduction.
+mov x0, #8
+mul x0, x1, x0

--- a/benches/algebraic_fusion/or_idempotent.s
+++ b/benches/algebraic_fusion/or_idempotent.s
@@ -1,0 +1,4 @@
+// Live-in: x1
+// Live-out: x0
+// Identity: x OR x ≡ x — single MOV is the canonical short form.
+orr x0, x1, x1

--- a/benches/algebraic_fusion/shift_fuse_lsl.s
+++ b/benches/algebraic_fusion/shift_fuse_lsl.s
@@ -1,0 +1,6 @@
+// Live-in: x1, x2
+// Live-out: x0
+// Identity: LSL + ADD can fuse into ADD with a shifted-register
+// operand (e.g. `add x0, x1, x2, lsl #2`).
+lsl x3, x2, #2
+add x0, x1, x3

--- a/benches/algebraic_fusion/sub_mul_msub.s
+++ b/benches/algebraic_fusion/sub_mul_msub.s
@@ -1,0 +1,5 @@
+// Live-in: x1, x2, x3
+// Live-out: x0
+// Identity: SUB after MUL fuses into MSUB (x0 = x3 - x1*x2).
+mul x0, x1, x2
+sub x0, x3, x0

--- a/benches/algebraic_fusion/sub_via_add.s
+++ b/benches/algebraic_fusion/sub_via_add.s
@@ -1,0 +1,5 @@
+// Live-in: x1
+// Live-out: x0
+// Identity: MOV+SUB imm collapses into a single SUB imm.
+mov x0, x1
+sub x0, x0, #1

--- a/benches/algebraic_fusion/xor_self_zero.s
+++ b/benches/algebraic_fusion/xor_self_zero.s
@@ -1,0 +1,4 @@
+// Live-in: x1
+// Live-out: x0
+// Identity: x XOR x ≡ 0 — collapses to MOV #0.
+eor x0, x1, x1

--- a/benches/algebraic_fusion/zero_idiom_eor.s
+++ b/benches/algebraic_fusion/zero_idiom_eor.s
@@ -1,0 +1,6 @@
+// Live-in:
+// Live-out: x0
+// Identity: MOV #0 ≡ EOR x0,x0,x0 (zeroing idiom). Each form is one
+// instruction; the bench measures whether the optimizer recognises
+// the equivalence rather than shortening.
+mov x0, #0

--- a/benches/hackers_delight.rs
+++ b/benches/hackers_delight.rs
@@ -1,5 +1,116 @@
-// Phase 1 — Hacker's Delight micro-suite. Real body lands in the
-// upcoming "Phase 1 criterion bench file" step. Placeholder keeps the
-// Cargo.toml [[bench]] entry resolvable.
+//! Phase 1 — Hacker's Delight micro-suite.
+//!
+//! Iterates every `.s` fixture under `benches/hackers_delight/`,
+//! drives `s11::bench_support::run_bench` once per criterion sample,
+//! and appends a JSON-Lines record per sample to
+//! `benches/results/results.jsonl`.
+//!
+//! Criterion measures the wall time of each sample loop; the
+//! per-sample non-time metrics (cost delta, SMT time, success) ride
+//! along in the JSONL sidecar — see `src/bench_support.rs` and the
+//! `BenchRecord` schema docs.
 
-fn main() {}
+use criterion::{Criterion, criterion_group, criterion_main};
+use s11::bench_support::{BenchRecord, BenchSpec, append_json, run_bench};
+use s11::search::config::Algorithm;
+use s11::semantics::cost::CostMetric;
+use std::path::PathBuf;
+use std::time::Duration;
+
+fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/hackers_delight")
+}
+
+fn results_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/results/results.jsonl")
+}
+
+fn run_provenance() -> (Option<String>, Option<String>) {
+    let sha = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            } else {
+                None
+            }
+        });
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .map(|d| format!("{}s", d.as_secs()));
+    (sha, ts)
+}
+
+fn discover_specs() -> Vec<BenchSpec> {
+    let dir = fixture_dir();
+    let mut specs: Vec<_> = std::fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("read {}: {e}", dir.display()))
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|x| x == "s"))
+        .map(|fixture| {
+            let id = fixture
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("unknown")
+                .to_string();
+            BenchSpec {
+                id,
+                fixture,
+                phase: 1,
+                algorithm: Algorithm::Enumerative,
+                cost_metric: CostMetric::InstructionCount,
+                seed: 42,
+                timeout: Duration::from_secs(30),
+            }
+        })
+        .collect();
+    specs.sort_by(|a, b| a.id.cmp(&b.id));
+    specs
+}
+
+fn phase1(c: &mut Criterion) {
+    let specs = discover_specs();
+    if specs.is_empty() {
+        eprintln!("no Phase 1 fixtures found; skipping");
+        return;
+    }
+
+    let (git_sha, timestamp_utc) = run_provenance();
+    let results = results_path();
+
+    let mut group = c.benchmark_group("hackers_delight");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(10));
+
+    for spec in &specs {
+        let spec_owned = spec.clone();
+        let sha = git_sha.clone();
+        let ts = timestamp_utc.clone();
+        let out = results.clone();
+        group.bench_function(spec_owned.id.clone(), |b| {
+            let mut next_sample = 0u32;
+            b.iter_custom(|iters| {
+                let mut total = Duration::ZERO;
+                for _ in 0..iters {
+                    let mut record: BenchRecord = run_bench(&spec_owned, next_sample);
+                    record.git_sha = sha.clone();
+                    record.timestamp_utc = ts.clone();
+                    let elapsed = Duration::from_millis(record.search_elapsed_ms);
+                    append_json(&record, &out);
+                    total += elapsed;
+                    next_sample = next_sample.wrapping_add(1);
+                }
+                total
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, phase1);
+criterion_main!(benches);

--- a/benches/hackers_delight.rs
+++ b/benches/hackers_delight.rs
@@ -2,6 +2,7 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use s11::bench_support::{append_json, discover_specs_in, run_bench, run_provenance};
+use std::cell::Cell;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -20,21 +21,29 @@ fn phase1(c: &mut Criterion) {
     group.measurement_time(Duration::from_secs(10));
 
     for spec in &specs {
-        // Canonical record — emitted exactly once per fixture per
-        // `cargo bench` invocation. Criterion's iter_custom would also
-        // run for warm-up/calibration; we deliberately keep JSON
-        // emission out of that closure to avoid warm-up rows.
-        let mut record = run_bench(spec);
-        record.git_sha = git_sha.clone();
-        record.timestamp_utc = timestamp_utc.clone();
-        append_json(&record, &out);
-
         let spec_owned = spec.clone();
+        let sha = git_sha.clone();
+        let ts = timestamp_utc.clone();
+        let out = out.clone();
         group.bench_function(spec_owned.id.clone(), |b| {
+            // JSON emission lives inside the closure so a filtered run
+            // (`cargo bench -- max`) only produces rows for fixtures
+            // criterion actually selects. Cell<bool> dedups across
+            // criterion's repeated iter_custom calls (warm-up +
+            // measurement) — exactly one record per fixture per
+            // `cargo bench` invocation. PR #269 review.
+            let emitted = Cell::new(false);
             b.iter_custom(|iters| {
                 let mut total = Duration::ZERO;
                 for _ in 0..iters {
-                    total += run_bench(&spec_owned).search_elapsed;
+                    let mut record = run_bench(&spec_owned);
+                    total += record.search_elapsed;
+                    if !emitted.get() {
+                        record.git_sha = sha.clone();
+                        record.timestamp_utc = ts.clone();
+                        append_json(&record, &out);
+                        emitted.set(true);
+                    }
                 }
                 total
             });

--- a/benches/hackers_delight.rs
+++ b/benches/hackers_delight.rs
@@ -1,86 +1,19 @@
 //! Phase 1 — Hacker's Delight micro-suite.
-//!
-//! Iterates every `.s` fixture under `benches/hackers_delight/`,
-//! drives `s11::bench_support::run_bench` once per criterion sample,
-//! and appends a JSON-Lines record per sample to
-//! `benches/results/results.jsonl`.
-//!
-//! Criterion measures the wall time of each sample loop; the
-//! per-sample non-time metrics (cost delta, SMT time, success) ride
-//! along in the JSONL sidecar — see `src/bench_support.rs` and the
-//! `BenchRecord` schema docs.
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use s11::bench_support::{BenchRecord, BenchSpec, append_json, run_bench};
-use s11::search::config::Algorithm;
-use s11::semantics::cost::CostMetric;
+use s11::bench_support::{BenchRecord, append_json, discover_specs_in, run_bench, run_provenance};
 use std::path::PathBuf;
 use std::time::Duration;
 
-fn fixture_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/hackers_delight")
-}
-
-fn results_path() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/results/results.jsonl")
-}
-
-fn run_provenance() -> (Option<String>, Option<String>) {
-    let sha = std::process::Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .output()
-        .ok()
-        .and_then(|o| {
-            if o.status.success() {
-                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
-            } else {
-                None
-            }
-        });
-    let ts = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .ok()
-        .map(|d| format!("{}s", d.as_secs()));
-    (sha, ts)
-}
-
-fn discover_specs() -> Vec<BenchSpec> {
-    let dir = fixture_dir();
-    let mut specs: Vec<_> = std::fs::read_dir(&dir)
-        .unwrap_or_else(|e| panic!("read {}: {e}", dir.display()))
-        .filter_map(Result::ok)
-        .map(|e| e.path())
-        .filter(|p| p.extension().is_some_and(|x| x == "s"))
-        .map(|fixture| {
-            let id = fixture
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or("unknown")
-                .to_string();
-            BenchSpec {
-                id,
-                fixture,
-                phase: 1,
-                algorithm: Algorithm::Enumerative,
-                cost_metric: CostMetric::InstructionCount,
-                seed: 42,
-                timeout: Duration::from_secs(30),
-            }
-        })
-        .collect();
-    specs.sort_by(|a, b| a.id.cmp(&b.id));
-    specs
-}
-
 fn phase1(c: &mut Criterion) {
-    let specs = discover_specs();
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/hackers_delight");
+    let specs = discover_specs_in(&dir, 1);
     if specs.is_empty() {
-        eprintln!("no Phase 1 fixtures found; skipping");
+        eprintln!("no Phase 1 fixtures under {}; skipping", dir.display());
         return;
     }
-
     let (git_sha, timestamp_utc) = run_provenance();
-    let results = results_path();
+    let out = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/results/results.jsonl");
 
     let mut group = c.benchmark_group("hackers_delight");
     group.sample_size(10);
@@ -90,7 +23,7 @@ fn phase1(c: &mut Criterion) {
         let spec_owned = spec.clone();
         let sha = git_sha.clone();
         let ts = timestamp_utc.clone();
-        let out = results.clone();
+        let out = out.clone();
         group.bench_function(spec_owned.id.clone(), |b| {
             let mut next_sample = 0u32;
             b.iter_custom(|iters| {

--- a/benches/hackers_delight.rs
+++ b/benches/hackers_delight.rs
@@ -1,7 +1,7 @@
 //! Phase 1 — Hacker's Delight micro-suite.
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use s11::bench_support::{BenchRecord, append_json, discover_specs_in, run_bench, run_provenance};
+use s11::bench_support::{append_json, discover_specs_in, run_bench, run_provenance};
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -20,22 +20,21 @@ fn phase1(c: &mut Criterion) {
     group.measurement_time(Duration::from_secs(10));
 
     for spec in &specs {
+        // Canonical record — emitted exactly once per fixture per
+        // `cargo bench` invocation. Criterion's iter_custom would also
+        // run for warm-up/calibration; we deliberately keep JSON
+        // emission out of that closure to avoid warm-up rows.
+        let mut record = run_bench(spec);
+        record.git_sha = git_sha.clone();
+        record.timestamp_utc = timestamp_utc.clone();
+        append_json(&record, &out);
+
         let spec_owned = spec.clone();
-        let sha = git_sha.clone();
-        let ts = timestamp_utc.clone();
-        let out = out.clone();
         group.bench_function(spec_owned.id.clone(), |b| {
-            let mut next_sample = 0u32;
             b.iter_custom(|iters| {
                 let mut total = Duration::ZERO;
                 for _ in 0..iters {
-                    let mut record: BenchRecord = run_bench(&spec_owned, next_sample);
-                    record.git_sha = sha.clone();
-                    record.timestamp_utc = ts.clone();
-                    let elapsed = record.search_elapsed;
-                    append_json(&record, &out);
-                    total += elapsed;
-                    next_sample = next_sample.wrapping_add(1);
+                    total += run_bench(&spec_owned).search_elapsed;
                 }
                 total
             });

--- a/benches/hackers_delight.rs
+++ b/benches/hackers_delight.rs
@@ -1,0 +1,5 @@
+// Phase 1 — Hacker's Delight micro-suite. Real body lands in the
+// upcoming "Phase 1 criterion bench file" step. Placeholder keeps the
+// Cargo.toml [[bench]] entry resolvable.
+
+fn main() {}

--- a/benches/hackers_delight.rs
+++ b/benches/hackers_delight.rs
@@ -32,7 +32,7 @@ fn phase1(c: &mut Criterion) {
                     let mut record: BenchRecord = run_bench(&spec_owned, next_sample);
                     record.git_sha = sha.clone();
                     record.timestamp_utc = ts.clone();
-                    let elapsed = Duration::from_millis(record.search_elapsed_ms);
+                    let elapsed = record.search_elapsed;
                     append_json(&record, &out);
                     total += elapsed;
                     next_sample = next_sample.wrapping_add(1);

--- a/benches/hackers_delight/abs.s
+++ b/benches/hackers_delight/abs.s
@@ -1,0 +1,7 @@
+// Live-in: x0
+// Live-out: x0
+// Reference: Hacker's Delight §2-4 (absolute value)
+// Pattern: arithmetic shift sign-extends x0; xor + sub turns it into |x0|.
+asr x1, x0, #63
+eor x0, x0, x1
+sub x0, x0, x1

--- a/benches/hackers_delight/abs_csel.s
+++ b/benches/hackers_delight/abs_csel.s
@@ -1,0 +1,8 @@
+// Live-in: x0
+// Live-out: x0
+// Reference: Hacker's Delight §2-4 (alt. |x| via CSEL/CSNEG path)
+// Companion to abs.s — same semantics, longer 4-instruction encoding.
+mov x1, #0
+sub x1, x1, x0
+cmp x0, #0
+csel x0, x1, x0, lt

--- a/benches/hackers_delight/average.s
+++ b/benches/hackers_delight/average.s
@@ -1,0 +1,8 @@
+// Live-in: x0, x1
+// Live-out: x0
+// Reference: Hacker's Delight §2-5 (overflow-free unsigned average)
+// Pattern: (a & b) + ((a ^ b) >> 1).
+and x2, x0, x1
+eor x3, x0, x1
+lsr x3, x3, #1
+add x0, x2, x3

--- a/benches/hackers_delight/clear_low_bit.s
+++ b/benches/hackers_delight/clear_low_bit.s
@@ -1,0 +1,5 @@
+// Live-in: x0
+// Live-out: x0
+// Reference: Hacker's Delight §2-1 (turn off lowest set bit: x & (x-1))
+sub x1, x0, #1
+and x0, x0, x1

--- a/benches/hackers_delight/conditional_neg.s
+++ b/benches/hackers_delight/conditional_neg.s
@@ -1,0 +1,8 @@
+// Live-in: x0, x1
+// Live-out: x0
+// Reference: Hacker's Delight §2-4 (conditional negate: if x1<0 return -x0 else x0)
+// CSNEG-based form should be discoverable.
+mov x2, #0
+sub x2, x2, x0
+cmp x1, #0
+csel x0, x2, x0, lt

--- a/benches/hackers_delight/doz.s
+++ b/benches/hackers_delight/doz.s
@@ -1,0 +1,7 @@
+// Live-in: x0, x1
+// Live-out: x0
+// Reference: Hacker's Delight §2-10 (difference or zero: max(a-b, 0))
+sub x2, x0, x1
+mov x3, #0
+cmp x0, x1
+csel x0, x2, x3, gt

--- a/benches/hackers_delight/extract_sign.s
+++ b/benches/hackers_delight/extract_sign.s
@@ -1,0 +1,6 @@
+// Live-in: x0
+// Live-out: x0
+// Reference: Hacker's Delight §2-7 (extract sign bit to bit 0: x >> 63)
+// One-instruction optimum (LSR by 63); a 2-instruction form via SBFX
+// is an alternative target the optimizer can also choose.
+lsr x0, x0, #63

--- a/benches/hackers_delight/is_pow2_flag.s
+++ b/benches/hackers_delight/is_pow2_flag.s
@@ -1,0 +1,7 @@
+// Live-in: x0
+// Live-out: ;nzcv
+// Reference: Hacker's Delight §2-1 (x is power-of-two iff x & (x-1) == 0)
+// Output via NZCV: Z=1 means x was a power of two (or zero).
+sub x1, x0, #1
+and x0, x0, x1
+cmp x0, #0

--- a/benches/hackers_delight/isolate_low_bit.s
+++ b/benches/hackers_delight/isolate_low_bit.s
@@ -1,0 +1,7 @@
+// Live-in: x0
+// Live-out: x0
+// Reference: Hacker's Delight §2-1 (isolate lowest set bit: x & -x)
+// AArch64 has no NEG mnemonic in s11's pool; build via SUB from XZR-substitute.
+mov x1, #0
+sub x1, x1, x0
+and x0, x0, x1

--- a/benches/hackers_delight/mask_low_bits.s
+++ b/benches/hackers_delight/mask_low_bits.s
@@ -1,0 +1,7 @@
+// Live-in: x0
+// Live-out: x0
+// Reference: Hacker's Delight §2-1 (mask the low 16 bits)
+// Pattern: shift left then right to mask; canonical form is an AND with
+// 0xFFFF (logical immediate) or a UBFX/UBFIZ.
+lsl x0, x0, #48
+lsr x0, x0, #48

--- a/benches/hackers_delight/max.s
+++ b/benches/hackers_delight/max.s
@@ -1,0 +1,5 @@
+// Live-in: x0, x1
+// Live-out: x0
+// Reference: Hacker's Delight §4 (max via conditional select)
+cmp x0, x1
+csel x0, x0, x1, gt

--- a/benches/hackers_delight/min.s
+++ b/benches/hackers_delight/min.s
@@ -1,0 +1,5 @@
+// Live-in: x0, x1
+// Live-out: x0
+// Reference: Hacker's Delight §4 (min via conditional select)
+cmp x0, x1
+csel x0, x0, x1, lt

--- a/benches/hackers_delight/mul_pow2.s
+++ b/benches/hackers_delight/mul_pow2.s
@@ -1,0 +1,6 @@
+// Live-in: x0
+// Live-out: x0
+// Reference: Hacker's Delight §10 (constant multiply by 16)
+// Search should rediscover the single-shift form.
+mov x1, #16
+mul x0, x0, x1

--- a/benches/hackers_delight/parity_low_byte.s
+++ b/benches/hackers_delight/parity_low_byte.s
@@ -1,0 +1,8 @@
+// Live-in: x0
+// Live-out: x0
+// Reference: Hacker's Delight §5-2 (parity of low byte via shift-XOR fold)
+// Each step folds high half onto low half; final result in bit 0.
+eor x1, x0, x0, lsr #4
+eor x1, x1, x1, lsr #2
+eor x0, x1, x1, lsr #1
+and x0, x0, #1

--- a/benches/hackers_delight/rotl_5.s
+++ b/benches/hackers_delight/rotl_5.s
@@ -1,0 +1,9 @@
+// Live-in: x0
+// Live-out: x0
+// Reference: Hacker's Delight §2-15 (rotate left by 5)
+// Pattern: shift two halves and combine; the canonical short form is a
+// single ROR/EXTR — neither is in s11's instruction pool yet, so the
+// optimizer should at best preserve the 3-instruction form.
+lsl x1, x0, #5
+lsr x0, x0, #59
+orr x0, x0, x1

--- a/benches/hackers_delight/rotr_5.s
+++ b/benches/hackers_delight/rotr_5.s
@@ -1,0 +1,6 @@
+// Live-in: x0
+// Live-out: x0
+// Reference: Hacker's Delight §2-15 (rotate right by 5)
+lsr x1, x0, #5
+lsl x0, x0, #59
+orr x0, x0, x1

--- a/benches/hackers_delight/sign_branchfree.s
+++ b/benches/hackers_delight/sign_branchfree.s
@@ -1,0 +1,11 @@
+// Live-in: x0
+// Live-out: x0
+// Reference: Hacker's Delight §2-7 (sign function via arithmetic shift)
+// Pattern: arithmetic shift right by 63 yields -1 / 0 sign mask; OR
+// with (-x >> 63) — but s11 has no NEG, so this slightly longer form
+// uses (0 - x).
+asr x1, x0, #63
+mov x2, #0
+sub x2, x2, x0
+lsr x2, x2, #63
+orr x0, x1, x2

--- a/benches/hackers_delight/sign_extend_w.s
+++ b/benches/hackers_delight/sign_extend_w.s
@@ -1,0 +1,7 @@
+// Live-in: x0
+// Live-out: x0
+// Reference: Hacker's Delight §2-6 (sign-extend low 32 bits)
+// Pattern: shift left then arithmetic right by 32 to sign-extend.
+// Single-instruction equivalents exist (sxtw / sbfx).
+lsl x0, x0, #32
+asr x0, x0, #32

--- a/benches/hackers_delight/swap_no_temp.s
+++ b/benches/hackers_delight/swap_no_temp.s
@@ -1,0 +1,6 @@
+// Live-in: x0, x1
+// Live-out: x0, x1
+// Reference: Hacker's Delight §2-19 (in-place swap via XOR)
+eor x0, x0, x1
+eor x1, x0, x1
+eor x0, x0, x1

--- a/benches/hackers_delight/zero_low_byte.s
+++ b/benches/hackers_delight/zero_low_byte.s
@@ -1,0 +1,7 @@
+// Live-in: x0
+// Live-out: x0
+// Reference: Hacker's Delight §2-1 (clear low 8 bits)
+// Pattern: shift right by 8 then left by 8 to zero the low byte.
+// A single AND with the right mask is the canonical short form.
+lsr x0, x0, #8
+lsl x0, x0, #8

--- a/benches/llvm_codegen.rs
+++ b/benches/llvm_codegen.rs
@@ -4,6 +4,7 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use s11::bench_support::{append_json, discover_specs_in, run_bench, run_provenance};
+use std::cell::Cell;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -26,17 +27,27 @@ fn phase2(c: &mut Criterion) {
     group.measurement_time(Duration::from_secs(10));
 
     for spec in &specs {
-        let mut record = run_bench(spec);
-        record.git_sha = git_sha.clone();
-        record.timestamp_utc = timestamp_utc.clone();
-        append_json(&record, &out);
-
         let spec_owned = spec.clone();
+        let sha = git_sha.clone();
+        let ts = timestamp_utc.clone();
+        let out = out.clone();
         group.bench_function(spec_owned.id.clone(), |b| {
+            // See benches/hackers_delight.rs for the rationale: JSON
+            // emission inside iter_custom so filtered runs only emit
+            // for selected fixtures; Cell<bool> dedups warm-up +
+            // measurement repeats. PR #269 review.
+            let emitted = Cell::new(false);
             b.iter_custom(|iters| {
                 let mut total = Duration::ZERO;
                 for _ in 0..iters {
-                    total += run_bench(&spec_owned).search_elapsed;
+                    let mut record = run_bench(&spec_owned);
+                    total += record.search_elapsed;
+                    if !emitted.get() {
+                        record.git_sha = sha.clone();
+                        record.timestamp_utc = ts.clone();
+                        append_json(&record, &out);
+                        emitted.set(true);
+                    }
                 }
                 total
             });

--- a/benches/llvm_codegen.rs
+++ b/benches/llvm_codegen.rs
@@ -38,7 +38,7 @@ fn phase2(c: &mut Criterion) {
                     let mut record: BenchRecord = run_bench(&spec_owned, next_sample);
                     record.git_sha = sha.clone();
                     record.timestamp_utc = ts.clone();
-                    let elapsed = Duration::from_millis(record.search_elapsed_ms);
+                    let elapsed = record.search_elapsed;
                     append_json(&record, &out);
                     total += elapsed;
                     next_sample = next_sample.wrapping_add(1);

--- a/benches/llvm_codegen.rs
+++ b/benches/llvm_codegen.rs
@@ -1,88 +1,25 @@
-//! Phase 2 — LLVM AArch64 codegen sample.
-//!
-//! Mirrors `benches/hackers_delight.rs` (phase=2). Fixtures are
-//! harvested by `scripts/harvest_llvm_codegen.sh` and live under
-//! `benches/llvm_codegen/`. The fixture set is intentionally absent
-//! from the repo at HEAD — the bench gracefully skips when no `.s`
-//! files are present, so `just bench` keeps passing on a fresh
-//! checkout that has not yet run the harvester.
+//! Phase 2 — LLVM AArch64 codegen sample. Fixtures are harvested by
+//! `scripts/harvest_llvm_codegen.sh`; the bench gracefully skips when
+//! `benches/llvm_codegen/` is empty.
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use s11::bench_support::{BenchRecord, BenchSpec, append_json, run_bench};
-use s11::search::config::Algorithm;
-use s11::semantics::cost::CostMetric;
+use s11::bench_support::{BenchRecord, append_json, discover_specs_in, run_bench, run_provenance};
 use std::path::PathBuf;
 use std::time::Duration;
 
-fn fixture_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/llvm_codegen")
-}
-
-fn results_path() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/results/results.jsonl")
-}
-
-fn run_provenance() -> (Option<String>, Option<String>) {
-    let sha = std::process::Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .output()
-        .ok()
-        .and_then(|o| {
-            if o.status.success() {
-                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
-            } else {
-                None
-            }
-        });
-    let ts = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .ok()
-        .map(|d| format!("{}s", d.as_secs()));
-    (sha, ts)
-}
-
-fn discover_specs() -> Vec<BenchSpec> {
-    let dir = fixture_dir();
-    let Ok(read) = std::fs::read_dir(&dir) else {
-        return Vec::new();
-    };
-    let mut specs: Vec<_> = read
-        .filter_map(Result::ok)
-        .map(|e| e.path())
-        .filter(|p| p.extension().is_some_and(|x| x == "s"))
-        .map(|fixture| {
-            let id = fixture
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or("unknown")
-                .to_string();
-            BenchSpec {
-                id,
-                fixture,
-                phase: 2,
-                algorithm: Algorithm::Enumerative,
-                cost_metric: CostMetric::InstructionCount,
-                seed: 42,
-                timeout: Duration::from_secs(30),
-            }
-        })
-        .collect();
-    specs.sort_by(|a, b| a.id.cmp(&b.id));
-    specs
-}
-
 fn phase2(c: &mut Criterion) {
-    let specs = discover_specs();
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/llvm_codegen");
+    let specs = discover_specs_in(&dir, 2);
     if specs.is_empty() {
         eprintln!(
-            "no Phase 2 fixtures under benches/llvm_codegen/ — run \
-             scripts/harvest_llvm_codegen.sh to populate. Skipping group."
+            "no Phase 2 fixtures under {} — run scripts/harvest_llvm_codegen.sh to populate. \
+             Skipping.",
+            dir.display()
         );
         return;
     }
-
     let (git_sha, timestamp_utc) = run_provenance();
-    let results = results_path();
+    let out = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/results/results.jsonl");
 
     let mut group = c.benchmark_group("llvm_codegen");
     group.sample_size(10);
@@ -92,7 +29,7 @@ fn phase2(c: &mut Criterion) {
         let spec_owned = spec.clone();
         let sha = git_sha.clone();
         let ts = timestamp_utc.clone();
-        let out = results.clone();
+        let out = out.clone();
         group.bench_function(spec_owned.id.clone(), |b| {
             let mut next_sample = 0u32;
             b.iter_custom(|iters| {

--- a/benches/llvm_codegen.rs
+++ b/benches/llvm_codegen.rs
@@ -1,4 +1,118 @@
-// Phase 2 — LLVM AArch64 codegen sample. Placeholder; real body
-// lands once the harvester script has populated benches/llvm_codegen/.
+//! Phase 2 — LLVM AArch64 codegen sample.
+//!
+//! Mirrors `benches/hackers_delight.rs` (phase=2). Fixtures are
+//! harvested by `scripts/harvest_llvm_codegen.sh` and live under
+//! `benches/llvm_codegen/`. The fixture set is intentionally absent
+//! from the repo at HEAD — the bench gracefully skips when no `.s`
+//! files are present, so `just bench` keeps passing on a fresh
+//! checkout that has not yet run the harvester.
 
-fn main() {}
+use criterion::{Criterion, criterion_group, criterion_main};
+use s11::bench_support::{BenchRecord, BenchSpec, append_json, run_bench};
+use s11::search::config::Algorithm;
+use s11::semantics::cost::CostMetric;
+use std::path::PathBuf;
+use std::time::Duration;
+
+fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/llvm_codegen")
+}
+
+fn results_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/results/results.jsonl")
+}
+
+fn run_provenance() -> (Option<String>, Option<String>) {
+    let sha = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            } else {
+                None
+            }
+        });
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .map(|d| format!("{}s", d.as_secs()));
+    (sha, ts)
+}
+
+fn discover_specs() -> Vec<BenchSpec> {
+    let dir = fixture_dir();
+    let Ok(read) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    let mut specs: Vec<_> = read
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|x| x == "s"))
+        .map(|fixture| {
+            let id = fixture
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("unknown")
+                .to_string();
+            BenchSpec {
+                id,
+                fixture,
+                phase: 2,
+                algorithm: Algorithm::Enumerative,
+                cost_metric: CostMetric::InstructionCount,
+                seed: 42,
+                timeout: Duration::from_secs(30),
+            }
+        })
+        .collect();
+    specs.sort_by(|a, b| a.id.cmp(&b.id));
+    specs
+}
+
+fn phase2(c: &mut Criterion) {
+    let specs = discover_specs();
+    if specs.is_empty() {
+        eprintln!(
+            "no Phase 2 fixtures under benches/llvm_codegen/ — run \
+             scripts/harvest_llvm_codegen.sh to populate. Skipping group."
+        );
+        return;
+    }
+
+    let (git_sha, timestamp_utc) = run_provenance();
+    let results = results_path();
+
+    let mut group = c.benchmark_group("llvm_codegen");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(10));
+
+    for spec in &specs {
+        let spec_owned = spec.clone();
+        let sha = git_sha.clone();
+        let ts = timestamp_utc.clone();
+        let out = results.clone();
+        group.bench_function(spec_owned.id.clone(), |b| {
+            let mut next_sample = 0u32;
+            b.iter_custom(|iters| {
+                let mut total = Duration::ZERO;
+                for _ in 0..iters {
+                    let mut record: BenchRecord = run_bench(&spec_owned, next_sample);
+                    record.git_sha = sha.clone();
+                    record.timestamp_utc = ts.clone();
+                    let elapsed = Duration::from_millis(record.search_elapsed_ms);
+                    append_json(&record, &out);
+                    total += elapsed;
+                    next_sample = next_sample.wrapping_add(1);
+                }
+                total
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, phase2);
+criterion_main!(benches);

--- a/benches/llvm_codegen.rs
+++ b/benches/llvm_codegen.rs
@@ -1,0 +1,4 @@
+// Phase 2 — LLVM AArch64 codegen sample. Placeholder; real body
+// lands once the harvester script has populated benches/llvm_codegen/.
+
+fn main() {}

--- a/benches/llvm_codegen.rs
+++ b/benches/llvm_codegen.rs
@@ -3,7 +3,7 @@
 //! `benches/llvm_codegen/` is empty.
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use s11::bench_support::{BenchRecord, append_json, discover_specs_in, run_bench, run_provenance};
+use s11::bench_support::{append_json, discover_specs_in, run_bench, run_provenance};
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -26,22 +26,17 @@ fn phase2(c: &mut Criterion) {
     group.measurement_time(Duration::from_secs(10));
 
     for spec in &specs {
+        let mut record = run_bench(spec);
+        record.git_sha = git_sha.clone();
+        record.timestamp_utc = timestamp_utc.clone();
+        append_json(&record, &out);
+
         let spec_owned = spec.clone();
-        let sha = git_sha.clone();
-        let ts = timestamp_utc.clone();
-        let out = out.clone();
         group.bench_function(spec_owned.id.clone(), |b| {
-            let mut next_sample = 0u32;
             b.iter_custom(|iters| {
                 let mut total = Duration::ZERO;
                 for _ in 0..iters {
-                    let mut record: BenchRecord = run_bench(&spec_owned, next_sample);
-                    record.git_sha = sha.clone();
-                    record.timestamp_utc = ts.clone();
-                    let elapsed = record.search_elapsed;
-                    append_json(&record, &out);
-                    total += elapsed;
-                    next_sample = next_sample.wrapping_add(1);
+                    total += run_bench(&spec_owned).search_elapsed;
                 }
                 total
             });

--- a/benches/llvm_codegen/README.md
+++ b/benches/llvm_codegen/README.md
@@ -1,0 +1,26 @@
+# Phase 2 — LLVM AArch64 codegen fixtures
+
+This directory hosts AArch64 basic blocks harvested from
+`llvm-project/llvm/test/CodeGen/AArch64/`. The fixtures themselves are
+not committed yet — run the harvester to populate:
+
+```bash
+scripts/harvest_llvm_codegen.sh [SEED] [SAMPLE_SIZE]
+```
+
+The script shallow-clones llvm-project, samples `.ll` files
+deterministically, runs `llc -mtriple=aarch64-linux-gnu -O2`, filters
+output to s11-supported mnemonics (see `CLAUDE.md:11`), and writes
+each surviving block as `<sha>_<offset>.s` with `// Source:` and
+`// Live-out:` headers.
+
+Review with `git status -- benches/llvm_codegen` and commit the
+generated `.s` files. The Phase 2 criterion bench
+(`benches/llvm_codegen.rs`) gracefully skips when this directory is
+empty, so CI / `just bench` still passes on a fresh checkout.
+
+## Refreshing the corpus
+
+Re-run the harvester with the same seed to deterministically refresh,
+or pick a new seed to draw a different sample. Diff the result, drop
+fixtures that look uninteresting, and commit.

--- a/scripts/harvest_llvm_codegen.sh
+++ b/scripts/harvest_llvm_codegen.sh
@@ -155,3 +155,10 @@ done
 
 echo "[4/4] wrote $kept fixtures to $OUT_DIR"
 echo "Review them with:   git -C $(git rev-parse --show-toplevel) status -- benches/llvm_codegen"
+echo
+echo "WARNING: every fixture inherits a hardcoded \`// Live-out: x0\` header."
+echo "         If the underlying basic block writes its result to a different"
+echo "         register (e.g. x8, x9, or a callee-saved reg), hand-edit the"
+echo "         header before committing — otherwise the benchmark will be"
+echo "         observing the wrong state. Per-block live-out inference is"
+echo "         tracked in https://github.com/pmatos/s11/issues/287."

--- a/scripts/harvest_llvm_codegen.sh
+++ b/scripts/harvest_llvm_codegen.sh
@@ -73,20 +73,63 @@ done
 MNEMONIC_RE="${MNEMONIC_RE%|})[[:space:]]"
 
 # 4. Run llc on each sample, emit .s blocks the s11 parser can consume.
+#
+# The body extractor is an awk state machine. It walks the llc output
+# one line at a time and accumulates a candidate straight-line block
+# composed only of supported-mnemonic instruction lines. A block ends
+# when any of these is hit:
+#   - a label                                    (start of next block)
+#   - a branch/return terminator (b/br/bl/blr/ret/cbz/cbnz/tbz/tbnz/b.cond)
+# Assembler directives and comments don't break a block (they're
+# noise inside a single function), but an unsupported instruction
+# disqualifies the currently-accumulating block — the harvester does
+# not silently splice supported lines across an unsupported one.
+#
+# The first qualifying block (2..32 supported instructions) is emitted
+# and awk exits. This guarantees one straight-line block per fixture,
+# preventing the previous behaviour of grep'ing across multiple basic
+# blocks / functions and gluing unrelated paths together (PR #269 review).
 echo "[3/4] running llc and extracting basic blocks..."
 kept=0
 for ll in "${SAMPLES[@]}"; do
     base="$(basename "${ll%.ll}")"
     asm="$(llc -mtriple=aarch64-linux-gnu -O2 -filetype=asm -o - "$ll" 2>/dev/null)" || continue
 
-    # Drop everything outside basic blocks: keep only lines whose first
-    # token is one of the supported mnemonics. This is conservative —
-    # genuine constants and directives are dropped, but the parser only
-    # handles instructions anyway.
-    body="$(printf '%s\n' "$asm" | grep -E "$MNEMONIC_RE" || true)"
-    # Skip empty or trivially short bodies.
-    insn_count="$(printf '%s\n' "$body" | grep -c '[^[:space:]]' || true)"
-    if (( insn_count < 2 || insn_count > 32 )); then
+    body="$(printf '%s\n' "$asm" | awk -v mnemonic_re="$MNEMONIC_RE" '
+        BEGIN { block = ""; count = 0; supported = 1; done = 0 }
+        function finish() {
+            if (supported && count >= 2 && count <= 32) {
+                print block
+                done = 1
+                exit 0
+            }
+            block = ""; count = 0; supported = 1
+        }
+        # Blank lines and stripped comments — keep accumulating.
+        /^[[:space:]]*$/ { next }
+        /^[[:space:]]*\/\// { next }
+        # Assembler directives (.text, .cfi_*, etc.) — keep accumulating.
+        /^[[:space:]]*\./ { next }
+        # Labels close the current block.
+        /^[[:space:]]*[A-Za-z_.][A-Za-z0-9_.]*:/ { finish(); next }
+        # Branch / return terminators close the current block.
+        /^[[:space:]]*(b|br|bl|blr|ret|cbz|cbnz|tbz|tbnz)([[:space:]]|$)/ { finish(); next }
+        /^[[:space:]]*b\.[a-z]+([[:space:]]|$)/ { finish(); next }
+        # Supported instruction — append to the in-flight block.
+        $0 ~ mnemonic_re {
+            block = (count == 0 ? $0 : block "\n" $0)
+            count++
+            next
+        }
+        # Any other instruction disqualifies the block.
+        { supported = 0 }
+        # END fires even after `exit 0`, so guard against double-emit.
+        END { if (!done) finish() }
+    ')"
+
+    # awk emits a block only on success; an empty body means no
+    # qualifying block was found in this .ll.
+    if [[ -z "$body" ]]; then
         continue
     fi
 

--- a/scripts/harvest_llvm_codegen.sh
+++ b/scripts/harvest_llvm_codegen.sh
@@ -53,12 +53,16 @@ mapfile -t SAMPLES < <(
 OUT_DIR="$(git rev-parse --show-toplevel)/benches/llvm_codegen"
 mkdir -p "$OUT_DIR"
 
-# Supported AArch64 mnemonics — keep in sync with CLAUDE.md:11.
+# Supported AArch64 mnemonics — keep in sync with CLAUDE.md:11 and the
+# top-level mnemonic dispatch in src/parser/mod.rs. `uxtw` is intentionally
+# omitted: the parser handles it as an extend-operand modifier only, not
+# as a standalone instruction, so a harvested block containing it would
+# panic in load_sequence at bench time.
 SUPPORTED_MNEMONICS=(
     mov add sub and orr eor lsl lsr asr mul sdiv udiv cmp cmn tst
     csel csinc csinv csneg madd msub mneg smulh umulh ccmp ccmn
     ubfx sbfx bfi bfxil ubfiz sbfiz
-    sxtb sxth sxtw uxtb uxth uxtw
+    sxtb sxth sxtw uxtb uxth
 )
 
 # Build a regex matching exactly one supported mnemonic at line start.

--- a/scripts/harvest_llvm_codegen.sh
+++ b/scripts/harvest_llvm_codegen.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Phase 2 — harvest AArch64 basic blocks from llvm-project's
+# test/CodeGen/AArch64 corpus into benches/llvm_codegen/.
+#
+# Maintainer-run, NOT bench-time. Output `.s` files are committed
+# alongside the bench target.
+#
+# Usage:
+#   scripts/harvest_llvm_codegen.sh [SEED] [SAMPLE_SIZE]
+#
+# Env:
+#   LLVM_CACHE  Directory for the cached llvm-project clone
+#               (default /tmp/s11-llvm).
+
+set -euo pipefail
+
+SEED="${1:-42}"
+SAMPLE_SIZE="${2:-30}"
+LLVM_CACHE="${LLVM_CACHE:-/tmp/s11-llvm}"
+
+# 1. Precheck: llc must include the AArch64 backend.
+if ! llc --version 2>/dev/null | grep -qE '^\s*aarch64\b'; then
+    echo "error: llc lacks the AArch64 backend" >&2
+    echo "       reinstall LLVM with AArch64 enabled or set PATH to a build that includes it." >&2
+    exit 2
+fi
+
+# 2. Clone (shallow) or update the llvm-project cache.
+if [[ ! -d "$LLVM_CACHE/.git" ]]; then
+    echo "[1/4] cloning llvm-project shallow into $LLVM_CACHE..."
+    git clone --depth=1 --filter=blob:none \
+        https://github.com/llvm/llvm-project.git "$LLVM_CACHE"
+else
+    echo "[1/4] refreshing llvm-project cache at $LLVM_CACHE..."
+    git -C "$LLVM_CACHE" fetch --depth=1 origin main >/dev/null 2>&1 || true
+    git -C "$LLVM_CACHE" reset --hard origin/main >/dev/null 2>&1 || true
+fi
+
+TEST_DIR="$LLVM_CACHE/llvm/test/CodeGen/AArch64"
+if [[ ! -d "$TEST_DIR" ]]; then
+    echo "error: expected $TEST_DIR after clone" >&2
+    exit 3
+fi
+
+# 3. Sample $SAMPLE_SIZE .ll files deterministically.
+echo "[2/4] sampling $SAMPLE_SIZE .ll files (seed=$SEED)..."
+mapfile -t SAMPLES < <(
+    find "$TEST_DIR" -maxdepth 1 -type f -name '*.ll' |
+        sort |
+        shuf --random-source=<(yes "$SEED" 2>/dev/null) -n "$SAMPLE_SIZE"
+)
+
+OUT_DIR="$(git rev-parse --show-toplevel)/benches/llvm_codegen"
+mkdir -p "$OUT_DIR"
+
+# Supported AArch64 mnemonics — keep in sync with CLAUDE.md:11.
+SUPPORTED_MNEMONICS=(
+    mov add sub and orr eor lsl lsr asr mul sdiv udiv cmp cmn tst
+    csel csinc csinv csneg madd msub mneg smulh umulh ccmp ccmn
+    ubfx sbfx bfi bfxil ubfiz sbfiz
+    sxtb sxth sxtw uxtb uxth uxtw
+)
+
+# Build a regex matching exactly one supported mnemonic at line start.
+MNEMONIC_RE="^[[:space:]]*("
+for m in "${SUPPORTED_MNEMONICS[@]}"; do
+    MNEMONIC_RE+="$m|"
+done
+MNEMONIC_RE="${MNEMONIC_RE%|})[[:space:]]"
+
+# 4. Run llc on each sample, emit .s blocks the s11 parser can consume.
+echo "[3/4] running llc and extracting basic blocks..."
+kept=0
+for ll in "${SAMPLES[@]}"; do
+    base="$(basename "${ll%.ll}")"
+    asm="$(llc -mtriple=aarch64-linux-gnu -O2 -filetype=asm -o - "$ll" 2>/dev/null)" || continue
+
+    # Drop everything outside basic blocks: keep only lines whose first
+    # token is one of the supported mnemonics. This is conservative —
+    # genuine constants and directives are dropped, but the parser only
+    # handles instructions anyway.
+    body="$(printf '%s\n' "$asm" | grep -E "$MNEMONIC_RE" || true)"
+    # Skip empty or trivially short bodies.
+    insn_count="$(printf '%s\n' "$body" | grep -c '[^[:space:]]' || true)"
+    if (( insn_count < 2 || insn_count > 32 )); then
+        continue
+    fi
+
+    out="$OUT_DIR/${base}.s"
+    {
+        printf '// Source: llvm-project/llvm/test/CodeGen/AArch64/%s\n' "$(basename "$ll")"
+        printf '// Live-in: x0, x1\n'
+        printf '// Live-out: x0\n'
+        printf '%s\n' "$body"
+    } > "$out"
+    kept=$((kept+1))
+done
+
+echo "[4/4] wrote $kept fixtures to $OUT_DIR"
+echo "Review them with:   git -C $(git rev-parse --show-toplevel) status -- benches/llvm_codegen"

--- a/scripts/harvest_llvm_codegen.sh
+++ b/scripts/harvest_llvm_codegen.sh
@@ -5,6 +5,10 @@
 # Maintainer-run, NOT bench-time. Output `.s` files are committed
 # alongside the bench target.
 #
+# Requires GNU coreutils — `shuf --random-source` is a GNU extension
+# and is not available on stock macOS / BSD shuf. On macOS install
+# coreutils via Homebrew and use `gshuf`, or run this on Linux.
+#
 # Usage:
 #   scripts/harvest_llvm_codegen.sh [SEED] [SAMPLE_SIZE]
 #
@@ -22,6 +26,12 @@ LLVM_CACHE="${LLVM_CACHE:-/tmp/s11-llvm}"
 if ! llc --version 2>/dev/null | grep -qE '^\s*aarch64\b'; then
     echo "error: llc lacks the AArch64 backend" >&2
     echo "       reinstall LLVM with AArch64 enabled or set PATH to a build that includes it." >&2
+    exit 2
+fi
+# Precheck: GNU shuf with --random-source. BSD shuf rejects the flag.
+if ! shuf --help 2>&1 | grep -q -- '--random-source'; then
+    echo "error: this script needs GNU coreutils shuf (--random-source for deterministic sampling)" >&2
+    echo "       on macOS:  brew install coreutils  and substitute gshuf, or run on Linux." >&2
     exit 2
 fi
 

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -8,9 +8,14 @@
 
 use crate::ir::Instruction;
 use crate::parser::{LineResult, parse_line};
+use crate::search::SearchAlgorithm;
+use crate::search::config::{Algorithm, SearchConfig};
+use crate::semantics::cost::{CostMetric, sequence_cost};
 use crate::semantics::live_out::LiveOut;
 use crate::validation::live_out::parse_live_out_contract;
-use std::path::Path;
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 /// Parse a benchmark `.s` fixture into its target sequence plus the
 /// live-out contract declared in its `// Live-out:` header.
@@ -62,6 +67,116 @@ pub fn load_sequence(path: &Path) -> (Vec<Instruction>, LiveOut, bool) {
     (sequence, live_out, flags_live)
 }
 
+/// One row of the benchmark JSON-Lines output. See
+/// `benches/common/schema.md` (added in step 8) for the canonical
+/// field listing.
+#[derive(Debug, Clone, Serialize)]
+pub struct BenchRecord {
+    pub benchmark_id: String,
+    pub sample_index: u32,
+    pub phase: u8,
+    pub algorithm: String,
+    pub seed: u64,
+    pub cost_metric: String,
+    pub original_length: usize,
+    pub found_length: Option<usize>,
+    pub original_cost: u64,
+    pub best_cost: u64,
+    pub search_elapsed_ms: u64,
+    pub smt_elapsed_ms: u64,
+    pub smt_queries: u64,
+    pub smt_equivalent: u64,
+    pub candidates_evaluated: u64,
+    pub success: bool,
+    pub timeout: bool,
+    pub git_sha: Option<String>,
+    pub timestamp_utc: Option<String>,
+}
+
+/// Spec for one benchmark — derived from the fixture path and the
+/// surrounding bench file. `sample_index` is supplied separately by
+/// `run_bench` so the same spec can drive criterion's per-sample loop.
+#[derive(Debug, Clone)]
+pub struct BenchSpec {
+    pub id: String,
+    pub fixture: PathBuf,
+    pub phase: u8,
+    pub algorithm: Algorithm,
+    pub cost_metric: CostMetric,
+    pub seed: u64,
+    pub timeout: Duration,
+}
+
+/// Run the optimizer against one fixture and synthesise a `BenchRecord`.
+///
+/// `sample_index` is mixed into the stochastic seed so multiple
+/// criterion samples explore independent RNG trajectories while staying
+/// deterministic given `(spec.seed, sample_index)`. Non-stochastic
+/// algorithms ignore the seed entirely.
+pub fn run_bench(spec: &BenchSpec, sample_index: u32) -> BenchRecord {
+    let (target, live_out, _flags_live) = load_sequence(&spec.fixture);
+    let original_length = target.len();
+    let original_cost = sequence_cost(&target, &spec.cost_metric);
+
+    let effective_seed = spec.seed.wrapping_add(sample_index as u64);
+    let mut config = SearchConfig::default()
+        .with_algorithm(spec.algorithm)
+        .with_cost_metric(spec.cost_metric)
+        .with_timeout(spec.timeout);
+    config.stochastic.seed = Some(effective_seed);
+
+    let (statistics, optimized) = match spec.algorithm {
+        Algorithm::Enumerative => {
+            let mut search = crate::search::EnumerativeSearch::new();
+            let result = search.search(&target, &live_out, &config);
+            (result.statistics, result.optimized_sequence)
+        }
+        Algorithm::Stochastic => {
+            let mut search = crate::search::StochasticSearch::<crate::isa::AArch64>::new();
+            let result = search.search(&target, &live_out, &config);
+            (result.statistics, result.optimized_sequence)
+        }
+        Algorithm::Symbolic => {
+            let mut search = crate::search::SymbolicSearch::<crate::isa::AArch64>::new();
+            let result = search.search(&target, &live_out, &config);
+            (result.statistics, result.optimized_sequence)
+        }
+        // Hybrid/LLM not wired into the bench harness — issue #70 keeps
+        // those out of scope. Caller should pre-filter.
+        other => panic!("run_bench: unsupported algorithm {other:?}"),
+    };
+
+    let found_length = optimized.as_ref().map(|s| s.len());
+    let best_cost = optimized
+        .as_ref()
+        .map(|s| sequence_cost(s, &spec.cost_metric))
+        .unwrap_or(original_cost);
+    let success = optimized.is_some();
+    let timed_out = statistics.elapsed_time >= spec.timeout;
+
+    BenchRecord {
+        benchmark_id: spec.id.clone(),
+        sample_index,
+        phase: spec.phase,
+        algorithm: spec.algorithm.to_string(),
+        seed: effective_seed,
+        cost_metric: format!("{:?}", spec.cost_metric).to_ascii_lowercase(),
+        original_length,
+        found_length,
+        original_cost,
+        best_cost,
+        search_elapsed_ms: statistics.elapsed_time.as_millis() as u64,
+        smt_elapsed_ms: statistics.smt_elapsed.as_millis() as u64,
+        smt_queries: statistics.smt_queries,
+        smt_equivalent: statistics.smt_equivalent,
+        candidates_evaluated: statistics.candidates_evaluated,
+        success,
+        timeout: timed_out,
+        git_sha: None,
+        timestamp_utc: None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -106,5 +221,42 @@ mod tests {
     fn load_sequence_panics_without_header() {
         let f = write_fixture("mov x0, #0\n");
         let _ = load_sequence(f.path());
+    }
+
+    #[test]
+    fn run_bench_enumerative_records_metrics_for_fusible_target() {
+        // `mov x0, x1; add x0, x0, #1` collapses into `add x0, x1, #1`
+        // under enumerative search — original_length=2 must shrink to
+        // found_length=1, success=true, and metrics must be populated.
+        let f = write_fixture(
+            "// Live-out: x0\n\
+             mov x0, x1\n\
+             add x0, x0, #1\n",
+        );
+        let spec = BenchSpec {
+            id: "mov_add_fuse".to_string(),
+            fixture: f.path().to_path_buf(),
+            phase: 1,
+            algorithm: Algorithm::Enumerative,
+            cost_metric: CostMetric::InstructionCount,
+            seed: 42,
+            timeout: Duration::from_secs(30),
+        };
+
+        let record = run_bench(&spec, 0);
+
+        assert_eq!(record.benchmark_id, "mov_add_fuse");
+        assert_eq!(record.sample_index, 0);
+        assert_eq!(record.phase, 1);
+        assert_eq!(record.algorithm, "enumerative");
+        assert_eq!(record.seed, 42);
+        assert_eq!(record.original_length, 2);
+        assert_eq!(record.original_cost, 2);
+        assert!(record.success, "fusion target should succeed");
+        assert_eq!(record.found_length, Some(1));
+        assert_eq!(record.best_cost, 1);
+        assert!(record.smt_queries > 0, "enumerative search must hit SMT");
+        assert!(record.candidates_evaluated > 0);
+        assert!(!record.timeout);
     }
 }

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -118,6 +118,13 @@ pub fn load_sequence(path: &Path) -> (Vec<Instruction>, LiveOut, bool) {
         }
     }
 
+    assert!(
+        !sequence.is_empty(),
+        "fixture {} parsed to zero instructions — bench fixtures must declare a body \
+         after the // Live-out: header (see benches/README.md)",
+        path.display()
+    );
+
     (sequence, live_out, flags_live)
 }
 
@@ -153,7 +160,12 @@ pub struct BenchRecord {
     pub smt_queries: u64,
     pub smt_equivalent: u64,
     pub candidates_evaluated: u64,
-    pub success: bool,
+    /// `true` if the search returned a strictly cheaper sequence than
+    /// the target. Note: this does NOT mean "search ran without error" —
+    /// a timeout that finds no improvement also reports `improved: false`.
+    /// Combine with `timeout` to distinguish "explored fully, no win"
+    /// from "ran out of time."
+    pub improved: bool,
     pub timeout: bool,
     pub git_sha: Option<String>,
     pub timestamp_utc: Option<String>,
@@ -247,7 +259,7 @@ pub fn run_bench(spec: &BenchSpec) -> BenchRecord {
         .as_ref()
         .map(|s| sequence_cost(s, &spec.cost_metric))
         .unwrap_or(original_cost);
-    let success = optimized.is_some();
+    let improved = optimized.is_some();
     let timed_out = statistics.elapsed_time >= spec.timeout;
 
     BenchRecord {
@@ -266,7 +278,7 @@ pub fn run_bench(spec: &BenchSpec) -> BenchRecord {
         smt_queries: statistics.smt_queries,
         smt_equivalent: statistics.smt_equivalent,
         candidates_evaluated: statistics.candidates_evaluated,
-        success,
+        improved,
         timeout: timed_out,
         git_sha: None,
         timestamp_utc: None,
@@ -339,7 +351,7 @@ mod tests {
             smt_queries: 3,
             smt_equivalent: 1,
             candidates_evaluated: 20,
-            success: true,
+            improved: true,
             timeout: false,
             git_sha: None,
             timestamp_utc: None,
@@ -397,7 +409,7 @@ mod tests {
     fn run_bench_enumerative_records_metrics_for_fusible_target() {
         // `mov x0, x1; add x0, x0, #1` collapses into `add x0, x1, #1`
         // under enumerative search — original_length=2 must shrink to
-        // found_length=1, success=true, and metrics must be populated.
+        // found_length=1, improved=true, and metrics must be populated.
         let f = write_fixture(
             "// Live-out: x0\n\
              mov x0, x1\n\
@@ -421,7 +433,10 @@ mod tests {
         assert_eq!(record.seed, 42);
         assert_eq!(record.original_length, 2);
         assert_eq!(record.original_cost, 2);
-        assert!(record.success, "fusion target should succeed");
+        assert!(
+            record.improved,
+            "fusion target should produce an improvement"
+        );
         assert_eq!(record.found_length, Some(1));
         assert_eq!(record.best_cost, 1);
         assert!(record.smt_queries > 0, "enumerative search must hit SMT");

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -293,6 +293,34 @@ mod tests {
         }
     }
 
+    /// Smoke-test every shipped Hacker's Delight fixture: each must
+    /// parse via `load_sequence` without panicking. Catches typos in
+    /// the fixture set without depending on running the optimizer.
+    #[test]
+    fn every_phase1_fixture_parses() {
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        let dir = std::path::Path::new(manifest_dir).join("benches/hackers_delight");
+        let entries: Vec<_> = std::fs::read_dir(&dir)
+            .expect("benches/hackers_delight must exist")
+            .filter_map(Result::ok)
+            .filter(|e| e.path().extension().is_some_and(|x| x == "s"))
+            .collect();
+        assert!(
+            entries.len() >= 15,
+            "expected at least 15 Phase 1 fixtures, found {}",
+            entries.len()
+        );
+        for entry in entries {
+            let path = entry.path();
+            let (seq, _live_out, _flags_live) = load_sequence(&path);
+            assert!(
+                !seq.is_empty(),
+                "fixture {} parsed to an empty sequence",
+                path.display()
+            );
+        }
+    }
+
     #[test]
     fn run_bench_enumerative_records_metrics_for_fusible_target() {
         // `mov x0, x1; add x0, x0, #1` collapses into `add x0, x1, #1`

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -121,13 +121,16 @@ pub fn load_sequence(path: &Path) -> (Vec<Instruction>, LiveOut, bool) {
     (sequence, live_out, flags_live)
 }
 
-/// One row of the benchmark JSON-Lines output. See
-/// `benches/common/schema.md` (added in step 8) for the canonical
-/// field listing.
+/// One canonical record per `(benchmark_id, cargo bench invocation)`.
+///
+/// JSON emission is gated to a single call site outside criterion's
+/// `iter_custom`, so the JSONL accumulator contains exactly one row
+/// per fixture per `cargo bench` run. Criterion's HTML report owns the
+/// per-sample variance; this record is the snapshot downstream tooling
+/// diffs across commits.
 #[derive(Debug, Clone, Serialize)]
 pub struct BenchRecord {
     pub benchmark_id: String,
-    pub sample_index: u32,
     pub phase: u8,
     pub algorithm: String,
     pub seed: u64,
@@ -187,8 +190,7 @@ pub fn append_json(record: &BenchRecord, path: &Path) {
 }
 
 /// Spec for one benchmark — derived from the fixture path and the
-/// surrounding bench file. `sample_index` is supplied separately by
-/// `run_bench` so the same spec can drive criterion's per-sample loop.
+/// surrounding bench file.
 #[derive(Debug, Clone)]
 pub struct BenchSpec {
     pub id: String,
@@ -202,21 +204,22 @@ pub struct BenchSpec {
 
 /// Run the optimizer against one fixture and synthesise a `BenchRecord`.
 ///
-/// `sample_index` is mixed into the stochastic seed so multiple
-/// criterion samples explore independent RNG trajectories while staying
-/// deterministic given `(spec.seed, sample_index)`. Non-stochastic
-/// algorithms ignore the seed entirely.
-pub fn run_bench(spec: &BenchSpec, sample_index: u32) -> BenchRecord {
+/// Deterministic given `spec.seed`. Bench drivers call this **once per
+/// `cargo bench` invocation** outside criterion's `iter_custom` so the
+/// JSON-Lines accumulator stays exactly one record per fixture —
+/// criterion's warmup phase would otherwise emit unmeasured records
+/// (PR #269 review). Inside `iter_custom`, drivers re-call `run_bench`
+/// just to read `search_elapsed` for criterion's timing model.
+pub fn run_bench(spec: &BenchSpec) -> BenchRecord {
     let (target, live_out, _flags_live) = load_sequence(&spec.fixture);
     let original_length = target.len();
     let original_cost = sequence_cost(&target, &spec.cost_metric);
 
-    let effective_seed = spec.seed.wrapping_add(sample_index as u64);
     let mut config = SearchConfig::default()
         .with_algorithm(spec.algorithm)
         .with_cost_metric(spec.cost_metric)
         .with_timeout(spec.timeout);
-    config.stochastic.seed = Some(effective_seed);
+    config.stochastic.seed = Some(spec.seed);
 
     let (statistics, optimized) = match spec.algorithm {
         Algorithm::Enumerative => {
@@ -249,10 +252,9 @@ pub fn run_bench(spec: &BenchSpec, sample_index: u32) -> BenchRecord {
 
     BenchRecord {
         benchmark_id: spec.id.clone(),
-        sample_index,
         phase: spec.phase,
         algorithm: spec.algorithm.to_string(),
-        seed: effective_seed,
+        seed: spec.seed,
         cost_metric: format!("{:?}", spec.cost_metric).to_ascii_lowercase(),
         original_length,
         found_length,
@@ -323,7 +325,6 @@ mod tests {
         let path = dir.path().join("results.jsonl");
         let record = BenchRecord {
             benchmark_id: "demo".to_string(),
-            sample_index: 0,
             phase: 1,
             algorithm: "enumerative".to_string(),
             seed: 7,
@@ -345,17 +346,18 @@ mod tests {
         };
         append_json(&record, &path);
         let mut second = record.clone();
-        second.sample_index = 1;
+        second.benchmark_id = "demo-2".to_string();
         append_json(&second, &path);
 
         let body = std::fs::read_to_string(&path).expect("read jsonl");
         let lines: Vec<&str> = body.lines().collect();
         assert_eq!(lines.len(), 2, "two appends → two lines");
-        for line in &lines {
-            let parsed: serde_json::Value =
-                serde_json::from_str(line).expect("each line must be valid JSON");
-            assert_eq!(parsed["benchmark_id"], "demo");
-        }
+        let parsed: Vec<serde_json::Value> = lines
+            .iter()
+            .map(|l| serde_json::from_str(l).expect("each line must be valid JSON"))
+            .collect();
+        assert_eq!(parsed[0]["benchmark_id"], "demo");
+        assert_eq!(parsed[1]["benchmark_id"], "demo-2");
     }
 
     /// Smoke-test every shipped fixture (Phase 1 + Phase 3): each
@@ -411,10 +413,9 @@ mod tests {
             timeout: Duration::from_secs(30),
         };
 
-        let record = run_bench(&spec, 0);
+        let record = run_bench(&spec);
 
         assert_eq!(record.benchmark_id, "mov_add_fuse");
-        assert_eq!(record.sample_index, 0);
         assert_eq!(record.phase, 1);
         assert_eq!(record.algorithm, "enumerative");
         assert_eq!(record.seed, 42);

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -293,31 +293,36 @@ mod tests {
         }
     }
 
-    /// Smoke-test every shipped Hacker's Delight fixture: each must
-    /// parse via `load_sequence` without panicking. Catches typos in
-    /// the fixture set without depending on running the optimizer.
+    /// Smoke-test every shipped fixture (Phase 1 + Phase 3): each
+    /// must parse via `load_sequence` without panicking. Catches typos
+    /// in the fixture set without depending on running the optimizer.
+    /// Phase 2 (benches/llvm_codegen/) is intentionally skipped — that
+    /// directory is empty in HEAD and only populated by the
+    /// harvester.
     #[test]
-    fn every_phase1_fixture_parses() {
+    fn every_committed_fixture_parses() {
         let manifest_dir = env!("CARGO_MANIFEST_DIR");
-        let dir = std::path::Path::new(manifest_dir).join("benches/hackers_delight");
-        let entries: Vec<_> = std::fs::read_dir(&dir)
-            .expect("benches/hackers_delight must exist")
-            .filter_map(Result::ok)
-            .filter(|e| e.path().extension().is_some_and(|x| x == "s"))
-            .collect();
-        assert!(
-            entries.len() >= 15,
-            "expected at least 15 Phase 1 fixtures, found {}",
-            entries.len()
-        );
-        for entry in entries {
-            let path = entry.path();
-            let (seq, _live_out, _flags_live) = load_sequence(&path);
+        for sub in ["benches/hackers_delight", "benches/algebraic_fusion"] {
+            let dir = std::path::Path::new(manifest_dir).join(sub);
+            let entries: Vec<_> = std::fs::read_dir(&dir)
+                .unwrap_or_else(|e| panic!("read {}: {e}", dir.display()))
+                .filter_map(Result::ok)
+                .filter(|e| e.path().extension().is_some_and(|x| x == "s"))
+                .collect();
             assert!(
-                !seq.is_empty(),
-                "fixture {} parsed to an empty sequence",
-                path.display()
+                entries.len() >= 10,
+                "expected at least 10 fixtures under {sub}, found {}",
+                entries.len()
             );
+            for entry in entries {
+                let path = entry.path();
+                let (seq, _live_out, _flags_live) = load_sequence(&path);
+                assert!(
+                    !seq.is_empty(),
+                    "fixture {} parsed to an empty sequence",
+                    path.display()
+                );
+            }
         }
     }
 

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -136,7 +136,16 @@ pub struct BenchRecord {
     pub found_length: Option<usize>,
     pub original_cost: u64,
     pub best_cost: u64,
+    /// Truncated to milliseconds for the JSON-Lines record so the file
+    /// is easy to skim. Bench files MUST use [`BenchRecord::search_elapsed`]
+    /// (precise `Duration`) when feeding criterion's `iter_custom`, or
+    /// sub-millisecond samples round to zero — see PR #269 review.
     pub search_elapsed_ms: u64,
+    /// Full-precision wall time of the search. Excluded from the JSON
+    /// serialization because `search_elapsed_ms` is the documented
+    /// schema field; this is the value criterion's timing model needs.
+    #[serde(skip)]
+    pub search_elapsed: Duration,
     pub smt_elapsed_ms: u64,
     pub smt_queries: u64,
     pub smt_equivalent: u64,
@@ -250,6 +259,7 @@ pub fn run_bench(spec: &BenchSpec, sample_index: u32) -> BenchRecord {
         original_cost,
         best_cost,
         search_elapsed_ms: statistics.elapsed_time.as_millis() as u64,
+        search_elapsed: statistics.elapsed_time,
         smt_elapsed_ms: statistics.smt_elapsed.as_millis() as u64,
         smt_queries: statistics.smt_queries,
         smt_equivalent: statistics.smt_equivalent,
@@ -323,6 +333,7 @@ mod tests {
             original_cost: 2,
             best_cost: 1,
             search_elapsed_ms: 5,
+            search_elapsed: Duration::from_millis(5),
             smt_elapsed_ms: 1,
             smt_queries: 3,
             smt_equivalent: 1,

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -81,7 +81,7 @@ pub fn discover_specs_in(dir: &Path, phase: u8) -> Vec<BenchSpec> {
 ///
 /// Panics if no `// Live-out:` header is found — bench fixtures are
 /// author-controlled, so a missing header is a fixture defect.
-pub fn load_sequence(path: &Path) -> (Vec<Instruction>, LiveOut, bool) {
+pub fn load_sequence(path: &Path) -> (Vec<Instruction>, LiveOut) {
     let source = std::fs::read_to_string(path)
         .unwrap_or_else(|e| panic!("failed to read fixture {}: {e}", path.display()));
 
@@ -99,7 +99,7 @@ pub fn load_sequence(path: &Path) -> (Vec<Instruction>, LiveOut, bool) {
             )
         });
 
-    let (live_out, flags_live) = parse_live_out_contract(live_spec).unwrap_or_else(|e| {
+    let live_out = parse_live_out_contract(live_spec).unwrap_or_else(|e| {
         panic!(
             "fixture {}: malformed live-out contract {live_spec:?}: {e:?}",
             path.display()
@@ -125,7 +125,7 @@ pub fn load_sequence(path: &Path) -> (Vec<Instruction>, LiveOut, bool) {
         path.display()
     );
 
-    (sequence, live_out, flags_live)
+    (sequence, live_out)
 }
 
 /// One canonical record per `(benchmark_id, cargo bench invocation)`.
@@ -225,13 +225,14 @@ pub struct BenchSpec {
 pub fn run_bench(spec: &BenchSpec) -> BenchRecord {
     // NOTE: The AArch64 backends invoked below hardcode `.with_flags(true)`
     // (`src/search/enumerative/search.rs`, `src/search/stochastic/backend.rs`,
-    // `src/search/symbolic/backend.rs`). The fixture's `flags_live` bit is
-    // therefore not consulted here: every benched candidate is verified
-    // under "NZCV is observable" semantics regardless of the header. This
-    // is conservative (pessimises rewrites that drop flag-setters when the
-    // fixture declares NZCV dead) but never unsound. Tracked for proper
-    // plumbing in #287.
-    let (target, live_out, _flags_live) = load_sequence(&spec.fixture);
+    // `src/search/symbolic/backend.rs`). The fixture's `flags_live` bit
+    // (carried on the returned `LiveOut`) is therefore not consulted here:
+    // every benched candidate is verified under "NZCV is observable"
+    // semantics regardless of the header. This is conservative
+    // (pessimises rewrites that drop flag-setters when the fixture
+    // declares NZCV dead) but never unsound. Tracked for proper plumbing
+    // in #287.
+    let (target, live_out) = load_sequence(&spec.fixture);
     let original_length = target.len();
     let original_cost = sequence_cost(&target, &spec.cost_metric);
 
@@ -316,20 +317,26 @@ mod tests {
              mov x0, x1\n\
              add x0, x0, #1\n",
         );
-        let (seq, live_out, flags_live) = load_sequence(f.path());
+        let (seq, live_out) = load_sequence(f.path());
         assert_eq!(seq.len(), 2, "expected MOV + ADD");
         assert!(
             live_out.contains_register(crate::ir::Register::X0),
             "live-out must include X0"
         );
-        assert!(!flags_live, "header without ;nzcv should be flags-dead");
+        assert!(
+            !live_out.flags_live(),
+            "header without ;nzcv should be flags-dead"
+        );
     }
 
     #[test]
     fn load_sequence_picks_up_flags_live() {
         let f = write_fixture("// Live-out: x0;nzcv\nmov x0, #1\n");
-        let (_, _, flags_live) = load_sequence(f.path());
-        assert!(flags_live, "header with ;nzcv must report flags_live=true");
+        let (_, live_out) = load_sequence(f.path());
+        assert!(
+            live_out.flags_live(),
+            "header with ;nzcv must report flags_live=true"
+        );
     }
 
     #[test]
@@ -403,7 +410,7 @@ mod tests {
             );
             for entry in entries {
                 let path = entry.path();
-                let (seq, _live_out, _flags_live) = load_sequence(&path);
+                let (seq, _live_out) = load_sequence(&path);
                 assert!(
                     !seq.is_empty(),
                     "fixture {} parsed to an empty sequence",

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -1,0 +1,110 @@
+//! Shared harness for the criterion benchmark suite (issue #70).
+//!
+//! Each bench file under `benches/` brings these helpers in via
+//! `use s11::bench_support::*;`. The module lives in the library —
+//! not under `benches/common/` — because `harness = false` benchmarks
+//! cannot run `#[test]` blocks; we need a regular lib-test path to
+//! exercise the helpers under TDD.
+
+use crate::ir::Instruction;
+use crate::parser::{LineResult, parse_line};
+use crate::semantics::live_out::LiveOut;
+use crate::validation::live_out::parse_live_out_contract;
+use std::path::Path;
+
+/// Parse a benchmark `.s` fixture into its target sequence plus the
+/// live-out contract declared in its `// Live-out:` header.
+///
+/// Header grammar matches `validation::live_out::parse_live_out_contract`
+/// — e.g. `// Live-out: x0,x1;nzcv`. Comments starting with `//` are
+/// stripped by `parse_line`; every non-comment line is parsed as
+/// AArch64 assembly.
+///
+/// Panics if no `// Live-out:` header is found — bench fixtures are
+/// author-controlled, so a missing header is a fixture defect.
+pub fn load_sequence(path: &Path) -> (Vec<Instruction>, LiveOut, bool) {
+    let source = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("failed to read fixture {}: {e}", path.display()));
+
+    let live_spec = source
+        .lines()
+        .find_map(|line| {
+            let trimmed = line.trim_start();
+            let body = trimmed.strip_prefix("//")?.trim_start();
+            body.strip_prefix("Live-out:").map(str::trim)
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "fixture {} missing required `// Live-out:` header — see benches/README.md",
+                path.display()
+            )
+        });
+
+    let (live_out, flags_live) = parse_live_out_contract(live_spec).unwrap_or_else(|e| {
+        panic!(
+            "fixture {}: malformed live-out contract {live_spec:?}: {e:?}",
+            path.display()
+        )
+    });
+
+    let mut sequence = Vec::new();
+    for line in source.lines() {
+        match parse_line(line) {
+            Ok(LineResult::Instruction(instr)) => sequence.push(instr),
+            Ok(LineResult::Skip) => {}
+            Err(e) => panic!(
+                "fixture {}: parse error on line {line:?}: {e:?}",
+                path.display()
+            ),
+        }
+    }
+
+    (sequence, live_out, flags_live)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_fixture(content: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new()
+            .prefix("bench-fixture")
+            .suffix(".s")
+            .tempfile()
+            .expect("tempfile");
+        f.write_all(content.as_bytes()).expect("write");
+        f
+    }
+
+    #[test]
+    fn load_sequence_parses_header_and_body() {
+        let f = write_fixture(
+            "// Live-out: x0\n\
+             // commentary\n\
+             mov x0, x1\n\
+             add x0, x0, #1\n",
+        );
+        let (seq, live_out, flags_live) = load_sequence(f.path());
+        assert_eq!(seq.len(), 2, "expected MOV + ADD");
+        assert!(
+            live_out.contains_register(crate::ir::Register::X0),
+            "live-out must include X0"
+        );
+        assert!(!flags_live, "header without ;nzcv should be flags-dead");
+    }
+
+    #[test]
+    fn load_sequence_picks_up_flags_live() {
+        let f = write_fixture("// Live-out: x0;nzcv\nmov x0, #1\n");
+        let (_, _, flags_live) = load_sequence(f.path());
+        assert!(flags_live, "header with ;nzcv must report flags_live=true");
+    }
+
+    #[test]
+    #[should_panic(expected = "missing required `// Live-out:` header")]
+    fn load_sequence_panics_without_header() {
+        let f = write_fixture("mov x0, #0\n");
+        let _ = load_sequence(f.path());
+    }
+}

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -17,6 +17,60 @@ use serde::Serialize;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+/// Short git SHA + a unix-epoch-seconds timestamp, captured once per
+/// process and stamped onto every `BenchRecord` emitted in this run.
+pub fn run_provenance() -> (Option<String>, Option<String>) {
+    let sha = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            } else {
+                None
+            }
+        });
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .map(|d| format!("{}s", d.as_secs()));
+    (sha, ts)
+}
+
+/// Discover every `.s` file under `dir` and turn each into a
+/// `BenchSpec`. Specs are returned sorted by id for deterministic
+/// criterion output ordering. Returns an empty vector if `dir` is
+/// missing or has no `.s` files.
+pub fn discover_specs_in(dir: &Path, phase: u8) -> Vec<BenchSpec> {
+    let Ok(read) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut specs: Vec<_> = read
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|x| x == "s"))
+        .map(|fixture| {
+            let id = fixture
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("unknown")
+                .to_string();
+            BenchSpec {
+                id,
+                fixture,
+                phase,
+                algorithm: Algorithm::Enumerative,
+                cost_metric: CostMetric::InstructionCount,
+                seed: 42,
+                timeout: Duration::from_secs(30),
+            }
+        })
+        .collect();
+    specs.sort_by(|a, b| a.id.cmp(&b.id));
+    specs
+}
+
 /// Parse a benchmark `.s` fixture into its target sequence plus the
 /// live-out contract declared in its `// Live-out:` header.
 ///

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -223,6 +223,14 @@ pub struct BenchSpec {
 /// (PR #269 review). Inside `iter_custom`, drivers re-call `run_bench`
 /// just to read `search_elapsed` for criterion's timing model.
 pub fn run_bench(spec: &BenchSpec) -> BenchRecord {
+    // NOTE: The AArch64 backends invoked below hardcode `.with_flags(true)`
+    // (`src/search/enumerative/search.rs`, `src/search/stochastic/backend.rs`,
+    // `src/search/symbolic/backend.rs`). The fixture's `flags_live` bit is
+    // therefore not consulted here: every benched candidate is verified
+    // under "NZCV is observable" semantics regardless of the header. This
+    // is conservative (pessimises rewrites that drop flag-setters when the
+    // fixture declares NZCV dead) but never unsound. Tracked for proper
+    // plumbing in #287.
     let (target, live_out, _flags_live) = load_sequence(&spec.fixture);
     let original_length = target.len();
     let original_cost = sequence_cost(&target, &spec.cost_metric);

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -93,6 +93,36 @@ pub struct BenchRecord {
     pub timestamp_utc: Option<String>,
 }
 
+/// Append one `BenchRecord` as a JSON line to `path`, creating the
+/// file (and any missing parent directories) on first use. A process-
+/// wide `Mutex` serialises concurrent appenders so multi-threaded
+/// criterion runs cannot interleave half-records into the file.
+pub fn append_json(record: &BenchRecord, path: &Path) {
+    use std::io::Write;
+    use std::sync::{Mutex, OnceLock};
+
+    static OUTPUT_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    let guard = OUTPUT_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("bench JSONL output lock poisoned");
+
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)
+            .unwrap_or_else(|e| panic!("create_dir_all {}: {e}", parent.display()));
+    }
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .unwrap_or_else(|e| panic!("open bench JSONL {}: {e}", path.display()));
+    let line = serde_json::to_string(record).expect("BenchRecord must serialise");
+    writeln!(file, "{line}").unwrap_or_else(|e| panic!("write bench JSONL: {e}"));
+    drop(guard);
+}
+
 /// Spec for one benchmark — derived from the fixture path and the
 /// surrounding bench file. `sample_index` is supplied separately by
 /// `run_bench` so the same spec can drive criterion's per-sample loop.
@@ -221,6 +251,46 @@ mod tests {
     fn load_sequence_panics_without_header() {
         let f = write_fixture("mov x0, #0\n");
         let _ = load_sequence(f.path());
+    }
+
+    #[test]
+    fn append_json_writes_one_jsonl_record_per_call() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("results.jsonl");
+        let record = BenchRecord {
+            benchmark_id: "demo".to_string(),
+            sample_index: 0,
+            phase: 1,
+            algorithm: "enumerative".to_string(),
+            seed: 7,
+            cost_metric: "instructioncount".to_string(),
+            original_length: 2,
+            found_length: Some(1),
+            original_cost: 2,
+            best_cost: 1,
+            search_elapsed_ms: 5,
+            smt_elapsed_ms: 1,
+            smt_queries: 3,
+            smt_equivalent: 1,
+            candidates_evaluated: 20,
+            success: true,
+            timeout: false,
+            git_sha: None,
+            timestamp_utc: None,
+        };
+        append_json(&record, &path);
+        let mut second = record.clone();
+        second.sample_index = 1;
+        append_json(&second, &path);
+
+        let body = std::fs::read_to_string(&path).expect("read jsonl");
+        let lines: Vec<&str> = body.lines().collect();
+        assert_eq!(lines.len(), 2, "two appends → two lines");
+        for line in &lines {
+            let parsed: serde_json::Value =
+                serde_json::from_str(line).expect("each line must be valid JSON");
+            assert_eq!(parsed["benchmark_id"], "demo");
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod assembler;
+pub mod bench_support;
 pub mod elf_patcher;
 pub mod ir;
 pub mod isa;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,12 @@
+pub mod assembler;
+pub mod elf_patcher;
+pub mod ir;
+pub mod isa;
+pub mod parser;
+pub mod search;
+pub mod semantics;
+pub mod validation;
+
+#[cfg(test)]
+#[path = "test_utils.rs"]
+mod test_utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,28 +5,23 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-mod assembler;
-mod elf_patcher;
-mod ir;
-mod isa;
-mod parser;
-mod search;
-mod semantics;
 #[cfg(test)]
+#[path = "test_utils.rs"]
 mod test_utils;
-mod validation;
 
-use assembler::AArch64Assembler;
-use elf_patcher::{AddressWindow, DetectedArch, ElfPatcher, parse_hex_address};
-use ir::instructions::split_terminator;
-use ir::{Instruction, Register};
-use search::config::{
+use s11::assembler::AArch64Assembler;
+use s11::elf_patcher::{AddressWindow, DetectedArch, ElfPatcher, parse_hex_address};
+use s11::ir::instructions::split_terminator;
+use s11::ir::{Instruction, Register};
+use s11::search::config::{
     Algorithm, LlmConfig, SearchConfig, SearchMode, StochasticConfig, SymbolicConfig,
 };
-use search::parallel::{ParallelConfig, run_parallel_search};
-use search::{EnumerativeSearch, SearchAlgorithm, StochasticSearch, SymbolicSearch};
-use semantics::LiveOut;
-use semantics::cost::CostMetric;
+use s11::search::parallel::{ParallelConfig, run_parallel_search};
+use s11::search::{EnumerativeSearch, SearchAlgorithm, StochasticSearch, SymbolicSearch};
+use s11::semantics::LiveOut;
+use s11::semantics::cost::CostMetric;
+#[allow(unused_imports)]
+use s11::{assembler, elf_patcher, ir, isa, parser, search, semantics, validation};
 
 // --- Command Line Arguments ---
 
@@ -2175,7 +2170,7 @@ mod cli_helper_tests {
             (
                 Instruction::Cbz {
                     rn: Register::X0,
-                    target: crate::ir::LabelId(0x1000),
+                    target: s11::ir::LabelId(0x1000),
                 },
                 Register::X0,
             ),
@@ -2183,7 +2178,7 @@ mod cli_helper_tests {
                 Instruction::Tbz {
                     rt: Register::X2,
                     bit: 5,
-                    target: crate::ir::LabelId(0x1000),
+                    target: s11::ir::LabelId(0x1000),
                 },
                 Register::X2,
             ),
@@ -2223,7 +2218,7 @@ mod cli_helper_tests {
         let last = ir.last().unwrap();
         match last {
             Instruction::BCond { cond, .. } => {
-                assert_eq!(*cond, crate::ir::types::Condition::EQ);
+                assert_eq!(*cond, s11::ir::types::Condition::EQ);
             }
             other => panic!("expected BCond terminator, got {:?}", other),
         }
@@ -2234,7 +2229,7 @@ mod cli_helper_tests {
     fn issue_69_acceptance_equivalence_rejects_different_branch_decisions() {
         // Same prefix, different conditional branch → NotEquivalent
         // (the branch decision differs, so equivalence must fail).
-        use crate::semantics::equivalence::{EquivalenceResult, check_equivalence};
+        use s11::semantics::equivalence::{EquivalenceResult, check_equivalence};
         let ir_eq =
             parser::parse_assembly_string("mov x0, x1\nb.eq 0x1000\n", "a".to_string()).unwrap();
         let ir_ne =
@@ -2256,8 +2251,8 @@ mod cli_helper_tests {
         //   1. `split_terminator` peels off the trailing `ret`.
         //   2. The search runs on the prefix only.
         //   3. The terminator is re-attached to the optimized prefix.
-        use crate::search::SearchAlgorithm;
-        use crate::search::config::SearchConfig;
+        use s11::search::SearchAlgorithm;
+        use s11::search::config::SearchConfig;
 
         let terminator = Instruction::Ret { rn: Register::X30 };
         let seq = vec![
@@ -2312,12 +2307,12 @@ mod cli_helper_tests {
         // — so the optimizer must reject it. With the live-out built by
         // `live_out_for_optimization_prefix`, x0 is included and the
         // clobbering candidate is correctly rejected.
-        use crate::semantics::EquivalenceConfig;
-        use crate::semantics::equivalence::{EquivalenceResult, check_equivalence_with_config};
+        use s11::semantics::EquivalenceConfig;
+        use s11::semantics::equivalence::{EquivalenceResult, check_equivalence_with_config};
 
         let terminator = Instruction::Cbz {
             rn: Register::X0,
-            target: crate::ir::LabelId(0x1000),
+            target: s11::ir::LabelId(0x1000),
         };
         let target = vec![
             Instruction::MovImm {
@@ -2368,7 +2363,7 @@ mod cli_helper_tests {
                 imm: 1,
             },
             Instruction::B {
-                target: crate::ir::LabelId(0x1000),
+                target: s11::ir::LabelId(0x1000),
             },
             Instruction::Add {
                 rd: Register::X1,

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -18,7 +18,9 @@ use crate::search::config::{Algorithm, SearchConfig};
 use crate::search::result::{SearchResult, SearchStatistics};
 use crate::semantics::cost::sequence_cost;
 use crate::semantics::live_out::LiveOut;
-use crate::semantics::{EquivalenceConfig, EquivalenceResult, check_equivalence_with_config};
+use crate::semantics::{
+    EquivalenceConfig, EquivalenceResult, check_equivalence_with_config_metrics,
+};
 
 /// Shared state for parallel workers. Counters are atomic to avoid locking; the
 /// best-so-far sequence is behind a `Mutex` because it is only touched on an
@@ -29,6 +31,7 @@ struct SharedState {
     candidates_evaluated: AtomicU64,
     smt_queries: AtomicU64,
     smt_equivalent: AtomicU64,
+    smt_elapsed_nanos: AtomicU64,
     candidates_passed_fast: AtomicU64,
     improvements_found: AtomicU64,
     best: Mutex<Option<Vec<Instruction>>>,
@@ -42,6 +45,7 @@ impl SharedState {
             candidates_evaluated: AtomicU64::new(0),
             smt_queries: AtomicU64::new(0),
             smt_equivalent: AtomicU64::new(0),
+            smt_elapsed_nanos: AtomicU64::new(0),
             candidates_passed_fast: AtomicU64::new(0),
             improvements_found: AtomicU64::new(0),
             best: Mutex::new(None),
@@ -92,7 +96,17 @@ fn verify_candidate(
         .with_flags(true);
 
     shared.smt_queries.fetch_add(1, Ordering::Relaxed);
-    match check_equivalence_with_config(target, candidate, &equiv_config) {
+    let (verdict, metrics) =
+        check_equivalence_with_config_metrics(target, candidate, &equiv_config);
+    let solver_nanos: u64 = metrics
+        .smt_elapsed
+        .as_nanos()
+        .try_into()
+        .unwrap_or(u64::MAX);
+    shared
+        .smt_elapsed_nanos
+        .fetch_add(solver_nanos, Ordering::Relaxed);
+    match verdict {
         EquivalenceResult::Equivalent => {
             shared.smt_equivalent.fetch_add(1, Ordering::Relaxed);
             shared
@@ -272,6 +286,8 @@ impl SearchAlgorithm<crate::isa::AArch64> for EnumerativeSearch {
         self.statistics.candidates_evaluated = shared.candidates_evaluated.load(Ordering::Relaxed);
         self.statistics.smt_queries = shared.smt_queries.load(Ordering::Relaxed);
         self.statistics.smt_equivalent = shared.smt_equivalent.load(Ordering::Relaxed);
+        self.statistics.smt_elapsed =
+            Duration::from_nanos(shared.smt_elapsed_nanos.load(Ordering::Relaxed));
         self.statistics.candidates_passed_fast =
             shared.candidates_passed_fast.load(Ordering::Relaxed);
         self.statistics.improvements_found = shared.improvements_found.load(Ordering::Relaxed);
@@ -309,6 +325,55 @@ mod tests {
         let result = search.search(&[], &LiveOut::all_registers(), &SearchConfig::default());
         assert!(!result.found_optimization);
         assert!(result.optimized_sequence.is_none());
+    }
+
+    #[test]
+    fn statistics_aggregate_smt_elapsed() {
+        // Reuse the same length-3 target as `finds_length_two_rewrite` —
+        // proven to drive at least one SMT equivalence check during the
+        // length-2 sweep. After the search returns, the cumulative SMT
+        // wall time must be non-zero, and it must be <= the overall search
+        // elapsed (sanity check on aggregation correctness).
+        let target = vec![
+            Instruction::MovReg {
+                rd: Register::X0,
+                rn: Register::X1,
+            },
+            Instruction::Eor {
+                rd: Register::X0,
+                rn: Register::X0,
+                rm: Operand::Register(Register::X0),
+            },
+            Instruction::Eor {
+                rd: Register::X2,
+                rn: Register::X2,
+                rm: Operand::Register(Register::X2),
+            },
+        ];
+        let live_out = LiveOut::from_registers(vec![Register::X0, Register::X2]);
+        let config = SearchConfig::default()
+            .with_registers(vec![Register::X0, Register::X1, Register::X2])
+            .with_immediates(vec![0, 1])
+            .with_timeout(std::time::Duration::from_secs(30));
+
+        let mut search = EnumerativeSearch::new();
+        let result = search.search(&target, &live_out, &config);
+
+        assert!(
+            result.statistics.smt_queries > 0,
+            "precondition: search must hit SMT"
+        );
+        assert!(
+            result.statistics.smt_elapsed > std::time::Duration::ZERO,
+            "smt_elapsed must aggregate non-zero solver time; got {:?}",
+            result.statistics.smt_elapsed
+        );
+        assert!(
+            result.statistics.smt_elapsed <= result.statistics.elapsed_time,
+            "smt_elapsed ({:?}) must be <= overall elapsed ({:?})",
+            result.statistics.smt_elapsed,
+            result.statistics.elapsed_time
+        );
     }
 
     fn small_config() -> SearchConfig {

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -95,7 +95,6 @@ fn verify_candidate(
         .timeout(smt_timeout)
         .with_flags(true);
 
-    shared.smt_queries.fetch_add(1, Ordering::Relaxed);
     let (verdict, metrics) =
         check_equivalence_with_config_metrics(target, candidate, &equiv_config);
     let solver_nanos: u64 = metrics
@@ -106,6 +105,15 @@ fn verify_candidate(
     shared
         .smt_elapsed_nanos
         .fetch_add(solver_nanos, Ordering::Relaxed);
+    // Count only candidates that actually reached `solver.check()`. The
+    // pre-SMT guard (`flag_writers_diverge && flags_live`) returns
+    // `NotEquivalent` with `metrics.smt_called == false`, and the
+    // fast-path returns `NotEquivalentFast` the same way — using the
+    // metric is both correct and future-proof against new early-return
+    // paths (PR #269 review).
+    if metrics.smt_called {
+        shared.smt_queries.fetch_add(1, Ordering::Relaxed);
+    }
     match verdict {
         EquivalenceResult::Equivalent => {
             shared.smt_equivalent.fetch_add(1, Ordering::Relaxed);
@@ -113,11 +121,6 @@ fn verify_candidate(
                 .candidates_passed_fast
                 .fetch_add(1, Ordering::Relaxed);
             true
-        }
-        EquivalenceResult::NotEquivalentFast(_) => {
-            // Rejected by random-test pre-filter; not a real SMT query.
-            shared.smt_queries.fetch_sub(1, Ordering::Relaxed);
-            false
         }
         _ => false,
     }

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -334,6 +334,14 @@ mod tests {
         // length-2 sweep. After the search returns, the cumulative SMT
         // wall time must be non-zero, and it must be <= the overall search
         // elapsed (sanity check on aggregation correctness).
+        //
+        // `cores = Some(1)` is required for the upper-bound assertion: the
+        // global rayon pool would let multiple worker threads each spend
+        // wall-clock time inside `solver.check()` in parallel, and the
+        // shared atomic accumulator sums those per-thread durations —
+        // making the cumulative `smt_elapsed` exceed total wall-clock
+        // `elapsed_time` on a multicore runner. Pinning to one thread
+        // restores the `smt_elapsed <= elapsed_time` invariant.
         let target = vec![
             Instruction::MovReg {
                 rd: Register::X0,
@@ -354,7 +362,8 @@ mod tests {
         let config = SearchConfig::default()
             .with_registers(vec![Register::X0, Register::X1, Register::X2])
             .with_immediates(vec![0, 1])
-            .with_timeout(std::time::Duration::from_secs(30));
+            .with_timeout(std::time::Duration::from_secs(30))
+            .with_cores(Some(1));
 
         let mut search = EnumerativeSearch::new();
         let result = search.search(&target, &live_out, &config);

--- a/src/search/result.rs
+++ b/src/search/result.rs
@@ -131,6 +131,10 @@ pub struct SearchStatistics {
     pub candidates_passed_fast: u64,
     /// Number of SMT queries made
     pub smt_queries: u64,
+    /// Cumulative wall-clock time spent inside Z3 `solver.check()` calls,
+    /// aggregated across every SMT-reaching candidate during the search.
+    /// `Duration::ZERO` when no candidate reached the solver.
+    pub smt_elapsed: Duration,
     /// Number of SMT queries that proved equivalence
     pub smt_equivalent: u64,
     /// Number of iterations (for stochastic search)

--- a/src/search/stochastic/backend.rs
+++ b/src/search/stochastic/backend.rs
@@ -19,8 +19,8 @@
 
 use crate::isa::ISA;
 use crate::search::config::SearchConfig;
-use crate::semantics::EquivalenceResult;
 use crate::semantics::cost::CostMetric;
+use crate::semantics::{EquivalenceMetrics, EquivalenceResult};
 use rand::RngExt;
 use std::time::Duration;
 
@@ -78,15 +78,16 @@ pub trait StochasticBackend<I: ISA>: Sized {
     fn is_encodable(seq: &[I::Instruction]) -> bool;
 
     /// Run the full equivalence check. AArch64 routes to
-    /// `check_equivalence_with_config`; x86 routes to
-    /// `check_equivalence_x86`.
+    /// `check_equivalence_with_config_metrics`; x86 routes to
+    /// `check_equivalence_x86` and returns default metrics (no x86
+    /// instrumentation yet — issue #70 only wires AArch64).
     fn check_equivalence(
         target: &[I::Instruction],
         proposal: &[I::Instruction],
         live_out: &Self::LiveOut,
         width: u32,
         timeout: Duration,
-    ) -> EquivalenceResult;
+    ) -> (EquivalenceResult, EquivalenceMetrics);
 
     /// Generate a random sequence of length `len` from the supplied
     /// pools.
@@ -169,7 +170,7 @@ impl StochasticBackend<crate::isa::AArch64> for crate::isa::AArch64 {
         live_out: &Self::LiveOut,
         _width: u32,
         timeout: Duration,
-    ) -> EquivalenceResult {
+    ) -> (EquivalenceResult, EquivalenceMetrics) {
         // Treat NZCV as live-out: the pre-refactor `mcmc.rs` body
         // built the EquivalenceConfig with `.with_flags(true)` so the
         // SMT solver cannot certify rewrites that diverge on flags
@@ -179,7 +180,7 @@ impl StochasticBackend<crate::isa::AArch64> for crate::isa::AArch64 {
             .random_tests(0)
             .timeout(timeout)
             .with_flags(true);
-        crate::semantics::check_equivalence_with_config(target, proposal, &cfg)
+        crate::semantics::equivalence::check_equivalence_with_config_metrics(target, proposal, &cfg)
     }
 
     fn random_sequence<R: RngExt>(
@@ -295,10 +296,11 @@ impl StochasticBackend<crate::isa::X86_64> for crate::isa::X86_64 {
         live_out: &Self::LiveOut,
         width: u32,
         timeout: Duration,
-    ) -> EquivalenceResult {
-        crate::semantics::equivalence::check_equivalence_x86_for_search(
+    ) -> (EquivalenceResult, EquivalenceMetrics) {
+        let result = crate::semantics::equivalence::check_equivalence_x86_for_search(
             target, proposal, live_out, width, timeout,
-        )
+        );
+        (result, EquivalenceMetrics::default())
     }
 
     fn random_sequence<R: RngExt>(
@@ -373,10 +375,11 @@ impl StochasticBackend<crate::isa::X86_32> for crate::isa::X86_32 {
         live_out: &Self::LiveOut,
         width: u32,
         timeout: Duration,
-    ) -> EquivalenceResult {
-        crate::semantics::equivalence::check_equivalence_x86_for_search(
+    ) -> (EquivalenceResult, EquivalenceMetrics) {
+        let result = crate::semantics::equivalence::check_equivalence_x86_for_search(
             target, proposal, live_out, width, timeout,
-        )
+        );
+        (result, EquivalenceMetrics::default())
     }
 
     fn random_sequence<R: RngExt>(
@@ -458,7 +461,7 @@ mod tests {
             64,
             Duration::from_secs(2),
         );
-        assert!(matches!(r, EquivalenceResult::Equivalent));
+        assert!(matches!(r.0, EquivalenceResult::Equivalent));
     }
 
     #[test]
@@ -475,6 +478,6 @@ mod tests {
             32,
             Duration::from_secs(2),
         );
-        assert!(matches!(r, EquivalenceResult::Equivalent));
+        assert!(matches!(r.0, EquivalenceResult::Equivalent));
     }
 }

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -209,29 +209,28 @@ where
             if proposal_cost < best_cost {
                 self.statistics.smt_queries += 1;
 
-                match <I as StochasticBackend<I>>::check_equivalence(
+                let (verdict, metrics) = <I as StochasticBackend<I>>::check_equivalence(
                     target,
                     &proposal,
                     live_out,
                     width,
                     smt_timeout,
-                ) {
-                    EquivalenceResult::Equivalent => {
-                        self.statistics.smt_equivalent += 1;
-                        self.statistics.improvements_found += 1;
+                );
+                self.statistics.smt_elapsed += metrics.smt_elapsed;
+                if let EquivalenceResult::Equivalent = verdict {
+                    self.statistics.smt_equivalent += 1;
+                    self.statistics.improvements_found += 1;
 
-                        best_equivalent = Some(proposal.clone());
-                        best_cost = proposal_cost;
-                        self.statistics.best_cost_found = best_cost;
+                    best_equivalent = Some(proposal.clone());
+                    best_cost = proposal_cost;
+                    self.statistics.best_cost_found = best_cost;
 
-                        if config.verbose {
-                            println!(
-                                "Found improvement at iteration {}: cost {} -> {}",
-                                iteration, original_cost, best_cost
-                            );
-                        }
+                    if config.verbose {
+                        println!(
+                            "Found improvement at iteration {}: cost {} -> {}",
+                            iteration, original_cost, best_cost
+                        );
                     }
-                    _ => {}
                 }
             }
 

--- a/src/search/symbolic/backend.rs
+++ b/src/search/symbolic/backend.rs
@@ -11,8 +11,8 @@
 
 use crate::isa::ISA;
 use crate::search::config::SearchConfig;
-use crate::semantics::EquivalenceResult;
 use crate::semantics::cost::CostMetric;
+use crate::semantics::{EquivalenceMetrics, EquivalenceResult};
 use std::time::Duration;
 
 /// Per-ISA dispatch surface for `SymbolicSearch`.
@@ -32,14 +32,15 @@ pub trait SymbolicBackend<I: ISA>: Sized {
     /// Sum the cost of every instruction in the sequence.
     fn sequence_cost(seq: &[I::Instruction], metric: &CostMetric, width: u32) -> u64;
 
-    /// Run the full equivalence check.
+    /// Run the full equivalence check. AArch64 returns populated
+    /// metrics (smt_elapsed, smt_called); x86 returns defaults.
     fn check_equivalence(
         target: &[I::Instruction],
         proposal: &[I::Instruction],
         live_out: &Self::LiveOut,
         width: u32,
         timeout: Duration,
-    ) -> EquivalenceResult;
+    ) -> (EquivalenceResult, EquivalenceMetrics);
 
     /// Width parameter for cost + state masking. AArch64 returns 64;
     /// x86 reads `SearchConfig::x86_width` (32 or 64).
@@ -73,14 +74,14 @@ impl SymbolicBackend<crate::isa::AArch64> for crate::isa::AArch64 {
         live_out: &Self::LiveOut,
         _width: u32,
         timeout: Duration,
-    ) -> EquivalenceResult {
+    ) -> (EquivalenceResult, EquivalenceMetrics) {
         // Treat NZCV as live-out so the solver cannot certify a
         // flag-divergent rewrite (see synthesis.rs's previous body).
         let cfg = crate::semantics::EquivalenceConfig::with_live_out(live_out.clone())
             .random_tests(5)
             .timeout(timeout)
             .with_flags(true);
-        crate::semantics::check_equivalence_with_config(target, proposal, &cfg)
+        crate::semantics::equivalence::check_equivalence_with_config_metrics(target, proposal, &cfg)
     }
 
     fn width(_config: &SearchConfig) -> u32 {
@@ -122,10 +123,11 @@ impl SymbolicBackend<crate::isa::X86_64> for crate::isa::X86_64 {
         live_out: &Self::LiveOut,
         width: u32,
         timeout: Duration,
-    ) -> EquivalenceResult {
-        crate::semantics::equivalence::check_equivalence_x86_for_search(
+    ) -> (EquivalenceResult, EquivalenceMetrics) {
+        let result = crate::semantics::equivalence::check_equivalence_x86_for_search(
             target, proposal, live_out, width, timeout,
-        )
+        );
+        (result, EquivalenceMetrics::default())
     }
 
     fn width(_config: &SearchConfig) -> u32 {
@@ -176,10 +178,11 @@ impl SymbolicBackend<crate::isa::X86_32> for crate::isa::X86_32 {
         live_out: &Self::LiveOut,
         width: u32,
         timeout: Duration,
-    ) -> EquivalenceResult {
-        crate::semantics::equivalence::check_equivalence_x86_for_search(
+    ) -> (EquivalenceResult, EquivalenceMetrics) {
+        let result = crate::semantics::equivalence::check_equivalence_x86_for_search(
             target, proposal, live_out, width, timeout,
-        )
+        );
+        (result, EquivalenceMetrics::default())
     }
 
     fn width(config: &SearchConfig) -> u32 {

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -263,9 +263,11 @@ where
 
         self.statistics.smt_queries += 1;
 
-        match <I as SymbolicBackend<I>>::check_equivalence(
+        let (verdict, metrics) = <I as SymbolicBackend<I>>::check_equivalence(
             target, candidate, live_out, width, timeout,
-        ) {
+        );
+        self.statistics.smt_elapsed += metrics.smt_elapsed;
+        match verdict {
             EquivalenceResult::Equivalent => {
                 self.statistics.smt_equivalent += 1;
                 self.statistics.candidates_passed_fast += 1;

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -240,6 +240,10 @@ pub struct EquivalenceMetrics {
     /// declarations) at the moment `check()` was called. None if SMT was
     /// not called.
     pub smt_formula_bytes: Option<usize>,
+    /// Wall-clock time spent inside `solver.check()`. `Duration::ZERO` when
+    /// the solver was not invoked (fast path resolved the candidate or the
+    /// pre-SMT guard fired).
+    pub smt_elapsed: Duration,
 }
 
 /// Build the fast-path input randomization set.
@@ -452,7 +456,9 @@ pub fn check_equivalence_with_config_metrics(
     }
 
     let solver = build_smt_solver(prefix1, prefix2, config);
+    let smt_start = std::time::Instant::now();
     let sat_result = solver.check();
+    let smt_elapsed = smt_start.elapsed();
     let smt_formula_bytes = if sat_result == SatResult::Unsat {
         Some(solver.to_string().len())
     } else {
@@ -464,6 +470,7 @@ pub fn check_equivalence_with_config_metrics(
         EquivalenceMetrics {
             smt_called: true,
             smt_formula_bytes,
+            smt_elapsed,
         },
     )
 }
@@ -2305,6 +2312,58 @@ mod tests {
             matches!(result, EquivalenceResult::NotEquivalentFast(_)),
             "expected NotEquivalentFast for csel-vs-mov under --fast-only --live-out x0, got {:?}",
             result
+        );
+    }
+
+    #[test]
+    fn smt_elapsed_is_nonzero_when_solver_runs() {
+        // MOV #0 vs EOR self — semantically equivalent under x0-only
+        // live-out, fast-path forwards to SMT because random concrete
+        // inputs all agree. Solver must run and report a nonzero
+        // smt_elapsed.
+        let seq1 = vec![Instruction::MovImm {
+            rd: Register::X0,
+            imm: 0,
+        }];
+        let seq2 = vec![Instruction::Eor {
+            rd: Register::X0,
+            rn: Register::X0,
+            rm: Operand::Register(Register::X0),
+        }];
+        let cfg =
+            EquivalenceConfig::default().live_out(LiveOut::from_registers(vec![Register::X0]));
+        let (result, metrics) = check_equivalence_with_config_metrics(&seq1, &seq2, &cfg);
+        assert_eq!(result, EquivalenceResult::Equivalent);
+        assert!(metrics.smt_called, "solver should have been invoked");
+        assert!(
+            metrics.smt_elapsed > Duration::ZERO,
+            "smt_elapsed must be nonzero when solver runs; got {:?}",
+            metrics.smt_elapsed
+        );
+    }
+
+    #[test]
+    fn smt_elapsed_is_zero_when_fast_path_rejects() {
+        // MOV #1 vs MOV #2 — the first random concrete input diverges,
+        // so fast-path rejects before SMT is built. smt_elapsed must
+        // be exactly zero.
+        let seq1 = vec![Instruction::MovImm {
+            rd: Register::X0,
+            imm: 1,
+        }];
+        let seq2 = vec![Instruction::MovImm {
+            rd: Register::X0,
+            imm: 2,
+        }];
+        let cfg =
+            EquivalenceConfig::default().live_out(LiveOut::from_registers(vec![Register::X0]));
+        let (result, metrics) = check_equivalence_with_config_metrics(&seq1, &seq2, &cfg);
+        assert!(matches!(result, EquivalenceResult::NotEquivalentFast(_)));
+        assert!(!metrics.smt_called, "fast path should reject before SMT");
+        assert_eq!(
+            metrics.smt_elapsed,
+            Duration::ZERO,
+            "smt_elapsed must be zero on fast-path rejection"
         );
     }
 }

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -397,28 +397,19 @@ fn run_fast_path(
 }
 
 /// Check equivalence with configuration (fast path + optional SMT). No metrics.
+///
+/// Thin wrapper around `check_equivalence_with_config_metrics` that drops
+/// the metrics. Callers that don't observe metrics pay the same
+/// `solver.to_string()` cost on the unsat branch as the metrics-aware
+/// caller; in practice that branch is rare (most candidates fail in the
+/// fast path or return sat) and the serialization is microseconds.
 pub fn check_equivalence_with_config(
     seq1: &[Instruction],
     seq2: &[Instruction],
     config: &EquivalenceConfig,
 ) -> EquivalenceResult {
-    // Issue #69: terminator-identity precheck — see `check_equivalence`.
-    let (prefix1, terminator1) = split_terminator(seq1);
-    let (prefix2, terminator2) = split_terminator(seq2);
-    if terminator1 != terminator2 {
-        return EquivalenceResult::NotEquivalentFast(ConcreteMachineState::new_zeroed());
-    }
-
-    if let Some(early) = pre_smt_guard(prefix1, prefix2, config.live_out.flags_live()) {
-        return early;
-    }
-
-    if let Some(fast) = run_fast_path(prefix1, prefix2, config) {
-        return fast;
-    }
-
-    let solver = build_smt_solver(prefix1, prefix2, config);
-    interpret_smt_result(solver.check())
+    let (result, _) = check_equivalence_with_config_metrics(seq1, seq2, config);
+    result
 }
 
 /// Like `check_equivalence_with_config`, but also reports per-call metrics


### PR DESCRIPTION
## Summary
- Adds a `criterion`-driven benchmark suite under `benches/` with three phases (Hacker's Delight micro-suite, LLVM AArch64 codegen sample, algebraic-identity catalog), each appending JSON-Lines records to `benches/results/results.jsonl`. Diffable across commits.
- Instruments the equivalence helper with SMT solver wall time: new `EquivalenceMetrics::smt_elapsed` and `SearchStatistics::smt_elapsed` aggregated across enumerative / stochastic / symbolic AArch64 search paths. x86 backends return defaults — not in scope.
- Promotes `s11` from a binary-only crate to a lib+bin crate so the benchmark targets can `use s11::…`. `src/main.rs` becomes a thin shim that pulls modules from `src/lib.rs`.

## What's in each phase
- **Phase 0 — prerequisites.** lib+bin restructure; `EquivalenceMetrics::smt_elapsed` timing; `check_equivalence_with_config` collapsed onto the `_metrics` workhorse; `SearchStatistics::smt_elapsed` plumbed through every AArch64 search path.
- **Phase 1 — Hacker's Delight.** `src/bench_support.rs` provides the shared harness (`load_sequence`, `run_bench`, `append_json`, `BenchSpec`, `BenchRecord`, `discover_specs_in`, `run_provenance`); 20 register-only `.s` fixtures under `benches/hackers_delight/`; `benches/hackers_delight.rs` criterion driver; `just bench` / `bench-phase1` / `bench-clean` recipes.
- **Phase 2 — LLVM CodeGen.** `scripts/harvest_llvm_codegen.sh` (maintainer-run; shallow-clones llvm-project, samples `.ll` files deterministically, runs `llc -mtriple=aarch64-linux-gnu -O2`, filters to supported mnemonics). Fixture directory ships empty with a README — bench driver skips gracefully.
- **Phase 3 — algebraic identities.** 15 textbook-identity fixtures under `benches/algebraic_fusion/` and a matching criterion driver.

## Schema
Each criterion sample emits one record:

```json
{ "benchmark_id": "mov_add_fuse", "sample_index": 0, "phase": 3, "algorithm": "enumerative",
  "seed": 42, "cost_metric": "instructioncount",
  "original_length": 2, "found_length": 1, "original_cost": 2, "best_cost": 1,
  "search_elapsed_ms": 22, "smt_elapsed_ms": 0, "smt_queries": 73000, "smt_equivalent": 1,
  "candidates_evaluated": 85000, "success": true, "timeout": false,
  "git_sha": "9ffe40a", "timestamp_utc": "1779000000s" }
```

Full schema + caveats in `benches/README.md`.

## Acceptance
- `just bench-phase1` runs Phase 1 end-to-end and emits a diffable report (issue #70 acceptance).
- `benches/README.md` documents how to add a benchmark.
- Benches are **not** wired into CI — full runs are tens of minutes and would burn through GitHub Actions budget (same posture as `cargo-mutants`).

## Notes
- Reproducibility relies on `StochasticConfig::seed`; the harness mixes `spec.seed + sample_index` per record.
- `smt_elapsed_ms` is often `0` even when `smt_queries` is high — the existing `pre_smt_guard` short-circuits flag-divergent candidates before the solver runs. Documented in `benches/README.md`.
- Phase 2 fixtures are not committed; run `scripts/harvest_llvm_codegen.sh` to populate from `llvm-project/llvm/test/CodeGen/AArch64`.

## Test plan
- [x] `cargo test --lib` — 803 passed, 0 failed
- [x] `cargo fmt --all -- --check`
- [x] `./ci_check.sh` — green
- [x] `cargo build --benches` — all three bench targets compile
- [x] `cargo bench --bench hackers_delight -- max --quick` — produces non-empty `benches/results/results.jsonl`
- [x] New unit tests in `src/bench_support.rs` cover `load_sequence` (success + missing-header panic + flags-live header), `run_bench` (deterministic record for fusible target), `append_json` (round-trip JSON-Lines), and a smoke test parsing every committed fixture
- [x] New unit test in `src/search/enumerative/search.rs` asserts `SearchStatistics::smt_elapsed > 0` and `<= elapsed_time` after a length-2 search that exercises SMT
- [x] New unit tests in `src/semantics/equivalence.rs` cover `smt_elapsed > 0` on solver-reaching pairs and `== 0` on fast-path-rejected pairs
- [ ] Reviewer: run `just bench-phase1` locally and skim `benches/results/results.jsonl` — confirm one record per criterion sample, schema matches `benches/README.md`
- [ ] Reviewer: optional — run `scripts/harvest_llvm_codegen.sh 42 20` to populate `benches/llvm_codegen/` and verify `just bench` includes the phase