### PR TITLE
Add AArch64 memory operations (LDR/STR/LDP/STP) — closes #68

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ s11 is a superoptimizer written in Rust. It finds shorter or faster equivalent i
 
 **Key Features:**
 - ELF binary reading and disassembly using Capstone engine (auto-detects e_machine)
-- **AArch64** (42 instructions): MOV, ADD, SUB, AND, ORR, EOR, LSL, LSR, ASR, MUL, SDIV, UDIV, CMP, CMN, TST, CSEL, CSINC, CSINV, CSNEG, MADD, MSUB, MNEG, SMULH, UMULH, CCMP, CCMN, UBFX, SBFX, BFI, BFXIL, UBFIZ, SBFIZ, plus branches/control-flow B, B.cond, RET, CBZ, CBNZ, TBZ, TBNZ, BL, BR (issue #69 — terminators only; search holds them fixed and rewrites only the straight-line prefix). Full pipeline including stochastic/symbolic/hybrid/LLM search.
+- **AArch64** (54+ instructions): MOV, ADD, SUB, AND, ORR, EOR, LSL, LSR, ASR, MUL, SDIV, UDIV, CMP, CMN, TST, CSEL, CSINC, CSINV, CSNEG, MADD, MSUB, MNEG, SMULH, UMULH, CCMP, CCMN, UBFX, SBFX, BFI, BFXIL, UBFIZ, SBFIZ, plus branches/control-flow B, B.cond, RET, CBZ, CBNZ, TBZ, TBNZ, BL, BR (issue #69 — terminators only; search holds them fixed and rewrites only the straight-line prefix), plus memory ops LDR, LDRB, LDRH, LDRSB, LDRSH, LDRSW, STR, STRB, STRH, LDP, STP, LDPSW (issue #68 — byte-addressed Z3-array memory model with sound full aliasing, whole-memory live-out auto-derived; see ADR-0007). Full pipeline including stochastic/symbolic/hybrid/LLM search.
 - **x86-64 + x86-32** (14 variants, 7 mnemonics): MOV, ADD, SUB, AND, OR, XOR, CMP (each with reg/imm forms) — enumerative, stochastic (MCMC), and symbolic (SMT) search supported. Hybrid (parallel coordinator) and LLM remain AArch64-only.
 - SMT-based equivalence checking using Z3 (width-parameterised for x86-32 vs x86-64)
 - Multi-threaded parallel search with worker coordination
@@ -162,6 +162,8 @@ There are two text-to-IR entry points and they MUST cover the same mnemonic set:
 To prevent drift, `convert_to_ir` does NOT maintain its own mnemonic switch — it formats `"{mnemonic} {op_str}"` and delegates to `parser::parse_line`. **Adding a new mnemonic means adding it to the parser only**; the binary path picks it up automatically. Do not reintroduce a parallel match-on-mnemonic in `convert_to_ir`.
 
 The regression test `convert_capstone_op_handles_all_supported_aarch64_mnemonics` in `src/main.rs` pins one canonical operand string per supported mnemonic — extend it whenever you add an opcode so a future Capstone-syntax regression on that mnemonic fails loudly.
+
+For instructions with multiple destinations (LDP, pre/post-index writeback), use `Instruction::destinations() -> Vec<Register>` rather than the singleton `destination() -> Option<Register>`. Memory ops are non-terminator, do not modify NZCV, and have observable memory side effects — `has_side_effects()` and `EquivalenceConfig::memory_live` model the latter. See ADR-0007 for the design.
 
 ### Search Algorithms
 

--- a/docs/adr/0007-memory-model.md
+++ b/docs/adr/0007-memory-model.md
@@ -1,0 +1,59 @@
+# ADR-0007 — AArch64 memory model for LDR/STR/LDP/STP equivalence
+
+Status: Accepted
+Date: 2026-05-18
+
+## Context
+
+Before this ADR, the AArch64 IR (`src/ir/instructions.rs:22-402`) and machine-state types (`src/semantics/state.rs:257-261`, `src/semantics/smt.rs:128-138`) carried no memory. The pipeline reasoned only about general-purpose registers and the four NZCV flag bits. Issue #68 closes that gap by adding the LDR / LDRB / LDRH / LDRSB / LDRSH / LDRSW / STR / STRB / STRH / LDP / STP / LDPSW family across all five addressing modes (immediate-offset, pre-index, post-index, register-offset, register-extend) and both W/X widths.
+
+The user-facing scope decision for this work was the most ambitious option on every axis: the *full* instruction family, *full* search wiring (enumerative + stochastic + symbolic + LLM), *whole-memory* live-out, and *sound full aliasing*. This ADR records the resulting model choices so a future reviewer of `src/semantics/concrete.rs` or `src/semantics/smt.rs` can reconstruct *why* the layers look the way they do — and so a future widening (multi-region live-out, typed-array model, etc.) has a single document to revise.
+
+The CLI grammar from ADR-0006 (`docs/adr/0006-live-out-cli-grammar.md`) reserves the per-flag tokens `n`/`z`/`c`/`v` after `;` for a future per-flag liveness rev. This ADR additionally reserves `mem` and `mem:<range>` in the same after-`;` namespace for an eventual multi-region memory-liveness grammar; the present implementation does not consume those tokens yet.
+
+## Decision
+
+1. **Memory is byte-addressed on both layers.** The concrete interpreter carries `memory: BTreeMap<u64, u8>` on `ConcreteMachineState`; the SMT layer carries `memory: z3::ast::Array<BV<64>, BV<8>>` on `MachineState`. Absent keys on the concrete side denote "zero", matching the SMT array's symbolic-default reading. No typed-by-width memory arrays — the byte granularity is the *only* representation that handles overlapping writes correctly (e.g. `STR x0, [x1]; STRH w2, [x1, #2]; LDR x3, [x1]` requires byte-level decomposition to give the right answer under Z3's array theory).
+
+2. **Little-endian via a shared splitter.** A single `value_to_le_bytes(v: u64, width: AccessWidth) -> [u8; N]` (concrete) and `bv_split_le(bv: &BV, width: AccessWidth) -> Vec<BV>` (SMT) carry the byte-order decision. They MUST agree by construction; a divergence would silently flip fast-path vs. SMT verdicts. AArch64 SCTLR_EL1.E0E defaults to 0 (little-endian); we do not model the big-endian alternative.
+
+3. **Sound full aliasing — no disjointness preconditions.** Z3's array theory reasons over every possible base-register overlap; we add no SMT-side preconditions about "distinct base registers refer to distinct regions". This is what the user requested with the "Full aliasing (sound)" answer to the planning grilling. Solver latency grows accordingly (see §Consequences).
+
+4. **Whole-memory live-out is auto-derived.** A new helper `validation::live_out::touches_memory(&[Instruction]) -> bool` flags any sequence containing a memory op. `EquivalenceConfig.memory_live` defaults to false but is force-set to `true` inside `check_equivalence_with_config` whenever `touches_memory()` returns true on either sequence. There is no CLI knob this PR — the user does not have to remember `;mem`. Search algorithms (enumerative, stochastic, symbolic) pin `with_memory(true)` analogously to the existing `with_flags(true)`.
+
+5. **`fast_only` is force-disabled on memory-bearing windows.** `EquivalenceConfig.fast_only` skips SMT entirely and trusts random concrete inputs. With memory in scope, sparse random inputs cannot enumerate all aliasing patterns, so a `fast_only` "Equivalent" verdict on a memory-bearing window is unsound. Inside `check_equivalence_with_config`, when `touches_memory()` returns true AND `fast_only == true`, force `fast_only = false` and log a one-line warning. This is a *code* change, not a documentation aside — the soundness floor matters more than the speed-up.
+
+6. **Writeback semantics: observed through `destinations()`.** Pre-index `LDR Xt, [Xn, #imm]!` and post-index `LDR Xt, [Xn], #imm` write *two* registers — `Xt` from memory and `Xn` from the writeback. The IR exposes this via `Instruction::destinations() -> Vec<Register>` (retiring the singleton `destination() -> Option<Register>`). `compute_live_in_registers` and `compute_written_registers` migrate automatically; the live-out machinery sees the writeback as just another writer.
+
+7. **Writeback `Xt == Xn` and pair `Xt == Xt2` are rejected at `is_encodable_aarch64`.** ARM ARM declares these CONSTRAINED UNPREDICTABLE / UNPREDICTABLE on real hardware. Rejection sits at the encodability gate (`src/ir/instructions.rs:564-810`) so it is enforced (a) at the parser exit, (b) during enumeration, and (c) inside the assembler — matching the precedent for SP-in-Xn slots and out-of-range immediates.
+
+8. **Misaligned access is defined.** Real AArch64 traps misaligned access at EL0 (unless SCTLR_EL1.A is cleared), but for an equivalence proof we want a total semantics. The byte-addressed model gives this automatically: a 4-byte access reads/writes 4 individual byte addresses, none of which can "trap". This matches the existing precedent for division-by-zero (defined as 0 in `src/semantics/concrete.rs:108-123` and `src/semantics/smt.rs:423-443`).
+
+9. **`LDR (literal)`, `LDUR`, `STUR` are out of scope.** Capstone emits `LDUR` for unscaled-signed-offset variants that LDR-immediate cannot encode, and `LDR (literal)` for PC-relative pool loads. Neither is part of this PR; the parser leaves them as `Unsupported`, and the Capstone-tripwire test (`src/main.rs:1768+`) pins three rows asserting that outcome so a future Capstone-syntax drift cannot silently start parsing them.
+
+10. **`memory_live` lives on `EquivalenceConfig`, not on `LiveOutMask<R>` (yet).** ADR-0004 §5 commits to eventually replacing `LiveOut` with the generic `LiveOutMask<R>` (today scaffolded but not wired through `check_equivalence`). When that migration lands, `memory_live` migrates with `flags_live` onto the mask. The interim home on `EquivalenceConfig` mirrors `flags_live`'s current shape — keeping the two analogous bits in one place avoids a third-location-fork.
+
+## Consequences
+
+**Positive:**
+
+- Real basic blocks (every "interesting" window in the issue's IP-checksum motivating example) become tractable for the first time. The store/load round-trip `STR x0, [x1]; LDR x2, [x1]` ≡ `MOV x2, x0` is provable by Z3 array extensionality.
+- Soundness is unconditional. No `fast_only` carve-out, no aliasing precondition, no typed-array shortcut. A reviewer can ask "what does s11 promise about LDR/STR equivalence?" and the answer is "every byte agrees, every aliasing, every overlap".
+- The CLI grammar of ADR-0006 (`<regs>[;nzcv]`) is unchanged. The `;mem` reservation is documented here for the future without breaking any in-flight scripts.
+- The byte-addressed Z3 array idiom — single `Array<BV64,BV8>`, byte-by-byte select/store, array extensionality for equality — is a known-good super-optimisation technique. We are not inventing a memory model.
+
+**Negative / scope:**
+
+- Z3 solver latency grows. A multi-store-and-load chain produces nested `store(store(...select(...)))` expressions that the array theory must canonicalise. The default solver timeout in `src/semantics/smt.rs:84-90` (30 s) and the `Opt --solver-timeout` (5 s default at `src/main.rs:197-198`) may need to grow as users start exercising memory-bearing windows; we document the knob rather than pre-tuning.
+- The `fast_only` carve-out for memory-bearing sequences eliminates a fast path. `equiv --fast-only` users will see a one-line warning and pay the SMT cost. This is the price of soundness.
+- `LiveOutMask<R>` stays scaffolding. ADR-0004 §5's migration is not done by this PR; the `memory_live` bit will move when that migration lands.
+- The `;mem` CLI grammar reservation is *not* parsed today. A user typing `--live-out "x0;mem"` gets an "unknown flag token" error. The reservation prevents a future per-region grammar from breaking, but does not yet provide the feature.
+
+**Reversibility:** medium. The byte-addressed array idiom is the only sound shape under "full aliasing"; switching to a typed-array (BV64-keyed-by-address) model is observably wrong on overlapping stores, so we cannot easily go back. The decision to derive `memory_live` automatically (vs. requiring an explicit `;mem`) is high-reversibility — adding a future grammar opt-in is a strict superset.
+
+## Notes on related ADRs
+
+- **ADR-0001** (live-in derivation): unchanged. `compute_live_in_registers` already routes through `Instruction::source_registers()` / `destinations()`; memory-base and index registers flow through automatically once the IR exposes them.
+- **ADR-0002** (flags live-out floor): the analogous floor for memory is "always live whenever a memory op appears". Implemented in §4 above.
+- **ADR-0004 §5** (`LiveOutMask<R>` migration): deferred. See decision 10.
+- **ADR-0006** (`--live-out` CLI grammar): this ADR extends the after-`;` reserved-token namespace to include `mem` / `mem:<range>` but does not yet consume them.

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -401,6 +401,19 @@ macro_rules! emit_mem_ext {
                 }
                 Ok::<(), String>(())
             }
+            // UXTX on an X-form index is architecturally equivalent to LSL
+            // (both select option=011 in the LDR-register encoding). dynasm
+            // disallows the UXTX token for memory operands but accepts the
+            // bare/LSL form, so dispatch through that. Mirrors GNU `as`,
+            // which silently rewrites `[Xn, Xm, UXTX]` to `[Xn, Xm]`.
+            ExtendKind::Uxtx => {
+                if shift_n == 0 {
+                    dynasm!($ops ; .arch aarch64 ; $mnem $rt_tok(rt_n), [XSP(base_n), X(idx_n)]);
+                } else {
+                    dynasm!($ops ; .arch aarch64 ; $mnem $rt_tok(rt_n), [XSP(base_n), X(idx_n), LSL shift_n]);
+                }
+                Ok::<(), String>(())
+            }
             _ => Err(format!(
                 "{} cannot use extend kind {:?} (rejected by is_encodable_aarch64)",
                 stringify!($mnem),
@@ -4323,6 +4336,43 @@ mod tests {
         let (m, op) = disasm_mnem_op(&bytes);
         assert_eq!(m, "ldr");
         assert_eq!(op, "x0, [x1, x2, sxtx #3]");
+    }
+
+    #[test]
+    fn ldr_x_uxtx_extended_index_no_shift() {
+        // UXTX on an X-form index is architecturally equivalent to LSL #0.
+        // Capstone renders the canonical form (`[x1, x2]`) since dynasm
+        // emits option=011 with shift=0.
+        let bytes = assemble_one(Instruction::Ldr {
+            rt: Register::X0,
+            addr: AddressOperand::Ext {
+                base: Register::X1,
+                idx: Register::X2,
+                kind: ExtendKind::Uxtx,
+                shift: 0,
+            },
+            width: AccessWidth::Extended,
+        });
+        let (m, op) = disasm_mnem_op(&bytes);
+        assert_eq!(m, "ldr");
+        assert_eq!(op, "x0, [x1, x2]");
+    }
+
+    #[test]
+    fn ldr_x_uxtx_extended_index_shift_three() {
+        let bytes = assemble_one(Instruction::Ldr {
+            rt: Register::X0,
+            addr: AddressOperand::Ext {
+                base: Register::X1,
+                idx: Register::X2,
+                kind: ExtendKind::Uxtx,
+                shift: 3,
+            },
+            width: AccessWidth::Extended,
+        });
+        let (m, op) = disasm_mnem_op(&bytes);
+        assert_eq!(m, "ldr");
+        assert_eq!(op, "x0, [x1, x2, lsl #3]");
     }
 
     #[test]

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -1449,6 +1449,14 @@ impl AArch64Assembler {
                 dynasm!(ops ; .arch aarch64 ; tbnz X(rt_reg), bit, offset);
                 Ok(())
             }
+            // Memory ops (issue #68). dynasm encoding lands in step 13.
+            Instruction::Ldr { .. }
+            | Instruction::Ldrs { .. }
+            | Instruction::Str { .. }
+            | Instruction::Ldp { .. }
+            | Instruction::Stp { .. } => {
+                Err("Memory-op encoding arrives in step 13 (issue #68)".into())
+            }
         }
     }
 }

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -1,6 +1,8 @@
 pub mod x86;
 
-use crate::ir::types::{Condition, ExtendKind, LabelId, ShiftKind};
+use crate::ir::types::{
+    AccessWidth, AddressOperand, Condition, ExtendKind, IndexMode, LabelId, ShiftKind,
+};
 use crate::ir::{Instruction, Operand, Register};
 use dynasmrt::{DynasmApi, dynasm};
 
@@ -288,6 +290,302 @@ macro_rules! emit_ccmp_imm {
             Condition::AL | Condition::NV => {
                 return Err("CCMP/CCMN forbid AL/NV per ARM ARM C6.2.36".to_string());
             }
+        }
+    }};
+}
+
+// ===== Memory-op encoder macros (issue #68 / ADR-0007) =====
+//
+// dynasm requires the register form (X / W), the modifier kind
+// (LSL / UXTW / SXTW / UXTX / SXTX), and the mnemonic itself to be
+// compile-time tokens. The macros below expand to a single dynasm! call
+// per addressing mode and accept the mnemonic + rt register form as
+// `ident` parameters so the encoder can dispatch on width without
+// duplicating the entire dynasm! invocation.
+
+/// `[base]` and `[base, #imm]` (positive scaled offset, dynasm `RefOffset`
+/// uses `Uscaled` → `u32`). The caller is responsible for routing negative
+/// / unscaled offsets to the LDUR-family macro below; the cast assumes the
+/// offset has already passed `can_use_scaled_offset`.
+macro_rules! emit_mem_imm_offset {
+    ($ops:expr, $mnem:ident, $rt_tok:ident, $rt:expr, $base:expr, $offset:expr) => {{
+        let rt_n: u8 = $rt;
+        let base_n: u8 = $base;
+        let off: u32 = $offset as u32;
+        if off == 0 {
+            dynasm!($ops ; .arch aarch64 ; $mnem $rt_tok(rt_n), [XSP(base_n)]);
+        } else {
+            dynasm!($ops ; .arch aarch64 ; $mnem $rt_tok(rt_n), [XSP(base_n), off]);
+        }
+    }};
+}
+
+/// LDUR / STUR-family (unscaled signed 9-bit). Used when the offset is
+/// negative or not divisible by the access width.
+macro_rules! emit_mem_imm_unscaled {
+    ($ops:expr, $mnem:ident, $rt_tok:ident, $rt:expr, $base:expr, $offset:expr) => {{
+        let rt_n: u8 = $rt;
+        let base_n: u8 = $base;
+        let off: i32 = $offset;
+        dynasm!($ops ; .arch aarch64 ; $mnem $rt_tok(rt_n), [XSP(base_n), off]);
+    }};
+}
+
+/// `[base, #imm]!` — pre-index writeback.
+macro_rules! emit_mem_imm_preindex {
+    ($ops:expr, $mnem:ident, $rt_tok:ident, $rt:expr, $base:expr, $offset:expr) => {{
+        let rt_n: u8 = $rt;
+        let base_n: u8 = $base;
+        let off: i32 = $offset;
+        dynasm!($ops ; .arch aarch64 ; $mnem $rt_tok(rt_n), [XSP(base_n), off]!);
+    }};
+}
+
+/// `[base], #imm` — post-index writeback.
+macro_rules! emit_mem_imm_postindex {
+    ($ops:expr, $mnem:ident, $rt_tok:ident, $rt:expr, $base:expr, $offset:expr) => {{
+        let rt_n: u8 = $rt;
+        let base_n: u8 = $base;
+        let off: i32 = $offset;
+        dynasm!($ops ; .arch aarch64 ; $mnem $rt_tok(rt_n), [XSP(base_n)], off);
+    }};
+}
+
+/// `[base, X(idx)]` and `[base, X(idx), LSL #shift]`. dynasm encodes the
+/// shift modifier; `shift` is the raw LSL amount (0 or `log2(access_bytes)`).
+macro_rules! emit_mem_reg {
+    ($ops:expr, $mnem:ident, $rt_tok:ident, $rt:expr, $base:expr, $idx:expr, $shift:expr) => {{
+        let rt_n: u8 = $rt;
+        let base_n: u8 = $base;
+        let idx_n: u8 = $idx;
+        let shift_n: u32 = $shift as u32;
+        if shift_n == 0 {
+            dynasm!($ops ; .arch aarch64 ; $mnem $rt_tok(rt_n), [XSP(base_n), X(idx_n)]);
+        } else {
+            dynasm!($ops ; .arch aarch64 ; $mnem $rt_tok(rt_n), [XSP(base_n), X(idx_n), LSL shift_n]);
+        }
+    }};
+}
+
+/// `[base, W/X(idx), UXTW/SXTW/UXTX/SXTX{, #shift}]`. UXTB/UXTH/SXTB/SXTH
+/// are rejected by `is_encodable_aarch64`; the macro errors at the catch-all
+/// arm for defensive depth.
+macro_rules! emit_mem_ext {
+    ($ops:expr, $mnem:ident, $rt_tok:ident, $rt:expr, $base:expr, $idx:expr, $kind:expr, $shift:expr) => {{
+        let rt_n: u8 = $rt;
+        let base_n: u8 = $base;
+        let idx_n: u8 = $idx;
+        let shift_n: u32 = $shift as u32;
+        match $kind {
+            ExtendKind::Uxtw => {
+                if shift_n == 0 {
+                    dynasm!($ops ; .arch aarch64 ; $mnem $rt_tok(rt_n), [XSP(base_n), W(idx_n), UXTW]);
+                } else {
+                    dynasm!($ops ; .arch aarch64 ; $mnem $rt_tok(rt_n), [XSP(base_n), W(idx_n), UXTW shift_n]);
+                }
+                Ok::<(), String>(())
+            }
+            ExtendKind::Sxtw => {
+                if shift_n == 0 {
+                    dynasm!($ops ; .arch aarch64 ; $mnem $rt_tok(rt_n), [XSP(base_n), W(idx_n), SXTW]);
+                } else {
+                    dynasm!($ops ; .arch aarch64 ; $mnem $rt_tok(rt_n), [XSP(base_n), W(idx_n), SXTW shift_n]);
+                }
+                Ok::<(), String>(())
+            }
+            ExtendKind::Sxtx => {
+                if shift_n == 0 {
+                    dynasm!($ops ; .arch aarch64 ; $mnem $rt_tok(rt_n), [XSP(base_n), X(idx_n), SXTX]);
+                } else {
+                    dynasm!($ops ; .arch aarch64 ; $mnem $rt_tok(rt_n), [XSP(base_n), X(idx_n), SXTX shift_n]);
+                }
+                Ok::<(), String>(())
+            }
+            _ => Err(format!(
+                "{} cannot use extend kind {:?} (rejected by is_encodable_aarch64)",
+                stringify!($mnem),
+                $kind
+            )),
+        }
+    }};
+}
+
+/// Pair `[base]` / `[base, #imm]` — RefOffset (signed 7-bit scaled).
+macro_rules! emit_pair_imm_offset {
+    ($ops:expr, $mnem:ident, $rt_tok:ident, $rt1:expr, $rt2:expr, $base:expr, $offset:expr) => {{
+        let rt1_n: u8 = $rt1;
+        let rt2_n: u8 = $rt2;
+        let base_n: u8 = $base;
+        let off: i32 = $offset;
+        if off == 0 {
+            dynasm!($ops ; .arch aarch64 ; $mnem $rt_tok(rt1_n), $rt_tok(rt2_n), [XSP(base_n)]);
+        } else {
+            dynasm!($ops ; .arch aarch64 ; $mnem $rt_tok(rt1_n), $rt_tok(rt2_n), [XSP(base_n), off]);
+        }
+    }};
+}
+
+/// Pair `[base, #imm]!` — pre-index writeback.
+macro_rules! emit_pair_imm_preindex {
+    ($ops:expr, $mnem:ident, $rt_tok:ident, $rt1:expr, $rt2:expr, $base:expr, $offset:expr) => {{
+        let rt1_n: u8 = $rt1;
+        let rt2_n: u8 = $rt2;
+        let base_n: u8 = $base;
+        let off: i32 = $offset;
+        dynasm!($ops ; .arch aarch64 ; $mnem $rt_tok(rt1_n), $rt_tok(rt2_n), [XSP(base_n), off]!);
+    }};
+}
+
+/// Pair `[base], #imm` — post-index writeback.
+macro_rules! emit_pair_imm_postindex {
+    ($ops:expr, $mnem:ident, $rt_tok:ident, $rt1:expr, $rt2:expr, $base:expr, $offset:expr) => {{
+        let rt1_n: u8 = $rt1;
+        let rt2_n: u8 = $rt2;
+        let base_n: u8 = $base;
+        let off: i32 = $offset;
+        dynasm!($ops ; .arch aarch64 ; $mnem $rt_tok(rt1_n), $rt_tok(rt2_n), [XSP(base_n)], off);
+    }};
+}
+
+/// True if `offset` fits the LDR/STR positive unsigned-scaled immediate
+/// encoding for the given access width: `0..=4095 * width_bytes`, divisible
+/// by `width_bytes`. Negative or unscaled offsets must route to LDUR/STUR.
+fn can_use_scaled_offset(offset: i64, width_bytes: u32) -> bool {
+    if offset < 0 {
+        return false;
+    }
+    let scale = width_bytes as i64;
+    if scale == 0 || offset % scale != 0 {
+        return false;
+    }
+    let max_scaled = 4095i64 * scale;
+    offset <= max_scaled
+}
+
+/// True if `offset` fits the LDUR/STUR / pre/post-index 9-bit signed
+/// unscaled immediate (`-256..=255`).
+fn can_use_unscaled_offset(offset: i64) -> bool {
+    (-256..=255).contains(&offset)
+}
+
+/// Single-register load/store dispatcher. Selects between scaled positive
+/// (LDR/STR-family) and unscaled signed (LDUR/STUR-family) encoding for the
+/// `Imm + Offset` mode and routes pre-/post-index / register-offset /
+/// register-extend modes to their dedicated macros.
+macro_rules! encode_load_or_store_with {
+    ($ops:expr, $addr:expr, $rt_n:expr, $base_n:expr, $width:expr,
+     $mnem:ident, $unscaled_mnem:ident, $rt_tok:ident) => {{
+        match $addr {
+            AddressOperand::Imm {
+                offset,
+                mode: IndexMode::Offset,
+                ..
+            } => {
+                let off = i32::try_from(*offset)
+                    .map_err(|_| format!("offset {} out of i32 range", offset))?;
+                if can_use_scaled_offset(*offset, $width) {
+                    emit_mem_imm_offset!($ops, $mnem, $rt_tok, $rt_n, $base_n, off);
+                    Ok::<(), String>(())
+                } else if can_use_unscaled_offset(*offset) {
+                    emit_mem_imm_unscaled!($ops, $unscaled_mnem, $rt_tok, $rt_n, $base_n, off);
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "offset {} not encodable for {}/{}",
+                        offset,
+                        stringify!($mnem),
+                        stringify!($unscaled_mnem),
+                    ))
+                }
+            }
+            AddressOperand::Imm {
+                offset,
+                mode: IndexMode::PreIndex,
+                ..
+            } => {
+                let off = i32::try_from(*offset)
+                    .map_err(|_| format!("offset {} out of i32 range", offset))?;
+                if !can_use_unscaled_offset(*offset) {
+                    return Err(format!(
+                        "pre-index offset {} out of 9-bit signed range",
+                        offset
+                    ));
+                }
+                emit_mem_imm_preindex!($ops, $mnem, $rt_tok, $rt_n, $base_n, off);
+                Ok(())
+            }
+            AddressOperand::Imm {
+                offset,
+                mode: IndexMode::PostIndex,
+                ..
+            } => {
+                let off = i32::try_from(*offset)
+                    .map_err(|_| format!("offset {} out of i32 range", offset))?;
+                if !can_use_unscaled_offset(*offset) {
+                    return Err(format!(
+                        "post-index offset {} out of 9-bit signed range",
+                        offset
+                    ));
+                }
+                emit_mem_imm_postindex!($ops, $mnem, $rt_tok, $rt_n, $base_n, off);
+                Ok(())
+            }
+            AddressOperand::Reg { idx, shift, .. } => {
+                let idx_n = register_to_dynasm(*idx)?;
+                emit_mem_reg!($ops, $mnem, $rt_tok, $rt_n, $base_n, idx_n, *shift);
+                Ok(())
+            }
+            AddressOperand::Ext {
+                idx, kind, shift, ..
+            } => {
+                let idx_n = register_to_dynasm(*idx)?;
+                emit_mem_ext!($ops, $mnem, $rt_tok, $rt_n, $base_n, idx_n, *kind, *shift)
+            }
+        }
+    }};
+}
+
+/// Pair load/store dispatcher (LDP/STP/LDPSW). Pair operations support
+/// only the three immediate addressing modes; Reg/Ext are rejected at the
+/// IR layer (`is_encodable_pair`).
+macro_rules! encode_pair_with {
+    ($ops:expr, $addr:expr, $rt1_n:expr, $rt2_n:expr, $base_n:expr,
+     $mnem:ident, $rt_tok:ident) => {{
+        match $addr {
+            AddressOperand::Imm {
+                offset,
+                mode: IndexMode::Offset,
+                ..
+            } => {
+                let off = i32::try_from(*offset)
+                    .map_err(|_| format!("offset {} out of i32 range", offset))?;
+                emit_pair_imm_offset!($ops, $mnem, $rt_tok, $rt1_n, $rt2_n, $base_n, off);
+                Ok::<(), String>(())
+            }
+            AddressOperand::Imm {
+                offset,
+                mode: IndexMode::PreIndex,
+                ..
+            } => {
+                let off = i32::try_from(*offset)
+                    .map_err(|_| format!("offset {} out of i32 range", offset))?;
+                emit_pair_imm_preindex!($ops, $mnem, $rt_tok, $rt1_n, $rt2_n, $base_n, off);
+                Ok(())
+            }
+            AddressOperand::Imm {
+                offset,
+                mode: IndexMode::PostIndex,
+                ..
+            } => {
+                let off = i32::try_from(*offset)
+                    .map_err(|_| format!("offset {} out of i32 range", offset))?;
+                emit_pair_imm_postindex!($ops, $mnem, $rt_tok, $rt1_n, $rt2_n, $base_n, off);
+                Ok(())
+            }
+            AddressOperand::Reg { .. } | AddressOperand::Ext { .. } => Err(format!(
+                "{} only supports immediate addressing modes",
+                stringify!($mnem)
+            )),
         }
     }};
 }
