### PR TITLE
Pretty-print LiveOut with self-documenting wrapper (#79)

### DIFF
--- a/src/semantics/live_out.rs
+++ b/src/semantics/live_out.rs
@@ -131,7 +131,7 @@ impl From<LiveOutRegisters> for LiveOut {
 
 impl fmt::Display for LiveOut {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "registers={}", self.registers)
+        write!(f, "LiveOut {{ registers={} }}", self.registers)
     }
 }
 
@@ -285,6 +285,24 @@ mod tests {
 
         mask.set_flags_live(true);
         assert!(mask.flags_live());
+    }
+
+    #[test]
+    fn test_live_out_display_single_register() {
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
+        assert_eq!(format!("{}", live_out), "LiveOut { registers={x0} }");
+    }
+
+    #[test]
+    fn test_live_out_display_multiple_registers_sorted() {
+        let live_out = LiveOut::from_registers(vec![Register::X1, Register::X0]);
+        assert_eq!(format!("{}", live_out), "LiveOut { registers={x0, x1} }");
+    }
+
+    #[test]
+    fn test_live_out_display_empty() {
+        let live_out = LiveOut::from_registers(vec![]);
+        assert_eq!(format!("{}", live_out), "LiveOut { registers={} }");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Change `impl fmt::Display for LiveOut` to render `LiveOut { registers={x0} }` instead of the bare `registers={x0}`, so the format extends naturally when more state slices (condition flags, memory, PC) join `registers`.
- Add three regression tests pinning the new format: single register, sorted multi-register, and empty.

Closes #79.

## Test plan
- [x] `cargo test --bin s11 semantics::live_out::tests::test_live_out_display` — 3 new tests pass
- [x] `./ci_check.sh` — fmt, build, 822 unit + 20 integration tests, full s11 test suite all green