### PR TITLE
fix(parallel): hybrid timeout and broadcasts cooperate with workers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -540,6 +540,38 @@ fn live_out_for_optimization_prefix(
     LiveOut::from_registers(live_registers)
 }
 
+/// Build the per-worker `SearchConfig` consumed by the hybrid parallel
+/// coordinator.
+///
+/// Issue #243: the CLI used to forget to propagate `options.timeout` into the
+/// `SearchConfig`, which left workers running with the default 60 s timeout
+/// even when the user passed a smaller `--timeout`. The coordinator-level
+/// `ParallelConfig::timeout` still acts as the primary deadline (now wired
+/// through `SharedBest::should_stop`); the search-config timeout is a
+/// per-worker backstop in case the coordinator itself stalls.
+fn build_hybrid_search_config(
+    options: &OptimizationOptions,
+    available_registers: Vec<Register>,
+    available_immediates: Vec<i64>,
+) -> SearchConfig {
+    let stochastic_config = StochasticConfig::default()
+        .with_beta(options.beta)
+        .with_iterations(options.iterations);
+
+    let symbolic_config = SymbolicConfig::default()
+        .with_search_mode(options.search_mode)
+        .with_timeout(options.solver_timeout);
+
+    SearchConfig::default()
+        .with_stochastic(stochastic_config)
+        .with_symbolic(symbolic_config)
+        .with_cost_metric(options.cost_metric)
+        .with_verbose(options.verbose)
+        .with_registers(available_registers)
+        .with_immediates(available_immediates)
+        .with_timeout_option(options.timeout)
+}
+
 /// Run optimization using the selected algorithm.
 ///
 /// Issue #69: if `target` ends in a terminator (branch / control-flow
@@ -719,21 +751,8 @@ fn run_optimization(
                 println!("  Base seed: {}", seed);
             }
 
-            let stochastic_config = StochasticConfig::default()
-                .with_beta(options.beta)
-                .with_iterations(options.iterations);
-
-            let symbolic_config = SymbolicConfig::default()
-                .with_search_mode(options.search_mode)
-                .with_timeout(options.solver_timeout);
-
-            let config = SearchConfig::default()
-                .with_stochastic(stochastic_config)
-                .with_symbolic(symbolic_config)
-                .with_cost_metric(options.cost_metric)
-                .with_verbose(options.verbose)
-                .with_registers(available_registers)
-                .with_immediates(available_immediates);
+            let config =
+                build_hybrid_search_config(options, available_registers, available_immediates);
 
             let parallel_config = ParallelConfig::default()
                 .with_workers(num_cores)
@@ -2404,6 +2423,28 @@ mod cli_helper_tests {
         stats.iterations = 10;
         stats.accepted_proposals = 5;
         print_search_statistics(&stats);
+    }
+
+    /// Regression for issue #243: the hybrid `SearchConfig` must inherit
+    /// `options.timeout` from the CLI, otherwise workers run with the
+    /// default 60 s timeout and the per-worker search loop is unbounded
+    /// (the coordinator-level deadline is now the primary cancel path, but
+    /// this stays as a backstop).
+    #[test]
+    fn build_hybrid_search_config_propagates_timeout() {
+        let mut opts = options_for(Algorithm::Hybrid);
+        opts.timeout = Some(Duration::from_millis(7));
+
+        let regs = vec![Register::X0];
+        let imms = vec![0, 1];
+        let config = build_hybrid_search_config(&opts, regs, imms);
+
+        assert_eq!(config.timeout, Some(Duration::from_millis(7)));
+
+        // None should propagate too.
+        opts.timeout = None;
+        let config = build_hybrid_search_config(&opts, vec![Register::X0], vec![0]);
+        assert_eq!(config.timeout, None);
     }
 
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1341,10 +1341,10 @@ fn parse_ccmp_like(
     }
     let rn = parse_register(operands[0])?;
     let rm = parse_operand(operands[1])?;
