### PR TITLE
docs(build): refresh BUILD.md and glue for current subcommand CLI

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -111,8 +111,8 @@ cargo test
 
 ## Performance Notes
 
-- Use **debug builds** (`just run`) for development — they compile faster
-- Use **release builds** (`just run-release`) for performance testing — they are significantly faster at runtime
+- Use **debug builds** (`just run`) for development - they compile faster
+- Use **release builds** (`just run-release`) for performance testing - they are significantly faster at runtime
 
 ## Example Session
 
@@ -159,7 +159,7 @@ cargo run -- opt /path/to/binary \
 ```
 
 The `opt` subcommand has many more flags (cost metric, MCMC tuning, SMT
-timeout, …) — see `cargo run -- opt --help` and `README.md` for the
+timeout, ...) - see `cargo run -- opt --help` and `README.md` for the
 full table.
 
 ### Example Output
@@ -218,7 +218,7 @@ cargo run -- disasm binaries/functions_opt
 The test suite demonstrates that s11 can:
 - Disassemble AArch64 and x86 ELF binaries across optimization levels.
 - Find shorter or cheaper equivalent instruction windows via `opt`
-  (enumerative, stochastic, symbolic, and — on AArch64 — hybrid / LLM
+  (enumerative, stochastic, symbolic, and - on AArch64 - hybrid / LLM
   search).
 - Prove equivalence of two assembly sequences via `equiv` and an
   explicit live-out set.

--- a/BUILD.md
+++ b/BUILD.md
@@ -141,7 +141,7 @@ and flag surface.
 cargo run -- disasm /path/to/binary
 
 # Or using just
-just run -- disasm /path/to/binary
+just analyze /path/to/binary
 ```
 
 `disasm` auto-detects the architecture from the ELF header; pass

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,6 +1,9 @@
 # Build Documentation
 
-This document explains how to build and run the AArch64 Super-Optimizer MVP.
+This document explains how to build and run s11, the AArch64 / x86
+superoptimizer. For the up-to-date list of supported instructions and
+search algorithms, see [`README.md`](README.md); this file only covers
+build, run, and test mechanics.
 
 ## Prerequisites
 
@@ -36,7 +39,7 @@ just clean
 ### Running the Application
 
 ```bash
-# Build and run in debug mode
+# Build and run in debug mode (prints clap help when given no subcommand)
 just run
 
 # Build and run in release mode (recommended for performance testing)
@@ -86,7 +89,7 @@ cargo clean
 ### Running the Application
 
 ```bash
-# Run in debug mode
+# Run in debug mode (prints clap help when given no subcommand)
 cargo run
 
 # Run in release mode
@@ -108,8 +111,8 @@ cargo test
 
 ## Performance Notes
 
-- Use **debug builds** (`just run`) for development - they compile faster
-- Use **release builds** (`just run-release`) for performance testing - they are significantly faster at runtime
+- Use **debug builds** (`just run`) for development — they compile faster
+- Use **release builds** (`just run-release`) for performance testing — they are significantly faster at runtime
 
 ## Example Session
 
@@ -117,56 +120,66 @@ cargo test
 # Check that everything compiles
 just check
 
-# Run the application
+# Show the available subcommands (s11 with no args prints help)
 just run
 
-# Build optimized version and run
-just run-release
+# Build optimized version
+just release
 ```
 
-## Current Functionality
+## Usage Examples
 
-The MVP demonstrates:
-1. **ELF Binary Analysis**: Read and disassemble AArch64 ELF binaries
-2. **IR Representation**: Basic AArch64 instructions (ADD, MOV with register/immediate variants)
-3. **Pattern Recognition**: Hardcoded equivalence patterns for demonstration
-4. **Enumerative Search**: Searches for shorter equivalent instruction sequences
+s11 is a subcommand-driven CLI. Run `s11 --help` (or `cargo run -- --help`)
+for the full list; the common entry points are `disasm`, `opt`, and
+`equiv`. See [`README.md`](README.md) for an overview of the algorithm
+and flag surface.
 
-### Usage Examples
+### Disassemble an ELF binary
 
-#### Analyze AArch64 ELF Binary
 ```bash
-# Analyze a binary file
-cargo run -- --binary /path/to/aarch64_binary
+# Pretty-print .text for an AArch64 or x86 ELF
+cargo run -- disasm /path/to/binary
 
 # Or using just
