### PR TITLE
docs(adr): reconcile NZCV live-out semantics between ADR-0002 and ADR-0006

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -14,13 +14,13 @@ A `Vec<Instruction>` produced by a search algorithm as a potential replacement f
 A candidate that is both **strictly cheaper** than the target and **proven equivalent** on the live-out contract. The metric of "cheaper" is search-config dependent (cost model in `src/semantics/cost.rs`, or byte count for the LLM-assisted flow).
 
 ### Live-out
-The observable architectural state whose values must agree between target and candidate after execution. Today this is represented by `LiveOut` in `src/semantics/live_out.rs`; its only populated slice is `LiveOutRegisters`. The intended concept is broader than registers: condition state, memory, and PC can also be live-out when downstream code observes them.
+The observable architectural state whose values must agree between target and candidate after execution. Today this is represented by `LiveOut` in `src/semantics/live_out.rs`; it populates two slices — a register set (`RegisterSet<R>` per ADR-0004 §5) and the AArch64 NZCV `flags_live` bit (ADR-0006). The intended concept is still broader: memory and PC can also be live-out when downstream code observes them, and they remain unmodeled.
 
 ### Live-out registers
 The register slice of the live-out contract. Represented by `LiveOutRegisters`, a set of architectural registers whose values must agree between target and candidate after execution. This is not the whole live-out concept.
 
 ### Observable state
-Any architectural state a downstream context can observe after the target executes. Registers are the only fully modeled observable state today. Condition state is the next known slice. Memory and PC are intentionally reserved in the term so the live-out contract can grow without being renamed.
+Any architectural state a downstream context can observe after the target executes. Registers and AArch64 condition state (NZCV) are modeled today (the latter via `LiveOut.flags_live`, ADR-0006). Memory and PC are intentionally reserved in the term so the live-out contract can grow without being renamed.
 
 ### Condition state
 Architecture-specific predicate or flag state that later instructions can read. On AArch64 this is NZCV. On a RISC-V integer subset there may be no condition state. Future architectures can map this term to their own flag or predicate state without changing the shared live-out vocabulary.
@@ -47,8 +47,8 @@ A `SearchAlgorithm` impl that delegates candidate generation to the OpenAI Codex
 
 **Deliverable:** local-only. A bash/`just` target that runs the search across a fixed corpus of 5–10 small asm targets known to be optimizable (drawn from existing equivalence tests). No CI, no mocked Codex backend, no `CandidateGenerator` trait abstraction.
 
-### Flags-live-out (MVP exclusion)
-For the LLM-assisted search MVP only, targets whose final architectural state includes meaningful AArch64 condition state (NZCV) are **refused** rather than processed. `LiveOut` does not currently populate a condition-state slice, and adding condition state to the live-out contract would require co-ordinated changes to the equivalence internals — out of scope for the MVP. The LLM flow detects flags-live-out by static inspection of the target and bails with an explicit message. See ADR-0002.
+### Flags-live-out (LLM-flow exclusion)
+AArch64 condition state (NZCV) is part of the equivalence contract via `LiveOut.flags_live` (set from the `;nzcv` suffix to `equiv --live-out` per ADR-0006). The fast and SMT equivalence paths both consume the bit. *Separately*, the LLM-assisted search flow statically refuses targets whose final state includes flag liveness (any flag-writing instruction in the sequence — see `flags_live_out` in `src/validation/live_out.rs`) and bails before invoking Codex. This is a conservative policy choice, not a soundness workaround, and is the only remaining surface on which ADR-0002 is authoritative. See ADR-0002 (as amended) and ADR-0006.
 
 ### Subset hint (intentionally absent)
 The LLM prompt does **not** enumerate the 20-opcode subset s11's parser accepts. The model is invited to use any AArch64 mnemonic it knows. Outputs that use unsupported instructions are recorded as a research signal (which mnemonics the model "wanted" to reach for), not treated as wasted calls. See ADR-0003.

--- a/docs/adr/0002-mvp-restricts-flags-live-out.md
+++ b/docs/adr/0002-mvp-restricts-flags-live-out.md
@@ -3,11 +3,24 @@
 Status: Accepted
 Date: 2026-05-07
 