-    if let Operand::Immediate(imm) = rm {
-        if !(0..=31).contains(&imm) {
-            return Err(format!("{} imm5 {} out of range (0..=31)", mnem, imm));
-        }
+    if let Operand::Immediate(imm) = rm
+        && !(0..=31).contains(&imm)
+    {
+        return Err(format!("{} imm5 {} out of range (0..=31)", mnem, imm));
     }
     let nzcv_raw = parse_immediate(operands[2])?;
     if !(0..=15).contains(&nzcv_raw) {

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -724,7 +724,7 @@ pub fn generate_random_instruction<R: rand::RngExt>(
             };
             let rn = pick_non_sp(rng);
             let rm = match random_operand(rng, registers, immediates) {
-                Operand::Register(r) if r == Register::SP => Operand::Register(pick_non_sp(rng)),
+                Operand::Register(Register::SP) => Operand::Register(pick_non_sp(rng)),
                 Operand::Register(r) => Operand::Register(r),
                 Operand::Immediate(v) => Operand::Immediate(v.rem_euclid(32)),
                 // random_operand only returns Register/Immediate, but the

--- a/src/search/config.rs
+++ b/src/search/config.rs
@@ -4,6 +4,8 @@
 
 use crate::ir::Register;
 use crate::semantics::cost::CostMetric;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 
 /// Search algorithm selection
@@ -344,6 +346,13 @@ pub struct SearchConfig {
     pub llm: LlmConfig,
     /// Verbose output during search
     pub verbose: bool,
+    /// Cooperative-cancel flag shared with an external coordinator.
+    ///
+    /// Single-threaded search callers leave this `None`; the parallel
+    /// coordinator (`run_parallel_search`) clones `SharedBest::stop_flag()`
+    /// into the per-worker config so the inner search loop can poll
+    /// cancellation alongside its own `timeout` check.
+    pub stop_flag: Option<Arc<AtomicBool>>,
 }
 
 impl Default for SearchConfig {
@@ -371,6 +380,7 @@ impl Default for SearchConfig {
             symbolic: SymbolicConfig::default(),
             llm: LlmConfig::default(),
             verbose: false,
+            stop_flag: None,
         }
     }
 }
@@ -444,6 +454,17 @@ impl SearchConfig {
     /// Set the x86 register pool (issue #73).
     pub fn with_x86_registers(mut self, registers: Vec<crate::isa::x86::X86Register>) -> Self {
         self.x86_available_registers = registers;
+        self
+    }
+
+    /// Attach a cooperative-cancel flag observable by the inner search loop.
+    ///
+    /// The flag is shared by `Arc`; cloning the resulting `SearchConfig`
+    /// preserves the same underlying `AtomicBool`. Single-threaded callers
+    /// can leave this unset and the search loops fall back to their usual
+    /// `config.timeout` deadline.
+    pub fn with_stop_flag(mut self, flag: Arc<AtomicBool>) -> Self {
+        self.stop_flag = Some(flag);
         self
     }
 
@@ -607,6 +628,37 @@ mod tests {
         assert_eq!("linear".parse::<SearchMode>().unwrap(), SearchMode::Linear);
         assert_eq!("binary".parse::<SearchMode>().unwrap(), SearchMode::Binary);
         assert!("diagonal".parse::<SearchMode>().is_err());
+    }
+
+    #[test]
+    fn search_config_with_stop_flag_round_trips() {
+        use std::sync::atomic::Ordering;
+
+        // Default config has no stop flag.
+        assert!(SearchConfig::default().stop_flag.is_none());
+
+        let flag = Arc::new(AtomicBool::new(false));
+        let config = SearchConfig::default().with_stop_flag(Arc::clone(&flag));
+        let cloned = config.clone();
+
+        // Both the config field and the clone observe the same `AtomicBool`.
+        flag.store(true, Ordering::SeqCst);
+        assert!(
+            config
+                .stop_flag
+                .as_ref()
+                .map(|f| f.load(Ordering::SeqCst))
+                .unwrap_or(false),
+            "original config should observe the signalled flag",
+        );
+        assert!(
+            cloned
+                .stop_flag
+                .as_ref()
+                .map(|f| f.load(Ordering::SeqCst))
+                .unwrap_or(false),
+            "cloned config should observe the same flag (Arc-shared, not deep-copied)",
+        );
     }
 
     #[test]

--- a/src/search/parallel/channel.rs
+++ b/src/search/parallel/channel.rs
@@ -52,15 +52,18 @@ pub enum CoordinatorMessage {
 pub struct SharedBest {
     /// Current best cost (AtomicU64::MAX means no solution yet).
     pub best_cost: AtomicU64,
-    /// Flag to signal all workers to stop.
-    pub should_stop: AtomicBool,
+    /// Flag to signal all workers to stop. Held in an `Arc` so workers can
+    /// take an independently-owned handle via [`SharedBest::stop_flag`] and
+    /// poll it from inside their search loops without needing a reference
+    /// back to the parent `SharedBest`.
+    pub should_stop: Arc<AtomicBool>,
 }
 
 impl Default for SharedBest {
     fn default() -> Self {
         Self {
             best_cost: AtomicU64::new(u64::MAX),
-            should_stop: AtomicBool::new(false),
+            should_stop: Arc::new(AtomicBool::new(false)),
         }
     }
 }
@@ -98,6 +101,18 @@ impl SharedBest {
     /// Get the current best cost (u64::MAX if none found).
     pub fn current_best(&self) -> u64 {
         self.best_cost.load(Ordering::SeqCst)
+    }
+
+    /// Clone the cooperative-cancel flag for an independent observer.
+    ///
+    /// The returned `Arc<AtomicBool>` shares the same underlying flag as the
+    /// `SharedBest` it was cloned from; calling [`SharedBest::signal_stop`]
+    /// (on any clone of the parent `Arc<SharedBest>`) is observable through
+    /// the returned handle. Workers embed this in their `SearchConfig` so the
+    /// inner search loop can poll cancellation without holding a reference
+    /// back to the coordinator.
+    pub fn stop_flag(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.should_stop)
     }
 }
 
@@ -185,6 +200,27 @@ mod tests {
         assert!(!shared.should_stop());
         shared.signal_stop();
         assert!(shared.should_stop());
+    }
+
+    /// `stop_flag()` returns an independently-owned handle that observes
+    /// signals from any clone of the parent `Arc<SharedBest>`. This pins the
+    /// contract used by parallel workers: a worker keeps the flag in its
+    /// `SearchConfig` and polls it after the coordinator has flipped it.
+    #[test]
+    fn shared_best_stop_flag_clone_is_observed() {
+        let shared = Arc::new(SharedBest::default());
+        let flag = shared.stop_flag();
+        assert!(!flag.load(Ordering::SeqCst));
+
+        // Cloning the parent `Arc<SharedBest>` and signalling through the
+        // clone must still be observable through the previously-taken flag
+        // handle.
+        let other = Arc::clone(&shared);
+        // Drop the original to confirm the flag handle owns its own slot.
+        drop(shared);
+        other.signal_stop();
+
+        assert!(flag.load(Ordering::SeqCst));
     }
 
     #[test]

--- a/src/search/parallel/coordinator.rs
+++ b/src/search/parallel/coordinator.rs
@@ -107,9 +107,13 @@ fn run_coordinator(
         // Check if we've exceeded timeout
         if deadline.is_some_and(|d| Instant::now() >= d) {
             channels.shared.signal_stop();
-            // Broadcast stop to all workers
+            // Broadcast stop to all workers. `try_send` is intentional: the
+            // per-worker bounded(8) channel may already be full of advisory
+            // `BetterSolution` broadcasts, and `signal_stop()` above is the
+            // authoritative cancellation path (workers poll it via
+            // `config.stop_flag`). Dropping a redundant `Stop` is safe.
             for tx in &channels.to_workers {
-                let _ = tx.send(CoordinatorMessage::Stop);
+                let _ = tx.try_send(CoordinatorMessage::Stop);
             }
         }
 
@@ -126,10 +130,16 @@ fn run_coordinator(
                     // Check if this is actually better than current best
                     if channels.shared.try_update(cost) {
                         if config.solution_sharing {
-                            // Broadcast to other workers
+                            // Broadcast to other workers. `try_send` is
+                            // intentional: workers do not currently consume
+                            // `BetterSolution`, so the bounded(8) channel
+                            // can backfill. The blocking variant would stall
+                            // the coordinator while workers are still in
+                            // their inner search loop. Dropping a missed
+                            // advisory broadcast is safe.
                             for (i, tx) in channels.to_workers.iter().enumerate() {
                                 if i != worker_id {
-                                    let _ = tx.send(CoordinatorMessage::BetterSolution {
+                                    let _ = tx.try_send(CoordinatorMessage::BetterSolution {
                                         sequence: sequence.clone(),
                                         cost,
                                     });
@@ -218,8 +228,13 @@ fn run_worker(
 ) {
     let is_symbolic_worker = parallel_config.include_symbolic && worker_id == 0;
 
-    // Build worker-specific config
-    let mut config = search_config.clone();
+    // Build worker-specific config. Inject the coordinator's cooperative-
+    // cancel flag so the inner search loops (`StochasticSearch::search`,
+    // `SymbolicSearch::search`) honour `SharedBest::signal_stop` even when
+    // `config.timeout` is `None` (issue #243).
+    let mut config = search_config
+        .clone()
+        .with_stop_flag(channels.shared.stop_flag());
 
     if is_symbolic_worker {
         // Run symbolic search
@@ -377,14 +392,104 @@ mod tests {
         assert!(result.total_statistics.candidates_evaluated > 0);
     }
 
+    /// Regression for issue #243: the coordinator must use `try_send`, not
+    /// blocking `send`, when broadcasting to per-worker channels — otherwise
+    /// a backlog of `BetterSolution` messages can stall the coordinator
+    /// while workers are still in their inner search loop.
+    ///
+    /// We test the channel contract directly: fill a single bounded(8)
+    /// channel with 8 messages, then assert that a 9th `try_send` returns
+    /// `Err(TrySendError::Full)` instead of blocking. This pins the
+    /// non-blocking property the coordinator now relies on.
+    #[test]
+    fn coordinator_does_not_stall_when_worker_channels_full() {
+        use crate::ir::{Operand, Register};
+        use crate::search::parallel::channel::{
+            CoordinatorMessage, WorkerMessage, create_channels,
+        };
+        use crossbeam_channel::TrySendError;
+
+        let (coordinator, _workers) = create_channels(1);
+        let tx = &coordinator.to_workers[0];
+
+        let seq = vec![Instruction::Add {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Immediate(1),
+        }];
+
+        // Fill the bounded(8) channel.
+        for cost in 0..8 {
+            tx.try_send(CoordinatorMessage::BetterSolution {
+                sequence: seq.clone(),
+                cost,
+            })
+            .expect("first 8 sends should fit in the bounded(8) channel");
+        }
+
+        // 9th `try_send` must fail with Full, not block.
+        let err = tx
+            .try_send(CoordinatorMessage::BetterSolution {
+                sequence: seq.clone(),
+                cost: 8,
+            })
+            .expect_err("9th try_send should fail because channel is full");
+        assert!(matches!(err, TrySendError::Full(_)));
+
+        // Stop broadcasts must also fall through to try_send drop-on-full.
+        let err = tx
+            .try_send(CoordinatorMessage::Stop)
+            .expect_err("Stop try_send should also fail when channel is full");
+        assert!(matches!(err, TrySendError::Full(_)));
+
+        // Sanity: no worker-side message dropped on the coordinator->worker
+        // channel; the worker→coordinator channel is unaffected.
+        let _ = WorkerMessage::Finished {
+            worker_id: 0,
+            candidates_evaluated: 0,
+        };
+    }
+
+    /// Regression for issue #243: hybrid coordinator with `Duration::ZERO`
+    /// timeout and unbounded worker iterations (no `SearchConfig::timeout`)
+    /// must return promptly. Pre-fix, the workers ignored the coordinator's
+    /// `signal_stop` and burned through `u64::MAX / 4` MCMC iterations.
+    #[test]
+    fn coordinator_timeout_zero_returns_promptly_with_no_search_timeout() {
+        let target = mov_add_sequence();
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
+
+        let search_config = SearchConfig::default()
+            .with_timeout_option(None)
+            .with_registers(vec![Register::X0, Register::X1])
+            .with_immediates(vec![0, 1, 2])
+            .with_stochastic(StochasticConfig::default().with_iterations(u64::MAX / 4));
+
+        let parallel_config = ParallelConfig::default()
+            .with_workers(2)
+            .with_symbolic(false)
+            .with_timeout(Duration::ZERO);
+
+        let start = Instant::now();
+        let _result = run_parallel_search(&target, &live_out, &search_config, &parallel_config);
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "expected run_parallel_search to return within 1 s when the \
+             coordinator deadline is Duration::ZERO; took {:?}",
+            elapsed,
+        );
+    }
+
     // Issue #77 stage 1 step 2 safety net:
     // verify that every spawned worker reports Finished and that no per-worker
     // statistics are silently dropped. Stage 1 step 12 genericises the
     // coordinator + channel types over <I: ISA>; this test must keep passing
     // through that refactor. Iteration count is sized so all workers finish
-    // naturally well inside the timeout (the current stochastic worker does
-    // not check CoordinatorMessage::Stop mid-search; timeout-driven shutdown
-    // is out of scope here).
+    // naturally well inside the timeout — keeping completion deterministic
+    // for this assertion. (Timeout-driven shutdown is now covered by
+    // `coordinator_timeout_zero_returns_promptly_with_no_search_timeout`.)
     #[test]
     fn test_parallel_search_no_dropped_finished_messages() {
         let target = mov_add_sequence();

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -27,6 +27,7 @@ use crate::semantics::state::ConcreteMachineState;
 use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use std::marker::PhantomData;
+use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
 
 /// Stochastic search using Metropolis-Hastings MCMC, generic over ISA.
@@ -163,6 +164,19 @@ where
                 if config.verbose {
                     println!("Search timed out after {} iterations", iteration);
                 }
+                break;
+            }
+
+            // Cooperative cancel: the parallel coordinator (or any external
+            // driver) can flip the shared flag to stop us promptly without
+            // waiting for `config.timeout` to elapse. `Relaxed` is fine: the
+            // flag is monotonic (false → true once) and late observation
+            // costs at most one extra iteration.
+            if config
+                .stop_flag
+                .as_ref()
+                .is_some_and(|f| f.load(Ordering::Relaxed))
+            {
                 break;
             }
 
@@ -479,6 +493,57 @@ mod tests {
         assert!(stats.elapsed_time.as_nanos() > 0);
         assert_eq!(stats.iterations, 1000);
         assert!(stats.candidates_evaluated >= stats.candidates_passed_fast);
+    }
+
+    /// Regression for issue #243: a stochastic search must abort promptly
+    /// when an external coordinator flips its cooperative-cancel flag, even
+    /// if `config.timeout` is `None` and `iterations` is unbounded.
+    #[test]
+    fn stochastic_search_respects_cooperative_stop_flag() {
+        use std::sync::Arc;
+        use std::sync::atomic::AtomicBool;
+        use std::thread;
+        use std::time::{Duration, Instant};
+
+        let flag = Arc::new(AtomicBool::new(false));
+        let flag_for_search = Arc::clone(&flag);
+
+        let configured_iterations: u64 = u64::MAX / 2;
+        let join = thread::spawn(move || {
+            let mut search: StochasticSearch<AArch64> = StochasticSearch::new();
+            let config = SearchConfig::default()
+                .with_timeout_option(None)
+                .with_stop_flag(flag_for_search)
+                .with_registers(vec![Register::X0, Register::X1])
+                .with_immediates(vec![-1, 0, 1])
+                .with_stochastic(
+                    StochasticConfig::default()
+                        .with_iterations(configured_iterations)
+                        .with_seed(7),
+                );
+            let live_out = LiveOut::from_registers(vec![Register::X0]);
+            let target = mov_add_sequence();
+            search.search(&target, &live_out, &config)
+        });
+
+        // Give the worker a moment to enter its main loop, then signal stop.
+        thread::sleep(Duration::from_millis(20));
+        flag.store(true, std::sync::atomic::Ordering::SeqCst);
+
+        let started_join = Instant::now();
+        let result = join.join().expect("stochastic worker panicked");
+        let join_elapsed = started_join.elapsed();
+
+        assert!(
+            join_elapsed < Duration::from_secs(2),
+            "stop flag should abort the MCMC loop promptly; took {:?}",
+            join_elapsed,
+        );
+        assert!(
+            result.statistics.iterations < configured_iterations,
+            "search should have aborted before exhausting iterations; got {}",
+            result.statistics.iterations,
+        );
     }
 
     #[test]

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -24,8 +24,8 @@ use std::time::{Duration, Instant};
 /// True if the configured `timeout` has elapsed *or* an external
 /// coordinator (e.g. the parallel hybrid coordinator) has flipped the
 /// cooperative-cancel flag carried in `config.stop_flag`. Centralised so
-/// the four checkpoint sites in `linear_search` / `search_at_length`
-/// stay in sync.
+/// the checkpoint sites in `linear_search` / `search_at_length` stay
+/// in sync.
 fn should_stop(config: &SearchConfig, start_time: Instant) -> bool {
     if config.timeout.is_some_and(|t| start_time.elapsed() >= t) {
         return true;
@@ -179,6 +179,10 @@ where
                 }
 
                 for instr2 in all_instructions {
+                    if should_stop(config, start_time) {
+                        return best_at_length;
+                    }
+
                     let candidate = with_term(vec![*instr1, *instr2]);
                     let candidate_cost = <I as SymbolicBackend<I>>::sequence_cost(
                         &candidate,
@@ -391,9 +395,196 @@ where
 mod tests {
     use super::*;
     use crate::ir::{Instruction, Operand, Register};
-    use crate::isa::AArch64;
+    use crate::isa::{AArch64, ISA, ISAMutator, InstructionType, OperandType, RegisterType, U64};
     use crate::search::config::SymbolicConfig;
+    use crate::semantics::EquivalenceMetrics;
+    use crate::semantics::cost::CostMetric;
     use crate::semantics::live_out::LiveOut;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    static LENGTH_TWO_EQUIVALENCE_CHECKS: AtomicUsize = AtomicUsize::new(0);
+
+    #[derive(Clone)]
+    struct TestIsa;
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+    struct TestRegister;
+
+    impl std::fmt::Display for TestRegister {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "R0")
+        }
+    }
+
+    impl RegisterType for TestRegister {
+        fn index(&self) -> Option<u8> {
+            Some(0)
+        }
+
+        fn from_index(idx: u8) -> Option<Self> {
+            (idx == 0).then_some(Self)
+        }
+
+        fn is_zero_register(&self) -> bool {
+            false
+        }
+
+        fn is_special(&self) -> bool {
+            false
+        }
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+    enum TestOperand {
+        Reg(TestRegister),
+        Imm(i64),
+    }
+
+    impl std::fmt::Display for TestOperand {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Reg(reg) => write!(f, "{reg}"),
+                Self::Imm(imm) => write!(f, "#{imm}"),
+            }
+        }
+    }
+
+    impl OperandType for TestOperand {
+        type Register = TestRegister;
+
+        fn as_register(&self) -> Option<Self::Register> {
+            match self {
+                Self::Reg(reg) => Some(*reg),
+                Self::Imm(_) => None,
+            }
+        }
+
+        fn as_immediate(&self) -> Option<i64> {
+            match self {
+                Self::Reg(_) => None,
+                Self::Imm(imm) => Some(*imm),
+            }
+        }
+
+        fn from_register(reg: Self::Register) -> Self {
+            Self::Reg(reg)
+        }
+
+        fn from_immediate(imm: i64) -> Self {
+            Self::Imm(imm)
+        }
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+    struct TestInstruction(u8);
+
+    impl std::fmt::Display for TestInstruction {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "test{}", self.0)
+        }
+    }
+
+    impl InstructionType for TestInstruction {
+        type Register = TestRegister;
+        type Operand = TestOperand;
+
+        fn destination(&self) -> Option<Self::Register> {
+            Some(TestRegister)
+        }
+
+        fn source_registers(&self) -> Vec<Self::Register> {
+            Vec::new()
+        }
+
+        fn opcode_id(&self) -> u8 {
+            self.0
+        }
+
+        fn mnemonic(&self) -> &'static str {
+            "test"
+        }
+    }
+
+    struct TestMutator;
+
+    impl ISAMutator<TestInstruction> for TestMutator {
+        fn mutate<R: rand::RngExt>(
+            &self,
+            _rng: &mut R,
+            sequence: &[TestInstruction],
+        ) -> Vec<TestInstruction> {
+            sequence.to_vec()
+        }
+    }
+
+    impl ISA for TestIsa {
+        type Register = TestRegister;
+        type Operand = TestOperand;
+        type Instruction = TestInstruction;
+        type Width = U64;
+        type Flags = ();
+        type Mutator = TestMutator;
+
+        fn name(&self) -> &'static str {
+            "Test"
+        }
+
+        fn register_count(&self) -> usize {
+            1
+        }
+
+        fn instruction_size(&self) -> Option<usize> {
+            Some(1)
+        }
+
+        fn general_registers(&self) -> Vec<Self::Register> {
+            vec![TestRegister]
+        }
+
+        fn zero_register(&self) -> Option<Self::Register> {
+            None
+        }
+    }
+
+    impl SymbolicBackend<TestIsa> for TestIsa {
+        type LiveOut = ();
+
+        fn registers_from_config(_config: &SearchConfig) -> Vec<TestRegister> {
+            vec![TestRegister]
+        }
+
+        fn immediates_from_config(_config: &SearchConfig) -> Vec<i64> {
+            vec![0]
+        }
+
+        fn enumerate_all(_regs: &[TestRegister], _imms: &[i64]) -> Vec<TestInstruction> {
+            vec![TestInstruction(0)]
+        }
+
+        fn sequence_cost(seq: &[TestInstruction], _metric: &CostMetric, _width: u32) -> u64 {
+            seq.len() as u64
+        }
+
+        fn check_equivalence(
+            _target: &[TestInstruction],
+            _proposal: &[TestInstruction],
+            _live_out: &Self::LiveOut,
+            _width: u32,
+            _timeout: Duration,
+        ) -> (EquivalenceResult, EquivalenceMetrics) {
+            LENGTH_TWO_EQUIVALENCE_CHECKS.fetch_add(1, Ordering::SeqCst);
+            std::thread::sleep(Duration::from_millis(1));
+            (
+                EquivalenceResult::NotEquivalent,
+                EquivalenceMetrics::default(),
+            )
+        }
+
+        fn width(_config: &SearchConfig) -> u32 {
+            64
+        }
+    }
 
     fn mov_add_sequence() -> Vec<Instruction> {
         vec![
@@ -529,7 +720,7 @@ mod tests {
         use std::sync::Arc;
         use std::sync::atomic::AtomicBool;
         use std::thread;
-        use std::time::{Duration, Instant};
+        use std::time::Instant;
 
         let flag = Arc::new(AtomicBool::new(false));
         let flag_for_search = Arc::clone(&flag);
@@ -568,6 +759,57 @@ mod tests {
             join_elapsed < Duration::from_secs(2),
             "stop flag should abort the symbolic loop promptly; took {:?}",
             join_elapsed,
+        );
+    }
+
+    #[test]
+    fn symbolic_length_two_inner_loop_respects_cooperative_stop_flag() {
+        use std::sync::Arc;
+        use std::sync::atomic::AtomicBool;
+        use std::thread;
+        use std::time::Instant;
+
+        LENGTH_TWO_EQUIVALENCE_CHECKS.store(0, Ordering::SeqCst);
+
+        let flag = Arc::new(AtomicBool::new(false));
+        let flag_for_stop = Arc::clone(&flag);
+
+        let stopper = thread::spawn(move || {
+            while LENGTH_TWO_EQUIVALENCE_CHECKS.load(Ordering::SeqCst) == 0 {
+                thread::yield_now();
+            }
+            flag_for_stop.store(true, Ordering::SeqCst);
+        });
+
+        let mut search: SymbolicSearch<TestIsa> = SymbolicSearch::new();
+        let config = SearchConfig::default()
+            .with_timeout_option(None)
+            .with_stop_flag(flag);
+        let all_instructions: Vec<_> = (0..64).map(TestInstruction).collect();
+        let target = [
+            TestInstruction(100),
+            TestInstruction(101),
+            TestInstruction(102),
+        ];
+        let mut best_cost = u64::MAX;
+
+        let result = search.search_at_length(
+            &target,
+            &(),
+            &config,
+            &all_instructions,
+            2,
+            &mut best_cost,
+            Instant::now(),
+        );
+
+        stopper.join().expect("stopper thread panicked");
+
+        let checks = LENGTH_TWO_EQUIVALENCE_CHECKS.load(Ordering::SeqCst);
+        assert_eq!(result, None);
+        assert!(
+            checks < 8,
+            "length-2 search should poll cancellation inside the instr2 loop; ran {checks} checks",
         );
     }
 

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -228,10 +228,16 @@ where
                     if count >= sample_size {
                         break;
                     }
+                    if should_stop(config, start_time) {
+                        return best_at_length;
+                    }
 
                     for instr3 in all_instructions {
                         if count >= sample_size {
                             break;
+                        }
+                        if should_stop(config, start_time) {
+                            return best_at_length;
                         }
 
                         let candidate = if length == 3 {
@@ -403,7 +409,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
-    static LENGTH_TWO_EQUIVALENCE_CHECKS: AtomicUsize = AtomicUsize::new(0);
+    static TEST_EQUIVALENCE_CHECKS: AtomicUsize = AtomicUsize::new(0);
 
     #[derive(Clone)]
     struct TestIsa;
@@ -573,7 +579,7 @@ mod tests {
             _width: u32,
             _timeout: Duration,
         ) -> (EquivalenceResult, EquivalenceMetrics) {
-            LENGTH_TWO_EQUIVALENCE_CHECKS.fetch_add(1, Ordering::SeqCst);
+            TEST_EQUIVALENCE_CHECKS.fetch_add(1, Ordering::SeqCst);
             std::thread::sleep(Duration::from_millis(1));
             (
                 EquivalenceResult::NotEquivalent,
@@ -769,13 +775,13 @@ mod tests {
         use std::thread;
         use std::time::Instant;
 
-        LENGTH_TWO_EQUIVALENCE_CHECKS.store(0, Ordering::SeqCst);
+        TEST_EQUIVALENCE_CHECKS.store(0, Ordering::SeqCst);
 
         let flag = Arc::new(AtomicBool::new(false));
         let flag_for_stop = Arc::clone(&flag);
 
         let stopper = thread::spawn(move || {
-            while LENGTH_TWO_EQUIVALENCE_CHECKS.load(Ordering::SeqCst) == 0 {
+            while TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst) == 0 {
                 thread::yield_now();
             }
             flag_for_stop.store(true, Ordering::SeqCst);
@@ -805,11 +811,63 @@ mod tests {
 
         stopper.join().expect("stopper thread panicked");
 
-        let checks = LENGTH_TWO_EQUIVALENCE_CHECKS.load(Ordering::SeqCst);
+        let checks = TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst);
         assert_eq!(result, None);
         assert!(
             checks < 8,
             "length-2 search should poll cancellation inside the instr2 loop; ran {checks} checks",
+        );
+    }
+
+    #[test]
+    fn symbolic_length_three_inner_loops_respect_cooperative_stop_flag() {
+        use std::sync::Arc;
+        use std::sync::atomic::AtomicBool;
+        use std::thread;
+        use std::time::Instant;
+
+        TEST_EQUIVALENCE_CHECKS.store(0, Ordering::SeqCst);
+
+        let flag = Arc::new(AtomicBool::new(false));
+        let flag_for_stop = Arc::clone(&flag);
+
+        let stopper = thread::spawn(move || {
+            while TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst) == 0 {
+                thread::yield_now();
+            }
+            flag_for_stop.store(true, Ordering::SeqCst);
+        });
+
+        let mut search: SymbolicSearch<TestIsa> = SymbolicSearch::new();
+        let config = SearchConfig::default()
+            .with_timeout_option(None)
+            .with_stop_flag(flag);
+        let all_instructions: Vec<_> = (0..16).map(TestInstruction).collect();
+        let target = [
+            TestInstruction(100),
+            TestInstruction(101),
+            TestInstruction(102),
+            TestInstruction(103),
+        ];
+        let mut best_cost = u64::MAX;
+
+        let result = search.search_at_length(
+            &target,
+            &(),
+            &config,
+            &all_instructions,
+            3,
+            &mut best_cost,
+            Instant::now(),
+        );
+
+        stopper.join().expect("stopper thread panicked");
+
+        let checks = TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst);
+        assert_eq!(result, None);
+        assert!(
+            checks < 8,
+            "length-3 search should poll cancellation inside the instr2/instr3 loops; ran {checks} checks",
         );
     }
 

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -406,10 +406,12 @@ mod tests {
     use crate::semantics::EquivalenceMetrics;
     use crate::semantics::cost::CostMetric;
     use crate::semantics::live_out::LiveOut;
+    use std::sync::Mutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
     static TEST_EQUIVALENCE_CHECKS: AtomicUsize = AtomicUsize::new(0);
+    static SYMBOLIC_INNER_LOOP_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[derive(Clone)]
     struct TestIsa;
@@ -775,6 +777,9 @@ mod tests {
         use std::thread;
         use std::time::Instant;
 
+        let _guard = SYMBOLIC_INNER_LOOP_TEST_LOCK
+            .lock()
+            .expect("symbolic inner-loop test lock poisoned");
         TEST_EQUIVALENCE_CHECKS.store(0, Ordering::SeqCst);
 
         let flag = Arc::new(AtomicBool::new(false));
@@ -826,6 +831,9 @@ mod tests {
         use std::thread;
         use std::time::Instant;
 
+        let _guard = SYMBOLIC_INNER_LOOP_TEST_LOCK
+            .lock()
+            .expect("symbolic inner-loop test lock poisoned");
         TEST_EQUIVALENCE_CHECKS.store(0, Ordering::SeqCst);
 
         let flag = Arc::new(AtomicBool::new(false));

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -16,7 +16,25 @@ use crate::search::symbolic::backend::SymbolicBackend;
 use crate::search::{Algorithm, SearchAlgorithm};
 use crate::semantics::EquivalenceResult;
 use std::marker::PhantomData;
+use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
+
+/// Whether the symbolic search loop should exit at the next checkpoint.
+///
+/// True if the configured `timeout` has elapsed *or* an external
+/// coordinator (e.g. the parallel hybrid coordinator) has flipped the
+/// cooperative-cancel flag carried in `config.stop_flag`. Centralised so
+/// the four checkpoint sites in `linear_search` / `search_at_length`
+/// stay in sync.
+fn should_stop(config: &SearchConfig, start_time: Instant) -> bool {
+    if config.timeout.is_some_and(|t| start_time.elapsed() >= t) {
+        return true;
+    }
+    config
+        .stop_flag
+        .as_ref()
+        .is_some_and(|f| f.load(Ordering::Relaxed))
+}
 
 /// Symbolic search using SMT-based synthesis, generic over ISA.
 ///
@@ -66,8 +84,8 @@ where
                 println!("Searching for equivalent sequences of length {}...", length);
             }
 
-            // Check timeout
-            if config.timeout.is_some_and(|t| start_time.elapsed() >= t) {
+            // Check timeout / cooperative-cancel flag.
+            if should_stop(config, start_time) {
                 if config.verbose {
                     println!("Search timed out");
                 }
@@ -124,8 +142,8 @@ where
         if length == 1 {
             // Single instruction search
             for instr in all_instructions {
-                // Check timeout
-                if config.timeout.is_some_and(|t| start_time.elapsed() >= t) {
+                // Check timeout / cooperative-cancel flag.
+                if should_stop(config, start_time) {
                     return best_at_length;
                 }
 
@@ -155,8 +173,8 @@ where
         } else if length == 2 {
             // Two instruction search
             for instr1 in all_instructions {
-                // Check timeout periodically
-                if config.timeout.is_some_and(|t| start_time.elapsed() >= t) {
+                // Check timeout / cooperative-cancel flag periodically.
+                if should_stop(config, start_time) {
                     return best_at_length;
                 }
 
@@ -198,7 +216,7 @@ where
                 if count >= sample_size {
                     break;
                 }
-                if config.timeout.is_some_and(|t| start_time.elapsed() >= t) {
+                if should_stop(config, start_time) {
                     return best_at_length;
                 }
 
@@ -501,6 +519,56 @@ mod tests {
         // MOV X0, #0 is sufficient (or EOR X0, X0, X0)
         assert!(result.found_optimization);
         assert_eq!(result.cost_savings(), 1);
+    }
+
+    /// Regression for issue #243: symbolic search must abort promptly when
+    /// an external coordinator flips its cooperative-cancel flag, even if
+    /// `config.timeout` is `None` and the candidate space is large.
+    #[test]
+    fn symbolic_search_respects_cooperative_stop_flag() {
+        use std::sync::Arc;
+        use std::sync::atomic::AtomicBool;
+        use std::thread;
+        use std::time::{Duration, Instant};
+
+        let flag = Arc::new(AtomicBool::new(false));
+        let flag_for_search = Arc::clone(&flag);
+
+        let join = thread::spawn(move || {
+            let mut search: SymbolicSearch<AArch64> = SymbolicSearch::new();
+            let config = SearchConfig::default()
+                .with_timeout_option(None)
+                .with_stop_flag(flag_for_search)
+                .with_symbolic(SymbolicConfig::default().with_timeout(Duration::from_secs(60)))
+                .with_registers(vec![
+                    Register::X0,
+                    Register::X1,
+                    Register::X2,
+                    Register::X3,
+                    Register::X4,
+                    Register::X5,
+                ])
+                .with_immediates(vec![
+                    0, 1, 2, 3, 4, 5, 7, 8, 10, 15, 16, 31, 32, 63, 64, 100, 255, 256, 1000, 4095,
+                ]);
+            let live_out = LiveOut::from_registers(vec![Register::X0]);
+            let target = mov_add_sequence();
+            search.search(&target, &live_out, &config)
+        });
+
+        // Give the worker a moment to enter `search_at_length`, then signal stop.
+        thread::sleep(Duration::from_millis(20));
+        flag.store(true, std::sync::atomic::Ordering::SeqCst);
+
+        let started_join = Instant::now();
+        let _result = join.join().expect("symbolic worker panicked");
+        let join_elapsed = started_join.elapsed();
+
+        assert!(
+            join_elapsed < Duration::from_secs(2),
+            "stop flag should abort the symbolic loop promptly; took {:?}",
+            join_elapsed,
+        );
     }
 
     #[test]

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -16,13 +16,16 @@ use z3::{Params, Solver, Sort};
 /// slices with byte 0 placed in the most-significant position. `width` must
 /// be a multiple of 8.
 fn bv_swap_bytes(value: &BV, width: u32) -> BV {
-    debug_assert!(width % 8 == 0, "bv_swap_bytes requires byte-multiple width");
+    debug_assert!(
+        width.is_multiple_of(8),
+        "bv_swap_bytes requires byte-multiple width"
+    );
     let num_bytes = width / 8;
     let mut result = value.extract(7, 0);
     for i in 1..num_bytes {
         let lo = i * 8;
         let hi = lo + 7;
-        result = result.concat(&value.extract(hi, lo));
+        result = result.concat(value.extract(hi, lo));
     }
     result
 }
@@ -50,7 +53,7 @@ fn bv_reverse_bits(value: &BV, width: u32) -> BV {
     // Bit 0 of `value` becomes the new MSB; bit width-1 becomes the new LSB.
     let mut result = value.extract(0, 0);
     for i in 1..width {
-        result = result.concat(&value.extract(i, i));
+        result = result.concat(value.extract(i, i));
     }
     result
 }
@@ -384,7 +387,7 @@ pub fn compute_flags_sub(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let v = lhs_sign.bvxor(&rhs_sign).bvand(&lhs_sign.bvxor(&res_sign));
+    let v = lhs_sign.bvxor(&rhs_sign).bvand(lhs_sign.bvxor(&res_sign));
     (n, z, c, v)
 }
 
@@ -457,7 +460,7 @@ pub fn condition_to_smt(cond: crate::ir::types::Condition, n: &BV, z: &BV, c: &B
         Condition::GE => n_eq_v.clone(),
         Condition::LT => n_eq_v.bvxor(&one), // N != V
         Condition::GT => not_z.bvand(&n_eq_v),
-        Condition::LE => z.bvor(&n_eq_v.bvxor(&one)),
+        Condition::LE => z.bvor(n_eq_v.bvxor(&one)),
         Condition::AL => one.clone(),
         // NV (0b1111) is reserved but per ARM ARM still satisfies
         // condition_holds = true — equivalent to AL. Concrete execution
@@ -562,13 +565,13 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let a = state.get_register(*rn).clone();
             let b = state.get_register(*rm).clone();
             let c = state.get_register(*ra).clone();
-            state.set_register(*rd, c.bvadd(&a.bvmul(&b)));
+            state.set_register(*rd, c.bvadd(a.bvmul(&b)));
         }
         Instruction::Msub { rd, rn, rm, ra } => {
             let a = state.get_register(*rn).clone();
             let b = state.get_register(*rm).clone();
             let c = state.get_register(*ra).clone();
-            state.set_register(*rd, c.bvsub(&a.bvmul(&b)));
+            state.set_register(*rd, c.bvsub(a.bvmul(&b)));
         }
         Instruction::Mneg { rd, rn, rm } => {
             let a = state.get_register(*rn).clone();
@@ -616,8 +619,7 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.eval_operand(rm);
             let (n_t, z_t, c_t, v_t) = compute_flags_sub(&lhs, &rhs, width);
-            let pred =
-                condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
+            let pred = condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(bv_one());
             let (n_f, z_f, c_f, v_f) = nzcv_to_bvs(*nzcv);
             state.set_flags(
                 pred.ite(&n_t, &n_f),
@@ -630,8 +632,7 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.eval_operand(rm);
             let (n_t, z_t, c_t, v_t) = compute_flags_add(&lhs, &rhs, width);
-            let pred =
-                condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
+            let pred = condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(bv_one());
             let (n_f, z_f, c_f, v_f) = nzcv_to_bvs(*nzcv);
             state.set_flags(
                 pred.ite(&n_t, &n_f),
@@ -645,29 +646,25 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
         Instruction::Csel { rd, rn, rm, cond } => {
             let rn_v = state.get_register(*rn).clone();
             let rm_v = state.get_register(*rm).clone();
-            let pred =
-                condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
+            let pred = condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(bv_one());
             state.set_register(*rd, pred.ite(&rn_v, &rm_v));
         }
         Instruction::Csinc { rd, rn, rm, cond } => {
             let rn_v = state.get_register(*rn).clone();
-            let rm_plus_one = state.get_register(*rm).bvadd(&BV::from_u64(1, width));
-            let pred =
-                condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
+            let rm_plus_one = state.get_register(*rm).bvadd(BV::from_u64(1, width));
+            let pred = condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(bv_one());
             state.set_register(*rd, pred.ite(&rn_v, &rm_plus_one));
         }
         Instruction::Csinv { rd, rn, rm, cond } => {
             let rn_v = state.get_register(*rn).clone();
             let rm_not = state.get_register(*rm).bvnot();
-            let pred =
-                condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
+            let pred = condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(bv_one());
             state.set_register(*rd, pred.ite(&rn_v, &rm_not));
         }
         Instruction::Csneg { rd, rn, rm, cond } => {
             let rn_v = state.get_register(*rn).clone();
             let rm_neg = state.get_register(*rm).bvneg();
-            let pred =
-                condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
+            let pred = condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(bv_one());
             state.set_register(*rd, pred.ite(&rn_v, &rm_neg));
         }
         Instruction::Mvn { rd, rm } => {
@@ -759,15 +756,13 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
         }
         // CSET / CSETM: rd = cond ? 1 : 0 (or all-ones for CSETM).
         Instruction::Cset { rd, cond } => {
-            let pred =
-                condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
+            let pred = condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(bv_one());
             let one = BV::from_u64(1, width);
             let zero = BV::from_u64(0, width);
             state.set_register(*rd, pred.ite(&one, &zero));
         }
         Instruction::Csetm { rd, cond } => {
-            let pred =
-                condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
+            let pred = condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(bv_one());
             let ones = BV::from_i64(-1, width); // all-ones at any width
             let zero = BV::from_u64(0, width);
             state.set_register(*rd, pred.ite(&ones, &zero));
@@ -791,10 +786,10 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
         // folded is zero, clz is `width`, and the result is `width - 1`.
         Instruction::Cls { rd, rn } => {
             let value = state.get_register(*rn).clone();
-            let asr = value.bvashr(&BV::from_u64((width - 1) as u64, width));
+            let asr = value.bvashr(BV::from_u64((width - 1) as u64, width));
             let folded = value.bvxor(&asr);
             let clz = bv_clz(&folded, width);
-            let result = clz.bvsub(&BV::from_u64(1, width));
+            let result = clz.bvsub(BV::from_u64(1, width));
             state.set_register(*rd, result);
         }
         // RBIT: reverse the bits of the value.
@@ -818,11 +813,11 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
                 let mut acc = h.extract(7, 0);
                 for i in 1..4u32 {
                     let l = i * 8;
-                    acc = acc.concat(&h.extract(l + 7, l));
+                    acc = acc.concat(h.extract(l + 7, l));
                 }
                 acc
             };
-            let result = rev_half(&hi).concat(&rev_half(&lo));
+            let result = rev_half(&hi).concat(rev_half(&lo));
             state.set_register(*rd, result);
         }
         // REV16: byte-reverse within each 16-bit half (four halves).
@@ -832,7 +827,7 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let swap_half = |start: u32| -> BV {
                 value
                     .extract(start + 7, start)
-                    .concat(&value.extract(start + 15, start + 8))
+                    .concat(value.extract(start + 15, start + 8))
             };
             let h3 = swap_half(48);
             let h2 = swap_half(32);


### PR DESCRIPTION
## Summary

Hybrid parallel search ignored `--timeout` and could stall on solution-sharing broadcasts because workers did not observe coordinator cancellation and the coordinator used blocking sends into bounded per-worker channels that workers never drained.

This PR closes that gap with cooperative cancellation and drop-safe broadcasts:

- `SharedBest` exposes an `Arc<AtomicBool>` stop handle for workers.
- `SearchConfig` carries an optional cooperative `stop_flag` with default `None` for non-parallel callers.
- Stochastic and symbolic search loops poll the flag alongside their existing timeout checks, including the symbolic length-two inner loop.
- Hybrid workers receive the coordinator stop flag in their cloned `SearchConfig`.
- Coordinator `Stop` / `BetterSolution` broadcasts use `try_send` so full advisory channels cannot stall the coordinator.
- The hybrid CLI config path propagates user `options.timeout` into the worker `SearchConfig`.
- After rebasing onto current `origin/main`, a small separate commit applies mechanical clippy suggestions required by the local warning gate.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test --all` (986 lib tests, 42 bin tests, 23 integration tests, doctest pass/ignored as expected)
- [x] `./ci_check.sh`
- [x] Focused regressions: `stop_flag`, `coordinator_timeout_zero_returns_promptly_with_no_search_timeout`, `coordinator_does_not_stall_when_worker_channels_full`, and `build_hybrid_search_config_propagates_timeout`

Closes #243

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**
