### PR TITLE
test(candidate): cover random MADD-family generation

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,261 +1,68 @@
-# Plan — issue #242: Parallel statistics mislabel symbolic workers and drop most worker metrics
+# Plan - issue #175: Add `test_generate_random_reaches_madd_family`
 
-## 1. Problem restated
+## 1. Problem Restated
 
-`WorkerMessage::Finished` (src/search/parallel/channel.rs:29-33) only ships `candidates_evaluated`, and the coordinator's `Finished` arm (src/search/parallel/coordinator.rs:150-158) unconditionally synthesises a fresh `SearchStatistics::new(Algorithm::Stochastic)` for every worker, copying only that single field. The symbolic worker — which is always `worker_id == 0` in hybrid mode (src/search/parallel/coordinator.rs:219, src/search/parallel/coordinator.rs:251-272) — therefore appears as `Algorithm::Stochastic` in `worker_statistics`, and `total_statistics` is the sum of one field across workers. Every other stat (`smt_queries`, `smt_equivalent`, `candidates_passed_fast`, `smt_elapsed`, `iterations`, `accepted_proposals`, `improvements_found`, `original_cost`, `best_cost_found`) is silently zero. Because the hybrid CLI path prints `result.total_statistics` (src/main.rs:746), user-visible hybrid reports show 0 SMT/improvement/cost metrics even when a worker has provably found and verified an optimization.
+Issue #175 asks for a focused regression test proving that the AArch64 random candidate generator still reaches the multiply-accumulate instruction family after the dispatch slot that used to be the catch-all became an explicit `29 =>` arm. The existing exhaustive generator already covers `Madd`, `Msub`, `Mneg`, `Smulh`, and `Umulh`, but the stochastic path needs its own fixed-seed 5000-draw guard over `generate_random_instruction` so future refactors cannot silently make opcode IDs `42..=46` unreachable.
 
-Fix scope: make `Finished` carry the full per-worker `SearchStatistics` (including its `algorithm` field), and have `run_coordinator` aggregate fields field-by-field rather than synthesising stats from scratch. Also: when an improvement wins, `best_result.statistics` should reflect the actual winning worker's stats, not a hollow `SearchStatistics::new(algorithm)`.
+## 2. Files To Touch
 
-## 2. Files to touch
+- `src/search/candidate.rs` - add one unit test in the existing `#[cfg(test)] mod tests`, near the current random reachability tests and reusing `random_opcode_ids(seed, draws)`.
 
-Production:
-- `src/search/parallel/channel.rs` — extend `WorkerMessage::Finished` payload (add `algorithm: Algorithm`, `statistics: SearchStatistics`); drop the now-redundant standalone `candidates_evaluated` field (the value is `statistics.candidates_evaluated`).
-- `src/search/parallel/coordinator.rs` — three call sites:
-  - `run_symbolic_worker` (lines ~244-276): send `result.statistics` (already carries `Algorithm::Symbolic`) instead of just `candidates_evaluated`.
-  - `run_stochastic_worker` (lines ~279-315): same — send `result.statistics`.
-  - `run_coordinator` (lines ~91-208): change the `Finished` arm to push the received `(worker_id, stats.algorithm, stats)` directly; track the winning worker_id when an `Improvement` wins so `best_result.statistics` can be filled with that worker's final stats; rewrite the aggregate `total_stats` to sum/min relevant fields instead of synthesising. Update the `Improvement` arm so `best_result` is populated *only* with sequence + worker_id + cost — defer assigning `statistics` until all workers have reported.
+No production code should change unless the new test unexpectedly exposes a real mismatch in the current generator. There are no `crates/` or `compiler/` directories in this repository, so this is not a Rust-stage/self-hosted cross-cutting change. There is no `docs/spec/` tree; `docs/capability.md` and the ADRs do not need updates because this PR adds coverage for already-documented AArch64 support rather than changing syntax, semantics, CLI flags, contracts, or supported mnemonics.
 
