### PR TITLE
Drop redundant type-name prefix from ParseLiveOutRegistersError Display (closes #80)

### DIFF
--- a/docs/adr/0006-live-out-cli-grammar.md
+++ b/docs/adr/0006-live-out-cli-grammar.md
@@ -42,3 +42,5 @@ ADR-0004 §5 commits to eventually replacing `LiveOut` and `X86LiveOutMask` with
 - The bit lives on `EquivalenceConfig` and (in scaffolding) on `LiveOutMask<R>`. When the mask migration of ADR-0004 §5 lands, this ADR's CLI grammar should remain stable but the parser will return `(LiveOutMask<Register>, ())` — a single-return shape — and the explicit `bool` plumbing in `run_equiv` will collapse.
 
 **Reversibility:** high for the per-flag rev — the `n`/`z`/`c`/`v` tokens are rejected with a "reserved" message today, so adding their semantics later is a strict superset of the current grammar. Reversibility low for the parser function itself: it becomes load-bearing for both CLI subcommands.
+
+**Resolution note (issue #80, 2026-05-18):** `ParseLiveOutRegistersError`'s `Display` impl writes only the message body. The `"invalid live-out: "` prefix from `run_equiv`/`run_llm_opt` (§2) is the sole documented user-visible prefix; pinned by `validation::live_out::tests::display_renders_message_without_type_prefix`.

--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -14,7 +14,7 @@ pub struct ParseLiveOutRegistersError {
 
 impl std::fmt::Display for ParseLiveOutRegistersError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ParseLiveOutRegistersError: {}", self.message)
+        f.write_str(&self.message)
     }
 }
 
@@ -236,6 +236,14 @@ pub fn x86_live_out_from_target(
 mod tests {
     use super::*;
     use crate::ir::{Condition, Operand};
+
+    #[test]
+    fn display_renders_message_without_type_prefix() {
+        let err = ParseLiveOutRegistersError {
+            message: "invalid register name: 'foo'".to_string(),
+        };
+        assert_eq!(err.to_string(), "invalid register name: 'foo'");
+    }
 
     #[test]
     fn test_parse_register_x0() {


### PR DESCRIPTION
## Summary

- `ParseLiveOutRegistersError`'s `Display` impl previously wrote `"ParseLiveOutRegistersError: <msg>"`, which the CLI callers in `src/main.rs:1348,1413` already wrapped as `"invalid live-out: ..."` — producing a doubled prefix like `invalid live-out: ParseLiveOutRegistersError: invalid register name: 'foo'`.
- ADR-0006 §2 commits to `"invalid live-out: ..."` as the sole user-visible CLI prefix, and no in-tree consumers (tests, README, TUTORIAL, scripts) depend on the old `Display` text. The type name remains available via `Debug`.
- `Display` now writes just the message body. A regression test pins the new format and a one-line resolution note has been added to ADR-0006 so the choice is discoverable.

Closes #80.

## Test plan

- [x] `cargo test --bin s11 validation::live_out` — 51/51 pass, including new `display_renders_message_without_type_prefix`
- [x] `./ci_check.sh` — fmt + build + unit + integration green