@@ -1449,13 +1747,114 @@ impl AArch64Assembler {
                 dynasm!(ops ; .arch aarch64 ; tbnz X(rt_reg), bit, offset);
                 Ok(())
             }
-            // Memory ops (issue #68). dynasm encoding lands in step 13.
-            Instruction::Ldr { .. }
-            | Instruction::Ldrs { .. }
-            | Instruction::Str { .. }
-            | Instruction::Ldp { .. }
-            | Instruction::Stp { .. } => {
-                Err("Memory-op encoding arrives in step 13 (issue #68)".into())
+            // Memory ops (issue #68). dynasm dispatch per width × mode.
+            Instruction::Ldr { rt, addr, width } => {
+                let rt_n = register_to_dynasm(*rt)?;
+                let base_n = register_to_dynasm_xsp(address_base_of(addr))?;
+                let bytes = width.bytes();
+                match width {
+                    AccessWidth::Byte => {
+                        encode_load_or_store_with!(ops, addr, rt_n, base_n, bytes, ldrb, ldurb, W)
+                    }
+                    AccessWidth::Half => {
+                        encode_load_or_store_with!(ops, addr, rt_n, base_n, bytes, ldrh, ldurh, W)
+                    }
+                    AccessWidth::Word => {
+                        encode_load_or_store_with!(ops, addr, rt_n, base_n, bytes, ldr, ldur, W)
+                    }
+                    AccessWidth::Extended => {
+                        encode_load_or_store_with!(ops, addr, rt_n, base_n, bytes, ldr, ldur, X)
+                    }
+                }
+            }
+            Instruction::Ldrs { rt, addr, width } => {
+                let rt_n = register_to_dynasm(*rt)?;
+                let base_n = register_to_dynasm_xsp(address_base_of(addr))?;
+                let bytes = width.bytes();
+                match width {
+                    AccessWidth::Byte => {
+                        encode_load_or_store_with!(ops, addr, rt_n, base_n, bytes, ldrsb, ldursb, X)
+                    }
+                    AccessWidth::Half => {
+                        encode_load_or_store_with!(ops, addr, rt_n, base_n, bytes, ldrsh, ldursh, X)
+                    }
+                    AccessWidth::Word => {
+                        encode_load_or_store_with!(ops, addr, rt_n, base_n, bytes, ldrsw, ldursw, X)
+                    }
+                    AccessWidth::Extended => {
+                        Err("LDRSX does not exist (Extended width rejected for Ldrs)".into())
+                    }
+                }
+            }
+            Instruction::Str { rt, addr, width } => {
+                let rt_n = register_to_dynasm(*rt)?;
+                let base_n = register_to_dynasm_xsp(address_base_of(addr))?;
+                let bytes = width.bytes();
+                match width {
+                    AccessWidth::Byte => {
+                        encode_load_or_store_with!(ops, addr, rt_n, base_n, bytes, strb, sturb, W)
+                    }
+                    AccessWidth::Half => {
+                        encode_load_or_store_with!(ops, addr, rt_n, base_n, bytes, strh, sturh, W)
+                    }
+                    AccessWidth::Word => {
+                        encode_load_or_store_with!(ops, addr, rt_n, base_n, bytes, str, stur, W)
+                    }
+                    AccessWidth::Extended => {
+                        encode_load_or_store_with!(ops, addr, rt_n, base_n, bytes, str, stur, X)
+                    }
+                }
+            }
+            Instruction::Ldp {
+                rt1,
+                rt2,
+                addr,
+                width,
+                signed,
+            } => {
+                let rt1_n = register_to_dynasm(*rt1)?;
+                let rt2_n = register_to_dynasm(*rt2)?;
+                let base_n = register_to_dynasm_xsp(address_base_of(addr))?;
+                match (width, signed) {
+                    (AccessWidth::Word, false) => {
+                        encode_pair_with!(ops, addr, rt1_n, rt2_n, base_n, ldp, W)
+                    }
+                    (AccessWidth::Word, true) => {
+                        encode_pair_with!(ops, addr, rt1_n, rt2_n, base_n, ldpsw, X)
+                    }
+                    (AccessWidth::Extended, false) => {
+                        encode_pair_with!(ops, addr, rt1_n, rt2_n, base_n, ldp, X)
+                    }
+                    (AccessWidth::Extended, true) => {
+                        Err("LDPSW only supports 32-bit access width".into())
+                    }
+                    (AccessWidth::Byte, _) | (AccessWidth::Half, _) => Err(format!(
+                        "LDP {:?} access width not supported (Word/Extended only)",
+                        width
+                    )),
+                }
+            }
+            Instruction::Stp {
+                rt1,
+                rt2,
+                addr,
+                width,
+            } => {
+                let rt1_n = register_to_dynasm(*rt1)?;
+                let rt2_n = register_to_dynasm(*rt2)?;
+                let base_n = register_to_dynasm_xsp(address_base_of(addr))?;
+                match width {
+                    AccessWidth::Word => {
+                        encode_pair_with!(ops, addr, rt1_n, rt2_n, base_n, stp, W)
+                    }
+                    AccessWidth::Extended => {
+                        encode_pair_with!(ops, addr, rt1_n, rt2_n, base_n, stp, X)
+                    }
+                    AccessWidth::Byte | AccessWidth::Half => Err(format!(
+                        "STP {:?} access width not supported (Word/Extended only)",
+                        width
+                    )),
+                }
             }
         }
     }
