### PR TITLE
fix(smt): mask AArch64 register shift amount to width-1

### DIFF
--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -2135,6 +2135,52 @@ mod tests {
         );
     }
 
+    /// Issue #241 regression: AArch64 variable LSL consumes only the low 6
+    /// bits of the shift amount, so `lsl x0, x1, x2` differs from a sequence
+    /// that forces x0 to zero whenever x2 >= 64. Before the fix the SMT
+    /// lowering matched Z3's `bvshl` (which zeroes when shift >= width),
+    /// so the equivalence checker certified the rewrite. With the shift
+    /// amount masked to `width - 1`, the divergence at `x2 = 64` is visible
+    /// either as a fast-path counterexample (random tester edge values) or
+    /// a full SMT refutation.
+    #[test]
+    fn test_lsl_reg_shift_amount_masked_for_equivalence() {
+        use crate::ir::types::Condition;
+
+        let target = vec![Instruction::Lsl {
+            rd: Register::X0,
+            rn: Register::X1,
+            shift: Operand::Register(Register::X2),
+        }];
+        let candidate = vec![
+            Instruction::Lsl {
+                rd: Register::X0,
+                rn: Register::X1,
+                shift: Operand::Register(Register::X2),
+            },
+            Instruction::Cmp {
+                rn: Register::X2,
+                rm: Operand::Immediate(64),
+            },
+            Instruction::Csel {
+                rd: Register::X0,
+                rn: Register::XZR,
+                rm: Register::X0,
+                cond: Condition::CS,
+            },
+        ];
+        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
+        let result = check_equivalence_with_config(&target, &candidate, &config);
+        assert!(
+            matches!(
+                result,
+                EquivalenceResult::NotEquivalent | EquivalenceResult::NotEquivalentFast(_)
+            ),
+            "expected NotEquivalent or NotEquivalentFast for shift-mask divergence, got {:?}",
+            result
+        );
+    }
+
     // ===== Issue #69: terminator-identity precheck =====
 
     use crate::ir::LabelId;

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -395,22 +395,26 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
         }
         Instruction::Lsl { rd, rn, shift } => {
             let value = state.get_register(*rn).clone();
-            let shift_amount = state.eval_operand(shift);
-            // LSL is logical shift left
+            // AArch64 variable shifts consume only the low log2(width) bits
+            // (concrete.rs masks with `& 63`). Z3's `bvshl` zeroes the result
+            // when the shift amount is >= width, so we must mask first to
+            // keep SMT and concrete in agreement (issue #241).
+            let mask = BV::from_u64((width - 1) as u64, width);
+            let shift_amount = state.eval_operand(shift).bvand(&mask);
             let result = value.bvshl(&shift_amount);
             state.set_register(*rd, result);
         }
         Instruction::Lsr { rd, rn, shift } => {
             let value = state.get_register(*rn).clone();
-            let shift_amount = state.eval_operand(shift);
-            // LSR is logical shift right
+            let mask = BV::from_u64((width - 1) as u64, width);
+            let shift_amount = state.eval_operand(shift).bvand(&mask);
             let result = value.bvlshr(&shift_amount);
             state.set_register(*rd, result);
         }
         Instruction::Asr { rd, rn, shift } => {
             let value = state.get_register(*rn).clone();
-            let shift_amount = state.eval_operand(shift);
-            // ASR is arithmetic shift right
+            let mask = BV::from_u64((width - 1) as u64, width);
+            let shift_amount = state.eval_operand(shift).bvand(&mask);
             let result = value.bvashr(&shift_amount);
             state.set_register(*rd, result);
         }
