### PR TITLE
Clamp mutate_operand immediates to encodable range (closes #87)

### DIFF
--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -2001,7 +2001,8 @@ mod tests {
 
         // (imm_max, host instruction builder used to wrap the resulting Operand
         // so we can call `is_encodable_aarch64` on a real Instruction).
-        let cases: Vec<(i64, Box<dyn Fn(Operand) -> Instruction>)> = vec![
+        type ImmCase = (i64, Box<dyn Fn(Operand) -> Instruction>);
+        let cases: Vec<ImmCase> = vec![
             (
                 0xFFF,
                 Box::new(|rm| Instruction::Add {

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -1110,11 +1110,11 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                         Instruction::MovImm { rd, imm: new_imm }
                     }
                     Instruction::Add { rd, rn, rm } => {
-                        let new_rm = mutate_operand(rng, rm, registers, immediates);
+                        let new_rm = mutate_operand(rng, rm, registers, immediates, 0xFFF);
                         Instruction::Add { rd, rn, rm: new_rm }
                     }
                     Instruction::Sub { rd, rn, rm } => {
-                        let new_rm = mutate_operand(rng, rm, registers, immediates);
+                        let new_rm = mutate_operand(rng, rm, registers, immediates, 0xFFF);
                         Instruction::Sub { rd, rn, rm: new_rm }
                     }
                     Instruction::And { rd, rn, rm: _ } => {
@@ -1223,11 +1223,11 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     }
                     // Comparison instructions - change operand
                     Instruction::Cmp { rn, rm } => {
-                        let new_rm = mutate_operand(rng, rm, registers, immediates);
+                        let new_rm = mutate_operand(rng, rm, registers, immediates, 0xFFF);
                         Instruction::Cmp { rn, rm: new_rm }
                     }
                     Instruction::Cmn { rn, rm } => {
-                        let new_rm = mutate_operand(rng, rm, registers, immediates);
+                        let new_rm = mutate_operand(rng, rm, registers, immediates, 0xFFF);
                         Instruction::Cmn { rn, rm: new_rm }
                     }
                     Instruction::Tst { rn, rm: _ } => {
@@ -1239,7 +1239,7 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     // dedicated mutate_operand path in
                     // `search/stochastic/mutation.rs` covers nzcv and cond.
                     Instruction::Ccmp { rn, rm, nzcv, cond } => {
-                        let new_rm = mutate_operand(rng, rm, registers, immediates);
+                        let new_rm = mutate_operand(rng, rm, registers, immediates, 31);
                         Instruction::Ccmp {
                             rn,
                             rm: new_rm,
@@ -1248,7 +1248,7 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                         }
                     }
                     Instruction::Ccmn { rn, rm, nzcv, cond } => {
-                        let new_rm = mutate_operand(rng, rm, registers, immediates);
+                        let new_rm = mutate_operand(rng, rm, registers, immediates, 31);
                         Instruction::Ccmn {
                             rn,
                             rm: new_rm,
@@ -1365,11 +1365,11 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                         Instruction::Eon { rd, rn, rm: new_rm }
                     }
                     Instruction::Adds { rd, rn, rm } => {
-                        let new_rm = mutate_operand(rng, rm, registers, immediates);
+                        let new_rm = mutate_operand(rng, rm, registers, immediates, 0xFFF);
                         Instruction::Adds { rd, rn, rm: new_rm }
                     }
                     Instruction::Subs { rd, rn, rm } => {
-                        let new_rm = mutate_operand(rng, rm, registers, immediates);
+                        let new_rm = mutate_operand(rng, rm, registers, immediates, 0xFFF);
                         Instruction::Subs { rd, rn, rm: new_rm }
                     }
                     Instruction::Ands { rd, rn, rm: _ } => {
@@ -1516,7 +1516,17 @@ fn mutate_operand<R: RngExt>(
     operand: Operand,
     registers: &[Register],
     immediates: &[i64],
+    imm_max: i64,
 ) -> Operand {
+    debug_assert!(imm_max >= 0, "imm_max must be non-negative");
+    let pick_imm = |rng: &mut R| {
+        let v = immediates[rng.random_range(0..immediates.len())];
+        // Issue #87: clamp to the caller's encodable upper bound. Mirrors
+        // the CCMP/CCMN clamp in `src/search/stochastic/mutation.rs` and
+        // matches `Instruction::is_encodable_aarch64`'s per-variant ranges
+        // (ADD/SUB/ADDS/SUBS/CMP/CMN: 0..=0xFFF; CCMP/CCMN: 0..=31).
+        Operand::Immediate(v.rem_euclid(imm_max + 1))
+    };
     match operand {
         Operand::Register(_)
         | Operand::ShiftedRegister { .. }
@@ -1524,12 +1534,12 @@ fn mutate_operand<R: RngExt>(
             if rng.random_bool(0.7) {
                 Operand::Register(registers[rng.random_range(0..registers.len())])
             } else {
-                Operand::Immediate(immediates[rng.random_range(0..immediates.len())])
+                pick_imm(rng)
             }
         }
         Operand::Immediate(_) => {
             if rng.random_bool(0.7) {
-                Operand::Immediate(immediates[rng.random_range(0..immediates.len())])
+                pick_imm(rng)
             } else {
                 Operand::Register(registers[rng.random_range(0..registers.len())])
             }
@@ -1975,6 +1985,100 @@ mod tests {
         for _ in 0..100 {
             let mutated = generator.mutate(&mut rng, &original, &regs, &imms);
             assert!(mutated.opcode_id() < generator.opcode_count());
+        }
+    }
+
+    /// Issue #87. The file-private `mutate_operand` helper at L1514 must
+    /// clamp `Operand::Immediate` values returned for ADD/SUB/ADDS/SUBS/
+    /// CMP/CMN (12-bit) and CCMP/CCMN (5-bit) so the result is encodable.
+    /// Hostile `imms` table deliberately includes values that would be
+    /// rejected by `is_encodable_aarch64` if returned unclamped.
+    #[test]
+    fn test_mutate_operand_clamps_arith_imm_to_encodable_range() {
+        let regs = vec![Register::X0, Register::X1, Register::X2];
+        let imms: Vec<i64> = vec![0, 1, 0xFFF, 0x1000, 8192, 0x1_0000, 1_000_000, -1];
+        let mut rng = ChaCha8Rng::seed_from_u64(42);
+
+        // (imm_max, host instruction builder used to wrap the resulting Operand
+        // so we can call `is_encodable_aarch64` on a real Instruction).
+        let cases: Vec<(i64, Box<dyn Fn(Operand) -> Instruction>)> = vec![
+            (
+                0xFFF,
+                Box::new(|rm| Instruction::Add {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm,
+                }),
+            ),
+            (
+                0xFFF,
+                Box::new(|rm| Instruction::Sub {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm,
+                }),
+            ),
+            (
+                0xFFF,
+                Box::new(|rm| Instruction::Adds {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm,
+                }),
+            ),
+            (
+                0xFFF,
+                Box::new(|rm| Instruction::Subs {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm,
+                }),
+            ),
+            (
+                0xFFF,
+                Box::new(|rm| Instruction::Cmp {
+                    rn: Register::X1,
+                    rm,
+                }),
+            ),
+            (
+                0xFFF,
+                Box::new(|rm| Instruction::Cmn {
+                    rn: Register::X1,
+                    rm,
+                }),
+            ),
+            (
+                31,
+                Box::new(|rm| Instruction::Ccmp {
+                    rn: Register::X1,
+                    rm,
+                    nzcv: 0,
+                    cond: Condition::EQ,
+                }),
+            ),
+            (
+                31,
+                Box::new(|rm| Instruction::Ccmn {
+                    rn: Register::X1,
+                    rm,
+                    nzcv: 0,
+                    cond: Condition::EQ,
+                }),
+            ),
+        ];
+
+        for (imm_max, build) in &cases {
+            for _ in 0..500 {
+                let new_rm =
+                    super::mutate_operand(&mut rng, Operand::Immediate(0), &regs, &imms, *imm_max);
+                let instr = build(new_rm);
+                assert!(
+                    instr.is_encodable_aarch64(),
+                    "imm_max={imm_max}, produced non-encodable {:?}",
+                    instr
+                );
+            }
         }
     }
 

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -154,7 +154,9 @@ impl Mutator {
                     0 => *rd = self.random_register(rng),
                     1 => *rn = self.random_register(rng),
                     // Add/Sub do not allow ROR in the shifted-register form.
-                    _ => *rm = self.random_operand_3op(rng, false),
+                    // Immediates must fit `is_encodable_aarch64`'s 12-bit
+                    // range (issue #87).
+                    _ => *rm = Self::clamp_imm12(self.random_operand_3op(rng, false)),
                 }
             }
             Instruction::And { rd, rn, rm }
@@ -215,7 +217,8 @@ impl Mutator {
                 if rng.random_bool(0.5) {
                     *rn = self.random_register(rng);
                 } else {
-                    *rm = self.random_operand_3op(rng, false);
+                    // Same 12-bit clamp as Add/Sub (issue #87).
+                    *rm = Self::clamp_imm12(self.random_operand_3op(rng, false));
                 }
             }
             Instruction::Tst { rn, rm } => {
@@ -237,6 +240,8 @@ impl Mutator {
             // operands are clamped to imm5 via rem_euclid(32) to match the
             // candidate generator (candidate.rs::generate_random_instruction)
             // and avoid avoidable is_encodable_aarch64 rejection churn.
+            // (See `clamp_imm12` for the 12-bit analogue used by
+            // ADD/SUB/ADDS/SUBS/CMP/CMN, issue #87.)
             Instruction::Ccmp { rn, rm, nzcv, cond } | Instruction::Ccmn { rn, rm, nzcv, cond } => {
                 match rng.random_range(0..4) {
                     0 => *rn = self.random_register(rng),
@@ -329,7 +334,8 @@ impl Mutator {
                 match choice {
                     0 => *rd = self.random_register(rng),
                     1 => *rn = self.random_register(rng),
-                    _ => *rm = self.random_operand(rng),
+                    // Same 12-bit clamp as Add/Sub (issue #87).
+                    _ => *rm = Self::clamp_imm12(self.random_operand(rng)),
                 }
             }
             Instruction::Ands { rd, rn, rm } => {
@@ -924,6 +930,18 @@ impl Mutator {
         }
     }
 
+    /// Issue #87. ADD/SUB/ADDS/SUBS/CMP/CMN immediates must fit the 12-bit
+    /// unsigned range `0..=0xFFF` (see `Instruction::is_encodable_aarch64`).
+    /// Mirrors the CCMP/CCMN clamp at L240-258 — the operand is only
+    /// rewritten when it's an `Immediate`; register/shifted forms pass
+    /// through unchanged.
+    fn clamp_imm12(operand: Operand) -> Operand {
+        match operand {
+            Operand::Immediate(v) => Operand::Immediate(v.rem_euclid(0x1000)),
+            other => other,
+        }
+    }
+
     /// Random rm operand for the in-scope arithmetic/logical/comparison
     /// shifted-register opcodes (issue #59). With low probability returns a
     /// `ShiftedRegister`; otherwise falls back to the plain register/immediate
@@ -1338,6 +1356,73 @@ mod tests {
             swapped_to_peer,
             "opcode mutation must reach a peer bit-field variant within 200 trials"
         );
+    }
+
+    /// Issue #87. If `available_immediates` includes values outside the
+    /// per-variant encodable range, mutate_operand must clamp them so the
+    /// MCMC search never wastes iterations on candidates that
+    /// `is_encodable_aarch64` will reject.
+    #[test]
+    fn test_mutate_operand_clamps_arith_imm_to_encodable_range() {
+        let regs = vec![Register::X0, Register::X1, Register::X2];
+        let imms = vec![0, 1, 0xFFF, 0x1000, 8192, 0x1_0000, 1_000_000, -1];
+        let mutator = Mutator::new(regs, imms, MutationWeights::default());
+
+        let starts = [
+            Instruction::Add {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Immediate(0),
+            },
+            Instruction::Sub {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Immediate(0),
+            },
+            Instruction::Adds {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Immediate(0),
+            },
+            Instruction::Subs {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Immediate(0),
+            },
+            Instruction::Cmp {
+                rn: Register::X1,
+                rm: Operand::Immediate(0),
+            },
+            Instruction::Cmn {
+                rn: Register::X1,
+                rm: Operand::Immediate(0),
+            },
+            Instruction::Ccmp {
+                rn: Register::X1,
+                rm: Operand::Immediate(0),
+                nzcv: 0,
+                cond: Condition::EQ,
+            },
+            Instruction::Ccmn {
+                rn: Register::X1,
+                rm: Operand::Immediate(0),
+                nzcv: 0,
+                cond: Condition::EQ,
+            },
+        ];
+
+        for seed in 0u64..200 {
+            let mut rng = StdRng::seed_from_u64(seed);
+            for start in &starts {
+                let mut seq = vec![*start];
+                mutator.mutate_operand(&mut rng, &mut seq);
+                assert!(
+                    seq[0].is_encodable_aarch64(),
+                    "seed {seed}, start {start:?} produced non-encodable {:?}",
+                    seq[0]
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Both AArch64 mutator paths could return `Operand::Immediate` values outside the per-variant encodable range (`is_encodable_aarch64` rejects them), wasting MCMC iterations on guaranteed-invalid candidates whenever `available_immediates` contains values beyond the bound. ADD/SUB/ADDS/SUBS/CMP/CMN require `0..=0xFFF`; CCMP/CCMN require `0..=31`. The default config table is currently all-in-range so the bug is latent there, but any non-default `--available-immediates` triggers it.
- Live MCMC path (`src/search/stochastic/mutation.rs`): new `Mutator::clamp_imm12` associated fn wraps the three call sites for Add/Sub, Cmp/Cmn, and Adds/Subs. Mirrors the existing CCMP/CCMN clamp at L246 (`rem_euclid(32)`).
- Legacy `AArch64InstructionGenerator::mutate` path (`src/isa/aarch64.rs`): the file-private `mutate_operand` helper gains an `imm_max: i64` parameter (`v.rem_euclid(imm_max + 1)`); all 8 call sites pass `0xFFF` for the 12-bit family or `31` for CCMP/CCMN.

Two files change because issue #87 was filed against the legacy helper, but the post-#77 refactor moved the live MCMC mutator into `mutation.rs`. Both helpers had the same defect.

## Out of scope (worth a follow-up)
`src/search/candidate.rs::random_operand` (L771) — used by `generate_random_instruction` — has the same missing clamp for the 12-bit family (only CCMP/CCMN is clamped, at L631). Not addressed here because the issue text named only `mutate_operand`; can be filed as a separate ticket.

## Test plan
- [x] New regression test `test_mutate_operand_clamps_arith_imm_to_encodable_range` in `src/search/stochastic/mutation.rs` — hostile imm table includes `0x1000`, `0x10000`, `1_000_000`, `-1`; loops 200 distinct seeds × 8 instruction variants; asserts `is_encodable_aarch64` on every result. Confirmed RED before fix, GREEN after.
- [x] Sibling test in `src/isa/aarch64.rs` drives the file-private `mutate_operand` directly with the same hostile table — 8 instruction-variant cases × 500 iterations per case, sharing one seeded RNG (`ChaCha8Rng::seed_from_u64(42)`). Compile-time RED before adding `imm_max` parameter, GREEN after.
- [x] `./ci_check.sh` passes (fmt + build + unit tests + test binaries + full test suite).
- [x] Full unit test suite: 824/824.

## Review follow-ups (filed as separate issues)
The PR-level review by `claude[bot]` raised four follow-up concerns that are tracked outside this PR: `rem_euclid` distribution bias, defensive `imm_max + 1` overflow guard, the candidate.rs adjacency, and one naming nit rejected as a style preference. Replies posted on the review comment with the rationale and tracking-issue links.