-Tests:
-- `src/search/parallel/coordinator.rs` `#[cfg(test)] mod tests` — add the new hybrid regression test the issue asks for (see slice 1) and update the existing tests that assert the dropped-Finished invariant.
-- `src/search/parallel/channel.rs` `#[cfg(test)] mod tests` — `test_create_channels` constructs a `WorkerMessage::Finished` literally and pattern-matches on its fields; update both the construction and the destructure to the new shape.
+## 3. TDD Slices
 
-No `docs/spec/*.md` updates required — `docs/spec/` is not a thing in this repo (the s11 architecture lives in `CLAUDE.md` and `docs/` is benchmark/ADR-style content). The `ParallelResult` doc comment is the API contract; update it inline.
+1. Add the regression test skeleton in `src/search/candidate.rs`, immediately after `test_generate_random_reaches_csel_family` (currently around lines 1211-1258). Name it `test_generate_random_reaches_madd_family`. It should call `let ids = random_opcode_ids(0x66, 5_000);`, matching the nearby fixed-seed random reach tests.
 
-## 3. TDD slices
+2. In that test, assert that `ids` contains `opcode_id` for representative instructions for each family member:
+   - `Instruction::Madd { rd: X0, rn: X1, rm: X2, ra: X0 }` -> opcode ID 42
+   - `Instruction::Msub { rd: X0, rn: X1, rm: X2, ra: X0 }` -> opcode ID 43
+   - `Instruction::Mneg { rd: X0, rn: X1, rm: X2 }` -> opcode ID 44
+   - `Instruction::Smulh { rd: X0, rn: X1, rm: X2 }` -> opcode ID 45
+   - `Instruction::Umulh { rd: X0, rn: X1, rm: X2 }` -> opcode ID 46
+   Use the same `(label, instr)` loop and failure message shape as `test_generate_random_reaches_mul_div_family`, `test_generate_random_reaches_compare_family`, and `test_generate_random_reaches_csel_family` (lines 1140-1258).
 
-### Slice 1 — Red: hybrid statistics regression test
+3. Red-check the test as a regression guard without committing sabotage: temporarily alter the random dispatch locally so slot 29 no longer emits the MADD family, for example by making arm `29` emit only an existing non-MADD instruction, then run:
+   ```bash
+   cargo test search::candidate::tests::test_generate_random_reaches_madd_family -- --exact
+   ```
+   Confirm the new test fails with a "random never produced ..." assertion, then immediately revert the temporary production-code mutation.
 
-Add to `src/search/parallel/coordinator.rs::tests`:
+4. Green-check against the real code. The production implementation that should satisfy the test already exists at `src/search/candidate.rs:804-821`: slot `29` samples `rng.random_range(0..5)` and emits `Madd`, `Msub`, `Mneg`, `Smulh`, or `Umulh`. Run the targeted test again and expect it to pass.
 
-```rust
-#[test]
-fn test_parallel_search_symbolic_worker_statistics_are_propagated() { … }
-```
+5. Refactor only if the test body duplicates enough local boilerplate to be worth a tiny cleanup. Prefer keeping the test parallel to the three existing random reachability tests over introducing a new abstraction. Do not change opcode numbering, random dispatch probabilities, candidate generation behavior, or documentation.
 