@@ -1508,6 +1907,17 @@ fn pc_relative_offset(target: LabelId, current_pc: u64, range: BranchRange) -> R
 impl Default for AArch64Assembler {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Extract the base register from an `AddressOperand`. Mirrors
+/// `ir::instructions::address_base` which is module-private; the encoder
+/// keeps a local copy to avoid widening that surface.
+fn address_base_of(addr: &AddressOperand) -> Register {
+    match addr {
+        AddressOperand::Imm { base, .. }
+        | AddressOperand::Reg { base, .. }
+        | AddressOperand::Ext { base, .. } => *base,
     }
 }
 
@@ -3656,5 +4066,392 @@ mod tests {
             .unwrap();
         let insns = cs.disasm_all(&bytes, 0x1000).unwrap();
         assert_eq!(insns.iter().next().unwrap().mnemonic().unwrap(), "b.eq");
+    }
+
+    // ===== Memory-op assembler tests (issue #68 / ADR-0007) =====
+    //
+    // Each test assembles one IR instruction and disassembles it back via
+    // Capstone, then asserts the printed (mnemonic, op_str). LDUR / STUR
+    // strings appear when the encoder routes an unscaled-or-negative offset
+    // to the unscaled-signed encoding; they are pinned here so any
+    // regression that silently flips the dispatch wakes the test up.
+
+    fn assemble_one(instr: Instruction) -> Vec<u8> {
+        let mut a = AArch64Assembler::new();
+        a.assemble_instructions(&[instr], 0)
+            .unwrap_or_else(|e| panic!("encode failed: {e}"))
+    }
+
+    fn disasm_mnem_op(bytes: &[u8]) -> (String, String) {
+        use capstone::prelude::*;
+        let cs = Capstone::new()
+            .arm64()
+            .mode(arch::arm64::ArchMode::Arm)
+            .build()
+            .unwrap();
+        let insns = cs.disasm_all(bytes, 0x1000).unwrap();
+        assert_eq!(insns.len(), 1, "expected one instruction in {:?}", bytes);
+        let i = insns.iter().next().unwrap();
+        (
+            i.mnemonic().unwrap_or("").to_string(),
+            i.op_str().unwrap_or("").to_string(),
+        )
+    }
+
+    #[test]
+    fn ldr_x_offset_zero_encodes_as_ldr_xn_xn() {
+        let bytes = assemble_one(Instruction::Ldr {
+            rt: Register::X0,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+        });
+        let (m, op) = disasm_mnem_op(&bytes);
+        assert_eq!(m, "ldr");
+        assert_eq!(op, "x0, [x1]");
+    }
+
+    #[test]
+    fn ldr_x_offset_positive_uses_scaled_encoding() {
+        let bytes = assemble_one(Instruction::Ldr {
+            rt: Register::X0,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 8,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+        });
+        let (m, op) = disasm_mnem_op(&bytes);
+        assert_eq!(m, "ldr");
+        assert_eq!(op, "x0, [x1, #8]");
+    }
+
+    #[test]
+    fn ldr_x_offset_negative_routes_to_ldur() {
+        let bytes = assemble_one(Instruction::Ldr {
+            rt: Register::X0,
+            addr: AddressOperand::Imm {
+                base: Register::SP,
+                offset: -8,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+        });
+        let (m, op) = disasm_mnem_op(&bytes);
+        assert_eq!(m, "ldur");
+        assert_eq!(op, "x0, [sp, #-8]");
+    }
+
+    #[test]
+    fn ldr_w_word_width_uses_w_register_form() {
+        let bytes = assemble_one(Instruction::Ldr {
+            rt: Register::X3,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 4,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Word,
+        });
+        let (m, op) = disasm_mnem_op(&bytes);
+        assert_eq!(m, "ldr");
+        assert_eq!(op, "w3, [x1, #4]");
+    }
+
+    #[test]
+    fn ldrb_emits_byte_load_into_w_form() {
+        let bytes = assemble_one(Instruction::Ldr {
+            rt: Register::X2,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Byte,
+        });
+        let (m, op) = disasm_mnem_op(&bytes);
+        assert_eq!(m, "ldrb");
+        assert_eq!(op, "w2, [x1]");
+    }
+
+    #[test]
+    fn ldrsb_emits_sign_extending_byte_load_into_x_form() {
+        let bytes = assemble_one(Instruction::Ldrs {
+            rt: Register::X2,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Byte,
+        });
+        let (m, op) = disasm_mnem_op(&bytes);
+        assert_eq!(m, "ldrsb");
+        assert_eq!(op, "x2, [x1]");
+    }
+
+    #[test]
+    fn ldrsw_emits_sign_extending_word_load() {
+        let bytes = assemble_one(Instruction::Ldrs {
+            rt: Register::X4,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 8,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Word,
+        });
+        let (m, op) = disasm_mnem_op(&bytes);
+        assert_eq!(m, "ldrsw");
+        assert_eq!(op, "x4, [x1, #8]");
+    }
+
+    #[test]
+    fn str_x_pre_index_emits_writeback_form() {
+        let bytes = assemble_one(Instruction::Str {
+            rt: Register::X0,
+            addr: AddressOperand::Imm {
+                base: Register::SP,
+                offset: -16,
+                mode: IndexMode::PreIndex,
+            },
+            width: AccessWidth::Extended,
+        });
+        let (m, op) = disasm_mnem_op(&bytes);
+        assert_eq!(m, "str");
+        assert_eq!(op, "x0, [sp, #-0x10]!");
+    }
+
+    #[test]
+    fn ldr_x_post_index_emits_post_writeback_form() {
+        let bytes = assemble_one(Instruction::Ldr {
+            rt: Register::X0,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 8,
+                mode: IndexMode::PostIndex,
+            },
+            width: AccessWidth::Extended,
+        });
+        let (m, op) = disasm_mnem_op(&bytes);
+        assert_eq!(m, "ldr");
+        assert_eq!(op, "x0, [x1], #8");
+    }
+
+    #[test]
+    fn ldr_x_register_offset_lsl_three() {
+        let bytes = assemble_one(Instruction::Ldr {
+            rt: Register::X0,
+            addr: AddressOperand::Reg {
+                base: Register::X1,
+                idx: Register::X2,
+                shift: 3,
+            },
+            width: AccessWidth::Extended,
+        });
+        let (m, op) = disasm_mnem_op(&bytes);
+        assert_eq!(m, "ldr");
+        assert_eq!(op, "x0, [x1, x2, lsl #3]");
+    }
+
+    #[test]
+    fn ldr_x_register_offset_no_shift_omits_lsl() {
+        let bytes = assemble_one(Instruction::Ldr {
+            rt: Register::X0,
+            addr: AddressOperand::Reg {
+                base: Register::X1,
+                idx: Register::X2,
+                shift: 0,
+            },
+            width: AccessWidth::Extended,
+        });
+        let (m, op) = disasm_mnem_op(&bytes);
+        assert_eq!(m, "ldr");
+        assert_eq!(op, "x0, [x1, x2]");
+    }
+
+    #[test]
+    fn ldr_x_uxtw_extended_index() {
+        let bytes = assemble_one(Instruction::Ldr {
+            rt: Register::X0,
+            addr: AddressOperand::Ext {
+                base: Register::X1,
+                idx: Register::X2,
+                kind: ExtendKind::Uxtw,
+                shift: 3,
+            },
+            width: AccessWidth::Extended,
+        });
+        let (m, op) = disasm_mnem_op(&bytes);
+        assert_eq!(m, "ldr");
+        assert_eq!(op, "x0, [x1, w2, uxtw #3]");
+    }
+
+    #[test]
+    fn ldr_x_sxtw_extended_index_no_shift() {
+        let bytes = assemble_one(Instruction::Ldr {
+            rt: Register::X0,
+            addr: AddressOperand::Ext {
+                base: Register::X1,
+                idx: Register::X2,
+                kind: ExtendKind::Sxtw,
+                shift: 0,
+            },
+            width: AccessWidth::Extended,
+        });
+        let (m, op) = disasm_mnem_op(&bytes);
+        assert_eq!(m, "ldr");
+        assert_eq!(op, "x0, [x1, w2, sxtw]");
+    }
+
+    #[test]
+    fn ldr_x_sxtx_extended_index() {
+        let bytes = assemble_one(Instruction::Ldr {
+            rt: Register::X0,
+            addr: AddressOperand::Ext {
+                base: Register::X1,
+                idx: Register::X2,
+                kind: ExtendKind::Sxtx,
+                shift: 3,
+            },
+            width: AccessWidth::Extended,
+        });
+        let (m, op) = disasm_mnem_op(&bytes);
+        assert_eq!(m, "ldr");
+        assert_eq!(op, "x0, [x1, x2, sxtx #3]");
+    }
+
+    #[test]
+    fn ldp_x_offset_zero() {
+        let bytes = assemble_one(Instruction::Ldp {
+            rt1: Register::X0,
+            rt2: Register::X1,
+            addr: AddressOperand::Imm {
+                base: Register::SP,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+            signed: false,
+        });
+        let (m, op) = disasm_mnem_op(&bytes);
+        assert_eq!(m, "ldp");
+        assert_eq!(op, "x0, x1, [sp]");
+    }
+
+    #[test]
+    fn ldp_x_pre_index_negative_offset() {
+        let bytes = assemble_one(Instruction::Ldp {
+            rt1: Register::X29,
+            rt2: Register::X30,
+            addr: AddressOperand::Imm {
+                base: Register::SP,
+                offset: -16,
+                mode: IndexMode::PreIndex,
+            },
+            width: AccessWidth::Extended,
+            signed: false,
+        });
+        let (m, op) = disasm_mnem_op(&bytes);
+        assert_eq!(m, "ldp");
+        assert_eq!(op, "x29, x30, [sp, #-0x10]!");
+    }
+
+    #[test]
+    fn stp_x_post_index_positive_offset() {
+        let bytes = assemble_one(Instruction::Stp {
+            rt1: Register::X29,
+            rt2: Register::X30,
+            addr: AddressOperand::Imm {
+                base: Register::SP,
+                offset: 16,
+                mode: IndexMode::PostIndex,
+            },
+            width: AccessWidth::Extended,
+        });
+        let (m, op) = disasm_mnem_op(&bytes);
+        assert_eq!(m, "stp");
+        assert_eq!(op, "x29, x30, [sp], #0x10");
+    }
+
+    #[test]
+    fn ldpsw_word_width_signed_emits_ldpsw() {
+        let bytes = assemble_one(Instruction::Ldp {
+            rt1: Register::X0,
+            rt2: Register::X1,
+            addr: AddressOperand::Imm {
+                base: Register::SP,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Word,
+            signed: true,
+        });
+        let (m, op) = disasm_mnem_op(&bytes);
+        assert_eq!(m, "ldpsw");
+        assert_eq!(op, "x0, x1, [sp]");
+    }
+
+    #[test]
+    fn ldp_w_word_width_uses_w_form() {
+        let bytes = assemble_one(Instruction::Ldp {
+            rt1: Register::X0,
+            rt2: Register::X1,
+            addr: AddressOperand::Imm {
+                base: Register::X2,
+                offset: 8,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Word,
+            signed: false,
+        });
+        let (m, op) = disasm_mnem_op(&bytes);
+        assert_eq!(m, "ldp");
+        assert_eq!(op, "w0, w1, [x2, #8]");
+    }
+
+    #[test]
+    fn ldrs_extended_width_is_rejected() {
+        let mut a = AArch64Assembler::new();
+        let res = a.assemble_instructions(
+            &[Instruction::Ldrs {
+                rt: Register::X0,
+                addr: AddressOperand::Imm {
+                    base: Register::X1,
+                    offset: 0,
+                    mode: IndexMode::Offset,
+                },
+                width: AccessWidth::Extended,
+            }],
+            0,
+        );
+        assert!(
+            res.is_err(),
+            "LDRSX does not exist — encoder must reject Extended-width Ldrs"
+        );
+    }
+
+    #[test]
+    fn ldp_byte_width_is_rejected() {
+        let mut a = AArch64Assembler::new();
+        let res = a.assemble_instructions(
+            &[Instruction::Ldp {
+                rt1: Register::X0,
+                rt2: Register::X1,
+                addr: AddressOperand::Imm {
+                    base: Register::X2,
+                    offset: 0,
+                    mode: IndexMode::Offset,
+                },
+                width: AccessWidth::Byte,
+                signed: false,
+            }],
+            0,
+        );
+        assert!(res.is_err(), "LDP only supports Word/Extended widths");
     }
 }

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -1165,6 +1165,15 @@ fn is_encodable_ldr_like(rt: Register, addr: &AddressOperand, width: AccessWidth
 
 /// Encodability gate for the LDP / STP family. See `is_encodable_ldr_like`
 /// for the shared base/XZR rules; pair-specific rules layered below.
+///
+/// Reject paths (codex P2 + claude review #8):
+///   * Non-immediate addressing — LDP/STP only accept `[base{, #imm}]`,
+///     `[base, #imm]!`, `[base], #imm`. `AddressOperand::Reg` / `Ext`
+///     parse cleanly today but the assembler errors at emit time, so
+///     drop them at the IR layer for parity with `parse_line`'s gate.
+///   * Out-of-range scaled-7-bit signed immediate — the LDP/STP imm7
+///     field encodes `-64..=63` scaled by the access width. Offsets
+///     outside that range pass IR validation but panic at dynasm.
 fn is_encodable_pair(
     rt1: Register,
     rt2: Register,
@@ -1183,6 +1192,21 @@ fn is_encodable_pair(
     // load-pair caller.
     if signed && width != AccessWidth::Word {
         // LDPSW is the only "signed pair" form; it is always 32→64.
+        return false;
+    }
+    // LDP/STP have no register-offset / register-extend addressing form.
+    let imm_offset = match addr {
+        AddressOperand::Imm { offset, .. } => *offset,
+        AddressOperand::Reg { .. } | AddressOperand::Ext { .. } => return false,
+    };
+    // Offset must fit the 7-bit signed scaled immediate. Pair access
+    // width is the per-register transfer width (4 or 8 bytes).
+    let scale = width.bytes() as i64;
+    if scale == 0 || imm_offset % scale != 0 {
+        return false;
+    }
+    let scaled = imm_offset / scale;
+    if !(-64..=63).contains(&scaled) {
         return false;
     }
     // Writeback `base == rtN` is rejected.
@@ -1678,6 +1702,103 @@ mod tests {
             signed: false,
         };
         assert_eq!(format!("{}", ldp), "ldp x0, x1, [sp, #16]");
+    }
+
+    #[test]
+    fn pair_reg_offset_mode_rejected_at_encodability() {
+        let ldp = Instruction::Ldp {
+            rt1: Register::X0,
+            rt2: Register::X1,
+            addr: AddressOperand::Reg {
+                base: Register::X2,
+                idx: Register::X3,
+                shift: 0,
+            },
+            width: AccessWidth::Extended,
+            signed: false,
+        };
+        assert!(!ldp.is_encodable_aarch64());
+        let stp = Instruction::Stp {
+            rt1: Register::X0,
+            rt2: Register::X1,
+            addr: AddressOperand::Reg {
+                base: Register::X2,
+                idx: Register::X3,
+                shift: 3,
+            },
+            width: AccessWidth::Word,
+        };
+        assert!(!stp.is_encodable_aarch64());
+    }
+
+    #[test]
+    fn pair_ext_mode_rejected_at_encodability() {
+        use crate::ir::ExtendKind;
+        let ldp = Instruction::Ldp {
+            rt1: Register::X0,
+            rt2: Register::X1,
+            addr: AddressOperand::Ext {
+                base: Register::X2,
+                idx: Register::X3,
+                kind: ExtendKind::Uxtw,
+                shift: 0,
+            },
+            width: AccessWidth::Extended,
+            signed: false,
+        };
+        assert!(!ldp.is_encodable_aarch64());
+    }
+
+    #[test]
+    fn pair_imm_offset_out_of_range_rejected() {
+        // 7-bit signed scaled immediate: at width=Extended (×8) the legal
+        // range is -512..=504 in steps of 8; 512 is just out of range.
+        let ldp = Instruction::Ldp {
+            rt1: Register::X0,
+            rt2: Register::X1,
+            addr: AddressOperand::Imm {
+                base: Register::SP,
+                offset: 512,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+            signed: false,
+        };
+        assert!(!ldp.is_encodable_aarch64());
+    }
+
+    #[test]
+    fn pair_imm_offset_unscaled_rejected() {
+        // Offset must be divisible by access width. 12 % 8 != 0.
+        let ldp = Instruction::Ldp {
+            rt1: Register::X0,
+            rt2: Register::X1,
+            addr: AddressOperand::Imm {
+                base: Register::SP,
+                offset: 12,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+            signed: false,
+        };
+        assert!(!ldp.is_encodable_aarch64());
+    }
+
+    #[test]
+    fn pair_imm_offset_in_range_accepted() {
+        // Boundary check: scaled = 63 (max positive) at width=Extended.
+        let ldp = Instruction::Ldp {
+            rt1: Register::X0,
+            rt2: Register::X1,
+            addr: AddressOperand::Imm {
+                base: Register::SP,
+                offset: 504,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+            signed: false,
+        };
+        assert!(ldp.is_encodable_aarch64());
     }
 
     #[test]

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -1140,11 +1140,15 @@ fn address_source_registers(addr: &AddressOperand) -> Vec<Register> {
 /// Encodability gate for the LDR / LDRS / STR family. Rules per ADR-0007:
 /// (a) base register cannot be XZR (the XSP slot rejects the zero register
 /// — SP is accepted); (b) `rt` cannot be SP (loads/stores use Xt/Wt
-/// slots); (c) writeback `rt == base` is CONSTRAINED UNPREDICTABLE and
-/// rejected at the IR level; (d) signed loads only support B/H/W access
-/// widths (LDRSX does not exist — LDR handles 64-bit zero-extension).
+/// slots); XZR is legal — `str xzr, [x0]` zero-stores and `ldr xzr, [x0]`
+/// discards the load per ARM ARM C6.2.131 / C6.2.205; (c) writeback
+/// `rt == base` is CONSTRAINED UNPREDICTABLE and rejected at the IR
+/// level; (d) signed loads only support B/H/W access widths (LDRSX does
+/// not exist — LDR handles 64-bit zero-extension); (e) for `Reg` / `Ext`
+/// address modes the index register cannot be SP — the Rm field encodes
+/// X0..X30 / XZR, not SP (`register_to_dynasm(SP)` returns None).
 fn is_encodable_ldr_like(rt: Register, addr: &AddressOperand, width: AccessWidth) -> bool {
-    if rt == Register::XZR || rt == Register::SP {
+    if rt == Register::SP {
         return false;
     }
     if address_base(addr) == Register::XZR {
@@ -1152,6 +1156,14 @@ fn is_encodable_ldr_like(rt: Register, addr: &AddressOperand, width: AccessWidth
     }
     if is_writeback(addr) && rt == address_base(addr) {
         return false;
+    }
+    match addr {
+        AddressOperand::Reg { idx, .. } | AddressOperand::Ext { idx, .. } => {
+            if *idx == Register::SP {
+                return false;
+            }
+        }
+        AddressOperand::Imm { .. } => {}
     }
     if width == AccessWidth::Extended {
         // The caller decides whether Extended is valid (LDR allows it, but
@@ -1702,6 +1714,72 @@ mod tests {
             signed: false,
         };
         assert_eq!(format!("{}", ldp), "ldp x0, x1, [sp, #16]");
+    }
+
+    #[test]
+    fn str_xzr_is_encodable() {
+        // ARM ARM C6.2.205: `str xzr, [x0]` stores a zero doubleword.
+        // Previously rejected because is_encodable_ldr_like bailed on
+        // `rt == XZR` (codex P2).
+        let str_xzr = Instruction::Str {
+            rt: Register::XZR,
+            addr: AddressOperand::Imm {
+                base: Register::X0,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+        };
+        assert!(str_xzr.is_encodable_aarch64());
+    }
+
+    #[test]
+    fn ldr_xzr_is_encodable() {
+        // ARM ARM C6.2.131: `ldr xzr, [x0]` is legal — the loaded value
+        // is discarded (write to ZR has no architectural effect).
+        let ldr_xzr = Instruction::Ldr {
+            rt: Register::XZR,
+            addr: AddressOperand::Imm {
+                base: Register::X0,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+        };
+        assert!(ldr_xzr.is_encodable_aarch64());
+    }
+
+    #[test]
+    fn ldr_with_sp_index_rejected() {
+        // SP is encoded via the XSP slot (base only), not the Rm slot.
+        // `register_to_dynasm(SP)` returns None, so the assembler errors;
+        // reject at IR layer to keep parse/encode in sync (codex P1).
+        let ldr = Instruction::Ldr {
+            rt: Register::X0,
+            addr: AddressOperand::Reg {
+                base: Register::X1,
+                idx: Register::SP,
+                shift: 0,
+            },
+            width: AccessWidth::Extended,
+        };
+        assert!(!ldr.is_encodable_aarch64());
+    }
+
+    #[test]
+    fn ldr_with_sp_index_via_ext_mode_rejected() {
+        use crate::ir::ExtendKind;
+        let ldr = Instruction::Ldr {
+            rt: Register::X0,
+            addr: AddressOperand::Ext {
+                base: Register::X1,
+                idx: Register::SP,
+                kind: ExtendKind::Uxtx,
+                shift: 0,
+            },
+            width: AccessWidth::Extended,
+        };
+        assert!(!ldr.is_encodable_aarch64());
     }
 
     #[test]

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -1206,6 +1206,13 @@ fn is_encodable_pair(
         // LDPSW is the only "signed pair" form; it is always 32→64.
         return false;
     }
+    // LDP/STP only have Word and Extended forms at the architecture level
+    // (no LDPB/LDPH/STPB/STPH). Byte/Half pair widths construct cleanly
+    // but the assembler errors at emit time — reject at the IR gate so
+    // parser and search candidates can't smuggle them through.
+    if !matches!(width, AccessWidth::Word | AccessWidth::Extended) {
+        return false;
+    }
     // LDP/STP have no register-offset / register-extend addressing form.
     let imm_offset = match addr {
         AddressOperand::Imm { offset, .. } => *offset,
@@ -1780,6 +1787,38 @@ mod tests {
             width: AccessWidth::Extended,
         };
         assert!(!ldr.is_encodable_aarch64());
+    }
+
+    #[test]
+    fn pair_byte_width_rejected_at_encodability() {
+        // LDP/STP have no Byte form at the architecture level.
+        let stp_byte = Instruction::Stp {
+            rt1: Register::X0,
+            rt2: Register::X1,
+            addr: AddressOperand::Imm {
+                base: Register::X2,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Byte,
+        };
+        assert!(!stp_byte.is_encodable_aarch64());
+    }
+
+    #[test]
+    fn pair_half_width_rejected_at_encodability() {
+        let ldp_half = Instruction::Ldp {
+            rt1: Register::X0,
+            rt2: Register::X1,
+            addr: AddressOperand::Imm {
+                base: Register::X2,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Half,
+            signed: false,
+        };
+        assert!(!ldp_half.is_encodable_aarch64());
     }
 
     #[test]

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -1,6 +1,8 @@
 //! AArch64 instruction definitions for the IR
 
-use crate::ir::types::{Condition, LabelId, Operand, Register, ShiftKind};
+use crate::ir::types::{
+    AccessWidth, AddressOperand, Condition, IndexMode, LabelId, Operand, Register, ShiftKind,
+};
 use std::fmt;
 
 /// Legal `lsl` amounts for the move-wide immediate family (MOVN / MOVZ / MOVK).
@@ -14,6 +16,65 @@ pub const MOVW_LEGAL_SHIFTS: [u8; 4] = [0, 16, 32, 48];
 /// AND/ORR/EOR/TST/ANDS immediate forms). Delegates to dynasmrt's encoder.
 fn logical_imm64_encodable(imm: i64) -> bool {
     dynasmrt::aarch64::encode_logical_immediate_64bit(imm as u64).is_some()
+}
+
+/// Helper for `Instruction::destinations` on single-register memory ops: the
+/// data register is always written, and PreIndex/PostIndex modes additionally
+/// write the base register through writeback. See ADR-0007.
+#[allow(dead_code)]
+fn writeback_destinations(rt: Register, addr: &AddressOperand) -> Vec<Register> {
+    match addr {
+        AddressOperand::Imm {
+            base,
+            mode: IndexMode::PreIndex,
+            ..
+        }
+        | AddressOperand::Imm {
+            base,
+            mode: IndexMode::PostIndex,
+            ..
+        } => vec![rt, *base],
+        _ => vec![rt],
+    }
+}
+
+/// Helper for `Instruction::destinations` on LDP-family ops: two register
+/// destinations plus the writeback base when applicable. See ADR-0007.
+#[allow(dead_code)]
+fn pair_load_destinations(rt1: Register, rt2: Register, addr: &AddressOperand) -> Vec<Register> {
+    match addr {
+        AddressOperand::Imm {
+            base,
+            mode: IndexMode::PreIndex,
+            ..
+        }
+        | AddressOperand::Imm {
+            base,
+            mode: IndexMode::PostIndex,
+            ..
+        } => vec![rt1, rt2, *base],
+        _ => vec![rt1, rt2],
+    }
+}
+
+/// Helper for `Instruction::destinations` on store ops: `rt` is read (not
+/// written), so the only destination is the writeback base — and only in
+/// PreIndex / PostIndex modes. See ADR-0007.
+#[allow(dead_code)]
+fn store_destinations(addr: &AddressOperand) -> Vec<Register> {
+    match addr {
+        AddressOperand::Imm {
+            base,
+            mode: IndexMode::PreIndex,
+            ..
+        }
+        | AddressOperand::Imm {
+            base,
+            mode: IndexMode::PostIndex,
+            ..
+        } => vec![*base],
+        _ => vec![],
+    }
 }
 
 /// AArch64 instructions supported by the IR
@@ -399,9 +460,72 @@ pub enum Instruction {
     Br {
         rn: Register,
     },
+
+    // Memory ops — see ADR-0007.
+    /// LDR / LDRB / LDRH — zero-extended load into `rt`. With PreIndex or
+    /// PostIndex mode the base register is also written (writeback).
+    Ldr {
+        rt: Register,
+        addr: AddressOperand,
+        width: AccessWidth,
+    },
+    /// LDRSB / LDRSH / LDRSW — sign-extending load into `rt` (always
+    /// X-form destination). Writeback handled identically to `Ldr`.
+    Ldrs {
+        rt: Register,
+        addr: AddressOperand,
+        width: AccessWidth,
+    },
+    /// STR / STRB / STRH — store `rt` into memory. `rt` is a *source*
+    /// register (no register destination); PreIndex / PostIndex modes
+    /// still write the base register through writeback.
+    Str {
+        rt: Register,
+        addr: AddressOperand,
+        width: AccessWidth,
+    },
+    /// LDP / LDPSW — load a pair of registers. Writeback writes the base
+    /// register as a third destination. `signed=true` is legal only when
+    /// `width == Word` (LDPSW); this is enforced by `is_encodable_aarch64`.
+    Ldp {
+        rt1: Register,
+        rt2: Register,
+        addr: AddressOperand,
+        width: AccessWidth,
+        signed: bool,
+    },
+    /// STP — store a pair of registers. `rt1`/`rt2` are read; writeback
+    /// addressing modes mutate the base register.
+    Stp {
+        rt1: Register,
+        rt2: Register,
+        addr: AddressOperand,
+        width: AccessWidth,
+    },
 }
 
 impl Instruction {
+    /// Registers this instruction writes (in canonical order). Empty for
+    /// pure flag-setters and branches; one entry for single-destination
+    /// arithmetic and logical ops; two entries for LDP and writeback
+    /// addressing modes (post-/pre-index update the base register as well
+    /// as the data register). See ADR-0007.
+    #[allow(dead_code)]
+    pub fn destinations(&self) -> Vec<Register> {
+        match self {
+            Instruction::Ldr { rt, addr, .. } | Instruction::Ldrs { rt, addr, .. } => {
+                writeback_destinations(*rt, addr)
+            }
+            Instruction::Str { addr, .. } => store_destinations(addr),
+            Instruction::Ldp { rt1, rt2, addr, .. } => pair_load_destinations(*rt1, *rt2, addr),
+            Instruction::Stp { addr, .. } => store_destinations(addr),
+            _ => match self.destination() {
+                Some(r) => vec![r],
+                None => Vec::new(),
+            },
+        }
+    }
+
     /// Get the destination register for this instruction (None for comparison instructions)
     #[allow(dead_code)]
     pub fn destination(&self) -> Option<Register> {
@@ -477,6 +601,15 @@ impl Instruction {
             | Instruction::Tbnz { .. }
             | Instruction::Bl { .. }
             | Instruction::Br { .. } => None,
+            // Memory ops may have multiple destinations (writeback) — callers
+            // must use `destinations()` instead. `destination()` is retained
+            // only for migration; it returns `None` here to avoid silently
+            // hiding the base-register writeback. See ADR-0007.
+            Instruction::Ldr { .. }
+            | Instruction::Ldrs { .. }
+            | Instruction::Str { .. }
+            | Instruction::Ldp { .. }
+            | Instruction::Stp { .. } => None,
         }
     }
 
@@ -807,6 +940,33 @@ impl Instruction {
             | Instruction::Br { .. } => true,
             Instruction::BCond { cond, .. } => !matches!(cond, Condition::AL | Condition::NV),
             Instruction::Tbz { bit, .. } | Instruction::Tbnz { bit, .. } => *bit <= 63,
+
+            // Memory ops (issue #68). See ADR-0007.
+            Instruction::Ldr { rt, addr, width } | Instruction::Str { rt, addr, width } => {
+                is_encodable_ldr_like(*rt, addr, *width)
+            }
+            // LDRSB/LDRSH/LDRSW — no LDRSX, so reject Extended.
+            Instruction::Ldrs { rt, addr, width } => {
+                if *width == AccessWidth::Extended {
+                    return false;
+                }
+                is_encodable_ldr_like(*rt, addr, *width)
+            }
+            // LDP additionally rejects rt1==rt2 (UNPREDICTABLE).
+            Instruction::Ldp {
+                rt1,
+                rt2,
+                addr,
+                width,
+                signed,
+            } => *rt1 != *rt2 && is_encodable_pair(*rt1, *rt2, addr, *width, *signed),
+            // STP allows rt1==rt2 (stores the same value twice).
+            Instruction::Stp {
+                rt1,
+                rt2,
+                addr,
+                width,
+            } => is_encodable_pair(*rt1, *rt2, addr, *width, false),
         }
     }
 
@@ -940,7 +1100,122 @@ impl Instruction {
             Instruction::Cbz { rn, .. } | Instruction::Cbnz { rn, .. } => vec![*rn],
             Instruction::Tbz { rt, .. } | Instruction::Tbnz { rt, .. } => vec![*rt],
             Instruction::Ret { rn } | Instruction::Br { rn } => vec![*rn],
+            // Memory ops read the base register; register-offset / register-
+            // extend modes also read the index register. Stores additionally
+            // read the data register, but LDR does not (the data register is
+            // a destination).
+            Instruction::Ldr { addr, .. } | Instruction::Ldrs { addr, .. } => {
+                address_source_registers(addr)
+            }
+            Instruction::Str { rt, addr, .. } => {
+                let mut regs = vec![*rt];
+                regs.extend(address_source_registers(addr));
+                regs
+            }
+            // LDP reads only the address operand (base/idx); rt1 and rt2 are
+            // destinations.
+            Instruction::Ldp { addr, .. } => address_source_registers(addr),
+            // STP reads rt1, rt2, and the address operand.
+            Instruction::Stp { rt1, rt2, addr, .. } => {
+                let mut regs = vec![*rt1, *rt2];
+                regs.extend(address_source_registers(addr));
+                regs
+            }
         }
+    }
+}
+
+/// Helper for `Instruction::source_registers` on memory ops. Returns the
+/// registers read by an `AddressOperand`: always the base, plus the index
+/// register for Reg/Ext modes.
+fn address_source_registers(addr: &AddressOperand) -> Vec<Register> {
+    match addr {
+        AddressOperand::Imm { base, .. } => vec![*base],
+        AddressOperand::Reg { base, idx, .. } | AddressOperand::Ext { base, idx, .. } => {
+            vec![*base, *idx]
+        }
+    }
+}
+
+/// Encodability gate for the LDR / LDRS / STR family. Rules per ADR-0007:
+/// (a) base register cannot be XZR (the XSP slot rejects the zero register
+/// — SP is accepted); (b) `rt` cannot be SP (loads/stores use Xt/Wt
+/// slots); (c) writeback `rt == base` is CONSTRAINED UNPREDICTABLE and
+/// rejected at the IR level; (d) signed loads only support B/H/W access
+/// widths (LDRSX does not exist — LDR handles 64-bit zero-extension).
+fn is_encodable_ldr_like(rt: Register, addr: &AddressOperand, width: AccessWidth) -> bool {
+    if rt == Register::XZR || rt == Register::SP {
+        return false;
+    }
+    if address_base(addr) == Register::XZR {
+        return false;
+    }
+    if is_writeback(addr) && rt == address_base(addr) {
+        return false;
+    }
+    if width == AccessWidth::Extended {
+        // The caller decides whether Extended is valid (LDR allows it, but
+        // is_encodable_ldr_like is also used for LDRS where it isn't). The
+        // Ldrs arm of is_encodable_aarch64 rejects Extended explicitly
+        // below; this helper conservatively allows it and the variant arm
+        // layers on the narrower rule.
+    }
+    true
+}
+
+/// Encodability gate for the LDP / STP family. See `is_encodable_ldr_like`
+/// for the shared base/XZR rules; pair-specific rules layered below.
+fn is_encodable_pair(
+    rt1: Register,
+    rt2: Register,
+    addr: &AddressOperand,
+    width: AccessWidth,
+    signed: bool,
+) -> bool {
+    if rt1 == Register::XZR || rt2 == Register::XZR || rt1 == Register::SP || rt2 == Register::SP {
+        return false;
+    }
+    if address_base(addr) == Register::XZR {
+        return false;
+    }
+    // LDP rejects rt1 == rt2 (UNPREDICTABLE per ARM ARM). STP allows it —
+    // stores the same value twice — so this rule fires only for the
+    // load-pair caller.
+    if signed && width != AccessWidth::Word {
+        // LDPSW is the only "signed pair" form; it is always 32→64.
+        return false;
+    }
+    // Writeback `base == rtN` is rejected.
+    if is_writeback(addr) {
+        let base = address_base(addr);
+        if base == rt1 || base == rt2 {
+            return false;
+        }
+    }
+    true
+}
+
+/// True if the address operand performs writeback (PreIndex / PostIndex).
+fn is_writeback(addr: &AddressOperand) -> bool {
+    matches!(
+        addr,
+        AddressOperand::Imm {
+            mode: IndexMode::PreIndex,
+            ..
+        } | AddressOperand::Imm {
+            mode: IndexMode::PostIndex,
+            ..
+        }
+    )
+}
+
+/// Extract the base register from an `AddressOperand`. All three variants
+/// carry one.
+fn address_base(addr: &AddressOperand) -> Register {
+    match addr {
+        AddressOperand::Imm { base, .. }
+        | AddressOperand::Reg { base, .. }
+        | AddressOperand::Ext { base, .. } => *base,
     }
 }
 
@@ -1069,7 +1344,64 @@ impl fmt::Display for Instruction {
             }
             Instruction::Bl { target } => write!(f, "bl {}", target),
             Instruction::Br { rn } => write!(f, "br {}", rn),
+
+            Instruction::Ldr { rt, addr, width } => {
+                write!(f, "{} {}, {}", ldr_mnemonic(*width), rt, addr)
+            }
+            Instruction::Ldrs { rt, addr, width } => {
+                write!(f, "{} {}, {}", ldrs_mnemonic(*width), rt, addr)
+            }
+            Instruction::Str { rt, addr, width } => {
+                write!(f, "{} {}, {}", str_mnemonic(*width), rt, addr)
+            }
+            Instruction::Ldp {
+                rt1,
+                rt2,
+                addr,
+                signed,
+                ..
+            } => write!(
+                f,
+                "{} {}, {}, {}",
+                if *signed { "ldpsw" } else { "ldp" },
+                rt1,
+                rt2,
+                addr
+            ),
+            Instruction::Stp { rt1, rt2, addr, .. } => write!(f, "stp {}, {}, {}", rt1, rt2, addr),
         }
+    }
+}
+
+/// Mnemonic for an LDR-family instruction at the given access width.
+/// Zero-extending loads only — `ldr` is the X/W form, `ldrb` / `ldrh` are
+/// the byte / half forms.
+fn ldr_mnemonic(width: AccessWidth) -> &'static str {
+    match width {
+        AccessWidth::Byte => "ldrb",
+        AccessWidth::Half => "ldrh",
+        AccessWidth::Word | AccessWidth::Extended => "ldr",
+    }
+}
+
+/// Mnemonic for the sign-extending load family. Always X-form destination;
+/// `Extended` width is meaningless for LDRS (no LDRSX exists — LDR handles
+/// the 64-bit zero-extending case).
+fn ldrs_mnemonic(width: AccessWidth) -> &'static str {
+    match width {
+        AccessWidth::Byte => "ldrsb",
+        AccessWidth::Half => "ldrsh",
+        AccessWidth::Word => "ldrsw",
+        AccessWidth::Extended => "ldrsw", // Should be rejected by is_encodable
+    }
+}
+
+/// Mnemonic for the store family.
+fn str_mnemonic(width: AccessWidth) -> &'static str {
+    match width {
+        AccessWidth::Byte => "strb",
+        AccessWidth::Half => "strh",
+        AccessWidth::Word | AccessWidth::Extended => "str",
     }
 }
 
@@ -1132,6 +1464,445 @@ mod tests {
             rm: Operand::Register(Register::X1),
         };
         assert_eq!(cmp.destination(), None);
+    }
+
+    #[test]
+    fn destinations_returns_single_element_for_one_dest_variant() {
+        let add = Instruction::Add {
+            rd: Register::X5,
+            rn: Register::X1,
+            rm: Operand::Immediate(10),
+        };
+        assert_eq!(add.destinations(), vec![Register::X5]);
+    }
+
+    #[test]
+    fn destinations_returns_empty_for_zero_dest_variant() {
+        let cmp = Instruction::Cmp {
+            rn: Register::X0,
+            rm: Operand::Register(Register::X1),
+        };
+        assert!(cmp.destinations().is_empty());
+    }
+
+    #[test]
+    fn ldr_offset_mode_writes_only_rt() {
+        let ldr = Instruction::Ldr {
+            rt: Register::X0,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 8,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+        };
+        assert_eq!(ldr.destinations(), vec![Register::X0]);
+    }
+
+    #[test]
+    fn ldr_pre_index_writes_both_rt_and_base() {
+        let ldr = Instruction::Ldr {
+            rt: Register::X0,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 8,
+                mode: IndexMode::PreIndex,
+            },
+            width: AccessWidth::Extended,
+        };
+        assert_eq!(ldr.destinations(), vec![Register::X0, Register::X1]);
+    }
+
+    #[test]
+    fn ldr_post_index_writes_both_rt_and_base() {
+        let ldr = Instruction::Ldr {
+            rt: Register::X0,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 8,
+                mode: IndexMode::PostIndex,
+            },
+            width: AccessWidth::Extended,
+        };
+        assert_eq!(ldr.destinations(), vec![Register::X0, Register::X1]);
+    }
+
+    #[test]
+    fn ldrs_byte_width_displays_as_ldrsb() {
+        let ldrs = Instruction::Ldrs {
+            rt: Register::X0,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 4,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Byte,
+        };
+        assert_eq!(format!("{}", ldrs), "ldrsb x0, [x1, #4]");
+    }
+
+    #[test]
+    fn ldrs_word_width_displays_as_ldrsw() {
+        let ldrs = Instruction::Ldrs {
+            rt: Register::X0,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Word,
+        };
+        assert_eq!(format!("{}", ldrs), "ldrsw x0, [x1]");
+    }
+
+    #[test]
+    fn str_offset_mode_has_no_destinations() {
+        let st = Instruction::Str {
+            rt: Register::X0,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+        };
+        assert!(st.destinations().is_empty());
+    }
+
+    #[test]
+    fn str_pre_index_writes_only_base_through_writeback() {
+        let st = Instruction::Str {
+            rt: Register::X0,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 8,
+                mode: IndexMode::PreIndex,
+            },
+            width: AccessWidth::Extended,
+        };
+        assert_eq!(st.destinations(), vec![Register::X1]);
+    }
+
+    #[test]
+    fn str_reads_rt_and_base() {
+        let st = Instruction::Str {
+            rt: Register::X0,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+        };
+        let sources = st.source_registers();
+        assert!(sources.contains(&Register::X0));
+        assert!(sources.contains(&Register::X1));
+    }
+
+    #[test]
+    fn str_byte_width_displays_as_strb() {
+        let st = Instruction::Str {
+            rt: Register::X0,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 4,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Byte,
+        };
+        assert_eq!(format!("{}", st), "strb x0, [x1, #4]");
+    }
+
+    #[test]
+    fn ldp_offset_writes_both_rt1_and_rt2() {
+        let ldp = Instruction::Ldp {
+            rt1: Register::X0,
+            rt2: Register::X1,
+            addr: AddressOperand::Imm {
+                base: Register::SP,
+                offset: 16,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+            signed: false,
+        };
+        assert_eq!(ldp.destinations(), vec![Register::X0, Register::X1]);
+    }
+
+    #[test]
+    fn ldp_writeback_adds_base_to_destinations() {
+        let ldp = Instruction::Ldp {
+            rt1: Register::X0,
+            rt2: Register::X1,
+            addr: AddressOperand::Imm {
+                base: Register::SP,
+                offset: -16,
+                mode: IndexMode::PreIndex,
+            },
+            width: AccessWidth::Extended,
+            signed: false,
+        };
+        assert_eq!(
+            ldp.destinations(),
+            vec![Register::X0, Register::X1, Register::SP]
+        );
+    }
+
+    #[test]
+    fn ldp_signed_word_width_displays_as_ldpsw() {
+        let ldp = Instruction::Ldp {
+            rt1: Register::X0,
+            rt2: Register::X1,
+            addr: AddressOperand::Imm {
+                base: Register::SP,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Word,
+            signed: true,
+        };
+        assert_eq!(format!("{}", ldp), "ldpsw x0, x1, [sp]");
+    }
+
+    #[test]
+    fn ldp_unsigned_extended_displays_as_ldp() {
+        let ldp = Instruction::Ldp {
+            rt1: Register::X0,
+            rt2: Register::X1,
+            addr: AddressOperand::Imm {
+                base: Register::SP,
+                offset: 16,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+            signed: false,
+        };
+        assert_eq!(format!("{}", ldp), "ldp x0, x1, [sp, #16]");
+    }
+
+    #[test]
+    fn stp_offset_has_no_destinations() {
+        let stp = Instruction::Stp {
+            rt1: Register::X0,
+            rt2: Register::X1,
+            addr: AddressOperand::Imm {
+                base: Register::SP,
+                offset: 16,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+        };
+        assert!(stp.destinations().is_empty());
+    }
+
+    #[test]
+    fn stp_pre_index_writes_base_through_writeback() {
+        let stp = Instruction::Stp {
+            rt1: Register::X29,
+            rt2: Register::X30,
+            addr: AddressOperand::Imm {
+                base: Register::SP,
+                offset: -16,
+                mode: IndexMode::PreIndex,
+            },
+            width: AccessWidth::Extended,
+        };
+        assert_eq!(stp.destinations(), vec![Register::SP]);
+    }
+
+    #[test]
+    fn stp_reads_both_rt1_and_rt2_plus_base() {
+        let stp = Instruction::Stp {
+            rt1: Register::X29,
+            rt2: Register::X30,
+            addr: AddressOperand::Imm {
+                base: Register::SP,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+        };
+        let sources = stp.source_registers();
+        assert!(sources.contains(&Register::X29));
+        assert!(sources.contains(&Register::X30));
+        assert!(sources.contains(&Register::SP));
+    }
+
+    #[test]
+    fn stp_pre_index_displays_with_trailing_bang() {
+        let stp = Instruction::Stp {
+            rt1: Register::X29,
+            rt2: Register::X30,
+            addr: AddressOperand::Imm {
+                base: Register::SP,
+                offset: -16,
+                mode: IndexMode::PreIndex,
+            },
+            width: AccessWidth::Extended,
+        };
+        assert_eq!(format!("{}", stp), "stp x29, x30, [sp, #-16]!");
+    }
+
+    // ---- is_encodable_aarch64 rules for memory ops ----
+
+    #[test]
+    fn ldr_rejects_xzr_base() {
+        let ldr = Instruction::Ldr {
+            rt: Register::X0,
+            addr: AddressOperand::Imm {
+                base: Register::XZR,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+        };
+        assert!(!ldr.is_encodable_aarch64());
+    }
+
+    #[test]
+    fn ldr_accepts_sp_base() {
+        let ldr = Instruction::Ldr {
+            rt: Register::X0,
+            addr: AddressOperand::Imm {
+                base: Register::SP,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+        };
+        assert!(ldr.is_encodable_aarch64());
+    }
+
+    #[test]
+    fn ldr_rejects_writeback_when_rt_equals_base() {
+        let ldr_pre = Instruction::Ldr {
+            rt: Register::X1,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 8,
+                mode: IndexMode::PreIndex,
+            },
+            width: AccessWidth::Extended,
+        };
+        assert!(!ldr_pre.is_encodable_aarch64());
+
+        let ldr_post = Instruction::Ldr {
+            rt: Register::X1,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 8,
+                mode: IndexMode::PostIndex,
+            },
+            width: AccessWidth::Extended,
+        };
+        assert!(!ldr_post.is_encodable_aarch64());
+    }
+
+    #[test]
+    fn ldr_offset_mode_allows_rt_equals_base() {
+        // Offset mode does not writeback, so rt==base is fine.
+        let ldr = Instruction::Ldr {
+            rt: Register::X1,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+        };
+        assert!(ldr.is_encodable_aarch64());
+    }
+
+    #[test]
+    fn ldp_rejects_same_pair_registers() {
+        let ldp = Instruction::Ldp {
+            rt1: Register::X0,
+            rt2: Register::X0,
+            addr: AddressOperand::Imm {
+                base: Register::SP,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+            signed: false,
+        };
+        assert!(!ldp.is_encodable_aarch64());
+    }
+
+    #[test]
+    fn stp_allows_same_pair_registers() {
+        // STP X0, X0, [base] is well-defined (stores X0 twice).
+        let stp = Instruction::Stp {
+            rt1: Register::X0,
+            rt2: Register::X0,
+            addr: AddressOperand::Imm {
+                base: Register::SP,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+        };
+        assert!(stp.is_encodable_aarch64());
+    }
+
+    #[test]
+    fn ldp_writeback_rejects_base_equals_either_rt() {
+        let ldp = Instruction::Ldp {
+            rt1: Register::SP,
+            rt2: Register::X1,
+            addr: AddressOperand::Imm {
+                base: Register::SP,
+                offset: -16,
+                mode: IndexMode::PreIndex,
+            },
+            width: AccessWidth::Extended,
+            signed: false,
+        };
+        assert!(!ldp.is_encodable_aarch64());
+    }
+
+    #[test]
+    fn ldp_signed_only_valid_at_word_width() {
+        let ldpsw_word = Instruction::Ldp {
+            rt1: Register::X0,
+            rt2: Register::X1,
+            addr: AddressOperand::Imm {
+                base: Register::SP,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Word,
+            signed: true,
+        };
+        assert!(ldpsw_word.is_encodable_aarch64());
+
+        let ldpsw_extended = Instruction::Ldp {
+            rt1: Register::X0,
+            rt2: Register::X1,
+            addr: AddressOperand::Imm {
+                base: Register::SP,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+            signed: true,
+        };
+        assert!(!ldpsw_extended.is_encodable_aarch64());
+    }
+
+    #[test]
+    fn ldrs_rejects_extended_width() {
+        // No LDRSX exists — extended-width zero-extends via LDR, not LDRS.
+        let bad = Instruction::Ldrs {
+            rt: Register::X0,
+            addr: AddressOperand::Imm {
+                base: Register::SP,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+        };
+        assert!(!bad.is_encodable_aarch64());
     }
 
     #[test]

--- a/src/ir/types.rs
+++ b/src/ir/types.rs
@@ -287,6 +287,132 @@ impl fmt::Display for LabelId {
     }
 }
 
+/// Access width for LDR/STR/LDP/STP families. Byte = 8 bits (LDRB/STRB),
+/// Half = 16 bits (LDRH/STRH), Word = 32 bits (LDR/STR W-form, LDRSW,
+/// LDPSW), Extended = 64 bits (LDR/STR X-form). See ADR-0007.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[allow(dead_code)]
+pub enum AccessWidth {
+    Byte,
+    Half,
+    Word,
+    Extended,
+}
+
+impl AccessWidth {
+    /// Number of bytes the access reads or writes.
+    #[must_use]
+    #[allow(dead_code)]
+    pub fn bytes(&self) -> u32 {
+        match self {
+            AccessWidth::Byte => 1,
+            AccessWidth::Half => 2,
+            AccessWidth::Word => 4,
+            AccessWidth::Extended => 8,
+        }
+    }
+}
+
+/// Writeback / index selector for memory-address operands (`[Xn, #imm]`,
+/// `[Xn, #imm]!`, `[Xn], #imm`). See ADR-0007.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[allow(dead_code)]
+pub enum IndexMode {
+    /// `[Xn, #imm]` — no writeback.
+    Offset,
+    /// `[Xn, #imm]!` — base updated to `Xn + imm` before the access.
+    PreIndex,
+    /// `[Xn], #imm` — base updated to `Xn + imm` after the access.
+    PostIndex,
+}
+
+/// AArch64 memory-address operand. See ADR-0007.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[allow(dead_code)]
+pub enum AddressOperand {
+    /// `[base{, #offset}]` / `[base, #offset]!` / `[base], #offset`.
+    Imm {
+        base: Register,
+        offset: i64,
+        mode: IndexMode,
+    },
+    /// `[base, idx{, lsl #shift}]`. LSL only (other shift kinds are not
+    /// part of AArch64 memory-operand grammar).
+    Reg {
+        base: Register,
+        idx: Register,
+        shift: u8,
+    },
+    /// `[base, idx, kind{ #shift}]` where `kind` is one of UXTW/SXTW (idx
+    /// is W-form) or UXTX/SXTX (idx is X-form). UXTB/UXTH/SXTB/SXTH are
+    /// not valid AArch64 memory-extend kinds and are rejected by
+    /// `is_encodable_aarch64`.
+    Ext {
+        base: Register,
+        idx: Register,
+        kind: ExtendKind,
+        shift: u8,
+    },
+}
+
+impl fmt::Display for AddressOperand {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AddressOperand::Imm {
+                base,
+                offset,
+                mode: IndexMode::Offset,
+            } => {
+                if *offset == 0 {
+                    write!(f, "[{}]", base)
+                } else {
+                    write!(f, "[{}, #{}]", base, offset)
+                }
+            }
+            AddressOperand::Imm {
+                base,
+                offset,
+                mode: IndexMode::PreIndex,
+            } => write!(f, "[{}, #{}]!", base, offset),
+            AddressOperand::Imm {
+                base,
+                offset,
+                mode: IndexMode::PostIndex,
+            } => write!(f, "[{}], #{}", base, offset),
+            AddressOperand::Reg { base, idx, shift } => {
+                if *shift == 0 {
+                    write!(f, "[{}, {}]", base, idx)
+                } else {
+                    write!(f, "[{}, {}, lsl #{}]", base, idx, shift)
+                }
+            }
+            AddressOperand::Ext {
+                base,
+                idx,
+                kind,
+                shift,
+            } => {
+                // UXTW/SXTW take a W-form index; UXTX/SXTX take an X-form.
+                // Match the existing Operand::ExtendedRegister convention
+                // for the inner-register print.
+                let inner = if kind.is_x_form() {
+                    format!("{}", idx)
+                } else {
+                    match idx.index() {
+                        Some(n) => format!("w{}", n),
+                        None => format!("{}", idx),
+                    }
+                };
+                if *shift == 0 {
+                    write!(f, "[{}, {}, {}]", base, inner, kind)
+                } else {
+                    write!(f, "[{}, {}, {} #{}]", base, inner, kind, shift)
+                }
+            }
+        }
+    }
+}
+
 /// Condition codes for AArch64
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[allow(dead_code)]
@@ -559,5 +685,116 @@ mod tests {
         assert_eq!(NORMAL_CONDITIONS.len(), 14);
         assert!(!NORMAL_CONDITIONS.contains(&Condition::AL));
         assert!(!NORMAL_CONDITIONS.contains(&Condition::NV));
+    }
+
+    #[test]
+    fn address_operand_imm_offset_zero_displays_as_bare_base() {
+        let addr = AddressOperand::Imm {
+            base: Register::X1,
+            offset: 0,
+            mode: IndexMode::Offset,
+        };
+        assert_eq!(format!("{}", addr), "[x1]");
+    }
+
+    #[test]
+    fn address_operand_imm_offset_nonzero_displays_with_immediate() {
+        let addr = AddressOperand::Imm {
+            base: Register::X1,
+            offset: 8,
+            mode: IndexMode::Offset,
+        };
+        assert_eq!(format!("{}", addr), "[x1, #8]");
+    }
+
+    #[test]
+    fn address_operand_imm_negative_offset_emits_minus_sign() {
+        let addr = AddressOperand::Imm {
+            base: Register::SP,
+            offset: -16,
+            mode: IndexMode::Offset,
+        };
+        assert_eq!(format!("{}", addr), "[sp, #-16]");
+    }
+
+    #[test]
+    fn address_operand_imm_pre_index_displays_with_trailing_bang() {
+        let addr = AddressOperand::Imm {
+            base: Register::X29,
+            offset: -16,
+            mode: IndexMode::PreIndex,
+        };
+        assert_eq!(format!("{}", addr), "[x29, #-16]!");
+    }
+
+    #[test]
+    fn address_operand_imm_post_index_emits_immediate_outside_bracket() {
+        let addr = AddressOperand::Imm {
+            base: Register::X1,
+            offset: 8,
+            mode: IndexMode::PostIndex,
+        };
+        assert_eq!(format!("{}", addr), "[x1], #8");
+    }
+
+    #[test]
+    fn address_operand_reg_zero_shift_omits_lsl_clause() {
+        let addr = AddressOperand::Reg {
+            base: Register::X1,
+            idx: Register::X2,
+            shift: 0,
+        };
+        assert_eq!(format!("{}", addr), "[x1, x2]");
+    }
+
+    #[test]
+    fn address_operand_reg_nonzero_shift_emits_lsl_immediate() {
+        let addr = AddressOperand::Reg {
+            base: Register::X1,
+            idx: Register::X2,
+            shift: 3,
+        };
+        assert_eq!(format!("{}", addr), "[x1, x2, lsl #3]");
+    }
+
+    #[test]
+    fn address_operand_ext_uxtw_index_prints_as_w_form() {
+        let addr = AddressOperand::Ext {
+            base: Register::X1,
+            idx: Register::X2,
+            kind: ExtendKind::Uxtw,
+            shift: 2,
+        };
+        assert_eq!(format!("{}", addr), "[x1, w2, uxtw #2]");
+    }
+
+    #[test]
+    fn address_operand_ext_sxtx_index_prints_as_x_form() {
+        let addr = AddressOperand::Ext {
+            base: Register::X1,
+            idx: Register::X2,
+            kind: ExtendKind::Sxtx,
+            shift: 3,
+        };
+        assert_eq!(format!("{}", addr), "[x1, x2, sxtx #3]");
+    }
+
+    #[test]
+    fn address_operand_ext_zero_shift_omits_immediate() {
+        let addr = AddressOperand::Ext {
+            base: Register::X1,
+            idx: Register::X2,
+            kind: ExtendKind::Uxtw,
+            shift: 0,
+        };
+        assert_eq!(format!("{}", addr), "[x1, w2, uxtw]");
+    }
+
+    #[test]
+    fn access_width_bytes_matches_arm_arm() {
+        assert_eq!(AccessWidth::Byte.bytes(), 1);
+        assert_eq!(AccessWidth::Half.bytes(), 2);
+        assert_eq!(AccessWidth::Word.bytes(), 4);
+        assert_eq!(AccessWidth::Extended.bytes(), 8);
     }
 }

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -254,6 +254,19 @@ impl InstructionType for Instruction {
             Instruction::Tbnz { .. } => 61,
             Instruction::Bl { .. } => 62,
             Instruction::Br { .. } => 63,
+
+            // Memory ops (issue #68). LDR/LDRB/LDRH share id 64 — the
+            // mnemonic table differentiates by `AccessWidth`; this id
+            // bucket is used only for coarse equality checks.
+            Instruction::Ldr { .. } => 64,
+            // Sign-extending loads (LDRSB / LDRSH / LDRSW).
+            Instruction::Ldrs { .. } => 65,
+            // Stores (STR / STRB / STRH).
+            Instruction::Str { .. } => 66,
+            // Pair loads (LDP, LDPSW).
+            Instruction::Ldp { .. } => 67,
+            // Pair store (STP).
+            Instruction::Stp { .. } => 68,
         }
     }
 
@@ -328,11 +341,56 @@ impl InstructionType for Instruction {
             Instruction::Tbnz { .. } => "tbnz",
             Instruction::Bl { .. } => "bl",
             Instruction::Br { .. } => "br",
+
+            // Memory ops (issue #68). LDR / LDRB / LDRH differ only by
+            // access width.
+            Instruction::Ldr { width, .. } => match width {
+                crate::ir::types::AccessWidth::Byte => "ldrb",
+                crate::ir::types::AccessWidth::Half => "ldrh",
+                crate::ir::types::AccessWidth::Word | crate::ir::types::AccessWidth::Extended => {
+                    "ldr"
+                }
+            },
+            // Sign-extending loads. `Extended` width is rejected by
+            // `is_encodable_aarch64`; fall through to "ldrsw" if it ever
+            // reaches here.
+            Instruction::Ldrs { width, .. } => match width {
+                crate::ir::types::AccessWidth::Byte => "ldrsb",
+                crate::ir::types::AccessWidth::Half => "ldrsh",
+                crate::ir::types::AccessWidth::Word | crate::ir::types::AccessWidth::Extended => {
+                    "ldrsw"
+                }
+            },
+            // Stores. STR / STRB / STRH; the X/W distinction is hidden in
+            // the AccessWidth (Extended vs Word).
+            Instruction::Str { width, .. } => match width {
+                crate::ir::types::AccessWidth::Byte => "strb",
+                crate::ir::types::AccessWidth::Half => "strh",
+                crate::ir::types::AccessWidth::Word | crate::ir::types::AccessWidth::Extended => {
+                    "str"
+                }
+            },
+            // LDP / LDPSW.
+            Instruction::Ldp { signed: true, .. } => "ldpsw",
+            Instruction::Ldp { signed: false, .. } => "ldp",
+            // STP.
+            Instruction::Stp { .. } => "stp",
         }
     }
 
     fn has_side_effects(&self) -> bool {
+        // Memory ops have observable side effects beyond NZCV: stores write
+        // memory, writeback modes mutate the base register, loads read from
+        // potentially-aliased memory. See ADR-0007.
         self.modifies_flags()
+            || matches!(
+                self,
+                Instruction::Ldr { .. }
+                    | Instruction::Ldrs { .. }
+                    | Instruction::Str { .. }
+                    | Instruction::Ldp { .. }
+                    | Instruction::Stp { .. }
+            )
     }
 }
 
@@ -1096,6 +1154,14 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     Instruction::Tbnz { rt, bit, target } => Instruction::Tbnz { rt, bit, target },
                     Instruction::Bl { target } => Instruction::Bl { target },
                     Instruction::Br { rn } => Instruction::Br { rn },
+                    // Memory ops: identity-mutate for now. Step 16 wires
+                    // dedicated rt/base/idx/offset rotation slots in
+                    // `mutate_operand` / `mutate_opcode`.
+                    Instruction::Ldr { .. }
+                    | Instruction::Ldrs { .. }
+                    | Instruction::Str { .. }
+                    | Instruction::Ldp { .. }
+                    | Instruction::Stp { .. } => *instruction,
                 }
             }
             2 => {
@@ -1485,6 +1551,13 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     Instruction::Tbnz { rt, bit, target } => Instruction::Tbnz { rt, bit, target },
                     Instruction::Bl { target } => Instruction::Bl { target },
                     Instruction::Br { rn } => Instruction::Br { rn },
+                    // Memory ops: identity-mutate for now. Step 16 wires
+                    // dedicated source-operand rotation slots.
+                    Instruction::Ldr { .. }
+                    | Instruction::Ldrs { .. }
+                    | Instruction::Str { .. }
+                    | Instruction::Ldp { .. }
+                    | Instruction::Stp { .. } => *instruction,
                 }
             }
             _ => unreachable!(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1878,9 +1878,11 @@ mod cli_helper_tests {
 
     #[test]
     fn convert_capstone_op_flags_unknown_mnemonic_as_unsupported() {
-        match convert_capstone_op("ldr", "x0, [x1]") {
+        // NEON FADD is not parsed; memory ops were promoted to supported in
+        // issue #68. See ADR-0007.
+        match convert_capstone_op("fadd", "v0.4s, v1.4s, v2.4s") {
             ConvertOutcome::Unsupported(line) => {
-                assert!(line.contains("ldr"), "warning line should name mnemonic");
+                assert!(line.contains("fadd"), "warning line should name mnemonic");
             }
             other => panic!("expected Unsupported, got {:?}", other),
         }
@@ -1888,10 +1890,10 @@ mod cli_helper_tests {
 
     #[test]
     fn convert_capstone_op_for_optimization_rejects_unsupported_instruction() {
-        let err = convert_capstone_op_for_optimization("ldr", "x0, [x1]", 0x1234)
+        let err = convert_capstone_op_for_optimization("fadd", "v0.4s, v1.4s, v2.4s", 0x1234)
             .expect_err("optimization conversion must reject unsupported non-NOP instructions");
 
-        assert!(err.contains("ldr x0, [x1]"));
+        assert!(err.contains("fadd v0.4s, v1.4s, v2.4s"));
         assert!(err.contains("0x1234"));
         assert!(err.contains("cannot optimize"));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -530,7 +530,7 @@ fn live_out_for_optimization_prefix(
 ) -> LiveOut {
     let mut live_registers: Vec<Register> = prefix
         .iter()
-        .filter_map(|instr| instr.destination())
+        .flat_map(|instr| instr.destinations())
         .collect();
 
     if let Some(terminator) = terminator {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1846,12 +1846,83 @@ mod cli_helper_tests {
             ("cbnz", "x5, #0x1000"),
             ("tbz", "w3, #5, #0x1000"),
             ("tbnz", "x3, #40, #0x1000"),
+            // Issue #68: memory ops. 9 single-register mnemonics × 5
+            // addressing modes = 45 rows; 3 pair mnemonics × 3 modes = 9
+            // rows. See ADR-0007.
+            // LDR (X/W form, immediate-offset / pre-index / post-index /
+            // register-offset / register-extend).
+            ("ldr", "x0, [x1]"),
+            ("ldr", "x0, [x1, #8]!"),
+            ("ldr", "x0, [x1], #8"),
+            ("ldr", "x0, [x1, x2]"),
+            ("ldr", "x0, [x1, w2, uxtw #3]"),
+            // LDRB.
+            ("ldrb", "w0, [x1]"),
+            ("ldrb", "w0, [x1, #1]!"),
+            ("ldrb", "w0, [x1], #1"),
+            ("ldrb", "w0, [x1, x2]"),
+            ("ldrb", "w0, [x1, w2, uxtw]"),
+            // LDRH.
+            ("ldrh", "w0, [x1]"),
+            ("ldrh", "w0, [x1, #2]!"),
+            ("ldrh", "w0, [x1], #2"),
+            ("ldrh", "w0, [x1, x2]"),
+            ("ldrh", "w0, [x1, w2, uxtw #1]"),
+            // LDRSB.
+            ("ldrsb", "x0, [x1]"),
+            ("ldrsb", "x0, [x1, #1]!"),
+            ("ldrsb", "x0, [x1], #1"),
+            ("ldrsb", "x0, [x1, x2]"),
+            ("ldrsb", "x0, [x1, w2, sxtw]"),
+            // LDRSH.
+            ("ldrsh", "x0, [x1]"),
+            ("ldrsh", "x0, [x1, #2]!"),
+            ("ldrsh", "x0, [x1], #2"),
+            ("ldrsh", "x0, [x1, x2]"),
+            ("ldrsh", "x0, [x1, w2, sxtw #1]"),
+            // LDRSW.
+            ("ldrsw", "x0, [x1]"),
+            ("ldrsw", "x0, [x1, #4]!"),
+            ("ldrsw", "x0, [x1], #4"),
+            ("ldrsw", "x0, [x1, x2]"),
+            ("ldrsw", "x0, [x1, w2, sxtw #2]"),
+            // STR.
+            ("str", "x0, [x1]"),
+            ("str", "x0, [x1, #8]!"),
+            ("str", "x0, [x1], #8"),
+            ("str", "x0, [x1, x2]"),
+            ("str", "x0, [x1, w2, uxtw #3]"),
+            // STRB.
+            ("strb", "w0, [x1]"),
+            ("strb", "w0, [x1, #1]!"),
+            ("strb", "w0, [x1], #1"),
+            ("strb", "w0, [x1, x2]"),
+            ("strb", "w0, [x1, w2, uxtw]"),
+            // STRH.
+            ("strh", "w0, [x1]"),
+            ("strh", "w0, [x1, #2]!"),
+            ("strh", "w0, [x1], #2"),
+            ("strh", "w0, [x1, x2]"),
+            ("strh", "w0, [x1, w2, uxtw #1]"),
+            // LDP (offset / pre-index / post-index — register-offset and
+            // register-extend are not part of the AArch64 pair grammar).
+            ("ldp", "x0, x1, [sp, #16]"),
+            ("ldp", "x0, x1, [sp, #-16]!"),
+            ("ldp", "x0, x1, [sp], #16"),
+            // STP.
+            ("stp", "x0, x1, [sp, #16]"),
+            ("stp", "x0, x1, [sp, #-16]!"),
+            ("stp", "x0, x1, [sp], #16"),
+            // LDPSW.
+            ("ldpsw", "x0, x1, [sp, #8]"),
+            ("ldpsw", "x0, x1, [sp, #-8]!"),
+            ("ldpsw", "x0, x1, [sp], #8"),
         ];
 
         // Tripwire: bump in lockstep when adding/removing rows. Catches
         // accidental row deletion and forces a re-read when adding a parser
         // mnemonic without a matching test row.
-        assert_eq!(cases.len(), 78);
+        assert_eq!(cases.len(), 132);
 
         for (mnem, ops) in cases {
             match convert_capstone_op(mnem, ops) {
@@ -1885,6 +1956,30 @@ mod cli_helper_tests {
                 assert!(line.contains("fadd"), "warning line should name mnemonic");
             }
             other => panic!("expected Unsupported, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn convert_capstone_op_keeps_related_memory_mnemonics_unsupported() {
+        // ADR-0007 §9 explicitly leaves these out of scope. Lock the outcome
+        // here so a future Capstone-syntax shift cannot silently start
+        // parsing them as supported instructions:
+        //   - LDUR / STUR: unscaled-signed-offset variants Capstone uses
+        //     for negative immediates that LDR-imm cannot encode.
+        //   - LDR (literal): PC-relative pool load — different operand
+        //     grammar than the bracketed forms supported by step 4.
+        for (mnem, ops) in [
+            ("ldur", "x0, [x1, #-1]"),
+            ("stur", "x0, [x1, #-1]"),
+            ("ldr", "x0, #0x1234"),
+        ] {
+            match convert_capstone_op(mnem, ops) {
+                ConvertOutcome::Unsupported(_) => {}
+                other => panic!(
+                    "expected Unsupported for `{} {}`, got {:?}",
+                    mnem, ops, other
+                ),
+            }
         }
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -301,9 +301,27 @@ fn is_directive(line: &str) -> bool {
     line.trim().starts_with('.')
 }
 
-/// Split operands by comma, handling whitespace
+/// Split operands by comma, handling whitespace. Bracket-aware: commas
+/// inside `[ ... ]` (memory-operand grammar) are kept inside the same
+/// token. See ADR-0007.
 fn split_operands(operands_str: &str) -> Vec<&str> {
-    operands_str.split(',').map(|s| s.trim()).collect()
+    let mut parts = Vec::new();
+    let bytes = operands_str.as_bytes();
+    let mut depth: i32 = 0;
+    let mut start = 0usize;
+    for (i, &b) in bytes.iter().enumerate() {
+        match b {
+            b'[' => depth += 1,
+            b']' => depth -= 1,
+            b',' if depth == 0 => {
+                parts.push(operands_str[start..i].trim());
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    parts.push(operands_str[start..].trim());
+    parts
 }
 
 /// Parse a MOV instruction
@@ -709,6 +727,293 @@ fn is_extend_keyword(kw: &str) -> bool {
         kw.to_ascii_lowercase().as_str(),
         "uxtb" | "uxth" | "uxtw" | "uxtx" | "sxtb" | "sxth" | "sxtw" | "sxtx"
     )
+}
+
+/// Parse an `AddressOperand` from the bracketed-operand tokens of a
+/// memory instruction. Accepts:
+///   - `[Xn]`                          → Imm { offset=0, mode=Offset }
+///   - `[Xn, #imm]`                    → Imm { mode=Offset }
+///   - `[Xn, #imm]!`                   → Imm { mode=PreIndex }
+///   - `[Xn], #imm` (two tokens)       → Imm { mode=PostIndex }
+///   - `[Xn, Xm]`                      → Reg { shift=0 }
+///   - `[Xn, Xm, LSL #shift]`          → Reg { shift }
+///   - `[Xn, {W|X}m, UXTW/SXTW/UXTX/SXTX{ #shift}]`  → Ext
+///
+/// Returns the parsed operand and the number of input tokens consumed (1 for
+/// the four bracketed forms, 2 for the trailing-immediate post-index form).
+/// See ADR-0007.
+fn parse_memory_operand(
+    tokens: &[&str],
+) -> Result<(crate::ir::types::AddressOperand, usize), String> {
+    use crate::ir::types::{AddressOperand, ExtendKind, IndexMode};
+
+    let first = tokens.first().ok_or("missing address operand")?.trim();
+    if !first.starts_with('[') {
+        return Err(format!(
+            "expected '[' at start of address operand, got `{}`",
+            first
+        ));
+    }
+
+    // Locate the closing bracket. The bracket-aware split puts the entire
+    // bracketed group in a single token, so the ']' is in this same token.
+    let close = first
+        .rfind(']')
+        .ok_or_else(|| format!("missing ']' in address operand `{}`", first))?;
+    let inner = first[1..close].trim();
+    let after_bracket = first[close + 1..].trim();
+
+    // Parse the inner pieces.
+    let inner_parts: Vec<&str> = inner.split(',').map(|s| s.trim()).collect();
+    let base = parse_register(inner_parts[0])
+        .map_err(|e| format!("invalid base register in memory operand: {}", e))?;
+
+    let mut addr = if inner_parts.len() == 1 {
+        AddressOperand::Imm {
+            base,
+            offset: 0,
+            mode: IndexMode::Offset,
+        }
+    } else if inner_parts.len() == 2 {
+        // Either `[Xn, #imm]` or `[Xn, Xm]`.
+        let second = inner_parts[1];
+        if let Ok(imm) = parse_immediate(second) {
+            AddressOperand::Imm {
+                base,
+                offset: imm,
+                mode: IndexMode::Offset,
+            }
+        } else {
+            // Register-offset, no shift.
+            let idx = parse_register(second)
+                .map_err(|e| format!("invalid index register in memory operand: {}", e))?;
+            AddressOperand::Reg {
+                base,
+                idx,
+                shift: 0,
+            }
+        }
+    } else if inner_parts.len() == 3 {
+        // `[Xn, Xm, LSL #N]` or `[Xn, Wm, UXTW/SXTW/UXTX/SXTX{ #N}]`.
+        let third = inner_parts[2];
+        let kw = third.split_whitespace().next().unwrap_or("");
+        if kw.eq_ignore_ascii_case("lsl") {
+            let idx = parse_register(inner_parts[1])
+                .map_err(|e| format!("invalid index register in memory operand: {}", e))?;
+            let shift = parse_lsl_amount(third)?;
+            AddressOperand::Reg { base, idx, shift }
+        } else if is_extend_keyword(kw) {
+            let idx = parse_w_or_x_register(inner_parts[1])
+                .map_err(|e| format!("invalid index register in memory operand: {}", e))?;
+            let (kind, shift) = parse_memory_extend_tail(third)?;
+            // Memory operands only accept the W/X-extend kinds (no byte/half).
+            if !matches!(
+                kind,
+                ExtendKind::Uxtw | ExtendKind::Sxtw | ExtendKind::Uxtx | ExtendKind::Sxtx
+            ) {
+                return Err(format!(
+                    "memory operand does not accept extend kind `{}`",
+                    kw.to_lowercase()
+                ));
+            }
+            AddressOperand::Ext {
+                base,
+                idx,
+                kind,
+                shift,
+            }
+        } else {
+            return Err(format!("unrecognised memory-operand tail: `{}`", third));
+        }
+    } else {
+        return Err(format!("unrecognised memory operand `{}`", first));
+    };
+
+    // Writeback (`!`) marker after `]`.
+    if after_bracket == "!" {
+        if let AddressOperand::Imm {
+            base,
+            offset,
+            mode: IndexMode::Offset,
+        } = addr
+        {
+            addr = AddressOperand::Imm {
+                base,
+                offset,
+                mode: IndexMode::PreIndex,
+            };
+            return Ok((addr, 1));
+        } else {
+            return Err("pre-index writeback `!` requires `[Xn, #imm]` form".into());
+        }
+    } else if !after_bracket.is_empty() {
+        return Err(format!(
+            "unexpected trailing text after `]`: `{}`",
+            after_bracket
+        ));
+    }
+
+    // Post-index uses a second top-level token: `[Xn], #imm`.
+    if tokens.len() >= 2 {
+        let second = tokens[1].trim();
+        if let Ok(imm) = parse_immediate(second) {
+            if let AddressOperand::Imm {
+                base,
+                offset: 0,
+                mode: IndexMode::Offset,
+            } = addr
+            {
+                addr = AddressOperand::Imm {
+                    base,
+                    offset: imm,
+                    mode: IndexMode::PostIndex,
+                };
+                return Ok((addr, 2));
+            } else {
+                return Err("post-index requires bare `[Xn]` base form".into());
+            }
+        }
+    }
+
+    Ok((addr, 1))
+}
+
+/// Parse a `LSL #N` tail (after the leading "lsl" keyword).
+fn parse_lsl_amount(tail: &str) -> Result<u8, String> {
+    let mut parts = tail.split_whitespace();
+    let kw = parts.next().unwrap_or("");
+    if !kw.eq_ignore_ascii_case("lsl") {
+        return Err(format!("expected `lsl`, got `{}`", kw));
+    }
+    let imm_tok = parts.next().ok_or("missing LSL amount")?;
+    let amt = parse_immediate(imm_tok)?;
+    if !(0..=63).contains(&amt) {
+        return Err(format!("LSL amount {} out of range", amt));
+    }
+    Ok(amt as u8)
+}
+
+/// Parse a `<extend> #shift` tail used in memory operands. Returns the
+/// extend kind plus the optional shift (defaults to 0 if absent).
+fn parse_memory_extend_tail(tail: &str) -> Result<(crate::ir::types::ExtendKind, u8), String> {
+    use crate::ir::types::ExtendKind;
+    let mut parts = tail.split_whitespace();
+    let kw = parts.next().unwrap_or("").to_lowercase();
+    let kind = match kw.as_str() {
+        "uxtw" => ExtendKind::Uxtw,
+        "sxtw" => ExtendKind::Sxtw,
+        "uxtx" => ExtendKind::Uxtx,
+        "sxtx" => ExtendKind::Sxtx,
+        _ => return Err(format!("unsupported memory extend keyword `{}`", kw)),
+    };
+    let shift = match parts.next() {
+        None => 0u8,
+        Some(imm_tok) => {
+            let amt = parse_immediate(imm_tok)?;
+            if !(0..=4).contains(&amt) {
+                return Err(format!("extend shift {} out of range (0..=4)", amt));
+            }
+            amt as u8
+        }
+    };
+    Ok((kind, shift))
+}
+
+/// Infer `AccessWidth` for the unsized LDR/STR mnemonics (where the data
+/// register's spelling — `wN` vs `xN` — chooses the width).
+fn ldr_width(operands: &[&str]) -> crate::ir::types::AccessWidth {
+    match operands.first().and_then(|s| s.trim().chars().next()) {
+        Some('w') | Some('W') => crate::ir::types::AccessWidth::Word,
+        _ => crate::ir::types::AccessWidth::Extended,
+    }
+}
+
+/// Infer `AccessWidth` for LDP / STP based on whether the first paired
+/// register is W-form or X-form.
+fn ldp_pair_width(operands: &[&str]) -> crate::ir::types::AccessWidth {
+    ldr_width(operands)
+}
+
+/// Parse a single-register LDR-family instruction (LDR/LDRB/LDRH/LDRSB/
+/// LDRSH/LDRSW/STR/STRB/STRH). The destination/source register is the
+/// first operand; the remaining tokens form the address operand.
+fn parse_single_reg_mem(
+    mnem: &str,
+    operands: &[&str],
+    width: crate::ir::types::AccessWidth,
+    builder: fn(
+        Register,
+        crate::ir::types::AddressOperand,
+        crate::ir::types::AccessWidth,
+    ) -> Instruction,
+) -> Result<Instruction, String> {
+    if operands.len() < 2 {
+        return Err(format!(
+            "{} requires register + address operand, got {}",
+            mnem,
+            operands.len()
+        ));
+    }
+    let rt =
+        parse_w_or_x_register(operands[0]).map_err(|e| format!("{}: invalid Xt: {}", mnem, e))?;
+    let (addr, consumed) = parse_memory_operand(&operands[1..])?;
+    if 1 + consumed != operands.len() {
+        return Err(format!(
+            "{} has {} operands, expected {}",
+            mnem,
+            operands.len(),
+            1 + consumed
+        ));
+    }
+    Ok(builder(rt, addr, width))
+}
+
+/// Parse a pair memory instruction (LDP/STP/LDPSW). The destination
+/// pair is the first two operands; the remaining tokens form the
+/// address operand. `signed=true` only for LDPSW.
+fn parse_pair_mem(
+    mnem: &str,
+    operands: &[&str],
+    width: crate::ir::types::AccessWidth,
+    is_load: bool,
+    signed: bool,
+) -> Result<Instruction, String> {
+    if operands.len() < 3 {
+        return Err(format!(
+            "{} requires two registers + address operand, got {}",
+            mnem,
+            operands.len()
+        ));
+    }
+    let rt1 = parse_w_or_x_register(operands[0])
+        .map_err(|e| format!("{}: invalid first register: {}", mnem, e))?;
+    let rt2 = parse_w_or_x_register(operands[1])
+        .map_err(|e| format!("{}: invalid second register: {}", mnem, e))?;
+    let (addr, consumed) = parse_memory_operand(&operands[2..])?;
+    if 2 + consumed != operands.len() {
+        return Err(format!(
+            "{} has {} operands, expected {}",
+            mnem,
+            operands.len(),
+            2 + consumed
+        ));
+    }
+    if is_load {
+        Ok(Instruction::Ldp {
+            rt1,
+            rt2,
+            addr,
+            width,
+            signed,
+        })
+    } else {
+        Ok(Instruction::Stp {
+            rt1,
+            rt2,
+            addr,
+            width,
+        })
+    }
 }
 
 /// Parse the rm slot for the 3-operand arith/logical instructions
@@ -1401,6 +1706,76 @@ pub fn parse_line(line: &str) -> Result<LineResult, ParseLineError> {
         "cbnz" => parse_cbnz(&operands).map_err(ParseLineError::Other)?,
         "tbz" => parse_tbz(&operands).map_err(ParseLineError::Other)?,
         "tbnz" => parse_tbnz(&operands).map_err(ParseLineError::Other)?,
+        // Memory ops (issue #68). Width-detecting load family.
+        "ldr" => parse_single_reg_mem("ldr", &operands, ldr_width(&operands), |rt, addr, w| {
+            Instruction::Ldr { rt, addr, width: w }
+        })
+        .map_err(ParseLineError::Other)?,
+        "ldrb" => parse_single_reg_mem(
+            "ldrb",
+            &operands,
+            crate::ir::types::AccessWidth::Byte,
+            |rt, addr, w| Instruction::Ldr { rt, addr, width: w },
+        )
+        .map_err(ParseLineError::Other)?,
+        "ldrh" => parse_single_reg_mem(
+            "ldrh",
+            &operands,
+            crate::ir::types::AccessWidth::Half,
+            |rt, addr, w| Instruction::Ldr { rt, addr, width: w },
+        )
+        .map_err(ParseLineError::Other)?,
+        "ldrsb" => parse_single_reg_mem(
+            "ldrsb",
+            &operands,
+            crate::ir::types::AccessWidth::Byte,
+            |rt, addr, w| Instruction::Ldrs { rt, addr, width: w },
+        )
+        .map_err(ParseLineError::Other)?,
+        "ldrsh" => parse_single_reg_mem(
+            "ldrsh",
+            &operands,
+            crate::ir::types::AccessWidth::Half,
+            |rt, addr, w| Instruction::Ldrs { rt, addr, width: w },
+        )
+        .map_err(ParseLineError::Other)?,
+        "ldrsw" => parse_single_reg_mem(
+            "ldrsw",
+            &operands,
+            crate::ir::types::AccessWidth::Word,
+            |rt, addr, w| Instruction::Ldrs { rt, addr, width: w },
+        )
+        .map_err(ParseLineError::Other)?,
+        "str" => parse_single_reg_mem("str", &operands, ldr_width(&operands), |rt, addr, w| {
+            Instruction::Str { rt, addr, width: w }
+        })
+        .map_err(ParseLineError::Other)?,
+        "strb" => parse_single_reg_mem(
+            "strb",
+            &operands,
+            crate::ir::types::AccessWidth::Byte,
+            |rt, addr, w| Instruction::Str { rt, addr, width: w },
+        )
+        .map_err(ParseLineError::Other)?,
+        "strh" => parse_single_reg_mem(
+            "strh",
+            &operands,
+            crate::ir::types::AccessWidth::Half,
+            |rt, addr, w| Instruction::Str { rt, addr, width: w },
+        )
+        .map_err(ParseLineError::Other)?,
+        "ldp" => parse_pair_mem("ldp", &operands, ldp_pair_width(&operands), true, false)
+            .map_err(ParseLineError::Other)?,
+        "stp" => parse_pair_mem("stp", &operands, ldp_pair_width(&operands), false, false)
+            .map_err(ParseLineError::Other)?,
+        "ldpsw" => parse_pair_mem(
+            "ldpsw",
+            &operands,
+            crate::ir::types::AccessWidth::Word,
+            true,
+            true,
+        )
+        .map_err(ParseLineError::Other)?,
         // b.<cond> — split on the dot, parse the condition, dispatch.
         op if op.starts_with("b.") => {
             let suffix = &op[2..];
@@ -2474,5 +2849,211 @@ mod tests {
         assert_eq!(a, b, "same label should hash to same LabelId");
         let c = parse_one("b .Lbar");
         assert_ne!(a, c, "different labels should hash differently");
+    }
+
+    #[test]
+    fn split_operands_treats_bracketed_commas_as_one_token() {
+        // Memory operands carry commas inside `[ ... ]`; the splitter must
+        // not break them apart.
+        let parts = split_operands("x0, [x1, x2, lsl #3]");
+        assert_eq!(parts, vec!["x0", "[x1, x2, lsl #3]"]);
+    }
+
+    #[test]
+    fn split_operands_flat_corpus_is_unchanged() {
+        // Existing comma-separated three-operand instructions must keep
+        // the same tokenisation after the bracket-aware rewrite.
+        assert_eq!(split_operands("x0, x1, #8"), vec!["x0", "x1", "#8"]);
+        assert_eq!(
+            split_operands("x0, x1, x2, x3"),
+            vec!["x0", "x1", "x2", "x3"]
+        );
+    }
+
+    #[test]
+    fn split_operands_handles_post_index_trailing_immediate() {
+        // Post-index uses `[base], #imm` — the trailing `, #imm` is a real
+        // top-level comma after the closing `]`.
+        let parts = split_operands("x0, [x1], #8");
+        assert_eq!(parts, vec!["x0", "[x1]", "#8"]);
+    }
+
+    #[test]
+    fn parse_ldr_bare_base_yields_offset_mode_with_zero_offset() {
+        use crate::ir::types::{AccessWidth, AddressOperand, IndexMode};
+        let instr = parse_one("ldr x0, [x1]");
+        assert_eq!(
+            instr,
+            Instruction::Ldr {
+                rt: Register::X0,
+                addr: AddressOperand::Imm {
+                    base: Register::X1,
+                    offset: 0,
+                    mode: IndexMode::Offset,
+                },
+                width: AccessWidth::Extended,
+            }
+        );
+    }
+
+    /// Round-trip helper: every input must `parse_line → Display` back to
+    /// itself (canonical Capstone-ish form).
+    fn assert_mem_round_trip(text: &str) {
+        let instr = parse_one(text);
+        assert_eq!(format!("{}", instr), text, "round-trip mismatch");
+    }
+
+    #[test]
+    fn memory_op_round_trips_across_all_addressing_modes() {
+        // Immediate-offset, including bare-base and negative offsets.
+        assert_mem_round_trip("ldr x0, [x1]");
+        assert_mem_round_trip("ldr x0, [x1, #8]");
+        assert_mem_round_trip("ldr x0, [sp, #-8]");
+        // Pre-index.
+        assert_mem_round_trip("ldr x0, [x1, #16]!");
+        assert_mem_round_trip("str x0, [sp, #-16]!");
+        // Post-index.
+        assert_mem_round_trip("ldr x0, [x1], #8");
+        assert_mem_round_trip("str x0, [x1], #-8");
+        // Register-offset, with and without LSL.
+        assert_mem_round_trip("ldr x0, [x1, x2]");
+        assert_mem_round_trip("ldr x0, [x1, x2, lsl #3]");
+        // Register-extend.
+        assert_mem_round_trip("ldr x0, [x1, w2, uxtw #2]");
+        assert_mem_round_trip("ldr x0, [x1, w2, sxtw]");
+        // Other mnemonics.
+        assert_mem_round_trip("ldrb x0, [x1]");
+        assert_mem_round_trip("ldrh x0, [x1, #4]");
+        assert_mem_round_trip("ldrsb x0, [x1]");
+        assert_mem_round_trip("ldrsh x0, [x1]");
+        assert_mem_round_trip("ldrsw x0, [x1]");
+        assert_mem_round_trip("strb x0, [x1]");
+        assert_mem_round_trip("strh x0, [x1]");
+        // Pair forms.
+        assert_mem_round_trip("ldp x0, x1, [sp]");
+        assert_mem_round_trip("ldp x0, x1, [sp, #16]");
+        assert_mem_round_trip("ldp x0, x1, [sp, #-16]!");
+        assert_mem_round_trip("ldp x0, x1, [sp], #16");
+        assert_mem_round_trip("stp x29, x30, [sp, #-16]!");
+        assert_mem_round_trip("ldpsw x0, x1, [sp]");
+    }
+
+    #[test]
+    fn parse_ldr_pre_index_yields_pre_index_mode() {
+        use crate::ir::types::{AccessWidth, AddressOperand, IndexMode};
+        let instr = parse_one("ldr x0, [x1, #8]!");
+        assert_eq!(
+            instr,
+            Instruction::Ldr {
+                rt: Register::X0,
+                addr: AddressOperand::Imm {
+                    base: Register::X1,
+                    offset: 8,
+                    mode: IndexMode::PreIndex,
+                },
+                width: AccessWidth::Extended,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_ldr_post_index_yields_post_index_mode() {
+        use crate::ir::types::{AccessWidth, AddressOperand, IndexMode};
+        let instr = parse_one("ldr x0, [x1], #8");
+        assert_eq!(
+            instr,
+            Instruction::Ldr {
+                rt: Register::X0,
+                addr: AddressOperand::Imm {
+                    base: Register::X1,
+                    offset: 8,
+                    mode: IndexMode::PostIndex,
+                },
+                width: AccessWidth::Extended,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_ldr_register_offset_with_shift() {
+        use crate::ir::types::{AccessWidth, AddressOperand};
+        let instr = parse_one("ldr x0, [x1, x2, lsl #3]");
+        assert_eq!(
+            instr,
+            Instruction::Ldr {
+                rt: Register::X0,
+                addr: AddressOperand::Reg {
+                    base: Register::X1,
+                    idx: Register::X2,
+                    shift: 3,
+                },
+                width: AccessWidth::Extended,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_ldr_register_extend_with_w_index() {
+        use crate::ir::types::{AccessWidth, AddressOperand, ExtendKind};
+        let instr = parse_one("ldr x0, [x1, w2, uxtw #2]");
+        assert_eq!(
+            instr,
+            Instruction::Ldr {
+                rt: Register::X0,
+                addr: AddressOperand::Ext {
+                    base: Register::X1,
+                    idx: Register::X2,
+                    kind: ExtendKind::Uxtw,
+                    shift: 2,
+                },
+                width: AccessWidth::Extended,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_ldp_yields_two_register_load() {
+        use crate::ir::types::{AccessWidth, AddressOperand, IndexMode};
+        let instr = parse_one("ldp x0, x1, [sp, #16]");
+        assert_eq!(
+            instr,
+            Instruction::Ldp {
+                rt1: Register::X0,
+                rt2: Register::X1,
+                addr: AddressOperand::Imm {
+                    base: Register::SP,
+                    offset: 16,
+                    mode: IndexMode::Offset,
+                },
+                width: AccessWidth::Extended,
+                signed: false,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_ldpsw_yields_signed_pair_load() {
+        let instr = parse_one("ldpsw x0, x1, [sp]");
+        match instr {
+            Instruction::Ldp {
+                signed: true,
+                width,
+                ..
+            } => {
+                assert_eq!(width, crate::ir::types::AccessWidth::Word);
+            }
+            _ => panic!("expected Ldp with signed=true"),
+        }
+    }
+
+    #[test]
+    fn parse_ldrb_uses_byte_width() {
+        let instr = parse_one("ldrb w0, [x1]");
+        match instr {
+            Instruction::Ldr { width, .. } => {
+                assert_eq!(width, crate::ir::types::AccessWidth::Byte);
+            }
+            _ => panic!("expected Ldr with byte width"),
+        }
     }
 }

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -401,6 +401,104 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
         }
     }
 
+    // Memory ops (issue #68, step 15). Sparse enumeration covering the
+    // common addressing modes for LDR/STR/LDP/STP. Width=Extended only
+    // (W-form variants land via stochastic mutation in step 16) so the
+    // candidate budget stays bounded — full width × addressing-mode ×
+    // signed coverage would explode the pool by ~30x. See ADR-0007 for
+    // the soundness argument; the SMT layer reasons over all widths
+    // regardless of which forms search enumerates.
+    {
+        use crate::ir::types::{AccessWidth, AddressOperand, IndexMode};
+        const MEM_IMM_SAMPLES: [i64; 5] = [0, 8, 16, 32, -8];
+        for &rt in registers {
+            if rt == Register::SP || rt == Register::XZR {
+                continue;
+            }
+            for &base in registers {
+                if base == Register::XZR {
+                    continue;
+                }
+                // Imm + Offset
+                for &offset in &MEM_IMM_SAMPLES {
+                    let addr = AddressOperand::Imm {
+                        base,
+                        offset,
+                        mode: IndexMode::Offset,
+                    };
+                    instrs.push(Instruction::Ldr {
+                        rt,
+                        addr,
+                        width: AccessWidth::Extended,
+                    });
+                    instrs.push(Instruction::Str {
+                        rt,
+                        addr,
+                        width: AccessWidth::Extended,
+                    });
+                }
+                // Reg-offset, X-form index, LSL #0 and #3
+                for &shift in &[0u8, 3] {
+                    for &idx in registers {
+                        if idx == Register::SP {
+                            continue;
+                        }
+                        let addr = AddressOperand::Reg { base, idx, shift };
+                        instrs.push(Instruction::Ldr {
+                            rt,
+                            addr,
+                            width: AccessWidth::Extended,
+                        });
+                        instrs.push(Instruction::Str {
+                            rt,
+                            addr,
+                            width: AccessWidth::Extended,
+                        });
+                    }
+                }
+            }
+        }
+        // Pair forms (LDP/STP) — exhaust (rt1, rt2, base) over a tiny offset
+        // set. Constrain rt1 < rt2 numeric index to avoid duplicates; the
+        // is_encodable_pair filter downstream still drops rt1==rt2.
+        const MEM_PAIR_IMM_SAMPLES: [i64; 3] = [0, 16, -16];
+        for &rt1 in registers {
+            if rt1 == Register::SP || rt1 == Register::XZR {
+                continue;
+            }
+            for &rt2 in registers {
+                if rt2 == Register::SP || rt2 == Register::XZR || rt1 == rt2 {
+                    continue;
+                }
+                for &base in registers {
+                    if base == Register::XZR {
+                        continue;
+                    }
+                    for &offset in &MEM_PAIR_IMM_SAMPLES {
+                        let addr = AddressOperand::Imm {
+                            base,
+                            offset,
+                            mode: IndexMode::Offset,
+                        };
+                        instrs.push(Instruction::Ldp {
+                            rt1,
+                            rt2,
+                            addr,
+                            width: AccessWidth::Extended,
+                            signed: false,
+                        });
+                        instrs.push(Instruction::Stp {
+                            rt1,
+                            rt2,
+                            addr,
+                            width: AccessWidth::Extended,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
     // Bit-field manipulation (UBFX/SBFX/BFI/BFXIL/UBFIZ/SBFIZ): sparse
     // (lsb, width) samples to keep the enumerative budget bounded. With
     // 31 non-SP registers × 31 rn × ~24 valid (lsb,width) pairs × 6 variants

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -882,6 +882,13 @@ pub fn opcode_id(instr: &Instruction) -> u8 {
         Instruction::Tbnz { .. } => 61,
         Instruction::Bl { .. } => 62,
         Instruction::Br { .. } => 63,
+        // Memory ops (issue #68). Mirrors `src/isa/aarch64.rs` so the two
+        // tables stay aligned. See ADR-0007.
+        Instruction::Ldr { .. } => 64,
+        Instruction::Ldrs { .. } => 65,
+        Instruction::Str { .. } => 66,
+        Instruction::Ldp { .. } => 67,
+        Instruction::Stp { .. } => 68,
     }
 }
 

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -93,7 +93,8 @@ fn verify_candidate(
     let equiv_config = EquivalenceConfig::with_live_out(live_out.clone())
         .random_tests(5)
         .timeout(smt_timeout)
-        .with_flags(true);
+        .with_flags(true)
+        .with_memory(true);
 
     let (verdict, metrics) =
         check_equivalence_with_config_metrics(target, candidate, &equiv_config);

--- a/src/search/llm/mod.rs
+++ b/src/search/llm/mod.rs
@@ -459,7 +459,11 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn fake_codex_parse_failure_records_unsupported_mnemonics() {
-        let fake = FakeCodex::new(&assembly_answer_writer_script("ldr x0, [x1]\nstr x2, [x3]"));
+        // Use NEON mnemonics — memory ops were promoted to supported in
+        // issue #68, so `ldr` / `str` no longer drive the unsupported path.
+        let fake = FakeCodex::new(&assembly_answer_writer_script(
+            "fadd v0.4s, v1.4s, v2.4s\nld1 {v3.16b}, [x4]",
+        ));
         let mut search = LlmSearch::new();
 
         let result = search.search(
@@ -471,7 +475,7 @@ mod tests {
         assert!(!result.found_optimization);
         assert_eq!(
             search.ledger().sorted_entries(),
-            vec![("ldr".to_string(), 1), ("str".to_string(), 1)]
+            vec![("fadd".to_string(), 1), ("ld1".to_string(), 1)]
         );
         assert_eq!(search.timings().codex_calls, 1);
         assert_eq!(search.timings().verifications, 0);

--- a/src/search/llm/outcome.rs
+++ b/src/search/llm/outcome.rs
@@ -120,11 +120,14 @@ mod tests {
             rd: Register::X0,
             imm: 1,
         }];
-        let (outcome, metrics) = classify(&target, "ldr x0, [x1]", &live_out_x0());
+        // NEON FADD is unsupported by the parser today; use it as the
+        // canonical unsupported mnemonic so the test does not fight the
+        // memory-ops support added in issue #68.
+        let (outcome, metrics) = classify(&target, "fadd v0.4s, v1.4s, v2.4s", &live_out_x0());
         assert_eq!(
             outcome,
             IterationOutcome::ParseFail {
-                unsupported_mnemonics: vec!["ldr".to_string()]
+                unsupported_mnemonics: vec!["fadd".to_string()]
             }
         );
         assert!(metrics.is_none(), "parse-fail must not invoke verifier");
@@ -134,13 +137,13 @@ mod tests {
     fn parse_fail_collects_all_unsupported_mnemonics_in_response() {
         // Response with three different unsupported instructions interleaved
         // with one supported `mov`. All three unsupported should be captured.
-        // (Note: branch mnemonics like `b`, `bl`, etc. are supported since
-        // issue #69; use memory ops as the unsupported set instead.)
+        // Use NEON forms; memory ops were promoted to supported in issue #68.
         let target = vec![Instruction::MovImm {
             rd: Register::X0,
             imm: 1,
         }];
-        let raw = "ldr x0, [x1]\nmov x0, x1\nstr x2, [x3]\nldp x4, x5, [x6]\n";
+        let raw =
+            "fadd v0.4s, v1.4s, v2.4s\nmov x0, x1\nfmla v3.4s, v4.4s, v5.4s\nld1 {v6.16b}, [x7]\n";
         let (outcome, metrics) = classify(&target, raw, &live_out_x0());
         let mnemonics = match outcome {
             IterationOutcome::ParseFail {
@@ -149,18 +152,18 @@ mod tests {
             other => panic!("expected ParseFail, got {:?}", other),
         };
         assert!(
-            mnemonics.contains(&"ldr".to_string()),
-            "ldr missing from {:?}",
+            mnemonics.contains(&"fadd".to_string()),
+            "fadd missing from {:?}",
             mnemonics
         );
         assert!(
-            mnemonics.contains(&"str".to_string()),
-            "str missing from {:?}",
+            mnemonics.contains(&"fmla".to_string()),
+            "fmla missing from {:?}",
             mnemonics
         );
         assert!(
-            mnemonics.contains(&"ldp".to_string()),
-            "ldp missing from {:?}",
+            mnemonics.contains(&"ld1".to_string()),
+            "ld1 missing from {:?}",
             mnemonics
         );
         assert!(metrics.is_none());

--- a/src/search/stochastic/backend.rs
+++ b/src/search/stochastic/backend.rs
@@ -152,8 +152,10 @@ impl StochasticBackend<crate::isa::AArch64> for crate::isa::AArch64 {
         // flag-writer guard in equivalence.rs pre-SMT already handles flag
         // divergence before stochastic comparison is reached. The mask may
         // carry `flags_live = true`, but it is honoured upstream, not here.
+        // `memory_live = false` here for the same reason — equivalence.rs
+        // force-enables it via `touches_memory()` before calling this path.
         // Mirrors mcmc.rs's existing call site.
-        crate::semantics::concrete::states_equal_for_live_out(s1, s2, live_out, false)
+        crate::semantics::concrete::states_equal_for_live_out(s1, s2, live_out, false, false)
     }
 
     fn sequence_cost(seq: &[crate::ir::Instruction], metric: &CostMetric, _width: u32) -> u64 {

--- a/src/search/stochastic/backend.rs
+++ b/src/search/stochastic/backend.rs
@@ -135,6 +135,7 @@ impl StochasticBackend<crate::isa::AArch64> for crate::isa::AArch64 {
             &crate::validation::random::RandomInputConfig {
                 count,
                 registers: regs.to_vec(),
+                memory_seed_size: 0,
             },
         )
     }

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -282,7 +282,7 @@ pub fn evaluate_with_tests(
 
     for (input, target_output) in test_inputs.iter().zip(target_outputs.iter()) {
         let proposal_output = apply_sequence_concrete(input.clone(), proposal);
-        if !states_equal_for_live_out(&proposal_output, target_output, live_out, false) {
+        if !states_equal_for_live_out(&proposal_output, target_output, live_out, false, false) {
             passes_all = false;
             break;
         }

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -1218,7 +1218,7 @@ mod tests {
         };
         let mut changed = false;
         for _ in 0..200 {
-            let mut seq = vec![initial.clone()];
+            let mut seq = vec![initial];
             mutator.mutate_operand(&mut rng, &mut seq);
             if seq[0] != initial {
                 changed = true;

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -403,6 +403,14 @@ impl Mutator {
             | Instruction::Tbnz { .. }
             | Instruction::Bl { .. }
             | Instruction::Br { .. } => {}
+
+            // Memory ops (issue #68): dedicated rt/base/idx/offset rotation
+            // slots arrive in step 16. Skip for now.
+            Instruction::Ldr { .. }
+            | Instruction::Ldrs { .. }
+            | Instruction::Str { .. }
+            | Instruction::Ldp { .. }
+            | Instruction::Stp { .. } => {}
         }
     }
 
@@ -874,6 +882,36 @@ impl Mutator {
             Instruction::Tbnz { rt, bit, target } => Instruction::Tbnz { rt, bit, target },
             Instruction::Bl { target } => Instruction::Bl { target },
             Instruction::Br { rn } => Instruction::Br { rn },
+
+            // Memory ops (issue #68): width/sign-extend bridges arrive in
+            // step 16. Identity-mutate for now.
+            Instruction::Ldr { rt, addr, width } => Instruction::Ldr { rt, addr, width },
+            Instruction::Ldrs { rt, addr, width } => Instruction::Ldrs { rt, addr, width },
+            Instruction::Str { rt, addr, width } => Instruction::Str { rt, addr, width },
+            Instruction::Ldp {
+                rt1,
+                rt2,
+                addr,
+                width,
+                signed,
+            } => Instruction::Ldp {
+                rt1,
+                rt2,
+                addr,
+                width,
+                signed,
+            },
+            Instruction::Stp {
+                rt1,
+                rt2,
+                addr,
+                width,
+            } => Instruction::Stp {
+                rt1,
+                rt2,
+                addr,
+                width,
+            },
         };
     }
 

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -404,13 +404,29 @@ impl Mutator {
             | Instruction::Bl { .. }
             | Instruction::Br { .. } => {}
 
-            // Memory ops (issue #68): dedicated rt/base/idx/offset rotation
-            // slots arrive in step 16. Skip for now.
-            Instruction::Ldr { .. }
-            | Instruction::Ldrs { .. }
-            | Instruction::Str { .. }
-            | Instruction::Ldp { .. }
-            | Instruction::Stp { .. } => {}
+            // Memory ops (issue #68 step 16). Rotate over the small set of
+            // mutable fields per variant: data register, base, optional
+            // index register, optional offset. Keep address-mode and width
+            // unchanged here (those are bridged via mutate_opcode in a
+            // future step); the encodability filter downstream drops any
+            // mutation that violates SP/XZR or writeback-aliasing rules.
+            Instruction::Ldr { rt, addr, .. }
+            | Instruction::Ldrs { rt, addr, .. }
+            | Instruction::Str { rt, addr, .. } => {
+                if rng.random_bool(0.5) {
+                    *rt = self.random_register(rng);
+                } else {
+                    mutate_address_operand(self, rng, addr);
+                }
+            }
+            Instruction::Ldp { rt1, rt2, addr, .. } | Instruction::Stp { rt1, rt2, addr, .. } => {
+                let choice = rng.random_range(0..3);
+                match choice {
+                    0 => *rt1 = self.random_register(rng),
+                    1 => *rt2 = self.random_register(rng),
+                    _ => mutate_address_operand(self, rng, addr),
+                }
+            }
         }
     }
 
@@ -944,6 +960,14 @@ impl Mutator {
         sequence[idx] = generate_random_instruction(rng, &self.registers, &self.immediates);
     }
 
+    fn random_address_offset<R: RngExt>(&self, rng: &mut R) -> i64 {
+        // Restrict to a tiny offset pool so mutations stay encodable.
+        // Values are chosen to cover the unscaled-signed (LDUR) and
+        // scaled-positive (LDR) ranges.
+        const POOL: [i64; 5] = [0, 8, 16, -8, -256];
+        POOL[rng.random_range(0..POOL.len())]
+    }
+
     fn random_register<R: RngExt>(&self, rng: &mut R) -> Register {
         if self.registers.is_empty() {
             Register::X0
@@ -1052,6 +1076,46 @@ impl crate::isa::ISAMutator<Instruction> for AArch64Mutator {
     }
 }
 
+/// Mutate one field of an `AddressOperand`. The variant kind (Imm vs Reg
+/// vs Ext) and IndexMode are preserved; only the base register, optional
+/// index register, optional offset, or optional shift amount changes.
+/// Width / writeback are untouched here — those bridges live in
+/// `mutate_opcode`.
+fn mutate_address_operand<R: RngExt>(
+    mutator: &Mutator,
+    rng: &mut R,
+    addr: &mut crate::ir::types::AddressOperand,
+) {
+    use crate::ir::types::AddressOperand;
+    match addr {
+        AddressOperand::Imm { base, offset, .. } => {
+            if rng.random_bool(0.5) {
+                *base = mutator.random_register(rng);
+            } else {
+                *offset = mutator.random_address_offset(rng);
+            }
+        }
+        AddressOperand::Reg { base, idx, shift } => {
+            let choice = rng.random_range(0..3);
+            match choice {
+                0 => *base = mutator.random_register(rng),
+                1 => *idx = mutator.random_register(rng),
+                _ => *shift = if rng.random_bool(0.5) { 0 } else { 3 },
+            }
+        }
+        AddressOperand::Ext {
+            base, idx, shift, ..
+        } => {
+            let choice = rng.random_range(0..3);
+            match choice {
+                0 => *base = mutator.random_register(rng),
+                1 => *idx = mutator.random_register(rng),
+                _ => *shift = if rng.random_bool(0.5) { 0 } else { 3 },
+            }
+        }
+    }
+}
+
 /// Perform operand mutation on a specific instruction (for testing)
 /// Number of instructions a mutation operator may rewrite. Equals
 /// `sequence.len()` for terminator-free sequences and `sequence.len() - 1`
@@ -1133,6 +1197,75 @@ mod tests {
         assert!(
             produced_shifted,
             "mutate_operand on Add must occasionally produce ShiftedRegister rm"
+        );
+    }
+
+    #[test]
+    fn mutate_operand_on_ldr_can_change_base_or_rt_or_offset() {
+        // Issue #68 step 16: mutate_operand must touch one of {rt, base,
+        // offset} on a memory op without changing the variant or width.
+        use crate::ir::types::{AccessWidth, AddressOperand, IndexMode};
+        let mutator = default_mutator();
+        let mut rng = rand::rng();
+        let initial = Instruction::Ldr {
+            rt: Register::X0,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+        };
+        let mut changed = false;
+        for _ in 0..200 {
+            let mut seq = vec![initial.clone()];
+            mutator.mutate_operand(&mut rng, &mut seq);
+            if seq[0] != initial {
+                changed = true;
+            }
+            // Width and variant must be invariant under mutate_operand.
+            match seq[0] {
+                Instruction::Ldr {
+                    width: AccessWidth::Extended,
+                    addr:
+                        AddressOperand::Imm {
+                            mode: IndexMode::Offset,
+                            ..
+                        },
+                    ..
+                } => {}
+                _ => panic!(
+                    "mutate_operand changed variant/width/mode on Ldr: {:?}",
+                    seq[0]
+                ),
+            }
+        }
+        assert!(changed, "mutate_operand never modified Ldr operands");
+    }
+
+    #[test]
+    fn generate_all_instructions_includes_memory_ops() {
+        // Step 15: enumerative pool must produce at least one each of
+        // Ldr / Str / Ldp / Stp for downstream search algorithms.
+        use crate::search::candidate::generate_all_encodable_instructions;
+        let regs = vec![Register::X0, Register::X1, Register::X2, Register::SP];
+        let imms = vec![0, 8, 16];
+        let pool = generate_all_encodable_instructions(&regs, &imms);
+        assert!(
+            pool.iter().any(|i| matches!(i, Instruction::Ldr { .. })),
+            "candidate pool must contain Ldr",
+        );
+        assert!(
+            pool.iter().any(|i| matches!(i, Instruction::Str { .. })),
+            "candidate pool must contain Str",
+        );
+        assert!(
+            pool.iter().any(|i| matches!(i, Instruction::Ldp { .. })),
+            "candidate pool must contain Ldp",
+        );
+        assert!(
+            pool.iter().any(|i| matches!(i, Instruction::Stp { .. })),
+            "candidate pool must contain Stp",
         );
     }
 

--- a/src/search/symbolic/backend.rs
+++ b/src/search/symbolic/backend.rs
@@ -77,10 +77,14 @@ impl SymbolicBackend<crate::isa::AArch64> for crate::isa::AArch64 {
     ) -> (EquivalenceResult, EquivalenceMetrics) {
         // Treat NZCV as live-out so the solver cannot certify a
         // flag-divergent rewrite (see synthesis.rs's previous body).
+        // `with_memory(true)` is informational here — the entry point in
+        // `check_equivalence_with_config` re-derives it from
+        // `touches_memory()` on the candidate / target. See ADR-0007.
         let cfg = crate::semantics::EquivalenceConfig::with_live_out(live_out.clone())
             .random_tests(5)
             .timeout(timeout)
-            .with_flags(true);
+            .with_flags(true)
+            .with_memory(true);
         crate::semantics::equivalence::check_equivalence_with_config_metrics(target, proposal, &cfg)
     }
 

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -1,5 +1,6 @@
 //! Concrete interpreter for fast validation of instruction sequences
 
+use crate::ir::types::{AccessWidth, AddressOperand, IndexMode};
 use crate::ir::{Condition, Instruction, Operand, Register, ShiftKind};
 use crate::semantics::live_out::RegisterSet;
 use crate::semantics::state::{ConcreteMachineState, ConcreteValue, ConditionFlags};
@@ -529,15 +530,147 @@ pub fn apply_instruction_concrete(
         // step 6; until the memory model is plumbed onto ConcreteMachineState
         // there is no way to evaluate these and callers should not synthesise
         // them yet.
-        Instruction::Ldr { .. }
-        | Instruction::Ldrs { .. }
-        | Instruction::Str { .. }
-        | Instruction::Ldp { .. }
-        | Instruction::Stp { .. } => {
-            unimplemented!("Memory-op concrete semantics arrive in step 6 (issue #68)")
+        Instruction::Ldr { rt, addr, width } => {
+            let (effective, writeback) = compute_address(&state, addr);
+            let raw = state.read_bytes(effective, *width);
+            let value = zero_extend_load(raw, *width);
+            state.set_register(*rt, ConcreteValue::new(value));
+            if let Some((base, new_base)) = writeback {
+                state.set_register(base, ConcreteValue::new(new_base));
+            }
+        }
+        Instruction::Ldrs { rt, addr, width } => {
+            let (effective, writeback) = compute_address(&state, addr);
+            let raw = state.read_bytes(effective, *width);
+            let value = sign_extend_load(raw, *width);
+            state.set_register(*rt, ConcreteValue::new(value));
+            if let Some((base, new_base)) = writeback {
+                state.set_register(base, ConcreteValue::new(new_base));
+            }
+        }
+        Instruction::Str { rt, addr, width } => {
+            let (effective, writeback) = compute_address(&state, addr);
+            let value = state.get_register(*rt).as_u64();
+            state.write_bytes(effective, value, *width);
+            if let Some((base, new_base)) = writeback {
+                state.set_register(base, ConcreteValue::new(new_base));
+            }
+        }
+        Instruction::Ldp {
+            rt1,
+            rt2,
+            addr,
+            width,
+            signed,
+        } => {
+            let (effective, writeback) = compute_address(&state, addr);
+            let bytes = width.bytes() as u64;
+            let raw1 = state.read_bytes(effective, *width);
+            let raw2 = state.read_bytes(effective.wrapping_add(bytes), *width);
+            let (v1, v2) = if *signed {
+                (
+                    sign_extend_load(raw1, *width),
+                    sign_extend_load(raw2, *width),
+                )
+            } else {
+                (
+                    zero_extend_load(raw1, *width),
+                    zero_extend_load(raw2, *width),
+                )
+            };
+            state.set_register(*rt1, ConcreteValue::new(v1));
+            state.set_register(*rt2, ConcreteValue::new(v2));
+            if let Some((base, new_base)) = writeback {
+                state.set_register(base, ConcreteValue::new(new_base));
+            }
+        }
+        Instruction::Stp {
+            rt1,
+            rt2,
+            addr,
+            width,
+        } => {
+            let (effective, writeback) = compute_address(&state, addr);
+            let bytes = width.bytes() as u64;
+            let v1 = state.get_register(*rt1).as_u64();
+            let v2 = state.get_register(*rt2).as_u64();
+            state.write_bytes(effective, v1, *width);
+            state.write_bytes(effective.wrapping_add(bytes), v2, *width);
+            if let Some((base, new_base)) = writeback {
+                state.set_register(base, ConcreteValue::new(new_base));
+            }
         }
     }
     state
+}
+
+/// Compute the effective address used by a memory access, together with
+/// any writeback `(base, new_base_value)` that must be committed to the
+/// register file. PreIndex updates the base *before* the access; the new
+/// value is also the effective address. PostIndex uses the original base
+/// as the effective address and updates afterwards.
+fn compute_address(
+    state: &ConcreteMachineState,
+    addr: &AddressOperand,
+) -> (u64, Option<(Register, u64)>) {
+    match addr {
+        AddressOperand::Imm { base, offset, mode } => {
+            let base_val = state.get_register(*base).as_u64();
+            let updated = base_val.wrapping_add(*offset as u64);
+            match mode {
+                IndexMode::Offset => (updated, None),
+                IndexMode::PreIndex => (updated, Some((*base, updated))),
+                IndexMode::PostIndex => (base_val, Some((*base, updated))),
+            }
+        }
+        AddressOperand::Reg { base, idx, shift } => {
+            let base_val = state.get_register(*base).as_u64();
+            let idx_val = state.get_register(*idx).as_u64();
+            (base_val.wrapping_add(idx_val << *shift), None)
+        }
+        AddressOperand::Ext {
+            base,
+            idx,
+            kind,
+            shift,
+        } => {
+            let base_val = state.get_register(*base).as_u64();
+            let idx_val = state.get_register(*idx).as_u64();
+            let extended = match kind {
+                crate::ir::ExtendKind::Uxtw => idx_val & 0xFFFF_FFFF,
+                crate::ir::ExtendKind::Sxtw => (idx_val as i32) as i64 as u64,
+                crate::ir::ExtendKind::Uxtx => idx_val,
+                crate::ir::ExtendKind::Sxtx => idx_val,
+                // Byte/half kinds are rejected by is_encodable for memory
+                // operands; treat as zero-extend to keep the eval total.
+                crate::ir::ExtendKind::Uxtb => idx_val & 0xFF,
+                crate::ir::ExtendKind::Uxth => idx_val & 0xFFFF,
+                crate::ir::ExtendKind::Sxtb => (idx_val as i8) as i64 as u64,
+                crate::ir::ExtendKind::Sxth => (idx_val as i16) as i64 as u64,
+            };
+            (base_val.wrapping_add(extended << *shift), None)
+        }
+    }
+}
+
+/// Zero-extend the low `width.bytes() * 8` bits of `raw` to u64.
+fn zero_extend_load(raw: u64, width: AccessWidth) -> u64 {
+    match width {
+        AccessWidth::Byte => raw & 0xFF,
+        AccessWidth::Half => raw & 0xFFFF,
+        AccessWidth::Word => raw & 0xFFFF_FFFF,
+        AccessWidth::Extended => raw,
+    }
+}
+
+/// Sign-extend the low `width.bytes() * 8` bits of `raw` to u64.
+fn sign_extend_load(raw: u64, width: AccessWidth) -> u64 {
+    match width {
+        AccessWidth::Byte => (raw as i8) as i64 as u64,
+        AccessWidth::Half => (raw as i16) as i64 as u64,
+        AccessWidth::Word => (raw as i32) as i64 as u64,
+        AccessWidth::Extended => raw,
+    }
 }
 
 /// Evaluate a condition code against the current flags
@@ -587,7 +720,13 @@ pub fn apply_sequence_concrete(
 }
 
 /// Check if two concrete states are equal for the specified live-out registers,
-/// optionally including the NZCV condition flags.
+/// optionally including the NZCV condition flags and the whole memory map.
+///
+/// `memory_live` is derived automatically by callers from whether either
+/// sequence touches memory (see ADR-0007). When set, every memory cell
+/// must agree between the two states — equivalently, the two `BTreeMap`s
+/// must be structurally equal (prune-on-write guarantees structural ==
+/// semantic equality).
 ///
 /// TODO(#282): The explicit `flags_live` parameter is now redundant with
 /// `live_out.flags_live()` for every caller except the stochastic backend
@@ -597,6 +736,7 @@ pub fn states_equal_for_live_out(
     state2: &ConcreteMachineState,
     live_out: &RegisterSet<Register>,
     flags_live: bool,
+    memory_live: bool,
 ) -> bool {
     for reg in live_out.iter() {
         if state1.get_register(*reg) != state2.get_register(*reg) {
@@ -604,6 +744,9 @@ pub fn states_equal_for_live_out(
         }
     }
     if flags_live && state1.get_flags() != state2.get_flags() {
+        return false;
+    }
+    if memory_live && state1.memory() != state2.memory() {
         return false;
     }
     true
@@ -985,7 +1128,7 @@ mod tests {
 
         let live_out = RegisterSet::<Register>::from_registers(vec![Register::X0]);
         assert!(states_equal_for_live_out(
-            &state1, &state2, &live_out, false
+            &state1, &state2, &live_out, false, false
         ));
     }
 
@@ -996,7 +1139,7 @@ mod tests {
 
         let live_out = RegisterSet::<Register>::from_registers(vec![Register::X0]);
         assert!(!states_equal_for_live_out(
-            &state1, &state2, &live_out, false
+            &state1, &state2, &live_out, false, false
         ));
     }
 
@@ -1043,7 +1186,7 @@ mod tests {
 
         let live_out = RegisterSet::<Register>::from_registers(vec![Register::X0]);
         assert!(states_equal_for_live_out(
-            &state1, &state2, &live_out, false
+            &state1, &state2, &live_out, false, false
         ));
     }
 
@@ -2317,5 +2460,163 @@ mod tests {
         };
         let after = apply_instruction_concrete(state, &instr);
         assert_eq!(after.get_register(Register::X0).as_u64(), 1);
+    }
+
+    // ---- Memory ops (issue #68 step 6) ----
+
+    #[test]
+    fn str_then_ldr_round_trips_via_memory() {
+        use crate::ir::types::{AccessWidth, AddressOperand, IndexMode};
+        let state = state_with(vec![
+            (Register::X0, 0xDEADBEEF_CAFEBABE),
+            (Register::X1, 0x1000),
+        ]);
+        // STR x0, [x1] ; LDR x2, [x1]
+        let seq = vec![
+            Instruction::Str {
+                rt: Register::X0,
+                addr: AddressOperand::Imm {
+                    base: Register::X1,
+                    offset: 0,
+                    mode: IndexMode::Offset,
+                },
+                width: AccessWidth::Extended,
+            },
+            Instruction::Ldr {
+                rt: Register::X2,
+                addr: AddressOperand::Imm {
+                    base: Register::X1,
+                    offset: 0,
+                    mode: IndexMode::Offset,
+                },
+                width: AccessWidth::Extended,
+            },
+        ];
+        let after = apply_sequence_concrete(state, &seq);
+        assert_eq!(
+            after.get_register(Register::X2).as_u64(),
+            0xDEADBEEF_CAFEBABE
+        );
+    }
+
+    #[test]
+    fn ldrb_zero_extends() {
+        use crate::ir::types::{AccessWidth, AddressOperand, IndexMode};
+        let mut state = state_with(vec![(Register::X1, 0x1000)]);
+        state.write_bytes(0x1000, 0xFF, AccessWidth::Byte);
+        let instr = Instruction::Ldr {
+            rt: Register::X0,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Byte,
+        };
+        let after = apply_instruction_concrete(state, &instr);
+        assert_eq!(after.get_register(Register::X0).as_u64(), 0xFF);
+    }
+
+    #[test]
+    fn ldrsb_sign_extends() {
+        use crate::ir::types::{AccessWidth, AddressOperand, IndexMode};
+        let mut state = state_with(vec![(Register::X1, 0x1000)]);
+        state.write_bytes(0x1000, 0xFF, AccessWidth::Byte);
+        let instr = Instruction::Ldrs {
+            rt: Register::X0,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Byte,
+        };
+        let after = apply_instruction_concrete(state, &instr);
+        assert_eq!(after.get_register(Register::X0).as_u64(), u64::MAX);
+    }
+
+    #[test]
+    fn pre_index_writeback_updates_base_before_access() {
+        use crate::ir::types::{AccessWidth, AddressOperand, IndexMode};
+        let mut state = state_with(vec![(Register::X0, 0x42), (Register::X1, 0x1000)]);
+        state.write_bytes(0x1008, 0x99, AccessWidth::Byte);
+        // LDR x2, [x1, #8]! — effective address is x1+8=0x1008, x1 updated to 0x1008.
+        let instr = Instruction::Ldr {
+            rt: Register::X2,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 8,
+                mode: IndexMode::PreIndex,
+            },
+            width: AccessWidth::Byte,
+        };
+        let after = apply_instruction_concrete(state, &instr);
+        assert_eq!(after.get_register(Register::X2).as_u64(), 0x99);
+        assert_eq!(after.get_register(Register::X1).as_u64(), 0x1008);
+    }
+
+    #[test]
+    fn post_index_writeback_uses_old_address_then_updates() {
+        use crate::ir::types::{AccessWidth, AddressOperand, IndexMode};
+        let mut state = state_with(vec![(Register::X1, 0x1000)]);
+        state.write_bytes(0x1000, 0x77, AccessWidth::Byte);
+        // LDR x0, [x1], #16 — read at original x1=0x1000, then x1 ← 0x1010.
+        let instr = Instruction::Ldr {
+            rt: Register::X0,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 16,
+                mode: IndexMode::PostIndex,
+            },
+            width: AccessWidth::Byte,
+        };
+        let after = apply_instruction_concrete(state, &instr);
+        assert_eq!(after.get_register(Register::X0).as_u64(), 0x77);
+        assert_eq!(after.get_register(Register::X1).as_u64(), 0x1010);
+    }
+
+    #[test]
+    fn ldp_reads_two_consecutive_words() {
+        use crate::ir::types::{AccessWidth, AddressOperand, IndexMode};
+        let mut state = state_with(vec![(Register::X2, 0x1000)]);
+        state.write_bytes(0x1000, 0x1111, AccessWidth::Extended);
+        state.write_bytes(0x1008, 0x2222, AccessWidth::Extended);
+        let instr = Instruction::Ldp {
+            rt1: Register::X0,
+            rt2: Register::X1,
+            addr: AddressOperand::Imm {
+                base: Register::X2,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+            signed: false,
+        };
+        let after = apply_instruction_concrete(state, &instr);
+        assert_eq!(after.get_register(Register::X0).as_u64(), 0x1111);
+        assert_eq!(after.get_register(Register::X1).as_u64(), 0x2222);
+    }
+
+    #[test]
+    fn stp_writes_two_consecutive_words() {
+        use crate::ir::types::{AccessWidth, AddressOperand, IndexMode};
+        let state = state_with(vec![
+            (Register::X0, 0xAAAA),
+            (Register::X1, 0xBBBB),
+            (Register::X2, 0x1000),
+        ]);
+        let instr = Instruction::Stp {
+            rt1: Register::X0,
+            rt2: Register::X1,
+            addr: AddressOperand::Imm {
+                base: Register::X2,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+        };
+        let after = apply_instruction_concrete(state, &instr);
+        assert_eq!(after.read_bytes(0x1000, AccessWidth::Extended), 0xAAAA);
+        assert_eq!(after.read_bytes(0x1008, AccessWidth::Extended), 0xBBBB);
     }
 }

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -525,6 +525,17 @@ pub fn apply_instruction_concrete(
             "Branches are terminators; strip them before apply_sequence_concrete. Reached: {:?}",
             instruction
         ),
+        // Memory ops (issue #68). Concrete semantics for LDR-family land in
+        // step 6; until the memory model is plumbed onto ConcreteMachineState
+        // there is no way to evaluate these and callers should not synthesise
+        // them yet.
+        Instruction::Ldr { .. }
+        | Instruction::Ldrs { .. }
+        | Instruction::Str { .. }
+        | Instruction::Ldp { .. }
+        | Instruction::Stp { .. } => {
+            unimplemented!("Memory-op concrete semantics arrive in step 6 (issue #68)")
+        }
     }
     state
 }

--- a/src/semantics/cost.rs
+++ b/src/semantics/cost.rs
@@ -97,6 +97,16 @@ fn instruction_latency(instr: &Instruction) -> u64 {
         | Instruction::Tbnz { .. }
         | Instruction::Bl { .. }
         | Instruction::Br { .. } => 1,
+        // Loads (issue #68): Cortex-A72/A76 L1-hit latency ~ 4 cycles. See
+        // ADR-0007 §Consequences for the calibration rationale.
+        Instruction::Ldr { .. } | Instruction::Ldrs { .. } => 4,
+        // Stores commit to the L1 store buffer in 1 cycle.
+        Instruction::Str { .. } => 1,
+        // Pair loads take one extra cycle vs single load (issue address
+        // generation + two-register writeback).
+        Instruction::Ldp { .. } => 5,
+        // Pair stores: two store-buffer entries.
+        Instruction::Stp { .. } => 2,
     }
 }
 

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -308,6 +308,7 @@ fn fast_path_initial_nzcv_variants(
     let variant_regs_config = RandomInputConfig {
         count: 16,
         registers: input_regs.to_vec(),
+        memory_seed_size: 0,
     };
     let mut variants = generate_random_inputs(&variant_regs_config);
     for (i, input) in variants.iter_mut().enumerate() {
@@ -344,9 +345,18 @@ fn run_fast_path(
         live_out_registers.iter().cloned().collect()
     };
 
+    // Seed memory when either sequence touches it, so that LDR observations
+    // during the fast-random pass return non-trivial values. See ADR-0007.
+    let touches_mem = crate::validation::live_out::touches_memory(seq1)
+        || crate::validation::live_out::touches_memory(seq2);
     let random_config = RandomInputConfig {
         count: config.random_test_count,
         registers: input_regs.clone(),
+        memory_seed_size: if touches_mem {
+            crate::validation::random::MEMORY_SEED_SIZE
+        } else {
+            0
+        },
     };
     let random_inputs = generate_random_inputs(&random_config);
 
@@ -604,9 +614,16 @@ pub fn find_counterexample_concrete(
     let live_out_registers = &config.live_out;
     let input_regs: Vec<_> = live_out_registers.iter().cloned().collect();
 
+    let touches_mem = crate::validation::live_out::touches_memory(seq1)
+        || crate::validation::live_out::touches_memory(seq2);
     let random_config = RandomInputConfig {
         count: config.random_test_count,
         registers: input_regs.clone(),
+        memory_seed_size: if touches_mem {
+            crate::validation::random::MEMORY_SEED_SIZE
+        } else {
+            0
+        },
     };
     let random_inputs = generate_random_inputs(&random_config);
 

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -457,6 +457,23 @@ pub fn check_equivalence_with_config_metrics(
         );
     }
 
+    // ADR-0007: auto-derive memory_live and force fast_only off when memory
+    // ops appear (see `check_equivalence_with_config` above for rationale).
+    let memory_touched = crate::validation::live_out::touches_memory(prefix1)
+        || crate::validation::live_out::touches_memory(prefix2);
+    let mut config_owned;
+    let config: &EquivalenceConfig = if memory_touched && (!config.memory_live || config.fast_only)
+    {
+        config_owned = config.clone();
+        config_owned.memory_live = true;
+        if config_owned.fast_only {
+            config_owned.fast_only = false;
+        }
+        &config_owned
+    } else {
+        config
+    };
+
     if let Some(early) = pre_smt_guard(prefix1, prefix2, config.live_out.flags_live()) {
         return (early, metrics);
     }

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -515,6 +515,7 @@ fn build_smt_solver(
         &final_state2,
         &config.live_out,
         config.live_out.flags_live(),
+        config.memory_live,
     ));
     solver
 }

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -104,6 +104,11 @@ pub struct EquivalenceConfig {
     pub smt_timeout: Option<Duration>,
     /// Skip SMT verification (fast path only)
     pub fast_only: bool,
+    /// Treat the entire memory image as live-out — every cell must agree
+    /// between the two sequences' final states. Auto-derived in
+    /// `check_equivalence_with_config` whenever either sequence touches
+    /// memory (see ADR-0007).
+    pub memory_live: bool,
 }
 
 impl Default for EquivalenceConfig {
@@ -113,6 +118,7 @@ impl Default for EquivalenceConfig {
             random_test_count: 10,
             smt_timeout: Some(Duration::from_secs(30)),
             fast_only: false,
+            memory_live: false,
         }
     }
 }
@@ -186,6 +192,16 @@ impl EquivalenceConfig {
     /// formula. Stores the bit on the live-out mask itself (ADR-0004 §5).
     pub fn with_flags(mut self, flags_live: bool) -> Self {
         self.live_out = self.live_out.with_flags(flags_live);
+        self
+    }
+
+    /// Builder method to mark whole memory as live-out. Search algorithms
+    /// pin `with_memory(true)` analogously to `with_flags(true)`; the
+    /// `check_equivalence_with_config` entry point auto-derives this from
+    /// `touches_memory()` on the candidate / target sequences. See
+    /// ADR-0007.
+    pub fn with_memory(mut self, memory_live: bool) -> Self {
+        self.memory_live = memory_live;
         self
     }
 }
@@ -343,6 +359,7 @@ fn run_fast_path(
             &state2,
             live_out_registers,
             config.live_out.flags_live(),
+            config.memory_live,
         ) {
             return Some(EquivalenceResult::NotEquivalentFast(input.clone()));
         }
@@ -358,6 +375,7 @@ fn run_fast_path(
             &state2,
             live_out_registers,
             config.live_out.flags_live(),
+            config.memory_live,
         ) {
             return Some(EquivalenceResult::NotEquivalentFast(input.clone()));
         }
@@ -383,6 +401,7 @@ fn run_fast_path(
                 &state2,
                 live_out_registers,
                 config.live_out.flags_live(),
+                config.memory_live,
             ) {
                 return Some(EquivalenceResult::NotEquivalentFast(input.clone()));
             }

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -2,12 +2,13 @@
 
 #![allow(dead_code)]
 
-use crate::ir::{Instruction, Operand, Register};
+use crate::ir::types::{AccessWidth, AddressOperand, IndexMode};
+use crate::ir::{ExtendKind, Instruction, Operand, Register};
 use crate::semantics::live_out::RegisterSet;
 use std::collections::HashMap;
 use std::time::Duration;
-use z3::ast::BV;
-use z3::{Params, Solver};
+use z3::ast::{Array, BV};
+use z3::{Params, Solver, Sort};
 
 /// Reverse the byte order of a 64-bit BV by concatenating its 8 byte slices
 /// with byte 0 placed in the most-significant position.
@@ -134,6 +135,12 @@ pub struct MachineState {
     pub z: BV,
     pub c: BV,
     pub v: BV,
+    /// Byte-addressed memory. Domain is BV<64> (the address); range is
+    /// BV<8> (the byte). Sound aliasing comes for free from Z3's array
+    /// theory — every possible overlap of two `store(addr, byte)`
+    /// operations is reasoned over without disjointness preconditions.
+    /// See ADR-0007.
+    pub memory: Array,
     width: u32,
 }
 
@@ -162,12 +169,22 @@ impl MachineState {
         let c = BV::new_const(format!("{}_c", prefix), 1);
         let v = BV::new_const(format!("{}_v", prefix), 1);
 
+        // Sparse symbolic memory: BV64 → BV8. The byte at address `a` is
+        // `memory.select(BV::from_u64(a, 64))`. Z3's array theory handles
+        // every aliasing case without disjointness preconditions.
+        let memory = Array::new_const(
+            format!("{}_mem", prefix),
+            &Sort::bitvector(64),
+            &Sort::bitvector(8),
+        );
+
         MachineState {
             registers,
             n,
             z,
             c,
             v,
+            memory,
             width,
         }
     }
@@ -201,6 +218,106 @@ impl MachineState {
         self.z = z;
         self.c = c;
         self.v = v;
+    }
+
+    /// Read `n` consecutive bytes starting at `addr_bv`, little-endian.
+    /// Returns a `(8 * n)`-bit BV whose low byte is at `addr+0` and whose
+    /// high byte is at `addr+n-1`. Used by the LDR-family arms.
+    pub fn select_n(&self, addr_bv: &BV, n: u32) -> BV {
+        assert!(n >= 1);
+        let addr0 = addr_bv.clone();
+        let byte0 = self
+            .memory
+            .select(&addr0)
+            .as_bv()
+            .expect("array<BV64,BV8>::select must return BV<8>");
+        let mut result = byte0;
+        for i in 1..n {
+            let offset = BV::from_u64(i as u64, 64);
+            let idx = addr_bv.bvadd(&offset);
+            let byte = self
+                .memory
+                .select(&idx)
+                .as_bv()
+                .expect("array<BV64,BV8>::select must return BV<8>");
+            // Byte at addr+i is the next byte up — concat in the high position.
+            result = byte.concat(&result);
+        }
+        result
+    }
+
+    /// Store the low `n` bytes of `value` to memory at `addr_bv`,
+    /// little-endian. Replaces `self.memory` with the chained-store result.
+    pub fn store_n(&mut self, addr_bv: &BV, value: &BV, n: u32) {
+        assert!(n >= 1);
+        let mut mem = self.memory.clone();
+        for i in 0..n {
+            let byte = value.extract(8 * i + 7, 8 * i);
+            let idx = if i == 0 {
+                addr_bv.clone()
+            } else {
+                let offset = BV::from_u64(i as u64, 64);
+                addr_bv.bvadd(&offset)
+            };
+            mem = mem.store(&idx, &byte);
+        }
+        self.memory = mem;
+    }
+
+    /// Evaluate the effective address of an `AddressOperand`. Mirrors the
+    /// concrete `compute_address` helper; returns the address as a BV64
+    /// plus an optional `(base, new_base_value)` writeback that the caller
+    /// commits to the register file.
+    pub fn eval_address(&self, addr: &AddressOperand) -> (BV, Option<(Register, BV)>) {
+        match addr {
+            AddressOperand::Imm { base, offset, mode } => {
+                let base_bv = self.get_register(*base).clone();
+                let off_bv = BV::from_i64(*offset, 64);
+                let updated = base_bv.bvadd(&off_bv);
+                match mode {
+                    IndexMode::Offset => (updated, None),
+                    IndexMode::PreIndex => (updated.clone(), Some((*base, updated))),
+                    IndexMode::PostIndex => (base_bv, Some((*base, updated))),
+                }
+            }
+            AddressOperand::Reg { base, idx, shift } => {
+                let base_bv = self.get_register(*base).clone();
+                let idx_bv = self.get_register(*idx).clone();
+                let shifted = if *shift == 0 {
+                    idx_bv
+                } else {
+                    idx_bv.bvshl(&BV::from_u64(*shift as u64, 64))
+                };
+                (base_bv.bvadd(&shifted), None)
+            }
+            AddressOperand::Ext {
+                base,
+                idx,
+                kind,
+                shift,
+            } => {
+                let base_bv = self.get_register(*base).clone();
+                let idx_bv = self.get_register(*idx).clone();
+                let extended = match kind {
+                    ExtendKind::Uxtw => idx_bv.extract(31, 0).zero_ext(32),
+                    ExtendKind::Sxtw => idx_bv.extract(31, 0).sign_ext(32),
+                    ExtendKind::Uxtx | ExtendKind::Sxtx => idx_bv,
+                    // Byte/half extends are rejected by is_encodable for
+                    // memory operands; the SMT path defaults to UXT to
+                    // keep apply_instruction total.
+                    ExtendKind::Uxtb => idx_bv.extract(7, 0).zero_ext(56),
+                    ExtendKind::Uxth => idx_bv.extract(15, 0).zero_ext(48),
+                    ExtendKind::Sxtb => idx_bv.extract(7, 0).sign_ext(56),
+                    ExtendKind::Sxth => idx_bv.extract(15, 0).sign_ext(48),
+                };
+                let shifted = if *shift == 0 {
+                    extended
+                } else {
+                    extended.bvshl(&BV::from_u64(*shift as u64, 64))
+                };
+                (base_bv.bvadd(&shifted), None)
+            }
+        }
     }
 
     /// Evaluate an operand to get its value
@@ -859,15 +976,109 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
         ),
         // Memory ops (issue #68). SMT lowering arrives in step 7 alongside
         // the `Array<BV64, BV8>` field on `MachineState`.
-        Instruction::Ldr { .. }
-        | Instruction::Ldrs { .. }
-        | Instruction::Str { .. }
-        | Instruction::Ldp { .. }
-        | Instruction::Stp { .. } => {
-            unimplemented!("Memory-op SMT lowering arrives in step 7 (issue #68)")
+        Instruction::Ldr { rt, addr, width } => {
+            let (effective, writeback) = state.eval_address(addr);
+            let raw = state.select_n(&effective, width.bytes());
+            let extended = ldr_zero_extend(&raw, *width, state.width);
+            state.set_register(*rt, extended);
+            if let Some((base, new_base)) = writeback {
+                state.set_register(base, new_base);
+            }
+        }
+        Instruction::Ldrs { rt, addr, width } => {
+            let (effective, writeback) = state.eval_address(addr);
+            let raw = state.select_n(&effective, width.bytes());
+            let extended = ldr_sign_extend(&raw, *width, state.width);
+            state.set_register(*rt, extended);
+            if let Some((base, new_base)) = writeback {
+                state.set_register(base, new_base);
+            }
+        }
+        Instruction::Str { rt, addr, width } => {
+            let (effective, writeback) = state.eval_address(addr);
+            let value = state.get_register(*rt).clone();
+            let bits = (width.bytes() * 8) as u32;
+            let low = value.extract(bits - 1, 0);
+            state.store_n(&effective, &low, width.bytes());
+            if let Some((base, new_base)) = writeback {
+                state.set_register(base, new_base);
+            }
+        }
+        Instruction::Ldp {
+            rt1,
+            rt2,
+            addr,
+            width,
+            signed,
+        } => {
+            let (effective, writeback) = state.eval_address(addr);
+            let bytes = width.bytes();
+            let raw1 = state.select_n(&effective, bytes);
+            let offset = BV::from_u64(bytes as u64, 64);
+            let effective2 = effective.bvadd(&offset);
+            let raw2 = state.select_n(&effective2, bytes);
+            let (v1, v2) = if *signed {
+                (
+                    ldr_sign_extend(&raw1, *width, state.width),
+                    ldr_sign_extend(&raw2, *width, state.width),
+                )
+            } else {
+                (
+                    ldr_zero_extend(&raw1, *width, state.width),
+                    ldr_zero_extend(&raw2, *width, state.width),
+                )
+            };
+            state.set_register(*rt1, v1);
+            state.set_register(*rt2, v2);
+            if let Some((base, new_base)) = writeback {
+                state.set_register(base, new_base);
+            }
+        }
+        Instruction::Stp {
+            rt1,
+            rt2,
+            addr,
+            width,
+        } => {
+            let (effective, writeback) = state.eval_address(addr);
+            let bytes = width.bytes();
+            let bits = (bytes * 8) as u32;
+            let v1 = state.get_register(*rt1).clone();
+            let v2 = state.get_register(*rt2).clone();
+            let low1 = v1.extract(bits - 1, 0);
+            let low2 = v2.extract(bits - 1, 0);
+            state.store_n(&effective, &low1, bytes);
+            let offset = BV::from_u64(bytes as u64, 64);
+            let effective2 = effective.bvadd(&offset);
+            state.store_n(&effective2, &low2, bytes);
+            if let Some((base, new_base)) = writeback {
+                state.set_register(base, new_base);
+            }
         }
     }
     state
+}
+
+/// Zero-extend the low `width.bytes() * 8` bits of `raw` to `target_width`.
+fn ldr_zero_extend(raw: &BV, width: AccessWidth, target_width: u32) -> BV {
+    let raw_bits = (width.bytes() * 8) as u32;
+    let pad = target_width - raw_bits;
+    if pad == 0 {
+        raw.clone()
+    } else {
+        raw.zero_ext(pad)
+    }
+}
+
+/// Sign-extend the low `width.bytes() * 8` bits of `raw` to `target_width`.
+fn ldr_sign_extend(raw: &BV, width: AccessWidth, target_width: u32) -> BV {
+    let raw_bits = (width.bytes() * 8) as u32;
+    let pad = target_width - raw_bits;
+    if pad == 0 {
+        raw.clone()
+    } else {
+        raw.sign_ext(pad)
+    }
 }
 
 /// Apply a sequence of instructions to a machine state
@@ -908,12 +1119,14 @@ pub fn states_not_equal(state1: &MachineState, state2: &MachineState) -> z3::ast
     let sp_not_equal = sp1.eq(sp2).not();
     not_equal = z3::ast::Bool::or(&[&not_equal, &sp_not_equal]);
 
-    // And the NZCV flag bits.
-    z3::ast::Bool::or(&[&not_equal, &flags_not_equal(state1, state2)])
+    // And the NZCV flag bits and the whole memory array.
+    not_equal = z3::ast::Bool::or(&[&not_equal, &flags_not_equal(state1, state2)]);
+    z3::ast::Bool::or(&[&not_equal, &state1.memory.eq(&state2.memory).not()])
 }
 
 /// Check if two machine states are not equal for the specified live-out
-/// registers, optionally including the NZCV flag bits.
+/// registers, optionally including the NZCV flag bits and the whole memory
+/// image (see ADR-0007).
 ///
 /// TODO(#282): The explicit `flags_live` parameter duplicates
 /// `live_out.flags_live()` for every non-stochastic caller. Tracked for
@@ -923,6 +1136,7 @@ pub fn states_not_equal_for_live_out(
     state2: &MachineState,
     live_out: &RegisterSet<Register>,
     flags_live: bool,
+    memory_live: bool,
 ) -> z3::ast::Bool {
     let mut not_equal = z3::ast::Bool::from_bool(false);
 
@@ -935,6 +1149,10 @@ pub fn states_not_equal_for_live_out(
 
     if flags_live {
         not_equal = z3::ast::Bool::or(&[&not_equal, &flags_not_equal(state1, state2)]);
+    }
+
+    if memory_live {
+        not_equal = z3::ast::Bool::or(&[&not_equal, &state1.memory.eq(&state2.memory).not()]);
     }
 
     not_equal
@@ -3223,5 +3441,104 @@ mod tests {
                 assert_concrete_smt_parity(&instr, &[(Register::X1, v1)], Register::X0);
             }
         }
+    }
+
+    // ---- Memory ops (issue #68 step 7) ----
+
+    /// `STR x0, [x1]; LDR x2, [x1]` must yield `x2 == x0` under Z3 array
+    /// extensionality, even with arbitrary aliasing of `x1` against other
+    /// addresses (none used here). This is the tracer-bullet test for the
+    /// sound aliasing model from ADR-0007.
+    #[test]
+    fn str_then_ldr_round_trips_via_z3_array() {
+        use crate::ir::types::{AccessWidth, AddressOperand, IndexMode};
+
+        let pre = MachineState::new_symbolic("pre");
+        let seq = vec![
+            Instruction::Str {
+                rt: Register::X0,
+                addr: AddressOperand::Imm {
+                    base: Register::X1,
+                    offset: 0,
+                    mode: IndexMode::Offset,
+                },
+                width: AccessWidth::Extended,
+            },
+            Instruction::Ldr {
+                rt: Register::X2,
+                addr: AddressOperand::Imm {
+                    base: Register::X1,
+                    offset: 0,
+                    mode: IndexMode::Offset,
+                },
+                width: AccessWidth::Extended,
+            },
+        ];
+        let post = apply_sequence(pre.clone(), &seq);
+        let x0_pre = pre.get_register(Register::X0);
+        let x2_post = post.get_register(Register::X2);
+
+        let solver = Solver::new();
+        solver.assert(x0_pre.eq(x2_post).not());
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "STR-then-LDR round-trip must imply x2 == x0 unconditionally"
+        );
+    }
+
+    /// `STR x0, [x1]; STRH w0, [x1, #2]; LDR x2, [x1]` must reflect the
+    /// half-word overlap precisely — bytes 0,1,4,5,6,7 stay from x0 while
+    /// bytes 2,3 come from w0. The byte-addressed array makes this fall
+    /// out for free.
+    #[test]
+    fn overlapping_stores_resolve_per_byte_in_smt() {
+        use crate::ir::types::{AccessWidth, AddressOperand, IndexMode};
+
+        let pre = MachineState::new_symbolic("pre");
+        let seq = vec![
+            Instruction::Str {
+                rt: Register::X0,
+                addr: AddressOperand::Imm {
+                    base: Register::X1,
+                    offset: 0,
+                    mode: IndexMode::Offset,
+                },
+                width: AccessWidth::Extended,
+            },
+            Instruction::Str {
+                rt: Register::X0,
+                addr: AddressOperand::Imm {
+                    base: Register::X1,
+                    offset: 2,
+                    mode: IndexMode::Offset,
+                },
+                width: AccessWidth::Half,
+            },
+            Instruction::Ldr {
+                rt: Register::X2,
+                addr: AddressOperand::Imm {
+                    base: Register::X1,
+                    offset: 0,
+                    mode: IndexMode::Offset,
+                },
+                width: AccessWidth::Extended,
+            },
+        ];
+        let post = apply_sequence(pre.clone(), &seq);
+        // The Z3 solver must be able to verify the load returns the expected
+        // mixed bytes. We just check satisfiability of a concrete example.
+        let solver = Solver::new();
+        let x0_pre = pre.get_register(Register::X0);
+        let zero = BV::from_u64(0, 64);
+        solver.assert(x0_pre.eq(&BV::from_u64(0xDEADBEEF_CAFEBABE, 64)));
+        solver.assert(pre.get_register(Register::X1).eq(&zero));
+        // Expected: low 2 bytes of x2 from x0 low 2 bytes = 0xBABE
+        // Then bytes 2..3 from x0 low 2 bytes (re-stored) = 0xBABE
+        // Then bytes 4..7 from x0 high 4 bytes = 0xDEADBEEF
+        let x2_post = post.get_register(Register::X2);
+        let expected = BV::from_u64(0xDEADBEEF_BABE_BABE, 64);
+        solver.assert(x2_post.eq(&expected));
+        assert_eq!(solver.check(), SatResult::Sat);
     }
 }

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -857,6 +857,15 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             "Branches are terminators; strip them before SMT apply_sequence. Reached: {:?}",
             instruction
         ),
+        // Memory ops (issue #68). SMT lowering arrives in step 7 alongside
+        // the `Array<BV64, BV8>` field on `MachineState`.
+        Instruction::Ldr { .. }
+        | Instruction::Ldrs { .. }
+        | Instruction::Str { .. }
+        | Instruction::Ldp { .. }
+        | Instruction::Stp { .. } => {
+            unimplemented!("Memory-op SMT lowering arrives in step 7 (issue #68)")
+        }
     }
     state
 }

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -286,7 +286,7 @@ impl MachineState {
                 let shifted = if *shift == 0 {
                     idx_bv
                 } else {
-                    idx_bv.bvshl(&BV::from_u64(*shift as u64, 64))
+                    idx_bv.bvshl(BV::from_u64(*shift as u64, 64))
                 };
                 (base_bv.bvadd(&shifted), None)
             }
@@ -313,7 +313,7 @@ impl MachineState {
                 let shifted = if *shift == 0 {
                     extended
                 } else {
-                    extended.bvshl(&BV::from_u64(*shift as u64, 64))
+                    extended.bvshl(BV::from_u64(*shift as u64, 64))
                 };
                 (base_bv.bvadd(&shifted), None)
             }
@@ -997,7 +997,7 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
         Instruction::Str { rt, addr, width } => {
             let (effective, writeback) = state.eval_address(addr);
             let value = state.get_register(*rt).clone();
-            let bits = (width.bytes() * 8) as u32;
+            let bits = width.bytes() * 8;
             let low = value.extract(bits - 1, 0);
             state.store_n(&effective, &low, width.bytes());
             if let Some((base, new_base)) = writeback {
@@ -1042,7 +1042,7 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
         } => {
             let (effective, writeback) = state.eval_address(addr);
             let bytes = width.bytes();
-            let bits = (bytes * 8) as u32;
+            let bits = bytes * 8;
             let v1 = state.get_register(*rt1).clone();
             let v2 = state.get_register(*rt2).clone();
             let low1 = v1.extract(bits - 1, 0);
@@ -1061,7 +1061,7 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
 
 /// Zero-extend the low `width.bytes() * 8` bits of `raw` to `target_width`.
 fn ldr_zero_extend(raw: &BV, width: AccessWidth, target_width: u32) -> BV {
-    let raw_bits = (width.bytes() * 8) as u32;
+    let raw_bits = width.bytes() * 8;
     let pad = target_width - raw_bits;
     if pad == 0 {
         raw.clone()
@@ -1072,7 +1072,7 @@ fn ldr_zero_extend(raw: &BV, width: AccessWidth, target_width: u32) -> BV {
 
 /// Sign-extend the low `width.bytes() * 8` bits of `raw` to `target_width`.
 fn ldr_sign_extend(raw: &BV, width: AccessWidth, target_width: u32) -> BV {
-    let raw_bits = (width.bytes() * 8) as u32;
+    let raw_bits = width.bytes() * 8;
     let pad = target_width - raw_bits;
     if pad == 0 {
         raw.clone()
@@ -3531,13 +3531,13 @@ mod tests {
         let solver = Solver::new();
         let x0_pre = pre.get_register(Register::X0);
         let zero = BV::from_u64(0, 64);
-        solver.assert(x0_pre.eq(&BV::from_u64(0xDEADBEEF_CAFEBABE, 64)));
+        solver.assert(x0_pre.eq(BV::from_u64(0xDEADBEEF_CAFEBABE, 64)));
         solver.assert(pre.get_register(Register::X1).eq(&zero));
         // Expected: low 2 bytes of x2 from x0 low 2 bytes = 0xBABE
         // Then bytes 2..3 from x0 low 2 bytes (re-stored) = 0xBABE
         // Then bytes 4..7 from x0 high 4 bytes = 0xDEADBEEF
         let x2_post = post.get_register(Register::X2);
-        let expected = BV::from_u64(0xDEADBEEF_BABE_BABE, 64);
+        let expected = BV::from_u64(0xDEAD_BEEF_BABE_BABE, 64);
         solver.assert(x2_post.eq(&expected));
         assert_eq!(solver.check(), SatResult::Sat);
     }

--- a/src/semantics/state.rs
+++ b/src/semantics/state.rs
@@ -3,8 +3,8 @@
 #![allow(dead_code)]
 
 use crate::ir::Register;
-use crate::ir::types::Condition;
-use std::collections::{HashMap, HashSet};
+use crate::ir::types::{AccessWidth, Condition};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
 
 /// NZCV condition flags (Negative, Zero, Carry, oVerflow)
@@ -258,6 +258,11 @@ pub struct ConcreteMachineState {
     registers: HashMap<Register, ConcreteValue>,
     flags: ConditionFlags,
     width: u32,
+    /// Sparse byte-addressed memory. Absent keys denote zero so that
+    /// structural equality of two states matches semantic equality (see
+    /// ADR-0007). `write_bytes` prunes zero entries to maintain that
+    /// invariant.
+    memory: BTreeMap<u64, u8>,
 }
 
 impl ConcreteMachineState {
@@ -283,6 +288,7 @@ impl ConcreteMachineState {
             registers,
             flags: ConditionFlags::new(),
             width,
+            memory: BTreeMap::new(),
         }
     }
 
@@ -331,6 +337,45 @@ impl ConcreteMachineState {
     /// Set the condition flags
     pub fn set_flags(&mut self, flags: ConditionFlags) {
         self.flags = flags;
+    }
+
+    /// Borrow the sparse memory map. Used by `states_equal_for_live_out`
+    /// to compare memory across two final states (see ADR-0007).
+    pub fn memory(&self) -> &BTreeMap<u64, u8> {
+        &self.memory
+    }
+
+    /// Read `width.bytes()` bytes starting at `addr`, little-endian, and
+    /// zero-extend into a u64. Absent keys denote zero.
+    pub fn read_bytes(&self, addr: u64, width: AccessWidth) -> u64 {
+        let n = width.bytes() as usize;
+        let mut value: u64 = 0;
+        for i in 0..n {
+            let byte = self
+                .memory
+                .get(&addr.wrapping_add(i as u64))
+                .copied()
+                .unwrap_or(0) as u64;
+            value |= byte << (8 * i);
+        }
+        value
+    }
+
+    /// Write `width.bytes()` low bytes of `value` to memory at `addr`,
+    /// little-endian. Zero bytes are pruned from the BTreeMap so that
+    /// structural equality continues to match semantic equality (absent
+    /// key = zero) — see ADR-0007.
+    pub fn write_bytes(&mut self, addr: u64, value: u64, width: AccessWidth) {
+        let n = width.bytes() as usize;
+        for i in 0..n {
+            let byte = ((value >> (8 * i)) & 0xff) as u8;
+            let key = addr.wrapping_add(i as u64);
+            if byte == 0 {
+                self.memory.remove(&key);
+            } else {
+                self.memory.insert(key, byte);
+            }
+        }
     }
 }
 
@@ -736,5 +781,77 @@ mod tests {
         assert!(f.cf, "borrow");
         assert!(f.sf, "32-bit MSB set");
         assert!(!f.zf);
+    }
+
+    // ---- Memory model (issue #68 step 5) ----
+
+    #[test]
+    fn read_bytes_returns_zero_on_fresh_state() {
+        use crate::ir::types::AccessWidth;
+        let state = ConcreteMachineState::new_zeroed();
+        assert_eq!(state.read_bytes(0x1000, AccessWidth::Extended), 0);
+        assert_eq!(state.read_bytes(0x1000, AccessWidth::Byte), 0);
+    }
+
+    #[test]
+    fn write_then_read_round_trips_at_each_width() {
+        use crate::ir::types::AccessWidth;
+        let mut state = ConcreteMachineState::new_zeroed();
+        state.write_bytes(0x1000, 0xDEADBEEF_CAFEBABE, AccessWidth::Extended);
+        assert_eq!(
+            state.read_bytes(0x1000, AccessWidth::Extended),
+            0xDEADBEEF_CAFEBABE
+        );
+
+        state.write_bytes(0x2000, 0x1234_5678, AccessWidth::Word);
+        assert_eq!(state.read_bytes(0x2000, AccessWidth::Word), 0x1234_5678);
+
+        state.write_bytes(0x3000, 0xAB, AccessWidth::Byte);
+        assert_eq!(state.read_bytes(0x3000, AccessWidth::Byte), 0xAB);
+    }
+
+    #[test]
+    fn write_is_little_endian() {
+        use crate::ir::types::AccessWidth;
+        let mut state = ConcreteMachineState::new_zeroed();
+        state.write_bytes(0x100, 0x0807_0605_0403_0201, AccessWidth::Extended);
+        // Byte at +0 holds the low byte (0x01); byte at +7 holds the high byte (0x08).
+        assert_eq!(state.read_bytes(0x100, AccessWidth::Byte), 0x01);
+        assert_eq!(state.read_bytes(0x107, AccessWidth::Byte), 0x08);
+    }
+
+    #[test]
+    fn overlapping_writes_resolve_per_byte() {
+        use crate::ir::types::AccessWidth;
+        let mut state = ConcreteMachineState::new_zeroed();
+        state.write_bytes(0x100, 0x0807_0605_0403_0201, AccessWidth::Extended);
+        // Overwrite bytes 2-3 with a half-word store.
+        state.write_bytes(0x102, 0xCAFE, AccessWidth::Half);
+        // The full 64-bit read sees the original bytes 0-1 and 4-7, plus the
+        // patched bytes at 2-3 (little-endian).
+        assert_eq!(
+            state.read_bytes(0x100, AccessWidth::Extended),
+            0x0807_0605_CAFE_0201
+        );
+    }
+
+    #[test]
+    fn write_of_zero_byte_prunes_entry() {
+        use crate::ir::types::AccessWidth;
+        let mut state = ConcreteMachineState::new_zeroed();
+        state.write_bytes(0x100, 0x1234_5678, AccessWidth::Word);
+        // Overwrite with zero — the BTreeMap entries should be removed so
+        // structural equality matches semantic equality (absent key = zero).
+        state.write_bytes(0x100, 0, AccessWidth::Word);
+        assert!(state.memory().is_empty(), "zero writes must prune");
+    }
+
+    #[test]
+    fn equality_of_states_is_structural_after_prune() {
+        use crate::ir::types::AccessWidth;
+        let mut a = ConcreteMachineState::new_zeroed();
+        let b = ConcreteMachineState::new_zeroed();
+        a.write_bytes(0x100, 0, AccessWidth::Word);
+        assert_eq!(a, b, "writing zeroes must not perturb structural equality");
     }
 }

--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -134,11 +134,13 @@ pub fn parse_live_out_contract(s: &str) -> Result<LiveOut, ParseRegisterSetError
     Ok(regs.with_flags(flags_live))
 }
 
-/// Compute the set of registers written by a sequence of instructions
+/// Compute the set of registers written by a sequence of instructions.
+/// Uses `destinations()` so memory ops with writeback (PreIndex / PostIndex)
+/// or pair loads (LDP) contribute multiple registers per instruction.
 pub fn compute_written_registers(instructions: &[Instruction]) -> RegisterSet<Register> {
     let mut mask = RegisterSet::empty();
     for instr in instructions {
-        if let Some(dest) = instr.destination() {
+        for dest in instr.destinations() {
             mask.add(dest);
         }
     }
@@ -206,7 +208,7 @@ pub fn compute_live_in_registers(instructions: &[Instruction]) -> RegisterSet<Re
                 live_in.add(src);
             }
         }
-        if let Some(dest) = instr.destination() {
+        for dest in instr.destinations() {
             written.add(dest);
         }
     }

--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -147,6 +147,22 @@ pub fn compute_written_registers(instructions: &[Instruction]) -> RegisterSet<Re
     mask
 }
 
+/// Returns true if the sequence contains any memory-touching instruction.
+/// Drives the auto-derivation of `EquivalenceConfig::memory_live` (and the
+/// `fast_only` carve-out) in `check_equivalence_with_config`. See ADR-0007.
+pub fn touches_memory(instructions: &[Instruction]) -> bool {
+    instructions.iter().any(|i| {
+        matches!(
+            i,
+            Instruction::Ldr { .. }
+                | Instruction::Ldrs { .. }
+                | Instruction::Str { .. }
+                | Instruction::Ldp { .. }
+                | Instruction::Stp { .. }
+        )
+    })
+}
+
 /// Returns true if NZCV may be observable after the sequence executes.
 ///
 /// Static check: returns true iff **any** flag-writing instruction appears

--- a/src/validation/random.rs
+++ b/src/validation/random.rs
@@ -1,9 +1,18 @@
 //! Random input generation for fast validation
 
 use crate::ir::Register;
+use crate::ir::types::AccessWidth;
 use crate::semantics::state::ConcreteMachineState;
 use rand::RngExt;
 use std::collections::HashMap;
+
+/// Base address of the random-input memory seed region. See ADR-0007.
+pub const MEMORY_SEED_BASE: u64 = 0x1000_0000;
+
+/// Size of the random-input memory seed region in bytes. 4 KiB matches a
+/// page; large enough to exercise meaningful overlap patterns yet small
+/// enough that filling it stays cheap.
+pub const MEMORY_SEED_SIZE: usize = 4096;
 
 /// Configuration for random input generation
 #[derive(Debug, Clone)]
@@ -12,6 +21,12 @@ pub struct RandomInputConfig {
     pub count: usize,
     /// Registers to randomize (others will be zero)
     pub registers: Vec<Register>,
+    /// If non-zero, seed each generated state's memory with this many
+    /// random bytes starting at `MEMORY_SEED_BASE`. Default 0 (no seed).
+    /// Set to `MEMORY_SEED_SIZE` for memory-bearing windows so memory
+    /// loads return non-trivial values during fast / counterexample
+    /// random testing.
+    pub memory_seed_size: usize,
 }
 
 impl Default for RandomInputConfig {
@@ -26,6 +41,7 @@ impl Default for RandomInputConfig {
                 Register::X4,
                 Register::X5,
             ],
+            memory_seed_size: 0,
         }
     }
 }
@@ -40,7 +56,18 @@ pub fn generate_random_inputs(config: &RandomInputConfig) -> Vec<ConcreteMachine
         for reg in &config.registers {
             values.insert(*reg, rng.random::<u64>());
         }
-        inputs.push(ConcreteMachineState::from_values(values));
+        let mut state = ConcreteMachineState::from_values(values);
+        if config.memory_seed_size > 0 {
+            for i in 0..config.memory_seed_size {
+                let byte = rng.random::<u8>();
+                state.write_bytes(
+                    MEMORY_SEED_BASE.wrapping_add(i as u64),
+                    byte as u64,
+                    AccessWidth::Byte,
+                );
+            }
+        }
+        inputs.push(state);
     }
 
     inputs
@@ -191,6 +218,7 @@ mod tests {
         let config = RandomInputConfig {
             count: 5,
             registers: vec![Register::X0, Register::X1],
+            memory_seed_size: 0,
         };
         let inputs = generate_random_inputs(&config);
         assert_eq!(inputs.len(), 5);
@@ -208,6 +236,7 @@ mod tests {
         let config = RandomInputConfig {
             count: 10,
             registers: vec![Register::X0],
+            memory_seed_size: 0,
         };
         let inputs = generate_random_inputs(&config);
 
@@ -221,6 +250,46 @@ mod tests {
             .collect::<std::collections::HashSet<_>>()
             .len();
         assert!(unique_count > 1);
+    }
+
+    #[test]
+    fn memory_seed_populates_region_when_size_nonzero() {
+        let config = RandomInputConfig {
+            count: 4,
+            registers: vec![Register::X0],
+            memory_seed_size: MEMORY_SEED_SIZE,
+        };
+        let inputs = generate_random_inputs(&config);
+        // At least one input must have a non-empty memory map (the random
+        // bytes might all be zero, but with 4 KiB of random bytes and four
+        // independent draws the probability of every byte being zero is
+        // 256^-(4*4096) — vastly below 2^-256, indistinguishable from zero).
+        let any_populated = inputs.iter().any(|s| !s.memory().is_empty());
+        assert!(any_populated, "memory seed produced no entries");
+        // Every populated byte must lie inside [MEMORY_SEED_BASE,
+        // MEMORY_SEED_BASE + MEMORY_SEED_SIZE).
+        for s in &inputs {
+            for (&addr, _) in s.memory() {
+                assert!(
+                    (MEMORY_SEED_BASE..MEMORY_SEED_BASE + MEMORY_SEED_SIZE as u64).contains(&addr),
+                    "address 0x{:x} outside seed region",
+                    addr
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn memory_seed_default_zero_leaves_memory_empty() {
+        let config = RandomInputConfig {
+            count: 4,
+            registers: vec![Register::X0],
+            memory_seed_size: 0,
+        };
+        let inputs = generate_random_inputs(&config);
+        for s in &inputs {
+            assert!(s.memory().is_empty(), "memory must stay empty without seed");
+        }
     }
 
     #[test]

--- a/src/validation/random.rs
+++ b/src/validation/random.rs
@@ -269,7 +269,7 @@ mod tests {
         // Every populated byte must lie inside [MEMORY_SEED_BASE,
         // MEMORY_SEED_BASE + MEMORY_SEED_SIZE).
         for s in &inputs {
-            for (&addr, _) in s.memory() {
+            for &addr in s.memory().keys() {
                 assert!(
                     (MEMORY_SEED_BASE..MEMORY_SEED_BASE + MEMORY_SEED_SIZE as u64).contains(&addr),
                     "address 0x{:x} outside seed region",

--- a/tests/integration/opt_test.rs
+++ b/tests/integration/opt_test.rs
@@ -452,10 +452,11 @@ fn test_opt_rejects_unsupported_instruction_window() {
 /// Helper for memory-op integration tests: assert that `s11 opt` on the
 /// given single-instruction window succeeds.
 ///
-/// Each test copies the source ELF to a unique tmp path (`std::env::temp_dir`
-/// + the supplied `fixture_tag`) so concurrent `cargo test` runs don't
-/// collide on the `<input>_optimized` artifact the binary always writes
-/// alongside its input. The artifact is cleaned up before the test returns.
+/// Each test copies the source ELF to a unique tmp path
+/// (`std::env::temp_dir` joined with the supplied `fixture_tag`) so
+/// concurrent `cargo test` runs don't collide on the
+/// `<input>_optimized` artifact the binary always writes alongside its
+/// input. The artifact is cleaned up before the test returns.
 fn assert_opt_succeeds_on_window(source_elf: &Path, fixture_tag: &str, start_addr: u64) {
     let binary = get_binary_path();
     let end_addr = start_addr + 4;

--- a/tests/integration/opt_test.rs
+++ b/tests/integration/opt_test.rs
@@ -449,6 +449,98 @@ fn test_opt_rejects_unsupported_instruction_window() {
     );
 }
 
+/// Helper for memory-op integration tests: assert that `s11 opt` on the
+/// given single-instruction window succeeds, then clean up the artifact.
+fn assert_opt_succeeds_on_window(test_elf: &Path, optimized_name: &str, start_addr: u64) {
+    let binary = get_binary_path();
+    let end_addr = start_addr + 4;
+    let optimized_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("binaries")
+        .join(optimized_name);
+    let _ = fs::remove_file(&optimized_path);
+
+    let output = Command::new(&binary)
+        .arg("opt")
+        .arg(test_elf)
+        .arg("--start-addr")
+        .arg(format!("0x{start_addr:x}"))
+        .arg("--end-addr")
+        .arg(format!("0x{end_addr:x}"))
+        .output()
+        .expect("Failed to execute s11");
+
+    if !output.status.success() {
+        let _ = fs::remove_file(&optimized_path);
+        panic!(
+            "opt failed on memory-op window 0x{start_addr:x}.\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Optimization completed successfully"),
+        "memory-op window must round-trip end-to-end; stdout: {stdout}",
+    );
+
+    let _ = fs::remove_file(&optimized_path);
+}
+
+#[test]
+fn test_opt_accepts_stp_writeback_window() {
+    // STP pre-index `stp x29, x30, [sp, #-16]!` — the standard AArch64
+    // function-prologue spill. Issue #68 moves this from "unsupported" to
+    // "supported"; this test pins that decision at the CLI boundary.
+    let test_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("binaries")
+        .join("loops_debug");
+    check_test_binary(&test_elf);
+    let start_addr = find_encoding_masked(
+        &test_elf,
+        &[0xfd, 0x7b, 0xbf, 0xa9],
+        &[0xff, 0xff, 0xff, 0xff],
+        "stp x29, x30, [sp, #-16]!",
+    );
+    assert_opt_succeeds_on_window(&test_elf, "loops_debug_optimized", start_addr);
+}
+
+#[test]
+fn test_opt_accepts_ldp_postindex_window() {
+    // LDP post-index `ldp x29, x30, [sp], #16` — function-epilogue
+    // restore. Verifies the post-index addressing mode runs cleanly
+    // through disasm → IR → SMT → reassemble.
+    let test_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("binaries")
+        .join("loops_debug");
+    check_test_binary(&test_elf);
+    let start_addr = find_encoding_masked(
+        &test_elf,
+        &[0xfd, 0x7b, 0xc1, 0xa8],
+        &[0xff, 0xff, 0xff, 0xff],
+        "ldp x29, x30, [sp], #16",
+    );
+    assert_opt_succeeds_on_window(&test_elf, "loops_debug_optimized", start_addr);
+}
+
+#[test]
+fn test_opt_accepts_ldr_positive_offset_window() {
+    // LDR with positive scaled offset `ldr x17, [x16, #8]` — covers the
+    // RefOffset / Uscaled encoding path (vs the LDUR Sbits path tested at
+    // the assembler unit-test layer).
+    let test_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("binaries")
+        .join("loops_debug");
+    check_test_binary(&test_elf);
+    let start_addr = find_encoding_masked(
+        &test_elf,
+        &[0x11, 0x06, 0x40, 0xf9],
+        &[0xff, 0xff, 0xff, 0xff],
+        "ldr x17, [x16, #8]",
+    );
+    assert_opt_succeeds_on_window(&test_elf, "loops_debug_optimized", start_addr);
+}
+
 #[test]
 fn test_opt_hex_address_formats() {
     let binary = get_binary_path();

--- a/tests/integration/opt_test.rs
+++ b/tests/integration/opt_test.rs
@@ -540,18 +540,22 @@ fn test_opt_accepts_ldp_postindex_window() {
 
 #[test]
 fn test_opt_accepts_ldr_positive_offset_window() {
-    // LDR with positive scaled offset `ldr x17, [x16, #8]` — covers the
-    // RefOffset / Uscaled encoding path (vs the LDUR Sbits path tested at
-    // the assembler unit-test layer).
+    // LDR X-form unsigned-offset family `ldr xN, [xM{, #imm}]` — covers
+    // the RefOffset / Uscaled encoding path (vs the LDUR Sbits path tested
+    // at the assembler unit-test layer). The exact (Rt, Rn, imm) tuple
+    // varies across `loops_debug` rebuilds (PLT layout depends on the
+    // toolchain), so the mask wildcards them and pins only the class bits:
+    // byte 3 = 11111001 (size=11, V=1, class=001, opc=01); byte 2 top
+    // bits 7-6 = 01 (LDR unsigned-offset variant).
     let source_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("binaries")
         .join("loops_debug");
     check_test_binary(&source_elf);
     let start_addr = find_encoding_masked(
         &source_elf,
-        &[0x11, 0x06, 0x40, 0xf9],
-        &[0xff, 0xff, 0xff, 0xff],
-        "ldr x17, [x16, #8]",
+        &[0x00, 0x00, 0x40, 0xf9],
+        &[0x00, 0x00, 0xc0, 0xff],
+        "ldr xN, [xM{, #imm}]",
     );
     assert_opt_succeeds_on_window(&source_elf, "ldr_offset", start_addr);
 }

--- a/tests/integration/opt_test.rs
+++ b/tests/integration/opt_test.rs
@@ -450,18 +450,26 @@ fn test_opt_rejects_unsupported_instruction_window() {
 }
 
 /// Helper for memory-op integration tests: assert that `s11 opt` on the
-/// given single-instruction window succeeds, then clean up the artifact.
-fn assert_opt_succeeds_on_window(test_elf: &Path, optimized_name: &str, start_addr: u64) {
+/// given single-instruction window succeeds.
+///
+/// Each test copies the source ELF to a unique tmp path (`std::env::temp_dir`
+/// + the supplied `fixture_tag`) so concurrent `cargo test` runs don't
+/// collide on the `<input>_optimized` artifact the binary always writes
+/// alongside its input. The artifact is cleaned up before the test returns.
+fn assert_opt_succeeds_on_window(source_elf: &Path, fixture_tag: &str, start_addr: u64) {
     let binary = get_binary_path();
     let end_addr = start_addr + 4;
-    let optimized_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("binaries")
-        .join(optimized_name);
-    let _ = fs::remove_file(&optimized_path);
+
+    let tmp_dir = std::env::temp_dir().join(format!("s11_opt_{fixture_tag}"));
+    let _ = fs::remove_dir_all(&tmp_dir);
+    fs::create_dir_all(&tmp_dir).expect("create temp fixture dir");
+    let test_elf = tmp_dir.join("loops_debug");
+    fs::copy(source_elf, &test_elf).expect("copy ELF fixture to tmp");
+    let optimized_path = tmp_dir.join("loops_debug_optimized");
 
     let output = Command::new(&binary)
         .arg("opt")
-        .arg(test_elf)
+        .arg(&test_elf)
         .arg("--start-addr")
         .arg(format!("0x{start_addr:x}"))
         .arg("--end-addr")
@@ -470,7 +478,7 @@ fn assert_opt_succeeds_on_window(test_elf: &Path, optimized_name: &str, start_ad
         .expect("Failed to execute s11");
 
     if !output.status.success() {
-        let _ = fs::remove_file(&optimized_path);
+        let _ = fs::remove_dir_all(&tmp_dir);
         panic!(
             "opt failed on memory-op window 0x{start_addr:x}.\nstdout: {}\nstderr: {}",
             String::from_utf8_lossy(&output.stdout),
@@ -479,12 +487,19 @@ fn assert_opt_succeeds_on_window(test_elf: &Path, optimized_name: &str, start_ad
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
+    let ok = stdout.contains("Optimization completed successfully");
+    let optimized_exists = optimized_path.exists();
+    let _ = fs::remove_dir_all(&tmp_dir);
+
     assert!(
-        stdout.contains("Optimization completed successfully"),
+        ok,
         "memory-op window must round-trip end-to-end; stdout: {stdout}",
     );
-
-    let _ = fs::remove_file(&optimized_path);
+    assert!(
+        optimized_exists,
+        "optimized binary must be created at {:?}",
+        optimized_path,
+    );
 }
 
 #[test]
@@ -492,17 +507,17 @@ fn test_opt_accepts_stp_writeback_window() {
     // STP pre-index `stp x29, x30, [sp, #-16]!` — the standard AArch64
     // function-prologue spill. Issue #68 moves this from "unsupported" to
     // "supported"; this test pins that decision at the CLI boundary.
-    let test_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    let source_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("binaries")
         .join("loops_debug");
-    check_test_binary(&test_elf);
+    check_test_binary(&source_elf);
     let start_addr = find_encoding_masked(
-        &test_elf,
+        &source_elf,
         &[0xfd, 0x7b, 0xbf, 0xa9],
         &[0xff, 0xff, 0xff, 0xff],
         "stp x29, x30, [sp, #-16]!",
     );
-    assert_opt_succeeds_on_window(&test_elf, "loops_debug_optimized", start_addr);
+    assert_opt_succeeds_on_window(&source_elf, "stp_writeback", start_addr);
 }
 
 #[test]
@@ -510,17 +525,17 @@ fn test_opt_accepts_ldp_postindex_window() {
     // LDP post-index `ldp x29, x30, [sp], #16` — function-epilogue
     // restore. Verifies the post-index addressing mode runs cleanly
     // through disasm → IR → SMT → reassemble.
-    let test_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    let source_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("binaries")
         .join("loops_debug");
-    check_test_binary(&test_elf);
+    check_test_binary(&source_elf);
     let start_addr = find_encoding_masked(
-        &test_elf,
+        &source_elf,
         &[0xfd, 0x7b, 0xc1, 0xa8],
         &[0xff, 0xff, 0xff, 0xff],
         "ldp x29, x30, [sp], #16",
     );
-    assert_opt_succeeds_on_window(&test_elf, "loops_debug_optimized", start_addr);
+    assert_opt_succeeds_on_window(&source_elf, "ldp_postindex", start_addr);
 }
 
 #[test]
@@ -528,17 +543,17 @@ fn test_opt_accepts_ldr_positive_offset_window() {
     // LDR with positive scaled offset `ldr x17, [x16, #8]` — covers the
     // RefOffset / Uscaled encoding path (vs the LDUR Sbits path tested at
     // the assembler unit-test layer).
-    let test_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    let source_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("binaries")
         .join("loops_debug");
-    check_test_binary(&test_elf);
+    check_test_binary(&source_elf);
     let start_addr = find_encoding_masked(
-        &test_elf,
+        &source_elf,
         &[0x11, 0x06, 0x40, 0xf9],
         &[0xff, 0xff, 0xff, 0xff],
         "ldr x17, [x16, #8]",
     );
-    assert_opt_succeeds_on_window(&test_elf, "loops_debug_optimized", start_addr);
+    assert_opt_succeeds_on_window(&source_elf, "ldr_offset", start_addr);
 }
 
 #[test]

--- a/tests/integration/opt_test.rs
+++ b/tests/integration/opt_test.rs
@@ -397,15 +397,16 @@ fn test_opt_rejects_unsupported_instruction_window() {
         .join("loops_debug");
     check_test_binary(&test_elf);
 
-    // Scan loops_debug for the first `stp x29, x30, [sp, #-0x10]!` — an
-    // unsupported mnemonic for the AArch64 optimization path. Targeting a
-    // 4-byte window on that instruction must abort before any output file
-    // is written.
+    // Scan loops_debug for the first `paciasp` — pointer authentication is
+    // unsupported by the AArch64 optimization path. (Memory ops moved to
+    // supported in issue #68, so the old `stp` fixture became valid; see
+    // ADR-0007.) Targeting a 4-byte window on this instruction must abort
+    // before any output file is written.
     let start_addr = find_encoding_masked(
         &test_elf,
-        &[0xfd, 0x7b, 0xbf, 0xa9],
+        &[0x3f, 0x23, 0x03, 0xd5],
         &[0xff, 0xff, 0xff, 0xff],
-        "stp x29, x30, [sp, #-0x10]!",
+        "paciasp",
     );
     let end_addr = start_addr + 4;
 
@@ -433,7 +434,7 @@ fn test_opt_rejects_unsupported_instruction_window() {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("unsupported instruction") && stderr.contains("stp"),
+        stderr.contains("unsupported instruction") && stderr.contains("paciasp"),
         "stderr should identify the offending mnemonic; got: {stderr}",
     );
     assert!(


### PR DESCRIPTION
## Summary
- Adds the full AArch64 memory-op family — LDR, LDRB, LDRH, LDRSB, LDRSH, LDRSW, STR, STRB, STRH, LDP, STP, LDPSW — across all five addressing modes (immediate-offset, pre-index, post-index, register-offset, register-extend) and both W/X widths.
- End-to-end pipeline: IR → parser → concrete interpreter → SMT (Z3 Array) → equivalence checker → assembler → cost → enumerative/stochastic search candidates → Capstone-tripwire tests → ELF round-trip integration tests.
- Sound aliasing via a single byte-addressed `Array<BV64, BV8>` on the SMT side and a sparse `BTreeMap<u64, u8>` (absent-key = 0, prune-on-write) on the concrete side; little-endian by construction. See [ADR-0007](docs/adr/0007-memory-model.md).

## Design decisions (pinned in ADR-0007)
- **Memory model**: byte-addressed Z3 array (SMT) + sparse `BTreeMap` (concrete). Sound full aliasing — no disjointness preconditions.
- **Live-out**: whole-memory live-out is auto-derived from `touches_memory()` on the candidate / target; no CLI grammar change.
- **`fast_only` carve-out**: force-disabled inside `check_equivalence_with_config` for memory-bearing windows (random inputs can't cover all aliasing patterns).
- **Writeback** via the broadened `Instruction::destinations() -> Vec<Register>` (pre-/post-index appends the base register).
- **LDPSW** folded into `Ldp` with a `signed: bool` field; encodable only when `width == Word`.
- **`Xt == Xn` writeback** and **LDP `Xt == Xt2`** rejected at `is_encodable_aarch64` per ARM ARM.

## Commit ledger (14 commits)
| # | Commit | What |
|---|--------|------|
| 1 | `a454ae0` | docs: ADR-0007 + plan |
| 2 | `0d81dea` | ir: `AddressOperand` / `IndexMode` / `AccessWidth` |
| 3 | `9aed269` | ir: variants + `destinations()` API |
| 4 | `d89867b` | parser: all addressing modes, bracket-aware tokenizer |
| 5 | `485bdc1` | semantics: sparse memory on `ConcreteMachineState` |
| 6 | `759bf81` | semantics: concrete eval for LDR/LDRS/STR/LDP/STP |
| 7 | `16da2ae` | semantics: SMT lowering via Z3 Array |
| 8/9 | `b579919` | semantics: auto-derive `memory_live` + `fast_only` carve-out |
| 17 | `51169cd` | test: extend Capstone tripwire with 54 memory-op rows |
| 21 | `755a410` | docs: update CLAUDE.md |
| 13 | `e873441` | assembler: dynasm encoder with LDUR/STUR dispatch (29 round-trip tests) |
| 11 | `366d576` | random: memory seed for memory-bearing windows |
| 20 | `7d07aee` | test: 3 end-to-end opt-window tests (STP/LDP/LDR in `loops_debug`) |
| 15/16 | `82c8888` | search: enumerative candidates + stochastic mutator slots |

Every commit passes `./ci_check.sh` independently.

## Out-of-scope follow-ups
- W-form enumeration (mutator can still flip width via a future opcode bridge).
- LDUR/STUR mnemonics as a parser entry point (round-trip via Capstone today produces them when the encoder routes a negative-offset LDR to LDUR; the parser pins them as `Unsupported` to avoid silent semantic drift).
- `LiveOutMask<R>` migration (ADR-0004 §5; ADR-0007 notes the `memory_live` bit moves there).
- Mutate-opcode width / signed bridges (e.g. `Ldr ↔ Ldrs`).

## Test plan
- [x] `./ci_check.sh` (formatting, build, unit tests, integration tests)
- [x] All 116 assembler tests pass (29 new memory-op round-trips)
- [x] Capstone-tripwire pins all 12 new mnemonics × 5 addressing modes (54 new rows)
- [x] 3 integration tests run the full `s11 opt` pipeline on real ELF windows containing STP / LDP / LDR
- [x] `mutate_operand_on_ldr_can_change_base_or_rt_or_offset` proves the mutator touches operand fields without changing variant/width/mode
- [x] `generate_all_instructions_includes_memory_ops` proves the enumerative pool produces each of LDR/STR/LDP/STP

Closes #68.