+## Amendment (2026-05-19)
+
+Superseded in part by [ADR-0006](0006-live-out-cli-grammar.md). The Context
+paragraph below originally claimed NZCV was not modeled by the equivalence
+pipeline (a "pre-existing soundness gap"). That claim no longer holds:
+`LiveOut` carries a `flags_live` bit (`src/semantics/live_out.rs`), and both
+the fast-path and SMT equivalence paths consume it
+(`src/semantics/equivalence.rs`); `equiv --live-out '...;nzcv'` is the
+user-facing knob (ADR-0006). What remains authoritative in this ADR is the
+LLM-specific *static refusal* of flag-live-out targets in
+`src/search/llm/mod.rs`; that policy is unchanged and is independent of how
+the equivalence pipeline handles NZCV.
+
 ## Context
 
-`LiveOut` (`src/semantics/live_out.rs`) names the broad live-out contract, but its only populated slice today is the register-only `LiveOutRegisters`. It does not encode whether AArch64 condition state (NZCV) is part of the broader live-out contract. The 20-opcode subset includes flag writers (`CMP`, `CMN`, `TST`) and flag readers (`CSEL`, `CSINC`, `CSINV`, `CSNEG`); a target whose final instruction is `CMP` (for example) has condition state as a real downstream output even though no register value reflects it.
+At the time this ADR was accepted, `LiveOut` (`src/semantics/live_out.rs`) named the broad live-out contract, but its only populated slice was the register-only `LiveOutRegisters`. It did not encode whether AArch64 condition state (NZCV) was part of the broader live-out contract. The 20-opcode subset includes flag writers (`CMP`, `CMN`, `TST`) and flag readers (`CSEL`, `CSINC`, `CSINV`, `CSNEG`); a target whose final instruction is `CMP` (for example) has condition state as a real downstream output even though no register value reflects it. (See the Amendment above for the present state of this part of the contract.)
 
-`EquivalenceConfig` and all four search algorithms thread `LiveOut` through, but equivalence currently checks only its `LiveOutRegisters` slice; none of them check NZCV equivalence. This is a pre-existing soundness gap with respect to condition-state live-out, but only matters for the LLM flow because the LLM is the only generator that might *legitimately* drop a final flag-setting instruction (the others enumerate from a pool that includes it).
+`EquivalenceConfig` and all four search algorithms threaded `LiveOut` through, but equivalence at that time checked only its `LiveOutRegisters` slice; none of them checked NZCV equivalence. That was a pre-existing soundness gap with respect to condition-state live-out, but only mattered for the LLM flow because the LLM is the only generator that might *legitimately* drop a final flag-setting instruction (the others enumerate from a pool that includes it).
 
 Two options:
 
@@ -26,6 +39,6 @@ Option 1. The LLM flow refuses to run on targets where static analysis says flag
 
 **Negative:**
 - The LLM flow has a **narrower applicable input class than the rest of the optimizer**. A user who feeds it a region ending in `CMP` for a downstream branch sees a refusal, not an attempt.
-- We are explicitly accepting a known pre-existing soundness gap (condition-state live-out is not checked by the equivalence internals for *all* algorithms) rather than fixing it. Fix is deferred.
+- The static refusal in the LLM flow is conservative: it bails *before* invoking Codex, even on targets whose equivalence the pipeline could now verify under ADR-0006. This is a deliberate cost/safety trade-off, not a soundness workaround.
 
-**Reversibility:** high. When flags-live-out becomes a supported part of the live-out contract (its own ADR), the static refusal in the LLM flow is replaced by passing the flag-live-out bit through to the prompt and the equivalence check.
+**Reversibility:** high. If the LLM flow is later judged to be sound on flag-live-out targets, the static refusal in `src/search/llm/mod.rs:116` becomes a one-line deletion and the inputs pass through to Codex like any other target.

--- a/docs/adr/0002-mvp-restricts-flags-live-out.md
+++ b/docs/adr/0002-mvp-restricts-flags-live-out.md
@@ -41,4 +41,4 @@ Option 1. The LLM flow refuses to run on targets where static analysis says flag
 - The LLM flow has a **narrower applicable input class than the rest of the optimizer**. A user who feeds it a region ending in `CMP` for a downstream branch sees a refusal, not an attempt.
 - The static refusal in the LLM flow is conservative: it bails *before* invoking Codex, even on targets whose equivalence the pipeline could now verify under ADR-0006. This is a deliberate cost/safety trade-off, not a soundness workaround.
 
-**Reversibility:** high. If the LLM flow is later judged to be sound on flag-live-out targets, the static refusal in `src/search/llm/mod.rs:116` becomes a one-line deletion and the inputs pass through to Codex like any other target.
+**Reversibility:** high. If the LLM flow is later judged to be sound on flag-live-out targets, the static refusal in `src/search/llm/mod.rs` (the `if flags_live_out(target)` guard inside `Llm::search`) becomes a one-line deletion and the inputs pass through to Codex like any other target.