-Behavior under test:
-- Run `run_parallel_search` with `include_symbolic = true`, `num_workers = 2`, on `mov_add_sequence()` with `LiveOut::from_registers(vec![Register::X0])`, registers `[X0, X1, X2]`, immediates `[-1, 0, 1, 2]`, symbolic config with a 10s solver timeout, stochastic iterations small enough to finish promptly, overall timeout ≥ 30s. (Mirror `test_symbolic_finds_mov_add_fusion` in src/search/symbolic/synthesis.rs:419 for hyperparameters known to land the optimization.)
-- Assert: exactly one entry in `result.worker_statistics` has `algorithm == Algorithm::Symbolic` and `worker_id == 0`; remaining entries have `algorithm == Algorithm::Stochastic`.
-- Assert: `result.total_statistics.smt_queries > 0` (proves symbolic stats are aggregated, not dropped).
-- Assert: `result.total_statistics.improvements_found > 0` (symbolic worker increments this when it finds the mov→add fusion — see src/search/symbolic/synthesis.rs:137,169,231).
-- Assert: `result.total_statistics.original_cost > 0` and `result.total_statistics.best_cost_found > 0` (proves cost fields are propagated).
-- Assert: `result.best_result.found_optimization == true` and `result.best_result.statistics.algorithm == Algorithm::Symbolic` (proves `best_result.statistics` is the winner's stats, not a stochastic placeholder).
+## 4. Verification Surface
 
-This will fail today because of the four bugs the issue calls out. It will pass after slices 2–6.
-
-### Slice 2 — Green: extend `WorkerMessage::Finished` payload
-
-Edit `src/search/parallel/channel.rs:29-33`:
-
-```rust
-Finished {
-    worker_id: usize,
-    algorithm: Algorithm,
-    statistics: SearchStatistics,
-},
-```
-
-(Drop the standalone `candidates_evaluated` field — `statistics.candidates_evaluated` carries the same value.)
-
-Add the `use crate::search::result::SearchStatistics;` import at the top of the file. Update the existing `test_create_channels` test (src/search/parallel/channel.rs:198-214) to construct the new shape:
-
-```rust
-let mut stats = SearchStatistics::new(Algorithm::Stochastic);
-stats.candidates_evaluated = 100;
-let msg = WorkerMessage::Finished {
-    worker_id: 0,
-    algorithm: Algorithm::Stochastic,
-    statistics: stats,
-};
-```
-
-…and destructure into `{ worker_id, algorithm, statistics }` in the assertion arm. Verify `worker_id == 0`, `algorithm == Algorithm::Stochastic`, `statistics.candidates_evaluated == 100`.
-
-At this point the project no longer compiles because the worker send sites are still using the old shape. Slice 3 fixes that.
-
-### Slice 3 — Green: worker send sites ship full stats
-
-In `src/search/parallel/coordinator.rs::run_symbolic_worker` and `::run_stochastic_worker`, replace:
-
-```rust
-let _ = channels.to_coordinator.send(WorkerMessage::Finished {
-    worker_id,
-    candidates_evaluated,
-});
-```
-
-with (per algorithm):
-
-```rust
-let _ = channels.to_coordinator.send(WorkerMessage::Finished {
-    worker_id,
-    algorithm: Algorithm::Symbolic, // or Algorithm::Stochastic
-    statistics: result.statistics.clone(),
-});
-```
-
-Note: `result.statistics.algorithm` is already set correctly by the search drivers (src/search/stochastic/mcmc.rs:81 and src/search/symbolic/synthesis.rs:35 both call `SearchStatistics::new(Algorithm::…)`). The explicit `algorithm:` on the message is for the coordinator's bookkeeping and to make the worker label invariant the test asserts; both fields agree by construction.
-
-The unused `candidates_evaluated` locals can be dropped (they are now only read in the `Improvement` send sites and may not even be needed there). Inspect: in the stochastic worker, `candidates_evaluated` is computed but only used in `Finished`; safe to remove. In the symbolic worker, same. Confirm during the edit.
-
-### Slice 4 — Green: rewrite the coordinator `Finished` arm and track the winning worker
-
-In `run_coordinator`:
-
-```rust
-let mut winning_worker_id: Option<usize> = None;
-```
-
-In the `Improvement` arm (after `if channels.shared.try_update(cost)` succeeds), remember the winner:
-
-```rust
-winning_worker_id = Some(worker_id);
-let result = SearchResult {
-    found_optimization: true,
-    original_sequence: target.to_vec(),
-    optimized_sequence: Some(sequence),
-    statistics: SearchStatistics::new(algorithm), // placeholder; filled in post-loop
-};
-best_result = Some(result);
-```
-
-(Keep the placeholder for now — the final value is set after the loop, slice 6.)
-
-Rewrite the `Finished` arm to:
-
-```rust
-WorkerMessage::Finished {
-    worker_id,
-    algorithm,
-    statistics,
-} => {
-    finished_count += 1;
-    let mut stats = statistics;
-    stats.elapsed_time = start_time.elapsed(); // wall-clock for this run, not the per-worker subtime
-    worker_stats.push((worker_id, algorithm, stats));
-    if finished_count >= total_workers {
-        break;
-    }
-}
-```
-
-Decision: we overwrite `stats.elapsed_time` with the coordinator's wall-clock-to-this-point. Rationale: per-worker `elapsed_time` from the search driver is the worker's *own* search wall-clock, which is consistent with what callers expect when comparing workers (they all started at `start_time`). Document this in the `ParallelResult` doc comment. (Alternative: keep the per-worker driver-reported value. We pick coordinator-clock to match today's behavior at src/search/parallel/coordinator.rs:157, minimising behavioral surprise for the existing dropped-Finished test.)
-
-### Slice 5 — Green: field-by-field aggregate
-
-Replace the post-loop block (src/search/parallel/coordinator.rs:186-194):
-
-```rust
-let elapsed = start_time.elapsed();
-let mut total_stats = SearchStatistics::new(Algorithm::Hybrid);
-total_stats.elapsed_time = elapsed;
-for (_, _, s) in &worker_stats {
-    total_stats.candidates_evaluated += s.candidates_evaluated;
-    total_stats.candidates_passed_fast += s.candidates_passed_fast;
-    total_stats.smt_queries += s.smt_queries;
-    total_stats.smt_elapsed += s.smt_elapsed;
-    total_stats.smt_equivalent += s.smt_equivalent;
-    total_stats.iterations += s.iterations;
-    total_stats.accepted_proposals += s.accepted_proposals;
-    total_stats.improvements_found += s.improvements_found;
-}
-// original_cost: workers see the same target, so any nonzero value works.
-// Take max to be defensive against zero-init workers (e.g. a worker that
-// failed before `search()` set the field).
-total_stats.original_cost = worker_stats
-    .iter()
-    .map(|(_, _, s)| s.original_cost)
-    .max()
-    .unwrap_or(0);
-// best_cost_found: minimum nonzero across workers, falling back to original_cost.
-total_stats.best_cost_found = worker_stats
-    .iter()
-    .map(|(_, _, s)| s.best_cost_found)
-    .filter(|&c| c > 0)
-    .min()
-    .unwrap_or(total_stats.original_cost);
-```
-
-`total_stats.algorithm` stays `Algorithm::Hybrid`.
-
-### Slice 6 — Green: best_result.statistics = winning worker's stats (or aggregate)
-
-After building `total_stats`, finalise `best_result.statistics`:
-
-```rust
-if let Some(ref mut br) = best_result {
-    if let Some(winner) = winning_worker_id
-        && let Some((_, _, ref winner_stats)) =
-            worker_stats.iter().find(|(id, _, _)| *id == winner)
-    {
-        br.statistics = winner_stats.clone();
-    } else {
-        // Workers finished after their Improvement message but their Finished
-        // never arrived (shouldn't happen given the loop exits on
-        // finished_count >= total_workers). Fall back to the aggregate so the
-        // CLI doesn't show zeroes.
-        br.statistics = total_stats.clone();
-    }
-}
-
-let final_result = best_result.unwrap_or_else(|| SearchResult {
-    found_optimization: false,
-    original_sequence: target.to_vec(),
-    optimized_sequence: None,
-    statistics: total_stats.clone(),
-});
-```
-
-Update the doc comment on `ParallelResult` (src/search/parallel/coordinator.rs:21-29):
-
-```rust
-/// Result from parallel search execution.
-///
-/// `best_result.statistics` is the *winning worker's* statistics when an
-/// optimization was found, and the cross-worker aggregate when none was.
-/// `total_statistics` is always the cross-worker aggregate (algorithm is
-/// `Algorithm::Hybrid`; `elapsed_time` is coordinator wall-clock; counter
-/// fields are sums; `original_cost` is max across workers; `best_cost_found`
-/// is min nonzero across workers, falling back to `original_cost`).
-/// `worker_statistics` carries the per-worker, per-algorithm breakdown.
-```
-
-### Slice 7 — Refactor: clean up existing tests
-
-- `test_create_channels` (src/search/parallel/channel.rs): updated in slice 2.
-- `test_parallel_search_no_dropped_finished_messages` (src/search/parallel/coordinator.rs:388-431): the assertion `total_statistics.candidates_evaluated > 0` continues to hold under the new aggregator. No edits expected unless cargo flags a compile error. Verify.
-- `test_parallel_search_single_worker` and `test_parallel_search_multiple_workers`: no statistical assertions broken; they should keep passing.
-
-### Slice 8 — `cargo fmt` and `./ci_check.sh`
-
-Run `cargo fmt --all`. Then `./ci_check.sh` (which the project's CLAUDE.md mandates pre-push). Address any clippy hits in the touched code only — do not bundle unrelated clippy fixes.
-
-## 4. Verification surface
-
-- **No ESBMC/contract verification**: this is a Rust-only API-contract bug. No `tests/run/` or `examples/` fixtures grow.
-- **Unit + integration**: `cargo test --workspace`. The slice-1 regression test exercises the new aggregation against a real hybrid run. The existing `test_parallel_search_no_dropped_finished_messages` continues to gate that every worker reports.
-- **Manual smoke (optional)**: `cargo run --release -- opt …` on an AArch64 ELF with `--algorithm hybrid` and watch `print_search_statistics(&result.total_statistics)` produce nonzero SMT and improvement numbers when the symbolic worker wins. Not required for the PR — the regression test is the authoritative check.
-
-## 5. Risk areas
-
-- **Hybrid CLI output (src/main.rs:746)**: now shows real SMT/improvement metrics. Numbers will be larger than they were yesterday for the same run — that's a fix, not a regression, but it's the most user-visible behavioural change in the PR. Mention in the PR body.
-- **`elapsed_time` semantics for per-worker stats**: I'm preserving today's behaviour (coordinator-clock at the moment each `Finished` arrives) rather than the worker's own reported `elapsed_time`. This keeps the existing dropped-Finished test working unchanged. Alternative discussed inline.
-- **Compile fan-out**: `WorkerMessage` is part of `crate::search::parallel::channel`. A quick grep for direct constructors outside `coordinator.rs` and `channel.rs` tests showed none. Worth one final pass during implementation:
+- No ESBMC proof work is needed. This does not touch contracts, codegen, the C model, SMT lowering, concrete semantics, parser behavior, or the binary patching path.
+- No `tests/run/`, `tests/asm/`, `tests/integration/`, `examples/`, or benchmark fixtures should grow.
+- Minimum verification:
   ```bash
-  rg "WorkerMessage::Finished" src tests
+  cargo test search::candidate::tests::test_generate_random_reaches_madd_family -- --exact
   ```
-- **`SearchStatistics` is `Clone` but not cheap**: it's a small struct of primitives + one `Duration` + an `Algorithm` enum — clone cost is negligible. No `Arc` wrapping needed.
-- **`Algorithm::Hybrid` as the top-level label**: unchanged; the existing CLI path expects this.
-- **Symbolic worker timing race**: with `num_workers == 2` the symbolic worker may not finish before the stochastic one in CI under load. The slice-1 test uses a 30s outer timeout and the same setup `test_symbolic_finds_mov_add_fusion` proved adequate, so this should be stable. If CI flakes, raise the outer timeout to 60s before raising any other flag.
-- **No SearchStatistics field additions**: keeping the payload to existing fields means no `BTreeMap`/`HashMap` ordering risk and no codegen-layout concerns. This is purely a Rust runtime change.
+- Broader local verification before PR/commit:
+  ```bash
+  cargo test search::candidate
+  cargo fmt -- --check
+  ```
+- Full pre-push verification remains the repository gate from `CLAUDE.md`:
+  ```bash
+  ./ci_check.sh
+  ```
 
-## 6. Out of scope
+## 5. Risk Areas
 
-- Adding `winning_worker_id: Option<usize>` to `ParallelResult` as a first-class field. (Would help testability further but expands the public-ish API beyond the minimum fix.)
-- Refactoring `WorkerMessage` to be generic over `<I: ISA>` — explicitly deferred to issue #77 stage 1 step 12 per the file-level comment at src/search/parallel/channel.rs:1-9.
-- Changing `print_search_statistics` formatting in src/main.rs:838-856.
-- Improving the timeout-driven shutdown path so stochastic workers honour `CoordinatorMessage::Stop` mid-search (called out as out-of-scope in src/search/parallel/coordinator.rs:380-387).
-- Renaming/restructuring `Algorithm::Hybrid` or introducing a `Algorithm::Parallel`.
-- Touching x86 / RISC-V parallel coordination (today AArch64-only).
-- Splitting `SearchStatistics` into algorithm-specific subtypes.
-- Reworking `SearchResult` vs `SearchResultFor<I>` (issue #77).
-- Any `cargo clippy` cleanups outside `src/search/parallel/channel.rs` and `src/search/parallel/coordinator.rs`.
+- Fixed-seed brittleness: `0x66` with 5000 draws is already used by nearby random reach tests and should have an extremely large margin for a 1-in-33 outer slot and 1-in-5 subslot, but if `rand_chacha` or the dispatch ordering changes later this test may fail honestly because the fixed trace changed.
+- Test runtime: 5000 draws are cheap and already match nearby tests, so keep the new test at the requested size and avoid expanding it into a statistical stress test.
+- Opcode ID coupling: the assertions intentionally use `opcode_id(&instr)` rather than hard-coded numbers in the test body. The issue's expected range is still documented in this plan and pinned by the representative instruction variants.
+- Clippy/format gate: the added test should not introduce unused imports or dead helper functions. Reuse existing imports from `super::*`, `default_registers`, `default_immediates`, and `random_opcode_ids`.
+- Parse/print/parse idempotency and binary fixed point are unaffected because no parser, printer, codegen, ordering-sensitive maps, stack-slot layout, or `vow-clif-shim`-style component exists in this repo slice.
+
+## 6. Out Of Scope
+
+- Changing `generate_random_instruction` dispatch weights, slot count, or sub-multiplexer structure.
+- Adding exhaustive-generator tests for the MADD family; `generate_all_instructions` already emits these variants at `src/search/candidate.rs:249-259`.
+- Adding docs or capability-matrix entries for `madd`, `msub`, `mneg`, `smulh`, or `umulh`; `docs/capability.md` already lists multiply-accumulate support.
+- Renumbering `opcode_id`, synchronizing with `src/isa/aarch64.rs`, or broadening the opcode-ID uniqueness tests.
+- Refactoring the existing random reach tests into a table-driven helper.
+- Running or modifying benchmark, integration, x86, RISC-V, parser, assembler, semantics, or LLM search code.

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -437,7 +437,10 @@ mod tests {
             algorithm: Algorithm::Enumerative,
             cost_metric: CostMetric::InstructionCount,
             seed: 42,
-            timeout: Duration::from_secs(30),
+            // Coverage instrumentation can make the enumerative verifier much
+            // slower than a normal test binary. Keep this regression about the
+            // emitted metrics, not the wall-clock budget.
+            timeout: Duration::from_secs(120),
         };
 
         let record = run_bench(&spec);

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -1258,6 +1258,61 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_random_reaches_madd_family() {
+        let ids = random_opcode_ids(0x66, 5_000);
+        for (label, instr) in [
+            (
+                "Madd",
+                Instruction::Madd {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Register::X2,
+                    ra: Register::X0,
+                },
+            ),
+            (
+                "Msub",
+                Instruction::Msub {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Register::X2,
+                    ra: Register::X0,
+                },
+            ),
+            (
+                "Mneg",
+                Instruction::Mneg {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Register::X2,
+                },
+            ),
+            (
+                "Smulh",
+                Instruction::Smulh {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Register::X2,
+                },
+            ),
+            (
+                "Umulh",
+                Instruction::Umulh {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Register::X2,
+                },
+            ),
+        ] {
+            assert!(
+                ids.contains(&opcode_id(&instr)),
+                "random never produced {}",
+                label
+            );
+        }
+    }
+
+    #[test]
     fn test_generate_all_instructions_contains_csel_family() {
         let instrs = generate_all_instructions(&default_registers(), &default_immediates());
         assert!(instrs.iter().any(|i| matches!(i, Instruction::Csel { .. })));

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -333,9 +333,10 @@ mod tests {
 
     #[test]
     fn statistics_aggregate_smt_elapsed() {
-        // Reuse the same length-3 target as `finds_length_two_rewrite` —
-        // proven to drive at least one SMT equivalence check during the
-        // length-2 sweep. After the search returns, the cumulative SMT
+        // Use the same small mov/add fusion as the bench-support smoke test:
+        // it drives at least one SMT equivalence check without spending most
+        // of the test's wall-clock budget in enumeration. After the search
+        // returns, the cumulative SMT
         // wall time must be non-zero, and it must be <= the overall search
         // elapsed (sanity check on aggregation correctness).
         //
@@ -351,21 +352,16 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
             },
-            Instruction::Eor {
+            Instruction::Add {
                 rd: Register::X0,
                 rn: Register::X0,
-                rm: Operand::Register(Register::X0),
-            },
-            Instruction::Eor {
-                rd: Register::X2,
-                rn: Register::X2,
-                rm: Operand::Register(Register::X2),
+                rm: Operand::Immediate(1),
             },
         ];
-        let live_out = LiveOut::from_registers(vec![Register::X0, Register::X2]);
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
         let config = SearchConfig::default()
-            .with_registers(vec![Register::X0, Register::X1, Register::X2])
-            .with_immediates(vec![0, 1])
+            .with_registers(vec![Register::X0, Register::X1])
+            .with_immediates(vec![1])
             .with_timeout(std::time::Duration::from_secs(30))
             .with_cores(Some(1));
 


### PR DESCRIPTION
Summary:
- Add a fixed-seed 5,000-draw regression test proving random candidate generation reaches the MADD-family opcode IDs 42..=46.
- Preserve the issue-specific implementation plan in PLAN.md for this reused workspace.
- Make two timing-sensitive smoke tests robust under coverage instrumentation after the first PR run exposed the bench timeout edge.

Closes #175

Verification:
- Temporary red check: forced random slot 29 away from the MADD family and saw the new test fail with `random never produced Madd`.
- `cargo test search::candidate::tests::test_generate_random_reaches_madd_family -- --exact`
- `cargo test bench_support::tests::run_bench_enumerative_records_metrics_for_fusible_target -- --exact`
- `cargo test search::enumerative::search::tests::statistics_aggregate_smt_elapsed -- --exact`
- `cargo clippy --all -- -D warnings`
- `./ci_check.sh`
- `cargo llvm-cov --workspace --all-features --lcov --output-path /tmp/s11-issue175-lcov.info`

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**