@@ -2156,12 +2160,9 @@ mod tests {
     #[test]
     fn test_lsl_imm_concrete_smt_parity() {
         // LSL is width-sensitive: concrete (concrete.rs:84-88) masks the shift
-        // amount with `& 63` before applying. SMT relies on Z3 bvshl with a
-        // 64-bit shift operand. For shift in [0, 63] the two paths agree; the
-        // width-aware refactor in Step 6 must preserve that. Shift values >= 64
-        // are a known latent divergence in the SMT lowering (Z3 bvshl returns 0
-        // while AArch64 architecturally shifts by `shift & 63`) and are NOT
-        // tested here; addressing it is out of scope for the NFC stage.
+        // amount with `& 63` before applying. After the issue-#241 fix the
+        // SMT lowering masks the shift operand with `width - 1` too, so the
+        // two paths agree for all shift values including >= 64.
         let values: &[u64] = &[
             0,
             1,
@@ -2169,7 +2170,7 @@ mod tests {
             0x8000_0000_0000_0000,
             0x1234_5678_9ABC_DEF0,
         ];
-        let shifts: &[i64] = &[0, 1, 5, 16, 32, 63];
+        let shifts: &[i64] = &[0, 1, 5, 16, 32, 63, 64, 65, 127];
         for &v1 in values {
             for &shift in shifts {
                 let instr = Instruction::Lsl {
@@ -2192,7 +2193,7 @@ mod tests {
             0x8000_0000_0000_0000,
             0x1234_5678_9ABC_DEF0,
         ];
-        let shifts: &[i64] = &[0, 1, 5, 16, 32, 63];
+        let shifts: &[i64] = &[0, 1, 5, 16, 32, 63, 64, 65, 127];
         for &v1 in values {
             for &shift in shifts {
                 let instr = Instruction::Lsr {
@@ -2201,6 +2202,93 @@ mod tests {
                     shift: Operand::Immediate(shift),
                 };
                 assert_concrete_smt_parity(&instr, &[(Register::X1, v1)], Register::X0);
+            }
+        }
+    }
+
+    #[test]
+    fn test_lsl_reg_concrete_smt_parity() {
+        // Register-form LSL: shift amount comes from a register and may
+        // legitimately hold values >= 64. Issue #241: SMT lowering must
+        // mask with `width - 1` to mirror AArch64's `shift & 63`.
+        let instr = Instruction::Lsl {
+            rd: Register::X0,
+            rn: Register::X1,
+            shift: Operand::Register(Register::X2),
+        };
+        let values: &[u64] = &[
+            0,
+            1,
+            5,
+            0xFFFF_FFFF_FFFF_FFFF,
+            0x8000_0000_0000_0000,
+            0x1234_5678_9ABC_DEF0,
+        ];
+        let shifts: &[u64] = &[0, 1, 5, 63, 64, 65, 127, 128, u64::MAX];
+        for &v1 in values {
+            for &s in shifts {
+                assert_concrete_smt_parity(
+                    &instr,
+                    &[(Register::X1, v1), (Register::X2, s)],
+                    Register::X0,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_lsr_reg_concrete_smt_parity() {
+        // Register-form LSR: mirrors LSL coverage.
+        let instr = Instruction::Lsr {
+            rd: Register::X0,
+            rn: Register::X1,
+            shift: Operand::Register(Register::X2),
+        };
+        let values: &[u64] = &[
+            0,
+            1,
+            5,
+            0xFFFF_FFFF_FFFF_FFFF,
+            0x8000_0000_0000_0000,
+            0x1234_5678_9ABC_DEF0,
+        ];
+        let shifts: &[u64] = &[0, 1, 5, 63, 64, 65, 127, 128, u64::MAX];
+        for &v1 in values {
+            for &s in shifts {
+                assert_concrete_smt_parity(
+                    &instr,
+                    &[(Register::X1, v1), (Register::X2, s)],
+                    Register::X0,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_asr_reg_concrete_smt_parity() {
+        // Register-form ASR exercises sign-fill in addition to the issue
+        // #241 mask, so negative dividends are added to the matrix.
+        let instr = Instruction::Asr {
+            rd: Register::X0,
+            rn: Register::X1,
+            shift: Operand::Register(Register::X2),
+        };
+        let values: &[u64] = &[
+            0,
+            1,
+            (-1_i64) as u64,
+            (-16_i64) as u64,
+            0x8000_0000_0000_0000,
+            0x1234_5678_9ABC_DEF0,
+        ];
+        let shifts: &[u64] = &[0, 1, 5, 63, 64, 65, 127, 128, u64::MAX];
+        for &v1 in values {
+            for &s in shifts {
+                assert_concrete_smt_parity(
+                    &instr,
+                    &[(Register::X1, v1), (Register::X2, s)],
+                    Register::X0,
+                );
             }
         }
     }
@@ -3195,6 +3283,7 @@ mod tests {
         // ASR is sign-sensitive: concrete (concrete.rs:96-101) routes through
         // `as_i64() >> shift` then back to u64; SMT uses Z3 `bvashr` which
         // sign-preserves. Negative inputs (MSB set) must keep the sign bit.
+        // Shifts >= 64 exercise the issue-#241 mask path.
         let values: &[u64] = &[
             0,
             1,
@@ -3203,7 +3292,7 @@ mod tests {
             0x4000_0000_0000_0000, // positive, MSB-1 set
             0x1234_5678_9ABC_DEF0,
         ];
-        let shifts: &[i64] = &[0, 1, 5, 16, 32, 63];
+        let shifts: &[i64] = &[0, 1, 5, 16, 32, 63, 64, 65, 127];
         for &v1 in values {
             for &shift in shifts {
                 let instr = Instruction::Asr {


### PR DESCRIPTION
## Summary
- AArch64 variable `LSL/LSR/ASR` use only the low 6 bits of the shift amount (`shift & 63`); the SMT lowering was feeding the raw operand to Z3 (`bvshl/bvlshr/bvashr`), which zeroes the destination when the shift is ≥ width. The equivalence checker therefore reasoned about a different machine than concrete/hardware for register-form shifts, accepting unsound rewrites and rejecting sound ones at shift register values ≥ 64.
- Mask the SMT shift operand with `BV::from_u64((width - 1) as u64, width)` before `bvshl/bvlshr/bvashr` in `Instruction::Lsl/Lsr/Asr`, reusing the same idiom already used inside `bv_ror`. The width-parametric mask keeps the fix correct if a 32-bit AArch64 (W-register) lowering is ever added.
- Adds register-form parity tests (`test_{lsl,lsr,asr}_reg_concrete_smt_parity`) covering shift values 0, 1, 5, 63, 64, 65, 127, 128, u64::MAX; extends immediate-form tests up to shift 127; adds the issue reproduction as an equivalence-level regression (`test_lsl_reg_shift_amount_masked_for_equivalence`) under `LiveOut::from_registers(vec![X0])` with flags dead, asserting `NotEquivalent` or `NotEquivalentFast`.

Closes #241

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**

## Test plan
- [x] `cargo test --lib semantics::smt::tests::test_{lsl,lsr,asr}_{imm,reg}_concrete_smt_parity` — all pass.
- [x] `cargo test --lib test_lsl_reg_shift_amount_masked_for_equivalence` — passes.
- [x] `./ci_check.sh` — green (fmt + build + unit/integration tests + test_all.sh).
- [x] No new clippy warnings in `src/semantics/{smt,equivalence}.rs` regions touched (pre-existing warnings in `smt_x86.rs` are not part of the local CI gate).