--- a/docs/adr/0006-live-out-cli-grammar.md
+++ b/docs/adr/0006-live-out-cli-grammar.md
@@ -11,6 +11,8 @@ PR #78 deferred this as issue #81 with the note that once the live-out contract 
 
 ADR-0004 §5 commits to replacing `LiveOut` and `X86LiveOutMask` with the generic `RegisterSet<R>` (`src/semantics/live_out.rs`). That migration has since landed: the CLI parser now produces a `LiveOut` (= `RegisterSet<Register>`) directly with `flags_live` set on the mask, and the `bool` was dropped from `parse_live_out_contract`'s return type. The grammar itself is unchanged.
 
+This ADR also supersedes the equivalence-semantics portion of [ADR-0002](0002-mvp-restricts-flags-live-out.md) (the paragraph that described NZCV as unmodeled by the equivalence pipeline); see the Amendment block on that ADR for the delta. ADR-0002 remains the authority for the LLM-flow refusal of flag-live-out targets.
+
 ## Decision
 
 1. Add a free function `validation::live_out::parse_live_out_contract(s: &str) -> Result<LiveOut, ParseRegisterSetError>` implementing the grammar `<regs>` or `<regs>;<flags>`:

--- a/src/search/llm/mod.rs
+++ b/src/search/llm/mod.rs
@@ -112,7 +112,10 @@ impl SearchAlgorithm<crate::isa::AArch64> for LlmSearch {
         let mut timings = LlmTimings::default();
         let started = Instant::now();
 
-        // Per ADR-0002: refuse targets where flags are live-out.
+        // Per ADR-0002 (as amended by ADR-0006): the equivalence pipeline
+        // now models NZCV, but the LLM flow still refuses flag-live-out
+        // targets as a conservative pre-Codex gate. Removing this is a
+        // deliberate policy decision, not a bug.
         if flags_live_out(target) {
             eprintln!(
                 "llm-search: target has flags live-out (per ADR-0002 the LLM \

--- a/src/search/llm/mod.rs
+++ b/src/search/llm/mod.rs
@@ -118,8 +118,9 @@ impl SearchAlgorithm<crate::isa::AArch64> for LlmSearch {
         // deliberate policy decision, not a bug.
         if flags_live_out(target) {
             eprintln!(
-                "llm-search: target has flags live-out (per ADR-0002 the LLM \
-                 flow is not sound on this input). Refusing."
+                "llm-search: target has flags live-out — the LLM flow does \
+                 not process flag-live-out targets (conservative policy per \
+                 ADR-0002 as amended by ADR-0006). Refusing."
             );
             stats.elapsed_time = started.elapsed();
             self.last_stats = stats.clone();


### PR DESCRIPTION
## Summary

ADR-0002 (2026-05-07) called NZCV equivalence a "pre-existing soundness gap"; ADR-0006 (2026-05-18) shipped first-class NZCV in the equivalence contract (`LiveOut.flags_live` + `equiv --live-out '...;nzcv'`). With both ADRs Accepted, future readers had no source of truth. This PR reconciles them.

- **ADR-0002**: adds a 2026-05-19 Amendment block under Status/Date pointing to ADR-0006; Context rewritten in past tense; Consequences/Reversibility drop the "soundness gap" framing — the LLM static refusal is reframed as a conservative pre-Codex gate, not a soundness workaround.
- **ADR-0006**: one-line back-reference in Context noting the partial supersession of ADR-0002.
- **CONTEXT.md**: glossary "Flags-live-out (MVP exclusion)" renamed to "(LLM-flow exclusion)" and body rewritten; "Live-out" and "Observable state" entries updated so they no longer imply NZCV is unmodeled.
- **src/search/llm/mod.rs:115**: inline comment updated to cite ADR-0002-as-amended-by-ADR-0006.

No production logic changes. No public API moves. No new tests required — the existing `flags_live_out_target_is_refused_without_calling_codex` regression already pins the LLM refusal.

Closes #245

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**

## Test plan

- [x] `./ci_check.sh` clean (fmt, build, unit tests, doctests, full test suite)
- [x] Repo-wide sweep: no stray "soundness gap" / "MVP exclusion" prose in the reconciled docs surface; every `ADR-0002` reference is contextually consistent with the amendment