-just run -- --binary /path/to/aarch64_binary
+just run -- disasm /path/to/binary
 ```
+
+`disasm` auto-detects the architecture from the ELF header; pass
+`--arch x86-64` (etc.) if you want to override.
+
+### Optimize a window of instructions
+
+```bash
+# Search for a cheaper equivalent of the instructions between two
+# addresses (hex, inside .text). Use `disasm` first to find the
+# boundaries you care about.
+cargo run -- opt /path/to/binary \
+    --start-addr 0x740 --end-addr 0x758 \
+    --algorithm hybrid --cores 4 --timeout 30
+```
+
+The `opt` subcommand has many more flags (cost metric, MCMC tuning, SMT
+timeout, …) — see `cargo run -- opt --help` and `README.md` for the
+full table.
 
 ### Example Output
 
-**Binary Analysis:**
-```
-AArch64 Super-Optimizer MVP
-Analyzing ELF binary: test_binary
-ELF Header:
-  Architecture: AArch64
-  Entry point: 0x600
-  Type: Shared object
+`disasm` prints one instruction per line as `addr: bytes mnemonic operands`:
 
-Text sections:
-Section: .text (offset: 0x600, size: 328 bytes)
-Disassembly:
-  0x00000724: mov	w0, #5
-  0x00000728: str	w0, [sp, #0xc]
-  0x0000072c: ldr	w0, [sp, #0xc]
-  0x00000730: add	w0, w0, #1
-  ...
+```
+0x598: 3f2303d5 paciasp
+0x59c: fd7bbfa9 stp x29, x30, [sp, #-0x10]!
+0x5a0: fd030091 mov x29, sp
+0x5a4: 34000094 bl #0x674
+0x5a8: fd7bc1a8 ldp x29, x30, [sp], #0x10
+0x5ac: bf2303d5 autiasp
+0x5b0: c0035fd6 ret
+...
 ```
 
 ## Testing
 
-The repository includes a comprehensive test suite with C programs compiled for AArch64:
+The repository includes a comprehensive test suite with C programs compiled for AArch64 (and x86 where the host toolchain supports it):
 
 ### Build Test Binaries
 ```bash
@@ -178,7 +191,7 @@ This creates binaries in the `binaries/` directory:
 - `simple_*`: Basic arithmetic operations
 - `functions_*`: Function calls and loops
 - `loops_*`: Control flow and loops
-- `optimizable_*`: Code with obvious optimization opportunities  
+- `optimizable_*`: Code with obvious optimization opportunities
 - `arrays_*`: Array operations
 
 Each test has three versions: `_debug` (O0), `_opt` (O2), and `_opt3` (O3).
@@ -191,20 +204,23 @@ Each test has three versions: `_debug` (O0), `_opt` (O2), and `_opt3` (O3).
 
 ### Individual Tests
 ```bash
-# Test specific binaries
+# Disassemble a specific binary
 just analyze binaries/simple_debug
 just analyze binaries/simple_opt
 
 # Compare debug vs optimized versions
-cargo run -- --binary binaries/functions_debug
-cargo run -- --binary binaries/functions_opt
+cargo run -- disasm binaries/functions_debug
+cargo run -- disasm binaries/functions_opt
 ```
 
 ### Expected Results
 
-The test suite demonstrates:
-- **Simple arithmetic**: `5+3` optimized from multiple instructions to `mov w0, #8`
-- **Function inlining**: Complex function calls optimized to single constants
-- **Loop unrolling**: Multiplication loops replaced with `mul` instructions
-- **Dead code elimination**: Unused variables completely removed
-- **Constant folding**: Compile-time arithmetic evaluation
+The test suite demonstrates that s11 can:
+- Disassemble AArch64 and x86 ELF binaries across optimization levels.
+- Find shorter or cheaper equivalent instruction windows via `opt`
+  (enumerative, stochastic, symbolic, and — on AArch64 — hybrid / LLM
+  search).
+- Prove equivalence of two assembly sequences via `equiv` and an
+  explicit live-out set.
+
+See `README.md` for worked examples of the kinds of rewrites s11 finds.

--- a/Justfile
+++ b/Justfile
@@ -1,4 +1,4 @@
-# Justfile for the AArch64 Super-Optimizer MVP
+# Justfile for s11
 
 # Default recipe to run when `just` is called without arguments
 default: build
@@ -33,7 +33,7 @@ run-release: release
     # Alternatively, run the executable directly:
     # ./target/release/s11
 
-# Run tests (currently, the MVP doesn't have dedicated unit tests beyond main's demo)
+# Run tests
 test:
     @echo "Running tests..."
     cargo test
@@ -106,7 +106,7 @@ coverage: build-tests
     @echo "Collecting coverage (HTML)..."
     cargo llvm-cov --workspace --all-features --html
 
-# Emit an LCOV report at target/llvm-cov/lcov.info — the format consumed by CI/Codecov.
+# Emit an LCOV report at target/llvm-cov/lcov.info - the format consumed by CI/Codecov.
 coverage-lcov: build-tests
     @echo "Collecting coverage (LCOV)..."
     @mkdir -p target/llvm-cov
@@ -114,7 +114,7 @@ coverage-lcov: build-tests
 
 # Help message (can be more detailed than just listing)
 help:
-    @echo "Available commands for AArch64 Super-Optimizer MVP (run with 'just <command>'):"
+    @echo "Available commands for s11 (run with 'just <command>'):"
     @echo "  build         - Build the project (debug mode)"
     @echo "  release       - Build the project in release mode (optimized)"
     @echo "  run           - Build and run the project (debug mode)"

--- a/Justfile
+++ b/Justfile
@@ -57,10 +57,10 @@ fmt:
 list:
     @just --list
 
-# Analyze an AArch64 ELF binary
+# Disassemble an ELF binary (AArch64 or x86; arch auto-detected)
 analyze binary_path: build
-    @echo "Analyzing binary: {{binary_path}}"
-    cargo run -- --binary "{{binary_path}}"
+    @echo "Disassembling binary: {{binary_path}}"
+    cargo run -- disasm "{{binary_path}}"
 
 # Build test binaries
 build-tests:
@@ -119,7 +119,7 @@ help:
     @echo "  release       - Build the project in release mode (optimized)"
     @echo "  run           - Build and run the project (debug mode)"
     @echo "  run-release   - Build and run the project (release mode)"
-    @echo "  analyze PATH  - Analyze an AArch64 ELF binary at PATH"
+    @echo "  analyze PATH  - Disassemble an ELF binary at PATH (runs `s11 disasm`)"
     @echo "  test          - Run tests"
     @echo "  build-tests   - Build AArch64 test binaries"
     @echo "  test-all      - Run complete test suite"

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1341,10 +1341,10 @@ fn parse_ccmp_like(
     }
     let rn = parse_register(operands[0])?;
     let rm = parse_operand(operands[1])?;
-    if let Operand::Immediate(imm) = rm {
-        if !(0..=31).contains(&imm) {
-            return Err(format!("{} imm5 {} out of range (0..=31)", mnem, imm));
-        }
+    if let Operand::Immediate(imm) = rm
+        && !(0..=31).contains(&imm)
+    {
+        return Err(format!("{} imm5 {} out of range (0..=31)", mnem, imm));
     }
     let nzcv_raw = parse_immediate(operands[2])?;
     if !(0..=15).contains(&nzcv_raw) {

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -724,7 +724,7 @@ pub fn generate_random_instruction<R: rand::RngExt>(
             };
             let rn = pick_non_sp(rng);
             let rm = match random_operand(rng, registers, immediates) {
-                Operand::Register(r) if r == Register::SP => Operand::Register(pick_non_sp(rng)),
+                Operand::Register(Register::SP) => Operand::Register(pick_non_sp(rng)),
                 Operand::Register(r) => Operand::Register(r),
                 Operand::Immediate(v) => Operand::Immediate(v.rem_euclid(32)),
                 // random_operand only returns Register/Immediate, but the

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -16,13 +16,16 @@ use z3::{Params, Solver, Sort};
 /// slices with byte 0 placed in the most-significant position. `width` must
 /// be a multiple of 8.
 fn bv_swap_bytes(value: &BV, width: u32) -> BV {
-    debug_assert!(width % 8 == 0, "bv_swap_bytes requires byte-multiple width");
+    debug_assert!(
+        width.is_multiple_of(8),
+        "bv_swap_bytes requires byte-multiple width"
+    );
     let num_bytes = width / 8;
     let mut result = value.extract(7, 0);
     for i in 1..num_bytes {
         let lo = i * 8;
         let hi = lo + 7;
-        result = result.concat(&value.extract(hi, lo));
+        result = result.concat(value.extract(hi, lo));
     }
     result
 }
@@ -50,7 +53,7 @@ fn bv_reverse_bits(value: &BV, width: u32) -> BV {
     // Bit 0 of `value` becomes the new MSB; bit width-1 becomes the new LSB.
     let mut result = value.extract(0, 0);
     for i in 1..width {
-        result = result.concat(&value.extract(i, i));
+        result = result.concat(value.extract(i, i));
     }
     result
 }
@@ -384,7 +387,7 @@ pub fn compute_flags_sub(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let v = lhs_sign.bvxor(&rhs_sign).bvand(&lhs_sign.bvxor(&res_sign));
+    let v = lhs_sign.bvxor(&rhs_sign).bvand(lhs_sign.bvxor(&res_sign));
     (n, z, c, v)
 }
 
@@ -457,7 +460,7 @@ pub fn condition_to_smt(cond: crate::ir::types::Condition, n: &BV, z: &BV, c: &B
         Condition::GE => n_eq_v.clone(),
         Condition::LT => n_eq_v.bvxor(&one), // N != V
         Condition::GT => not_z.bvand(&n_eq_v),
-        Condition::LE => z.bvor(&n_eq_v.bvxor(&one)),
+        Condition::LE => z.bvor(n_eq_v.bvxor(&one)),
         Condition::AL => one.clone(),
         // NV (0b1111) is reserved but per ARM ARM still satisfies
         // condition_holds = true — equivalent to AL. Concrete execution
@@ -562,13 +565,13 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let a = state.get_register(*rn).clone();
             let b = state.get_register(*rm).clone();
             let c = state.get_register(*ra).clone();
-            state.set_register(*rd, c.bvadd(&a.bvmul(&b)));
+            state.set_register(*rd, c.bvadd(a.bvmul(&b)));
         }
         Instruction::Msub { rd, rn, rm, ra } => {
             let a = state.get_register(*rn).clone();
             let b = state.get_register(*rm).clone();
             let c = state.get_register(*ra).clone();
-            state.set_register(*rd, c.bvsub(&a.bvmul(&b)));
+            state.set_register(*rd, c.bvsub(a.bvmul(&b)));
         }
         Instruction::Mneg { rd, rn, rm } => {
             let a = state.get_register(*rn).clone();
@@ -616,8 +619,7 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.eval_operand(rm);
             let (n_t, z_t, c_t, v_t) = compute_flags_sub(&lhs, &rhs, width);
-            let pred =
-                condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
+            let pred = condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(bv_one());
             let (n_f, z_f, c_f, v_f) = nzcv_to_bvs(*nzcv);
             state.set_flags(
                 pred.ite(&n_t, &n_f),
@@ -630,8 +632,7 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.eval_operand(rm);
             let (n_t, z_t, c_t, v_t) = compute_flags_add(&lhs, &rhs, width);
-            let pred =
-                condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
+            let pred = condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(bv_one());
             let (n_f, z_f, c_f, v_f) = nzcv_to_bvs(*nzcv);
             state.set_flags(
                 pred.ite(&n_t, &n_f),
@@ -645,29 +646,25 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
         Instruction::Csel { rd, rn, rm, cond } => {
             let rn_v = state.get_register(*rn).clone();
             let rm_v = state.get_register(*rm).clone();
-            let pred =
-                condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
+            let pred = condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(bv_one());
             state.set_register(*rd, pred.ite(&rn_v, &rm_v));
         }
         Instruction::Csinc { rd, rn, rm, cond } => {
             let rn_v = state.get_register(*rn).clone();
-            let rm_plus_one = state.get_register(*rm).bvadd(&BV::from_u64(1, width));
-            let pred =
-                condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
+            let rm_plus_one = state.get_register(*rm).bvadd(BV::from_u64(1, width));
+            let pred = condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(bv_one());
             state.set_register(*rd, pred.ite(&rn_v, &rm_plus_one));
         }
         Instruction::Csinv { rd, rn, rm, cond } => {
             let rn_v = state.get_register(*rn).clone();
             let rm_not = state.get_register(*rm).bvnot();
-            let pred =
-                condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
+            let pred = condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(bv_one());
             state.set_register(*rd, pred.ite(&rn_v, &rm_not));
         }
         Instruction::Csneg { rd, rn, rm, cond } => {
             let rn_v = state.get_register(*rn).clone();
             let rm_neg = state.get_register(*rm).bvneg();
-            let pred =
-                condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
+            let pred = condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(bv_one());
             state.set_register(*rd, pred.ite(&rn_v, &rm_neg));
         }
         Instruction::Mvn { rd, rm } => {
@@ -759,15 +756,13 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
         }
         // CSET / CSETM: rd = cond ? 1 : 0 (or all-ones for CSETM).
         Instruction::Cset { rd, cond } => {
-            let pred =
-                condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
+            let pred = condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(bv_one());
             let one = BV::from_u64(1, width);
             let zero = BV::from_u64(0, width);
             state.set_register(*rd, pred.ite(&one, &zero));
         }
         Instruction::Csetm { rd, cond } => {
-            let pred =
-                condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(&bv_one());
+            let pred = condition_to_smt(*cond, &state.n, &state.z, &state.c, &state.v).eq(bv_one());
             let ones = BV::from_i64(-1, width); // all-ones at any width
             let zero = BV::from_u64(0, width);
             state.set_register(*rd, pred.ite(&ones, &zero));
@@ -791,10 +786,10 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
         // folded is zero, clz is `width`, and the result is `width - 1`.
         Instruction::Cls { rd, rn } => {
             let value = state.get_register(*rn).clone();
-            let asr = value.bvashr(&BV::from_u64((width - 1) as u64, width));
+            let asr = value.bvashr(BV::from_u64((width - 1) as u64, width));
             let folded = value.bvxor(&asr);
             let clz = bv_clz(&folded, width);
-            let result = clz.bvsub(&BV::from_u64(1, width));
+            let result = clz.bvsub(BV::from_u64(1, width));
             state.set_register(*rd, result);
         }
         // RBIT: reverse the bits of the value.
@@ -818,11 +813,11 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
                 let mut acc = h.extract(7, 0);
                 for i in 1..4u32 {
                     let l = i * 8;
-                    acc = acc.concat(&h.extract(l + 7, l));
+                    acc = acc.concat(h.extract(l + 7, l));
                 }
                 acc
             };
-            let result = rev_half(&hi).concat(&rev_half(&lo));
+            let result = rev_half(&hi).concat(rev_half(&lo));
             state.set_register(*rd, result);
         }
         // REV16: byte-reverse within each 16-bit half (four halves).
@@ -832,7 +827,7 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let swap_half = |start: u32| -> BV {
                 value
                     .extract(start + 7, start)
-                    .concat(&value.extract(start + 15, start + 8))
+                    .concat(value.extract(start + 15, start + 8))
             };
             let h3 = swap_half(48);
             let h2 = swap_half(32);

--- a/test_all.sh
+++ b/test_all.sh
@@ -33,11 +33,12 @@ run_test() {
     echo "=== Testing $name ==="
     echo "Binary: $binary"
     
-    # Run the analyzer and extract main function area
-    cargo run -- --binary "$binary" 2>/dev/null | \
-        awk '/Section: \.text/,/Section:|Binary analysis/' | \
+    # Run the disassembler and show the last ~20 instructions of .text
+    # (usually contains main). `s11 disasm` prints one
+    # "addr: bytes mnemonic" line per instruction with no header.
+    cargo run -- disasm "$binary" 2>/dev/null | \
         grep -E "0x[0-9a-f]+:" | \
-        tail -20  # Show last 20 instructions which usually include main
+        tail -20
     echo
 }
 

--- a/tests/integration/disasm_test.rs
+++ b/tests/integration/disasm_test.rs
@@ -214,3 +214,73 @@ fn test_disasm_requires_binary() {
         "Should print error about missing arguments"
     );
 }
+
+/// Issue #248: BUILD.md historically documented `s11 --binary <file>`,
+/// which is a legacy pre-subcommand invocation that no longer parses.
+/// This test pins that contract: the legacy form must be rejected, so
+/// any future regression that re-introduces a top-level `--binary` flag
+/// trips this test loudly instead of silently re-inviting the broken
+/// documentation.
+#[test]
+fn legacy_top_level_binary_flag_is_rejected() {
+    let binary = get_binary_path();
+    let test_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("binaries")
+        .join("simple_debug");
+    if !test_elf.exists() {
+        eprintln!("Skipping: {:?} not present (run build_tests.sh)", test_elf);
+        return;
+    }
+
+    let output = Command::new(binary)
+        .arg("--binary")
+        .arg(&test_elf)
+        .output()
+        .expect("Failed to execute s11");
+
+    assert!(
+        !output.status.success(),
+        "Legacy `--binary` form should not be accepted"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Usage: s11 <COMMAND>"),
+        "Expected clap usage hint with <COMMAND>; got stderr: {stderr}"
+    );
+}
+
+/// Issue #248 (counterpart to the test above): the form BUILD.md now
+/// documents — `s11 disasm <file>` — must succeed and print the
+/// `0xADDR: BYTES MNEMONIC` listing that BUILD.md's "Example Output"
+/// block claims it does. This is a small, fast guard against drift
+/// between the docs and the subcommand surface.
+#[test]
+fn documented_disasm_form_succeeds() {
+    let binary = get_binary_path();
+    let test_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("binaries")
+        .join("simple_debug");
+    if !test_elf.exists() {
+        eprintln!("Skipping: {:?} not present (run build_tests.sh)", test_elf);
+        return;
+    }
+
+    let output = Command::new(binary)
+        .arg("disasm")
+        .arg(&test_elf)
+        .output()
+        .expect("Failed to execute s11");
+
+    assert!(
+        output.status.success(),
+        "`s11 disasm <file>` (the documented form) should succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout
+            .lines()
+            .any(|line| line.trim_start().starts_with("0x")),
+        "disasm output should include `0xADDR:` lines as BUILD.md shows"
+    );
+}

--- a/tests/integration/disasm_test.rs
+++ b/tests/integration/disasm_test.rs
@@ -244,8 +244,8 @@ fn legacy_top_level_binary_flag_is_rejected() {
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("Usage: s11 <COMMAND>"),
-        "Expected clap usage hint with <COMMAND>; got stderr: {stderr}"
+        stderr.contains("<COMMAND>"),
+        "Expected clap subcommand-required hint mentioning <COMMAND>; got stderr: {stderr}"
     );
 }
 

--- a/tests/integration/disasm_test.rs
+++ b/tests/integration/disasm_test.rs
@@ -161,7 +161,7 @@ fn test_disasm_functions_binary() {
 
 /// Disassemble an x86-64 binary if build_tests.sh has produced one. We
 /// only assert that s11 exits successfully and reports the architecture
-/// header — we don't pin specific instruction mnemonics because the
+/// header - we don't pin specific instruction mnemonics because the
 /// compiler is free to choose any encoding it wants.
 #[test]
 fn test_disasm_x86_64_binary_if_present() {
@@ -187,7 +187,7 @@ fn test_disasm_x86_64_binary_if_present() {
         "s11 disasm failed on x86-64 binary: stderr={}",
         String::from_utf8_lossy(&output.stderr)
     );
-    // stdout in disasm mode is the per-instruction listing — should not
+    // stdout in disasm mode is the per-instruction listing - should not
     // contain the architecture header.
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("0x"), "expected hex addresses in output");
@@ -250,7 +250,7 @@ fn legacy_top_level_binary_flag_is_rejected() {
 }
 
 /// Issue #248 (counterpart to the test above): the form BUILD.md now
-/// documents — `s11 disasm <file>` — must succeed and print the
+/// documents - `s11 disasm <file>` - must succeed and print the
 /// `0xADDR: BYTES MNEMONIC` listing that BUILD.md's "Example Output"
 /// block claims it does. This is a small, fast guard against drift
 /// between the docs and the subcommand surface.


### PR DESCRIPTION
## Summary

`BUILD.md` still documented the retired pre-subcommand shape (`cargo run -- --binary <file>`), while the current CLI is subcommand-driven. This PR refreshes the BUILD.md examples around `s11 disasm <file>` and `s11 opt <file> --start-addr ... --end-addr ...`, and updates adjacent helper paths that still exercised the old form.

## What changed

- Rewrote BUILD.md usage, example output, and individual-test snippets to use `disasm` / `opt` instead of `--binary`.
- Retargeted `just analyze` and `test_all.sh` to `cargo run -- disasm <file>` so the documented helper commands keep working.
- Added integration coverage that rejects the legacy top-level `--binary` flag and proves the documented `s11 disasm <file>` form succeeds.
- Applied mechanical clippy fixes required by the current local warning set after rebasing the PR branch onto `origin/main`.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test --all`
- [x] `./ci_check.sh` (fmt check, build, build_tests, cargo test, test_all.sh)
- [x] `scripts/full_test.sh` checked: not present in this repository

Closes #248

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**
