### PR TITLE
Introduce RegisterSet<R> as neutral live-in/live-out carrier (closes #85)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ src/
 │   ├── cost.rs          # AArch64 cost model
 │   ├── cost_x86.rs      # x86 cost model (variable-length CodeSize)
 │   ├── equivalence.rs   # check_equivalence (AArch64) + check_equivalence_x86 (EFLAGS fast-path)
-│   └── state.rs         # Machine state: ConditionFlags (NZCV), Eflags, *MachineState, LiveOutMask
+│   └── state.rs         # Machine state: ConditionFlags (NZCV), Eflags, *MachineState, X86LiveOutMask. RegisterSet<R> lives in live_out.rs.
 ├── search/              # Search algorithms (AArch64-typed in v1)
 │   ├── candidate.rs     # AArch64 candidate generation
 │   ├── candidate_x86.rs # x86 candidate generation

--- a/docs/adr/0004-isa-trait-collapse.md
+++ b/docs/adr/0004-isa-trait-collapse.md
@@ -37,11 +37,13 @@ Rationale: text-input flows (`s11 equiv`, `--algorithm llm`) are AArch64-only fo
 
 Rationale: the only consumer that round-trips full operand structure is the stochastic mutator, and mutators are already per-ISA. Generalising `OperandType` to cover every ISA's operand grammar (extended registers for AArch64, ModR/M-shaped operands for x86, future RISC-V operand encodings) would balloon the trait and provide no real abstraction win.
 
-### 5. `LiveOutMask<R>` replaces `LiveOut` and `X86LiveOutMask`; `flags_live` lives on the mask
+### 5. `RegisterSet<R>` replaces `LiveOut` and `X86LiveOutMask`; `flags_live` lives on the mask
 
-A new generic `pub struct LiveOutMask<R: RegisterType> { regs: HashSet<R>, flags_live: bool }` is added to `src/semantics/live_out.rs` in stage 1 step 7. AArch64's existing `LiveOut` becomes a type alias `pub type LiveOut = LiveOutMask<crate::ir::Register>;`. In stage 2 step 16, `X86LiveOutMask` (`src/semantics/state.rs:397-441`) is deleted and x86 callers move to `LiveOutMask<X86Register>`. RISC-V uses `LiveOutMask<RiscVRegister>` with `flags_live` always `false`.
+A generic `pub struct RegisterSet<R: RegisterType> { regs: HashSet<R>, flags_live: bool }` lives in `src/semantics/live_out.rs`. AArch64's `LiveOut` is the type alias `pub type LiveOut = RegisterSet<crate::ir::Register>;`. In stage 2 step 16, `X86LiveOutMask` (`src/semantics/state.rs:397-441`) is deleted and x86 callers move to `RegisterSet<X86Register>`. RISC-V uses `RegisterSet<RiscVRegister>` with `flags_live` always `false`.
 
-Today's asymmetry — x86 puts `flags_live` on the mask, AArch64 puts it on `EquivalenceConfig.flags_live` — resolves in x86's favour. The AArch64 `EquivalenceConfig.flags_live` field is removed in stage 1 step 9; consumers consult `live_out.flags_live` instead.
+The neutral name `RegisterSet` (closes #85) acknowledges that the same shape carries both live-in (`compute_live_in_registers`) and live-out sets — previously the AArch64 path used `LiveOutRegisters` for both, which surprised readers. The earlier working name `LiveOutMask<R>` from the original ADR draft was renamed during stage 1 step 9 to land both renames in a single PR.
+
+Today's asymmetry — x86 puts `flags_live` on the mask, AArch64 puts it on `EquivalenceConfig.flags_live` — resolves in x86's favour. The AArch64 `EquivalenceConfig.flags_live` field is removed in stage 1 step 9; consumers consult `live_out.flags_live()` instead.
 
 Rationale: `flags_live` is a property of the live-out contract, not of the equivalence configuration. The x86 location is the principled one. ADR-0002 ("LLM-assisted search MVP refuses targets with flags live-out") remains the authoritative statement about how `flags_live` is propagated for the LLM flow; this ADR only changes *where* the bit is stored.
 
@@ -90,5 +92,5 @@ Rationale: stage 1 and stage 2 are unaffected by this decision; deferring it doe
 **Reversibility:**
 - Decision 1 (width as associated type vs const generic) is the hardest to reverse — every generic function in the refactored consumer layer depends on it. Switching to const generics later means re-touching every `<I: ISA>` bound. Picked deliberately as the safer choice given today's Rust.
 - Decision 2 (`type Mutator` on `ISA` vs on `InstructionGenerator`) is moderately reversible. Moving the associated type later means updating every ISA impl block, but no consumer signature changes (consumers reach through the trait either way).
-- Decision 5 (`LiveOutMask<R>` with `flags_live` on the mask) is reversible by promoting `flags_live` back to `EquivalenceConfig` or to a third location; every consumer of `flags_live` is contained in `src/semantics/equivalence.rs` and `src/validation/live_out.rs`.
+- Decision 5 (`RegisterSet<R>` with `flags_live` on the mask) is reversible by promoting `flags_live` back to `EquivalenceConfig` or to a third location; every consumer of `flags_live` is contained in `src/semantics/equivalence.rs` and `src/validation/live_out.rs`.
 - Decisions 3, 4, 6, 7, 8 are all individually reversible without disturbing the rest of the plan. Decision 8 in particular is deliberately deferred.

--- a/docs/adr/0006-live-out-cli-grammar.md
+++ b/docs/adr/0006-live-out-cli-grammar.md
@@ -21,7 +21,7 @@ ADR-0004 §5 commits to replacing `LiveOut` and `X86LiveOutMask` with the generi
 
 2. Route both `run_equiv` (`src/main.rs`) and `run_llm_opt` through `parse_live_out_contract`, using a uniform `"invalid live-out: ..."` error prefix.
 
-3. In `run_equiv`, pass the parsed `LiveOut` (with its `flags_live` bit already set) to `EquivalenceConfig::with_live_out(...)`. The verbose printout gains `Live-out flags: nzcv` when `live_out.flags_live()` is true.
+3. In `run_equiv`, pass the parsed `LiveOut` (with its `flags_live` bit already set) into the `EquivalenceConfig` builder via `.live_out(...)`. The verbose printout gains `Live-out flags: nzcv` when `live_out.flags_live()` is true.
 
 4. In `run_llm_opt`, accept the same grammar but discard the bit. The LLM verification path pins `flags_live=true` internally at `src/search/llm/outcome.rs:67`, so the CLI bit is informational only on that subcommand. Keeping the parser consistent across both subcommands avoids a CLI-vocabulary fork.
 

--- a/docs/adr/0006-live-out-cli-grammar.md
+++ b/docs/adr/0006-live-out-cli-grammar.md
@@ -9,37 +9,37 @@ Before this ADR, the `--live-out` CLI argument on the `equiv` and `llm-opt` subc
 
 PR #78 deferred this as issue #81 with the note that once the live-out contract grew beyond registers, the CLI parser would need broadening. The deferral was contingent on a syntax decision and on the absence of a flag bit on the contract object; that absence is no longer load-bearing because the bit lives on `EquivalenceConfig`, not on `LiveOut`.
 
-ADR-0004 §5 commits to eventually replacing `LiveOut` and `X86LiveOutMask` with the generic `LiveOutMask<R>` (already scaffolded at `src/semantics/live_out.rs:25-87` with its own `flags_live`/`set_flags_live` API). When that migration lands, the CLI parser introduced here will simply produce a `LiveOutMask<Register>` directly; the grammar does not need to change.
+ADR-0004 §5 commits to replacing `LiveOut` and `X86LiveOutMask` with the generic `RegisterSet<R>` (`src/semantics/live_out.rs`). That migration has since landed: the CLI parser now produces a `LiveOut` (= `RegisterSet<Register>`) directly with `flags_live` set on the mask, and the `bool` was dropped from `parse_live_out_contract`'s return type. The grammar itself is unchanged.
 
 ## Decision
 
-1. Add a free function `validation::live_out::parse_live_out_contract(s: &str) -> Result<(LiveOut, bool), ParseLiveOutRegistersError>` implementing the grammar `<regs>` or `<regs>;<flags>`:
-   - Register half follows the existing `LiveOutRegisters::from_str` rules (comma- or space-separated, case-insensitive, accepts `x0..x30`, `sp`, `xzr`).
+1. Add a free function `validation::live_out::parse_live_out_contract(s: &str) -> Result<LiveOut, ParseRegisterSetError>` implementing the grammar `<regs>` or `<regs>;<flags>`:
+   - Register half follows the existing `RegisterSet::<Register>::from_str` rules (comma- or space-separated, case-insensitive, accepts `x0..x30`, `sp`, `xzr`).
    - Flag half accepts only the group token `nzcv` (case-insensitive). The per-flag tokens `n`, `z`, `c`, `v` are **explicitly reserved** so a future per-flag liveness rev can add them without a second grammar break. They are rejected today with a "reserved" diagnostic.
    - Bareword `nzcv` (no leading `;`) is rejected so the bareword reservation is unambiguous.
    - At most one `;` is permitted.
 
 2. Route both `run_equiv` (`src/main.rs`) and `run_llm_opt` through `parse_live_out_contract`, using a uniform `"invalid live-out: ..."` error prefix.
 
-3. In `run_equiv`, plug the returned `flags_live` bit into `EquivalenceConfig::with_flags(flags_live)`. The verbose printout gains `Live-out flags: nzcv` when the bit is set.
+3. In `run_equiv`, pass the parsed `LiveOut` (with its `flags_live` bit already set) to `EquivalenceConfig::with_live_out(...)`. The verbose printout gains `Live-out flags: nzcv` when `live_out.flags_live()` is true.
 
 4. In `run_llm_opt`, accept the same grammar but discard the bit. The LLM verification path pins `flags_live=true` internally at `src/search/llm/outcome.rs:67`, so the CLI bit is informational only on that subcommand. Keeping the parser consistent across both subcommands avoids a CLI-vocabulary fork.
 
-5. Do **not** add a `flags_live` field to `LiveOut` or a `with_flags` builder. The bit lives on `EquivalenceConfig` today and on `LiveOutMask<R>` in the future (ADR-0004 §5); adding a third home would create exactly the kind of state-duplication the ISA-trait-collapse ADR cautions against.
+5. `flags_live` lives on `LiveOut` (= `RegisterSet<Register>`) per ADR-0004 §5; `EquivalenceConfig::with_flags` is preserved as a thin builder that writes through to `self.live_out.with_flags(...)` so existing callers keep working.
 
-6. Do **not** drop `impl FromStr for LiveOutRegisters`. Existing callers (and the existing `from_str` test suite) keep working.
+6. The `FromStr` impl that used to live on `LiveOutRegisters` is now `impl FromStr for RegisterSet<Register>`. Existing callers (and the existing `from_str` test suite) keep working through the `LiveOut` alias.
 
 ## Consequences
 
 **Positive:**
 - The `equiv` subcommand can finally express "match registers and NZCV after execution" — a real user-facing capability gap closed without semantic churn.
 - The CLI grammar reserves the per-flag tokens up front, so a per-flag rev (when one is needed) lands without breaking in-flight scripts.
-- The two divergent CLI parse paths (`run_llm_opt` via `LiveOutRegisters::from_str`, `run_equiv` via hand-rolled `parser::parse_register` splitting) now share a single helper. Error messages match.
+- The two divergent CLI parse paths (`run_llm_opt` via `RegisterSet::<Register>::from_str`, `run_equiv` via hand-rolled `parser::parse_register` splitting) now share a single helper. Error messages match.
 
 **Negative / scope:**
 - `run_llm_opt --live-out "x0;nzcv"` and `run_llm_opt --live-out "x0"` are observationally identical on the LLM path today because `outcome.rs:67` pins `flags_live=true`. Users may be surprised that the suffix is "accepted but ignored" on this subcommand. Documented in the help text and in the `run_llm_opt` source comment.
 - `opt` (ELF optimization) does not accept `--live-out` and is unchanged. The search algorithms it dispatches still pin `flags_live=true` internally, so the conservative semantics there are preserved.
-- The bit lives on `EquivalenceConfig` and (in scaffolding) on `LiveOutMask<R>`. When the mask migration of ADR-0004 §5 lands, this ADR's CLI grammar should remain stable but the parser will return `(LiveOutMask<Register>, ())` — a single-return shape — and the explicit `bool` plumbing in `run_equiv` will collapse.
+- The mask migration of ADR-0004 §5 has landed in lockstep with this ADR's update. The parser now returns a single `LiveOut`, with `flags_live` set on the mask itself; the explicit `bool` plumbing in `run_equiv` has collapsed.
 
 **Reversibility:** high for the per-flag rev — the `n`/`z`/`c`/`v` tokens are rejected with a "reserved" message today, so adding their semantics later is a strict superset of the current grammar. Reversibility low for the parser function itself: it becomes load-bearing for both CLI subcommands.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1344,7 +1344,7 @@ fn run_llm_opt(
     // what the user requests here, so the `;nzcv` suffix is accepted (for
     // CLI vocabulary parity with `equiv`) but does not change behaviour on
     // this path. See ADR-0006.
-    let (live_out, _flags_live) = validation::live_out::parse_live_out_contract(live_out_str)
+    let live_out = validation::live_out::parse_live_out_contract(live_out_str)
         .map_err(|e| format!("invalid live-out: {}", e))?;
 
     let llm = LlmConfig::default()
@@ -1409,22 +1409,21 @@ fn run_equiv(
         }
     }
 
-    let (live_out, flags_live) = validation::live_out::parse_live_out_contract(live_out_str)
+    let live_out = validation::live_out::parse_live_out_contract(live_out_str)
         .map_err(|e| format!("invalid live-out: {}", e))?;
 
     if verbose {
-        let mut regs: Vec<_> = live_out.registers().iter().collect();
+        let mut regs: Vec<_> = live_out.iter().collect();
         regs.sort_by_key(|r| r.index().unwrap_or(u8::MAX));
         let names: Vec<String> = regs.iter().map(|r| format!("{}", r)).collect();
         println!("Live-out registers: {}", names.join(", "));
-        if flags_live {
+        if live_out.flags_live() {
             println!("Live-out flags: nzcv");
         }
     }
 
     let config = EquivalenceConfig::default()
         .live_out(live_out)
-        .with_flags(flags_live)
         .timeout(Duration::from_secs(timeout))
         .set_fast_only(fast_only);
 

--- a/src/search/llm/mod.rs
+++ b/src/search/llm/mod.rs
@@ -126,7 +126,7 @@ impl SearchAlgorithm<crate::isa::AArch64> for LlmSearch {
         }
 
         let live_in = compute_live_in_registers(target);
-        let prompt = build_prompt(target, &live_in, live_out.registers());
+        let prompt = build_prompt(target, &live_in, live_out);
         let timeout = config.timeout.unwrap_or(Duration::from_secs(60));
         let max_calls = config.llm.max_codex_calls;
 

--- a/src/search/llm/prompt.rs
+++ b/src/search/llm/prompt.rs
@@ -8,10 +8,10 @@
 //! generification of this module is planned.
 
 use crate::ir::{Instruction, Register};
-use crate::semantics::live_out::LiveOutRegisters;
+use crate::semantics::live_out::RegisterSet;
 
 /// Render a register set as a comma-separated list (e.g. "x0, x1, x2").
-fn render_register_set(mask: &LiveOutRegisters) -> String {
+fn render_register_set(mask: &RegisterSet<Register>) -> String {
     let mut names: Vec<String> = (0..=30u8)
         .filter_map(Register::from_index)
         .filter(|r| mask.contains(*r))
@@ -26,8 +26,8 @@ fn render_register_set(mask: &LiveOutRegisters) -> String {
 /// Build the full prompt sent to `codex exec`.
 pub fn build_prompt(
     target: &[Instruction],
-    live_in: &LiveOutRegisters,
-    live_out: &LiveOutRegisters,
+    live_in: &RegisterSet<Register>,
+    live_out: &RegisterSet<Register>,
 ) -> String {
     let mut s = String::new();
     s.push_str(
@@ -71,8 +71,8 @@ mod tests {
     use super::*;
     use crate::ir::{Operand, Register};
 
-    fn mask(regs: &[Register]) -> LiveOutRegisters {
-        let mut m = LiveOutRegisters::empty();
+    fn mask(regs: &[Register]) -> RegisterSet<Register> {
+        let mut m = RegisterSet::empty();
         for r in regs {
             m.add(*r);
         }

--- a/src/search/stochastic/backend.rs
+++ b/src/search/stochastic/backend.rs
@@ -136,7 +136,7 @@ impl StochasticBackend<crate::isa::AArch64> for crate::isa::AArch64 {
         // AArch64's `LiveOut` does not carry a flags_live bit (the
         // over-approximate flag-writer guard lives in equivalence.rs
         // pre-SMT). Mirror mcmc.rs's existing call which passes false.
-        crate::semantics::concrete::states_equal_for_live_out(s1, s2, live_out.registers(), false)
+        crate::semantics::concrete::states_equal_for_live_out(s1, s2, live_out, false)
     }
 
     fn sequence_cost(seq: &[crate::ir::Instruction], metric: &CostMetric, _width: u32) -> u64 {

--- a/src/search/stochastic/backend.rs
+++ b/src/search/stochastic/backend.rs
@@ -56,6 +56,14 @@ pub trait StochasticBackend<I: ISA>: Sized {
     /// Loop-execute a sequence against an initial state.
     fn apply_sequence(state: Self::State, seq: &[I::Instruction]) -> Self::State;
     /// Compare two states over the live-out contract.
+    ///
+    /// **Invariant:** any `flags_live` bit on the mask is honoured by the
+    /// equivalence-checking layer (`semantics::equivalence`), not here.
+    /// Implementations of this trait method **must** treat the comparison as
+    /// register-only — the pre-SMT flag-writer guard upstream rejects
+    /// flag-divergent candidates before stochastic comparison runs. If the
+    /// call path is ever rearranged so stochastic compares states without
+    /// passing through the upstream guard, this invariant has to be revisited.
     fn states_equal(s1: &Self::State, s2: &Self::State, live_out: &Self::LiveOut) -> bool;
 
     /// Sum the cost of every instruction in the sequence.

--- a/src/search/stochastic/backend.rs
+++ b/src/search/stochastic/backend.rs
@@ -64,6 +64,12 @@ pub trait StochasticBackend<I: ISA>: Sized {
     /// flag-divergent candidates before stochastic comparison runs. If the
     /// call path is ever rearranged so stochastic compares states without
     /// passing through the upstream guard, this invariant has to be revisited.
+    ///
+    /// This is the only known caller in the codebase that intentionally
+    /// passes `flags_live=false` to `concrete::states_equal_for_live_out`
+    /// regardless of the mask's `flags_live()` value; the cleanup tracked in
+    /// issue #282 must preserve this exception (e.g. by routing every other
+    /// caller through `live_out.flags_live()` and leaving this one explicit).
     fn states_equal(s1: &Self::State, s2: &Self::State, live_out: &Self::LiveOut) -> bool;
 
     /// Sum the cost of every instruction in the sequence.

--- a/src/search/stochastic/backend.rs
+++ b/src/search/stochastic/backend.rs
@@ -133,9 +133,11 @@ impl StochasticBackend<crate::isa::AArch64> for crate::isa::AArch64 {
     }
 
     fn states_equal(s1: &Self::State, s2: &Self::State, live_out: &Self::LiveOut) -> bool {
-        // AArch64's `LiveOut` does not carry a flags_live bit (the
-        // over-approximate flag-writer guard lives in equivalence.rs
-        // pre-SMT). Mirror mcmc.rs's existing call which passes false.
+        // Pass `flags_live = false` deliberately: the over-approximate
+        // flag-writer guard in equivalence.rs pre-SMT already handles flag
+        // divergence before stochastic comparison is reached. The mask may
+        // carry `flags_live = true`, but it is honoured upstream, not here.
+        // Mirrors mcmc.rs's existing call site.
         crate::semantics::concrete::states_equal_for_live_out(s1, s2, live_out, false)
     }
 

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -13,7 +13,7 @@
 //!    d. Accept/reject based on Metropolis-Hastings criterion
 //! 4. Return best found optimization
 
-use crate::ir::Instruction;
+use crate::ir::{Instruction, Register};
 use crate::isa::{ISA, ISAMutator};
 use crate::search::config::SearchConfig;
 use crate::search::result::{SearchResultFor, SearchStatistics};
@@ -22,7 +22,7 @@ use crate::search::stochastic::backend::StochasticBackend;
 use crate::search::{Algorithm, SearchAlgorithm};
 use crate::semantics::EquivalenceResult;
 use crate::semantics::concrete::{apply_sequence_concrete, states_equal_for_live_out};
-use crate::semantics::live_out::LiveOutRegisters;
+use crate::semantics::live_out::RegisterSet;
 use crate::semantics::state::ConcreteMachineState;
 use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha8Rng;
@@ -277,7 +277,7 @@ pub fn evaluate_with_tests(
     _target: &[Instruction],
     test_inputs: &[ConcreteMachineState],
     target_outputs: &[ConcreteMachineState],
-    live_out: &LiveOutRegisters,
+    live_out: &RegisterSet<Register>,
 ) -> (u64, bool) {
     let mut passes_all = true;
 
@@ -422,7 +422,7 @@ mod tests {
         let input = ConcreteMachineState::new_zeroed();
         let target_output = apply_sequence_concrete(input.clone(), &target);
 
-        let live_out = LiveOutRegisters::from_registers(vec![Register::X0]);
+        let live_out = RegisterSet::<Register>::from_registers(vec![Register::X0]);
         let (cost, passes) =
             evaluate_with_tests(&proposal, &target, &[input], &[target_output], &live_out);
 
@@ -441,7 +441,7 @@ mod tests {
         let input = ConcreteMachineState::new_zeroed();
         let target_output = apply_sequence_concrete(input.clone(), &target);
 
-        let live_out = LiveOutRegisters::from_registers(vec![Register::X0]);
+        let live_out = RegisterSet::<Register>::from_registers(vec![Register::X0]);
         let (cost, passes) =
             evaluate_with_tests(&proposal, &target, &[input], &[target_output], &live_out);
 

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -1,7 +1,7 @@
 //! Concrete interpreter for fast validation of instruction sequences
 
 use crate::ir::{Condition, Instruction, Operand, Register, ShiftKind};
-use crate::semantics::live_out::LiveOutRegisters;
+use crate::semantics::live_out::RegisterSet;
 use crate::semantics::state::{ConcreteMachineState, ConcreteValue, ConditionFlags};
 
 /// Evaluate an operand to get its concrete value
@@ -580,7 +580,7 @@ pub fn apply_sequence_concrete(
 pub fn states_equal_for_live_out(
     state1: &ConcreteMachineState,
     state2: &ConcreteMachineState,
-    live_out: &LiveOutRegisters,
+    live_out: &RegisterSet<Register>,
     flags_live: bool,
 ) -> bool {
     for reg in live_out.iter() {
@@ -600,7 +600,7 @@ pub fn states_equal_for_live_out(
 pub fn find_first_difference(
     state1: &ConcreteMachineState,
     state2: &ConcreteMachineState,
-    live_out: &LiveOutRegisters,
+    live_out: &RegisterSet<Register>,
     flags_live: bool,
 ) -> Option<(Register, ConcreteValue, ConcreteValue)> {
     for reg in live_out.iter() {
@@ -965,7 +965,7 @@ mod tests {
         let state1 = state_with(vec![(Register::X0, 42), (Register::X1, 100)]);
         let state2 = state_with(vec![(Register::X0, 42), (Register::X1, 999)]);
 
-        let live_out = LiveOutRegisters::from_registers(vec![Register::X0]);
+        let live_out = RegisterSet::<Register>::from_registers(vec![Register::X0]);
         assert!(states_equal_for_live_out(
             &state1, &state2, &live_out, false
         ));
@@ -976,7 +976,7 @@ mod tests {
         let state1 = state_with(vec![(Register::X0, 42)]);
         let state2 = state_with(vec![(Register::X0, 43)]);
 
-        let live_out = LiveOutRegisters::from_registers(vec![Register::X0]);
+        let live_out = RegisterSet::<Register>::from_registers(vec![Register::X0]);
         assert!(!states_equal_for_live_out(
             &state1, &state2, &live_out, false
         ));
@@ -987,7 +987,7 @@ mod tests {
         let state1 = state_with(vec![(Register::X0, 42), (Register::X1, 100)]);
         let state2 = state_with(vec![(Register::X0, 42), (Register::X1, 200)]);
 
-        let live_out = LiveOutRegisters::from_registers(vec![Register::X0, Register::X1]);
+        let live_out = RegisterSet::<Register>::from_registers(vec![Register::X0, Register::X1]);
         let diff = find_first_difference(&state1, &state2, &live_out, false);
         assert!(diff.is_some());
         let (reg, v1, v2) = diff.unwrap();
@@ -1001,7 +1001,7 @@ mod tests {
         let state1 = state_with(vec![(Register::X0, 42)]);
         let state2 = state_with(vec![(Register::X0, 42)]);
 
-        let live_out = LiveOutRegisters::from_registers(vec![Register::X0]);
+        let live_out = RegisterSet::<Register>::from_registers(vec![Register::X0]);
         let diff = find_first_difference(&state1, &state2, &live_out, false);
         assert!(diff.is_none());
     }
@@ -1023,7 +1023,7 @@ mod tests {
         }];
         let state2 = apply_sequence_concrete(state, &seq2);
 
-        let live_out = LiveOutRegisters::from_registers(vec![Register::X0]);
+        let live_out = RegisterSet::<Register>::from_registers(vec![Register::X0]);
         assert!(states_equal_for_live_out(
             &state1, &state2, &live_out, false
         ));

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -577,6 +577,10 @@ pub fn apply_sequence_concrete(
 
 /// Check if two concrete states are equal for the specified live-out registers,
 /// optionally including the NZCV condition flags.
+///
+/// TODO(#282): The explicit `flags_live` parameter is now redundant with
+/// `live_out.flags_live()` for every caller except the stochastic backend
+/// (which deliberately passes `false`). Tracked for cleanup in issue #282.
 pub fn states_equal_for_live_out(
     state1: &ConcreteMachineState,
     state2: &ConcreteMachineState,
@@ -597,6 +601,9 @@ pub fn states_equal_for_live_out(
 /// Find the first differing register between two states for live-out registers.
 /// Flag divergence (when `flags_live` is set) is reported via the `XZR`
 /// sentinel since the function signature is register-typed.
+///
+/// TODO(#282): see `states_equal_for_live_out` — the same `flags_live`
+/// redundancy applies here. Tracked for follow-up cleanup.
 pub fn find_first_difference(
     state1: &ConcreteMachineState,
     state2: &ConcreteMachineState,

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -143,6 +143,14 @@ impl EquivalenceConfig {
     /// `flags_live` moved from `EquivalenceConfig` onto the mask (ADR-0004
     /// §5). The OR-merge makes the builder order-independent: flags are
     /// live if either the existing config OR the new mask says so.
+    ///
+    /// **One-way ratchet:** once a previous builder step set `flags_live`
+    /// to true (via `.with_flags(true)` or a `LiveOut` with that bit
+    /// already set), this method cannot clear it — callers who genuinely
+    /// want a flags-dead replacement must mutate `config.live_out`
+    /// directly. The trade-off is deliberate; silently *losing* flag
+    /// liveness in a chained builder is a much more dangerous failure
+    /// mode than retaining it.
     pub fn live_out(mut self, live_out: LiveOut) -> Self {
         let merged_flags = self.live_out.flags_live() || live_out.flags_live();
         self.live_out = live_out.with_flags(merged_flags);

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -135,8 +135,17 @@ impl EquivalenceConfig {
     }
 
     /// Builder method to set live-out contract.
+    ///
+    /// Preserves any previously-set `flags_live` bit. Without this carry,
+    /// `.with_flags(true).live_out(LiveOut::from_registers(...))` would
+    /// silently drop NZCV-liveness because `from_registers` defaults
+    /// `flags_live` to `false` — a regression footgun introduced when
+    /// `flags_live` moved from `EquivalenceConfig` onto the mask (ADR-0004
+    /// §5). The OR-merge makes the builder order-independent: flags are
+    /// live if either the existing config OR the new mask says so.
     pub fn live_out(mut self, live_out: LiveOut) -> Self {
-        self.live_out = live_out;
+        let merged_flags = self.live_out.flags_live() || live_out.flags_live();
+        self.live_out = live_out.with_flags(merged_flags);
         self
     }
 
@@ -771,6 +780,33 @@ mod tests {
 
         let config = EquivalenceConfig::default().with_flags(false);
         assert!(!config.live_out.flags_live());
+    }
+
+    #[test]
+    fn aarch64_live_out_builder_preserves_flags_live() {
+        // Regression: with `flags_live` on the mask, the builder order
+        // `.with_flags(true).live_out(...)` used to silently drop the flag bit
+        // because `LiveOut::from_registers(...)` defaults `flags_live` to
+        // false. The builder must merge (OR) the prior flag state so flags
+        // stay live regardless of builder order.
+        let config = EquivalenceConfig::default()
+            .with_flags(true)
+            .live_out(LiveOut::from_registers(vec![Register::X0]));
+        assert!(
+            config.live_out.flags_live(),
+            "live_out() must preserve flags_live set by an earlier with_flags()"
+        );
+
+        // Reverse order (already known-good) still works.
+        let config = EquivalenceConfig::default()
+            .live_out(LiveOut::from_registers(vec![Register::X0]))
+            .with_flags(true);
+        assert!(config.live_out.flags_live());
+
+        // Explicit flags on the new mask propagate even with no prior with_flags.
+        let config = EquivalenceConfig::default()
+            .live_out(LiveOut::from_registers(vec![Register::X0]).with_flags(true));
+        assert!(config.live_out.flags_live());
     }
 
     #[test]

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -2,7 +2,7 @@
 //!
 //! Issue #77 stage 2 step 19 plans to delete `X86EquivalenceConfig`,
 //! `check_equivalence_x86`, and `run_fast_path_x86` once
-//! `EquivalenceConfig<I>` is wired to consume `LiveOutMask<I::Register>`
+//! `EquivalenceConfig<I>` is wired to consume `RegisterSet<I::Register>`
 //! and the SearchAlgorithm<I> follow-up to step 11 lands. The CMP-presence
 //! heuristic in `run_fast_path_x86` merges into the generic `run_fast_path`
 //! as an `I::Flags`-aware optimisation (only triggers when `I::Flags != ()`).
@@ -95,6 +95,8 @@ pub enum EquivalenceResult {
 #[derive(Debug, Clone)]
 pub struct EquivalenceConfig {
     /// Observable architectural state that must match after execution.
+    /// Per ADR-0004 decision 5, `flags_live` lives on the mask itself
+    /// (`live_out.flags_live()`) rather than as a separate config field.
     pub live_out: LiveOut,
     /// Number of random tests to run before SMT
     pub random_test_count: usize,
@@ -102,9 +104,6 @@ pub struct EquivalenceConfig {
     pub smt_timeout: Option<Duration>,
     /// Skip SMT verification (fast path only)
     pub fast_only: bool,
-    /// Treat NZCV as live-out (include flag equality in both fast-path and
-    /// SMT comparisons).
-    pub flags_live: bool,
 }
 
 impl Default for EquivalenceConfig {
@@ -114,7 +113,6 @@ impl Default for EquivalenceConfig {
             random_test_count: 10,
             smt_timeout: Some(Duration::from_secs(30)),
             fast_only: false,
-            flags_live: false,
         }
     }
 }
@@ -168,9 +166,9 @@ impl EquivalenceConfig {
 
     /// Builder method to mark NZCV as live-out — flag inequality then
     /// participates in both the fast-path concrete comparison and the SMT
-    /// formula. Mirrors `X86LiveOutMask::with_flags(true)` on the x86 side.
+    /// formula. Stores the bit on the live-out mask itself (ADR-0004 §5).
     pub fn with_flags(mut self, flags_live: bool) -> Self {
-        self.flags_live = flags_live;
+        self.live_out = self.live_out.with_flags(flags_live);
         self
     }
 }
@@ -238,7 +236,7 @@ pub struct EquivalenceMetrics {
 /// vs `tst x1, #2` under a flag-only contract — see the regression test in
 /// this module). The SMT path is unaffected; it operates on symbolic inputs.
 fn fast_path_input_registers(
-    live_out_registers: &crate::semantics::live_out::LiveOutRegisters,
+    live_out_registers: &crate::semantics::live_out::RegisterSet<crate::ir::Register>,
     seq1: &[Instruction],
     seq2: &[Instruction],
 ) -> Vec<crate::ir::Register> {
@@ -294,7 +292,7 @@ fn run_fast_path(
     seq2: &[Instruction],
     config: &EquivalenceConfig,
 ) -> Option<EquivalenceResult> {
-    let live_out_registers = config.live_out.registers();
+    let live_out_registers = &config.live_out;
     // Under `fast_only`, the SMT path that would otherwise catch divergences
     // depending on source registers outside `live_out` is skipped — extend
     // the random-input mask to cover seq1+seq2 source registers so e.g.
@@ -319,7 +317,12 @@ fn run_fast_path(
         let state1 = apply_sequence_concrete(input.clone(), seq1);
         let state2 = apply_sequence_concrete(input.clone(), seq2);
 
-        if !states_equal_for_live_out(&state1, &state2, live_out_registers, config.flags_live) {
+        if !states_equal_for_live_out(
+            &state1,
+            &state2,
+            live_out_registers,
+            config.live_out.flags_live(),
+        ) {
             return Some(EquivalenceResult::NotEquivalentFast(input.clone()));
         }
     }
@@ -329,7 +332,12 @@ fn run_fast_path(
         let state1 = apply_sequence_concrete(input.clone(), seq1);
         let state2 = apply_sequence_concrete(input.clone(), seq2);
 
-        if !states_equal_for_live_out(&state1, &state2, live_out_registers, config.flags_live) {
+        if !states_equal_for_live_out(
+            &state1,
+            &state2,
+            live_out_registers,
+            config.live_out.flags_live(),
+        ) {
             return Some(EquivalenceResult::NotEquivalentFast(input.clone()));
         }
     }
@@ -341,7 +349,7 @@ fn run_fast_path(
     // handles this correctly via symbolic initial state, and adding 16
     // inputs to every search-algorithm candidate would burn significant
     // wall-clock time on a verifier that's normally SMT-authoritative.
-    // NOT gated on `config.flags_live` — a flag-reading sequence whose
+    // NOT gated on `config.live_out.flags_live()` — a flag-reading sequence whose
     // *register* output depends on incoming NZCV (e.g. `csel x0, x1, x2, mi`
     // under `--live-out x0`) also needs the variants for the fast path to
     // catch divergence on the condition-true branch.
@@ -349,7 +357,12 @@ fn run_fast_path(
         for input in &fast_path_initial_nzcv_variants(&input_regs) {
             let state1 = apply_sequence_concrete(input.clone(), seq1);
             let state2 = apply_sequence_concrete(input.clone(), seq2);
-            if !states_equal_for_live_out(&state1, &state2, live_out_registers, config.flags_live) {
+            if !states_equal_for_live_out(
+                &state1,
+                &state2,
+                live_out_registers,
+                config.live_out.flags_live(),
+            ) {
                 return Some(EquivalenceResult::NotEquivalentFast(input.clone()));
             }
         }
@@ -375,7 +388,7 @@ pub fn check_equivalence_with_config(
         return EquivalenceResult::NotEquivalentFast(ConcreteMachineState::new_zeroed());
     }
 
-    if let Some(early) = pre_smt_guard(prefix1, prefix2, config.flags_live) {
+    if let Some(early) = pre_smt_guard(prefix1, prefix2, config.live_out.flags_live()) {
         return early;
     }
 
@@ -413,7 +426,7 @@ pub fn check_equivalence_with_config_metrics(
         );
     }
 
-    if let Some(early) = pre_smt_guard(prefix1, prefix2, config.flags_live) {
+    if let Some(early) = pre_smt_guard(prefix1, prefix2, config.live_out.flags_live()) {
         return (early, metrics);
     }
 
@@ -466,8 +479,8 @@ fn build_smt_solver(
     solver.assert(states_not_equal_for_live_out(
         &final_state1,
         &final_state2,
-        config.live_out.registers(),
-        config.flags_live,
+        &config.live_out,
+        config.live_out.flags_live(),
     ));
     solver
 }
@@ -536,7 +549,7 @@ pub fn find_counterexample_concrete(
     crate::semantics::state::ConcreteValue,
     crate::semantics::state::ConcreteValue,
 )> {
-    let live_out_registers = config.live_out.registers();
+    let live_out_registers = &config.live_out;
     let input_regs: Vec<_> = live_out_registers.iter().cloned().collect();
 
     let random_config = RandomInputConfig {
@@ -549,9 +562,12 @@ pub fn find_counterexample_concrete(
         let state1 = apply_sequence_concrete(input.clone(), seq1);
         let state2 = apply_sequence_concrete(input.clone(), seq2);
 
-        if let Some(diff) =
-            find_first_difference(&state1, &state2, live_out_registers, config.flags_live)
-        {
+        if let Some(diff) = find_first_difference(
+            &state1,
+            &state2,
+            live_out_registers,
+            config.live_out.flags_live(),
+        ) {
             return Some(diff);
         }
     }
@@ -561,9 +577,12 @@ pub fn find_counterexample_concrete(
         let state1 = apply_sequence_concrete(input.clone(), seq1);
         let state2 = apply_sequence_concrete(input.clone(), seq2);
 
-        if let Some(diff) =
-            find_first_difference(&state1, &state2, live_out_registers, config.flags_live)
-        {
+        if let Some(diff) = find_first_difference(
+            &state1,
+            &state2,
+            live_out_registers,
+            config.live_out.flags_live(),
+        ) {
             return Some(diff);
         }
     }
@@ -742,6 +761,17 @@ mod tests {
     use crate::ir::{Operand, Register};
     use crate::isa::x86::{X86Instruction, X86Register};
     use crate::semantics::state::X86LiveOutMask;
+
+    #[test]
+    fn aarch64_with_flags_writes_through_mask() {
+        // After moving `flags_live` from `EquivalenceConfig` onto the mask,
+        // `with_flags(true)` must make `config.live_out.flags_live()` true.
+        let config = EquivalenceConfig::default().with_flags(true);
+        assert!(config.live_out.flags_live());
+
+        let config = EquivalenceConfig::default().with_flags(false);
+        assert!(!config.live_out.flags_live());
+    }
 
     #[test]
     fn x86_mov_zero_equivalent_to_xor_self_when_flags_dead() {
@@ -2140,7 +2170,7 @@ mod tests {
     /// `tst x1, #1` and `tst x1, #2` differ on NZCV when bit 0 vs bit 1 of
     /// x1 is set, so a flag-aware live-out contract must classify them as
     /// non-equivalent. Prior to the source-register randomization fix, the
-    /// fast path only varied registers in `config.live_out.registers()` —
+    /// fast path only varied registers in `config.live_out` —
     /// empty for a flag-only contract — so x1 stayed at zero across all
     /// random + edge-case inputs and both sequences reported flags as zero,
     /// returning `Equivalent` under `--fast-only`. The fix unions the source
@@ -2204,7 +2234,7 @@ mod tests {
     /// `csel x0, x1, x2, mi` reads incoming N to decide whether x0 = x1
     /// (N=true) or x0 = x2 (N=false). With a register-live contract
     /// (`--live-out x0` but `flags_live=false`), the initial-NZCV variants
-    /// were originally gated on `config.flags_live` — so all fast-path
+    /// were originally gated on `config.live_out.flags_live()` — so all fast-path
     /// inputs left N=false and the candidate `mov x0, x2` was accepted as
     /// equivalent even when x1 != x2 and N=true would differ. Broadening
     /// the gate to fire on any flag-reading sequence (regardless of whether

--- a/src/semantics/live_out.rs
+++ b/src/semantics/live_out.rs
@@ -1,13 +1,16 @@
-//! Live-out contract for equivalence checking.
+//! Live-out and live-in register contracts for equivalence checking.
 //!
-//! `LiveOut` names the full observable architectural state contract. Today the
-//! only populated slice is `LiveOutRegisters`; condition state, memory, and PC
-//! can be added beside it without renaming the search/equivalence boundary.
+//! `RegisterSet<R>` is the per-ISA generic carrier: a set of architectural
+//! registers plus a `flags_live` bit. The same shape is reused for live-in
+//! analyses (see `validation::live_out::compute_live_in_registers`) because
+//! live-in and live-out are both register sets — hence the neutral name
+//! (closes #85; supersedes the earlier `LiveOutMask<R>` / `LiveOutRegisters`
+//! split).
 //!
-//! `LiveOutMask<R>` (added in #77 stage 1 step 7) is the per-ISA-register
-//! generic shape that stage 1 step 9 wires into `EquivalenceConfig<I>` and
-//! stage 2 step 16 lifts to subsume `X86LiveOutMask`. `flags_live` lives on
-//! the mask per ADR-0004 decision 5.
+//! `LiveOut` is the AArch64 alias `RegisterSet<crate::ir::Register>` and is
+//! the boundary type the search and equivalence layers use. ADR-0004 decision
+//! 5 documents the consolidation; x86 (`X86LiveOutMask`) follows in #77 stage
+//! 2 step 16.
 
 use crate::ir::Register;
 use crate::isa::RegisterType;
@@ -20,15 +23,15 @@ use std::fmt;
 /// the same contract object. Stage 1 step 9 migrates `EquivalenceConfig` to
 /// `EquivalenceConfig<I>` and threads this type through every consumer; stage
 /// 2 step 16 replaces the parallel `X86LiveOutMask` with
-/// `LiveOutMask<X86Register>` and drops the duplicate type.
+/// `RegisterSet<X86Register>` and drops the duplicate type.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LiveOutMask<R: RegisterType> {
+pub struct RegisterSet<R: RegisterType> {
     regs: HashSet<R>,
     flags_live: bool,
 }
 
 #[allow(dead_code)] // public API, wired in #77 stage 1 step 9
-impl<R: RegisterType> LiveOutMask<R> {
+impl<R: RegisterType> RegisterSet<R> {
     /// Empty mask, flags not live.
     pub fn empty() -> Self {
         Self {
@@ -50,6 +53,12 @@ impl<R: RegisterType> LiveOutMask<R> {
         if !reg.is_zero_register() {
             self.regs.insert(reg);
         }
+    }
+
+    /// Remove a register from the set.
+    #[allow(dead_code)]
+    pub fn remove(&mut self, reg: R) {
+        self.regs.remove(&reg);
     }
 
     /// Returns true if `reg` is live-out.
@@ -84,134 +93,55 @@ impl<R: RegisterType> LiveOutMask<R> {
     pub fn set_flags_live(&mut self, live: bool) {
         self.flags_live = live;
     }
+
+    /// Builder form of `set_flags_live`. Mirrors `X86LiveOutMask::with_flags`.
+    pub fn with_flags(mut self, flags_live: bool) -> Self {
+        self.flags_live = flags_live;
+        self
+    }
+
+    /// AArch64-flavored alias for `contains`. Kept so call sites using
+    /// the old `LiveOut::contains_register(reg)` keep compiling after
+    /// `LiveOut` becomes a type alias for this mask.
+    pub fn contains_register(&self, reg: R) -> bool {
+        self.contains(reg)
+    }
 }
 
-/// Observable architectural state that must match after executing a sequence.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LiveOut {
-    registers: LiveOutRegisters,
-}
-
-impl LiveOut {
-    /// Create a live-out contract containing all general-purpose registers.
+impl RegisterSet<Register> {
+    /// All general-purpose AArch64 registers (X0..X30, SP); excludes XZR.
     pub fn all_registers() -> Self {
-        Self {
-            registers: LiveOutRegisters::all_registers(),
-        }
-    }
-
-    /// Create a live-out contract from the register slice.
-    pub fn from_registers(regs: Vec<Register>) -> Self {
-        Self {
-            registers: LiveOutRegisters::from_registers(regs),
-        }
-    }
-
-    /// Create a live-out contract from an already parsed register slice.
-    pub fn from_register_set(registers: LiveOutRegisters) -> Self {
-        Self { registers }
-    }
-
-    /// The register slice of this live-out contract.
-    pub fn registers(&self) -> &LiveOutRegisters {
-        &self.registers
-    }
-
-    /// Check whether a register is live-out.
-    pub fn contains_register(&self, reg: Register) -> bool {
-        self.registers.contains(reg)
-    }
-}
-
-impl From<LiveOutRegisters> for LiveOut {
-    fn from(registers: LiveOutRegisters) -> Self {
-        Self::from_register_set(registers)
-    }
-}
-
-impl fmt::Display for LiveOut {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "LiveOut {{ registers={} }}", self.registers)
-    }
-}
-
-/// Register set specifying which registers are live-out (need to be preserved)
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LiveOutRegisters {
-    registers: HashSet<Register>,
-}
-
-impl LiveOutRegisters {
-    /// Create a register set with all general-purpose registers (X0-X30, SP)
-    pub fn all_registers() -> Self {
-        let mut registers = HashSet::new();
+        let mut mask = Self::empty();
         for i in 0..=30 {
             if let Some(reg) = Register::from_index(i) {
-                registers.insert(reg);
+                mask.add(reg);
             }
         }
-        registers.insert(Register::SP);
-        LiveOutRegisters { registers }
-    }
-
-    /// Create a register set from a list of registers
-    pub fn from_registers(regs: Vec<Register>) -> Self {
-        LiveOutRegisters {
-            registers: regs.into_iter().collect(),
-        }
-    }
-
-    /// Create an empty register set
-    pub fn empty() -> Self {
-        LiveOutRegisters {
-            registers: HashSet::new(),
-        }
-    }
-
-    /// Add a register to the register set
-    pub fn add(&mut self, reg: Register) {
-        if reg != Register::XZR {
-            self.registers.insert(reg);
-        }
-    }
-
-    /// Remove a register from the register set
-    #[allow(dead_code)]
-    pub fn remove(&mut self, reg: Register) {
-        self.registers.remove(&reg);
-    }
-
-    /// Check if a register is in the register set
-    pub fn contains(&self, reg: Register) -> bool {
-        self.registers.contains(&reg)
-    }
-
-    /// Iterate over registers in the register set
-    pub fn iter(&self) -> impl Iterator<Item = &Register> {
-        self.registers.iter()
-    }
-
-    /// Get the number of registers in the register set
-    #[allow(dead_code)]
-    pub fn len(&self) -> usize {
-        self.registers.len()
-    }
-
-    /// Check if the register set is empty
-    #[allow(dead_code)]
-    pub fn is_empty(&self) -> bool {
-        self.registers.is_empty()
+        mask.add(Register::SP);
+        mask
     }
 }
 
-impl fmt::Display for LiveOutRegisters {
+/// Self-documenting Display: `LiveOut { registers={x0, x1} }`.
+///
+/// Format from PR #79: wrapping the register slice in a labelled outer
+/// keeps the rendering forward-compatible with extra state slices
+/// (flags_live today, memory/PC tomorrow) without breaking log readers.
+impl fmt::Display for RegisterSet<Register> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut regs: Vec<_> = self.registers.iter().collect();
+        let mut regs: Vec<_> = self.iter().collect();
         regs.sort_by_key(|r| r.index().unwrap_or(255));
         let names: Vec<_> = regs.iter().map(|r| format!("{}", r)).collect();
-        write!(f, "{{{}}}", names.join(", "))
+        write!(f, "LiveOut {{ registers={{{}}} }}", names.join(", "))
     }
 }
+
+/// AArch64 live-out / live-in carrier.
+///
+/// Type alias for `RegisterSet<Register>` per ADR-0004 decision 5. The
+/// previous separate `LiveOut` wrapper struct and `LiveOutRegisters`
+/// register-only set were collapsed onto this alias (closes #85).
+pub type LiveOut = RegisterSet<Register>;
 
 #[cfg(test)]
 mod tests {
@@ -219,7 +149,7 @@ mod tests {
 
     #[test]
     fn test_live_out_registers_all_registers() {
-        let mask = LiveOutRegisters::all_registers();
+        let mask = LiveOut::all_registers();
         assert!(mask.contains(Register::X0));
         assert!(mask.contains(Register::X30));
         assert!(mask.contains(Register::SP));
@@ -228,7 +158,7 @@ mod tests {
 
     #[test]
     fn test_live_out_registers_from_registers() {
-        let mask = LiveOutRegisters::from_registers(vec![Register::X0, Register::X1, Register::X2]);
+        let mask = LiveOut::from_registers(vec![Register::X0, Register::X1, Register::X2]);
         assert!(mask.contains(Register::X0));
         assert!(mask.contains(Register::X1));
         assert!(mask.contains(Register::X2));
@@ -238,14 +168,14 @@ mod tests {
 
     #[test]
     fn test_live_out_registers_empty() {
-        let mask = LiveOutRegisters::empty();
+        let mask = LiveOut::empty();
         assert!(mask.is_empty());
         assert!(!mask.contains(Register::X0));
     }
 
     #[test]
     fn test_live_out_registers_add_remove() {
-        let mut mask = LiveOutRegisters::empty();
+        let mut mask = LiveOut::empty();
         mask.add(Register::X0);
         assert!(mask.contains(Register::X0));
 
@@ -255,23 +185,23 @@ mod tests {
 
     #[test]
     fn test_live_out_registers_xzr_ignored() {
-        let mut mask = LiveOutRegisters::empty();
+        let mut mask = LiveOut::empty();
         mask.add(Register::XZR);
         assert!(!mask.contains(Register::XZR));
         assert!(mask.is_empty());
     }
 
     #[test]
-    fn test_live_out_wraps_register_slice() {
+    fn test_live_out_alias_exposes_register_set_api() {
         let live_out = LiveOut::from_registers(vec![Register::X0]);
         assert!(live_out.contains_register(Register::X0));
-        assert_eq!(live_out.registers().len(), 1);
+        assert_eq!(live_out.len(), 1);
     }
 
-    // Issue #77 stage 1 step 7: generic LiveOutMask coverage.
+    // Issue #77 stage 1 step 7: generic RegisterSet coverage.
     #[test]
     fn test_live_out_mask_aarch64_basics() {
-        let mut mask: LiveOutMask<Register> = LiveOutMask::empty();
+        let mut mask: RegisterSet<Register> = RegisterSet::empty();
         assert!(mask.is_empty());
         assert!(!mask.flags_live());
 
@@ -307,10 +237,44 @@ mod tests {
 
     #[test]
     fn test_live_out_mask_from_registers() {
-        let mask: LiveOutMask<Register> =
-            LiveOutMask::from_registers(vec![Register::X0, Register::X5, Register::X30]);
+        let mask: RegisterSet<Register> =
+            RegisterSet::from_registers(vec![Register::X0, Register::X5, Register::X30]);
         assert_eq!(mask.len(), 3);
         assert!(mask.contains(Register::X5));
         assert!(!mask.flags_live());
+    }
+
+    #[test]
+    fn test_live_out_mask_with_flags_builder() {
+        let mask: RegisterSet<Register> = RegisterSet::empty().with_flags(true);
+        assert!(mask.flags_live());
+
+        let mask: RegisterSet<Register> =
+            RegisterSet::from_registers(vec![Register::X0]).with_flags(false);
+        assert!(!mask.flags_live());
+        assert!(mask.contains(Register::X0));
+    }
+
+    #[test]
+    fn test_live_out_mask_contains_register_alias() {
+        let mask: RegisterSet<Register> = RegisterSet::from_registers(vec![Register::X3]);
+        assert!(mask.contains_register(Register::X3));
+        assert!(!mask.contains_register(Register::X4));
+    }
+
+    #[test]
+    fn test_register_set_aarch64_all_registers() {
+        let mask = RegisterSet::<Register>::all_registers();
+        assert!(mask.contains(Register::X0));
+        assert!(mask.contains(Register::X30));
+        assert!(mask.contains(Register::SP));
+        assert!(!mask.contains(Register::XZR));
+    }
+
+    #[test]
+    fn test_register_set_aarch64_display_sorted() {
+        let mask: RegisterSet<Register> =
+            RegisterSet::from_registers(vec![Register::X5, Register::X1, Register::X3]);
+        assert_eq!(format!("{}", mask), "LiveOut { registers={x1, x3, x5} }");
     }
 }

--- a/src/semantics/live_out.rs
+++ b/src/semantics/live_out.rs
@@ -30,7 +30,6 @@ pub struct RegisterSet<R: RegisterType> {
     flags_live: bool,
 }
 
-#[allow(dead_code)] // public API, wired in #77 stage 1 step 9
 impl<R: RegisterType> RegisterSet<R> {
     /// Empty mask, flags not live.
     pub fn empty() -> Self {
@@ -72,24 +71,25 @@ impl<R: RegisterType> RegisterSet<R> {
     }
 
     /// Number of live-out registers.
+    #[allow(dead_code)]
     pub fn len(&self) -> usize {
         self.regs.len()
     }
 
     /// True if the mask contains no registers (flag-only liveness still
     /// possible if `flags_live()` returns true).
+    #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self.regs.is_empty()
     }
 
     /// True if the condition flags are part of the live-out contract.
-    #[allow(dead_code)] // wired in #77 stage 1 step 9
     pub fn flags_live(&self) -> bool {
         self.flags_live
     }
 
     /// Set whether the condition flags are live-out.
-    #[allow(dead_code)] // wired in #77 stage 1 step 9
+    #[allow(dead_code)]
     pub fn set_flags_live(&mut self, live: bool) {
         self.flags_live = live;
     }
@@ -98,13 +98,6 @@ impl<R: RegisterType> RegisterSet<R> {
     pub fn with_flags(mut self, flags_live: bool) -> Self {
         self.flags_live = flags_live;
         self
-    }
-
-    /// AArch64-flavored alias for `contains`. Kept so call sites using
-    /// the old `LiveOut::contains_register(reg)` keep compiling after
-    /// `LiveOut` becomes a type alias for this mask.
-    pub fn contains_register(&self, reg: R) -> bool {
-        self.contains(reg)
     }
 }
 
@@ -119,6 +112,14 @@ impl RegisterSet<Register> {
         }
         mask.add(Register::SP);
         mask
+    }
+
+    /// AArch64-flavored alias for `contains`. Kept so call sites using the
+    /// old `LiveOut::contains_register(reg)` (where `LiveOut` was a struct
+    /// wrapping `LiveOutRegisters`) keep compiling against the
+    /// `LiveOut = RegisterSet<Register>` alias.
+    pub fn contains_register(&self, reg: Register) -> bool {
+        self.contains(reg)
     }
 }
 

--- a/src/semantics/mod.rs
+++ b/src/semantics/mod.rs
@@ -19,6 +19,6 @@ pub use equivalence::{EquivalenceConfig, EquivalenceResult, check_equivalence_wi
 #[allow(unused_imports)]
 pub use equivalence::{EquivalenceMetrics, check_equivalence_with_config_metrics};
 #[allow(unused_imports)]
-pub use live_out::{LiveOut, LiveOutRegisters};
+pub use live_out::{LiveOut, RegisterSet};
 #[allow(unused_imports)]
 pub use state::{ConcreteMachineState, ConcreteValue, ConditionFlags};

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -3,7 +3,7 @@
 #![allow(dead_code)]
 
 use crate::ir::{Instruction, Operand, Register};
-use crate::semantics::live_out::LiveOutRegisters;
+use crate::semantics::live_out::RegisterSet;
 use std::collections::HashMap;
 use std::time::Duration;
 use z3::ast::BV;
@@ -908,7 +908,7 @@ pub fn states_not_equal(state1: &MachineState, state2: &MachineState) -> z3::ast
 pub fn states_not_equal_for_live_out(
     state1: &MachineState,
     state2: &MachineState,
-    live_out: &LiveOutRegisters,
+    live_out: &RegisterSet<Register>,
     flags_live: bool,
 ) -> z3::ast::Bool {
     let mut not_equal = z3::ast::Bool::from_bool(false);

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -905,6 +905,10 @@ pub fn states_not_equal(state1: &MachineState, state2: &MachineState) -> z3::ast
 
 /// Check if two machine states are not equal for the specified live-out
 /// registers, optionally including the NZCV flag bits.
+///
+/// TODO(#282): The explicit `flags_live` parameter duplicates
+/// `live_out.flags_live()` for every non-stochastic caller. Tracked for
+/// cleanup in issue #282.
 pub fn states_not_equal_for_live_out(
     state1: &MachineState,
     state2: &MachineState,

--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -3,27 +3,27 @@
 #![allow(dead_code)]
 
 use crate::ir::{Instruction, Register};
-use crate::semantics::live_out::{LiveOut, LiveOutRegisters};
+use crate::semantics::live_out::{LiveOut, RegisterSet};
 use std::str::FromStr;
 
 /// Error type for parsing live-out register sets.
 #[derive(Debug, Clone, PartialEq)]
-pub struct ParseLiveOutRegistersError {
+pub struct ParseRegisterSetError {
     pub message: String,
 }
 
-impl std::fmt::Display for ParseLiveOutRegistersError {
+impl std::fmt::Display for ParseRegisterSetError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.message)
     }
 }
 
-impl std::error::Error for ParseLiveOutRegistersError {}
+impl std::error::Error for ParseRegisterSetError {}
 
 /// Parse a register name like "x0", "X1", "sp", "SP". Accepts the standard
 /// AArch64 aliases `fp` (x29) and `lr` (x30) to match the assembly parser at
 /// `src/parser/mod.rs::parse_register`.
-fn parse_register(s: &str) -> Result<Register, ParseLiveOutRegistersError> {
+fn parse_register(s: &str) -> Result<Register, ParseRegisterSetError> {
     let s = s.trim().to_lowercase();
 
     if s == "sp" {
@@ -46,25 +46,25 @@ fn parse_register(s: &str) -> Result<Register, ParseLiveOutRegistersError> {
         return Ok(reg);
     }
 
-    Err(ParseLiveOutRegistersError {
+    Err(ParseRegisterSetError {
         message: format!("invalid register name: '{}'", s),
     })
 }
 
-impl FromStr for LiveOutRegisters {
-    type Err = ParseLiveOutRegistersError;
+impl FromStr for RegisterSet<Register> {
+    type Err = ParseRegisterSetError;
 
     /// Parse a comma or space-separated list of register names
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let s = s.trim();
 
         if s.is_empty() {
-            return Ok(LiveOutRegisters::empty());
+            return Ok(RegisterSet::empty());
         }
 
         let separator = if s.contains(',') { ',' } else { ' ' };
 
-        let mut mask = LiveOutRegisters::empty();
+        let mut mask = RegisterSet::empty();
         for part in s.split(separator) {
             let part = part.trim();
             if part.is_empty() {
@@ -81,42 +81,44 @@ impl FromStr for LiveOutRegisters {
 /// Parse the CLI `--live-out` contract string.
 ///
 /// Grammar: `<regs>` or `<regs>;<flags>`. The register half follows
-/// `LiveOutRegisters::from_str` (comma- or space-separated, case-insensitive,
+/// `RegisterSet::<Register>::from_str` (comma- or space-separated, case-insensitive,
 /// accepts `x0..x30`, `sp`, `xzr`). The flag half currently accepts only the
 /// group token `nzcv`; per-flag tokens `n`/`z`/`c`/`v` are reserved for a
 /// future per-flag liveness extension and rejected today. A bareword `nzcv`
 /// with no leading `;` is rejected to keep that reservation unambiguous.
 ///
-/// Returns `(LiveOut, flags_live)`. Callers pass `flags_live` to
-/// `EquivalenceConfig::with_flags(...)` (see ADR-0006).
-pub fn parse_live_out_contract(s: &str) -> Result<(LiveOut, bool), ParseLiveOutRegistersError> {
+/// Returns a `LiveOut` whose `flags_live()` bit reflects the optional
+/// `;nzcv` suffix (ADR-0006). The mask is consumed directly by
+/// `EquivalenceConfig::with_live_out(...)`; callers no longer need to thread
+/// a separate `flags_live` boolean.
+pub fn parse_live_out_contract(s: &str) -> Result<LiveOut, ParseRegisterSetError> {
     let trimmed = s.trim();
     let semicolon_count = trimmed.matches(';').count();
     if semicolon_count > 1 {
-        return Err(ParseLiveOutRegistersError {
+        return Err(ParseRegisterSetError {
             message: format!("--live-out accepts at most one ';' (got: '{}')", s),
         });
     }
     if semicolon_count == 0 {
         if trimmed.eq_ignore_ascii_case("nzcv") {
-            return Err(ParseLiveOutRegistersError {
+            return Err(ParseRegisterSetError {
                 message: format!(
                     "flag-only live-out requires a leading ';' (e.g. \";nzcv\"); got '{}'",
                     s
                 ),
             });
         }
-        let regs = LiveOutRegisters::from_str(trimmed)?;
-        return Ok((LiveOut::from_register_set(regs), false));
+        let regs = RegisterSet::<Register>::from_str(trimmed)?;
+        return Ok(regs);
     }
     let (regs_part, flags_part) = trimmed.split_once(';').unwrap();
-    let regs = LiveOutRegisters::from_str(regs_part.trim())?;
+    let regs = RegisterSet::<Register>::from_str(regs_part.trim())?;
     let flags_tok = flags_part.trim().to_ascii_lowercase();
     let flags_live = match flags_tok.as_str() {
         "" => false,
         "nzcv" => true,
         "n" | "z" | "c" | "v" => {
-            return Err(ParseLiveOutRegistersError {
+            return Err(ParseRegisterSetError {
                 message: format!(
                     "per-flag token '{}' is reserved for a future extension; use 'nzcv' for all flags",
                     flags_tok
@@ -124,17 +126,17 @@ pub fn parse_live_out_contract(s: &str) -> Result<(LiveOut, bool), ParseLiveOutR
             });
         }
         other => {
-            return Err(ParseLiveOutRegistersError {
+            return Err(ParseRegisterSetError {
                 message: format!("unknown flag token '{}'; expected 'nzcv'", other),
             });
         }
     };
-    Ok((LiveOut::from_register_set(regs), flags_live))
+    Ok(regs.with_flags(flags_live))
 }
 
 /// Compute the set of registers written by a sequence of instructions
-pub fn compute_written_registers(instructions: &[Instruction]) -> LiveOutRegisters {
-    let mut mask = LiveOutRegisters::empty();
+pub fn compute_written_registers(instructions: &[Instruction]) -> RegisterSet<Register> {
+    let mut mask = RegisterSet::empty();
     for instr in instructions {
         if let Some(dest) = instr.destination() {
             mask.add(dest);
@@ -190,13 +192,13 @@ pub fn reads_flags_before_writing(instructions: &[Instruction]) -> bool {
 
 /// Compute the set of registers read before written by a sequence of instructions.
 ///
-/// This is the intra-sequence live-in set: any register the sequence reads
-/// before defining (writing) is in the result. XZR is never included.
-/// It reuses `LiveOutRegisters` because live-in and live-out registers are both
-/// architecture-register sets; see ADR-0001 for the design rationale.
-pub fn compute_live_in_registers(instructions: &[Instruction]) -> LiveOutRegisters {
-    let mut live_in = LiveOutRegisters::empty();
-    let mut written = LiveOutRegisters::empty();
+/// Returns the set of registers the sequence reads before defining (writing).
+/// XZR is never included. The return type `RegisterSet<Register>` is the same
+/// neutral carrier used by live-out analyses — live-in and live-out are both
+/// architecture-register sets (closes #85; see ADR-0001 for the design rationale).
+pub fn compute_live_in_registers(instructions: &[Instruction]) -> RegisterSet<Register> {
+    let mut live_in = RegisterSet::empty();
+    let mut written = RegisterSet::empty();
 
     for instr in instructions {
         for src in instr.source_registers() {
@@ -239,7 +241,7 @@ mod tests {
 
     #[test]
     fn display_renders_message_without_type_prefix() {
-        let err = ParseLiveOutRegistersError {
+        let err = ParseRegisterSetError {
             message: "invalid register name: 'foo'".to_string(),
         };
         assert_eq!(err.to_string(), "invalid register name: 'foo'");
@@ -286,22 +288,22 @@ mod tests {
 
     #[test]
     fn test_parse_live_out_contract_accepts_fp_lr_aliases() {
-        let (live_out, flags_live) = parse_live_out_contract("fp,lr").unwrap();
+        let live_out = parse_live_out_contract("fp,lr").unwrap();
         assert!(live_out.contains_register(Register::X29));
         assert!(live_out.contains_register(Register::X30));
-        assert!(!flags_live);
+        assert!(!live_out.flags_live());
     }
 
     #[test]
     fn test_parse_live_out_contract_fp_lr_with_flags() {
-        let (live_out, flags_live) = parse_live_out_contract("lr;nzcv").unwrap();
+        let live_out = parse_live_out_contract("lr;nzcv").unwrap();
         assert!(live_out.contains_register(Register::X30));
-        assert!(flags_live);
+        assert!(live_out.flags_live());
     }
 
     #[test]
     fn test_live_out_registers_from_str_comma_separated() {
-        let mask: LiveOutRegisters = "x0, x1, x2".parse().unwrap();
+        let mask: LiveOut = "x0, x1, x2".parse().unwrap();
         assert!(mask.contains(Register::X0));
         assert!(mask.contains(Register::X1));
         assert!(mask.contains(Register::X2));
@@ -310,7 +312,7 @@ mod tests {
 
     #[test]
     fn test_live_out_registers_from_str_space_separated() {
-        let mask: LiveOutRegisters = "x0 x1 x2".parse().unwrap();
+        let mask: LiveOut = "x0 x1 x2".parse().unwrap();
         assert!(mask.contains(Register::X0));
         assert!(mask.contains(Register::X1));
         assert!(mask.contains(Register::X2));
@@ -318,7 +320,7 @@ mod tests {
 
     #[test]
     fn test_live_out_registers_from_str_mixed_case() {
-        let mask: LiveOutRegisters = "X0, x1, SP".parse().unwrap();
+        let mask: LiveOut = "X0, x1, SP".parse().unwrap();
         assert!(mask.contains(Register::X0));
         assert!(mask.contains(Register::X1));
         assert!(mask.contains(Register::SP));
@@ -326,20 +328,20 @@ mod tests {
 
     #[test]
     fn test_live_out_registers_from_str_empty() {
-        let mask: LiveOutRegisters = "".parse().unwrap();
+        let mask: LiveOut = "".parse().unwrap();
         assert!(mask.is_empty());
     }
 
     #[test]
     fn test_live_out_registers_from_str_whitespace() {
-        let mask: LiveOutRegisters = "  x0  ,  x1  ".parse().unwrap();
+        let mask: LiveOut = "  x0  ,  x1  ".parse().unwrap();
         assert!(mask.contains(Register::X0));
         assert!(mask.contains(Register::X1));
     }
 
     #[test]
     fn test_live_out_registers_from_str_invalid() {
-        let result: Result<LiveOutRegisters, _> = "x0, invalid, x1".parse();
+        let result: Result<LiveOut, _> = "x0, invalid, x1".parse();
         assert!(result.is_err());
     }
 
@@ -584,68 +586,68 @@ mod tests {
 
     #[test]
     fn test_parse_live_out_contract_regs_and_flags() {
-        let (live_out, flags_live) = parse_live_out_contract("x0,x1;nzcv").unwrap();
+        let live_out = parse_live_out_contract("x0,x1;nzcv").unwrap();
         assert!(live_out.contains_register(Register::X0));
         assert!(live_out.contains_register(Register::X1));
-        assert!(flags_live);
+        assert!(live_out.flags_live());
     }
 
     #[test]
     fn test_parse_live_out_contract_regs_only_flags_off() {
-        let (live_out, flags_live) = parse_live_out_contract("x0,x1").unwrap();
+        let live_out = parse_live_out_contract("x0,x1").unwrap();
         assert!(live_out.contains_register(Register::X0));
         assert!(live_out.contains_register(Register::X1));
-        assert!(!flags_live);
+        assert!(!live_out.flags_live());
     }
 
     #[test]
     fn test_parse_live_out_contract_flags_only() {
-        let (live_out, flags_live) = parse_live_out_contract(";nzcv").unwrap();
-        assert_eq!(live_out.registers().len(), 0);
-        assert!(flags_live);
+        let live_out = parse_live_out_contract(";nzcv").unwrap();
+        assert_eq!(live_out.len(), 0);
+        assert!(live_out.flags_live());
     }
 
     #[test]
     fn test_parse_live_out_contract_trailing_semicolon() {
-        let (live_out, flags_live) = parse_live_out_contract("x0,x1;").unwrap();
+        let live_out = parse_live_out_contract("x0,x1;").unwrap();
         assert!(live_out.contains_register(Register::X0));
-        assert!(!flags_live);
+        assert!(!live_out.flags_live());
     }
 
     #[test]
     fn test_parse_live_out_contract_uppercase_passes() {
-        let (live_out, flags_live) = parse_live_out_contract("X0,X1;NZCV").unwrap();
+        let live_out = parse_live_out_contract("X0,X1;NZCV").unwrap();
         assert!(live_out.contains_register(Register::X0));
         assert!(live_out.contains_register(Register::X1));
-        assert!(flags_live);
+        assert!(live_out.flags_live());
     }
 
     #[test]
     fn test_parse_live_out_contract_empty_input() {
-        let (live_out, flags_live) = parse_live_out_contract("").unwrap();
-        assert_eq!(live_out.registers().len(), 0);
-        assert!(!flags_live);
+        let live_out = parse_live_out_contract("").unwrap();
+        assert_eq!(live_out.len(), 0);
+        assert!(!live_out.flags_live());
     }
 
     #[test]
     fn test_parse_live_out_contract_whitespace_around_semicolon() {
-        let (live_out, flags_live) = parse_live_out_contract("x0 ; nzcv").unwrap();
+        let live_out = parse_live_out_contract("x0 ; nzcv").unwrap();
         assert!(live_out.contains_register(Register::X0));
-        assert!(flags_live);
+        assert!(live_out.flags_live());
     }
 
     #[test]
     fn test_parse_live_out_contract_lone_semicolon() {
-        let (live_out, flags_live) = parse_live_out_contract(";").unwrap();
-        assert_eq!(live_out.registers().len(), 0);
-        assert!(!flags_live);
+        let live_out = parse_live_out_contract(";").unwrap();
+        assert_eq!(live_out.len(), 0);
+        assert!(!live_out.flags_live());
     }
 
     #[test]
     fn test_parse_live_out_contract_whitespace_only_sides() {
-        let (live_out, flags_live) = parse_live_out_contract("  ;  ").unwrap();
-        assert_eq!(live_out.registers().len(), 0);
-        assert!(!flags_live);
+        let live_out = parse_live_out_contract("  ;  ").unwrap();
+        assert_eq!(live_out.len(), 0);
+        assert!(!live_out.flags_live());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Bundles GitHub issue #85 with the in-flight #77 stage 1 step 9:

- Renames the generic `LiveOutMask<R>` to `RegisterSet<R>` — the neutral name acknowledges that the same shape carries both live-in (`compute_live_in_registers`) and live-out sets. Previously the AArch64 path used `LiveOutRegisters` for both, which surprised readers.
- Collapses the AArch64-specific `LiveOut` struct + `LiveOutRegisters` into a single type alias: `pub type LiveOut = RegisterSet<Register>`.
- Moves `flags_live` from `EquivalenceConfig` onto the mask per ADR-0004 decision 5. `EquivalenceConfig::with_flags` is preserved as a thin builder that writes through.
- Collapses `parse_live_out_contract` return type from `Result<(LiveOut, bool), _>` to `Result<LiveOut, _>` since the bit now travels on the mask.
- Renames `ParseLiveOutRegistersError` → `ParseRegisterSetError`.
- Updates ADR-0004, ADR-0006, and CLAUDE.md.

`X86LiveOutMask` is unchanged; #77 stage 2 step 16 will replace it with `RegisterSet<X86Register>` in a follow-up.

## Test plan

- [x] `./ci_check.sh` clean (fmt, build, unit + integration tests)
- [x] 830 tests pass (827 existing + 3 new behavior tests)
- [x] New behaviors test-driven: `RegisterSet::with_flags` builder, `RegisterSet::contains_register`, `RegisterSet<Register>::all_registers`, `aarch64_with_flags_writes_through_mask` (verifies `flags_live` truly moved onto the mask)
- [x] Display format kept compatible with the just-merged PR #79 wrapper (`LiveOut { registers={x0, x1} }`)
- [x] CLI `equiv --live-out "x0,x1;nzcv"` and `;nzcv` suffix still parse and set the bit on the mask