### PR TITLE
fix(assembler): encode ADD/SUB immediates from SP

### DIFF
--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -671,10 +671,10 @@ impl AArch64Assembler {
             }
             Instruction::Add { rd, rn, rm } => {
                 let rd_reg = register_to_dynasm(*rd)?;
-                let rn_reg = register_to_dynasm(*rn)?;
 
                 match rm {
                     Operand::Register(rm_reg) => {
+                        let rn_reg = register_to_dynasm(*rn)?;
                         let rm_reg_num = register_to_dynasm(*rm_reg)?;
                         dynasm!(ops
                             ; .arch aarch64
@@ -689,6 +689,7 @@ impl AArch64Assembler {
                         // ADD immediate requires XSP register type (Xn|SP format) per AArch64 spec.
                         // The X register type only works for register operands, not immediates.
                         // XSP allows both general-purpose X registers and SP in this encoding.
+                        let rn_reg = register_to_dynasm_xsp(*rn)?;
                         dynasm!(ops
                             ; .arch aarch64
                             ; add XSP(rd_reg), XSP(rn_reg), #*imm as u32
@@ -696,6 +697,7 @@ impl AArch64Assembler {
                         Ok(())
                     }
                     Operand::ShiftedRegister { reg, kind, amount } => {
+                        let rn_reg = register_to_dynasm(*rn)?;
                         let rm_reg_num = register_to_dynasm(*reg)?;
                         emit_shifted_reg_3op_arith!(
                             ops, add, rd_reg, rn_reg, rm_reg_num, kind, *amount
@@ -719,10 +721,10 @@ impl AArch64Assembler {
             }
             Instruction::Sub { rd, rn, rm } => {
                 let rd_reg = register_to_dynasm(*rd)?;
-                let rn_reg = register_to_dynasm(*rn)?;
 
                 match rm {
                     Operand::Register(rm_reg) => {
+                        let rn_reg = register_to_dynasm(*rn)?;
                         let rm_reg_num = register_to_dynasm(*rm_reg)?;
                         dynasm!(ops
                             ; .arch aarch64
@@ -735,6 +737,7 @@ impl AArch64Assembler {
                             return Err(format!("Immediate {} out of range for SUB", imm));
                         }
                         // SUB immediate also requires XSP register type (Xn|SP format)
+                        let rn_reg = register_to_dynasm_xsp(*rn)?;
                         dynasm!(ops
                             ; .arch aarch64
                             ; sub XSP(rd_reg), XSP(rn_reg), #*imm as u32
@@ -742,6 +745,7 @@ impl AArch64Assembler {
                         Ok(())
                     }
                     Operand::ShiftedRegister { reg, kind, amount } => {
+                        let rn_reg = register_to_dynasm(*rn)?;
                         let rm_reg_num = register_to_dynasm(*reg)?;
                         emit_shifted_reg_3op_arith!(
                             ops, sub, rd_reg, rn_reg, rm_reg_num, kind, *amount
@@ -2992,6 +2996,67 @@ mod tests {
         }
     }
 
+    /// ADD/SUB immediate-form accepts SP as `rn` for the same `Xn|SP`
+    /// source slot covered by the ADDS/SUBS regression above.
+    #[test]
+    fn test_add_sub_imm_accept_sp_rn() {
+        let mut assembler = AArch64Assembler::new();
+        for instr in [
+            Instruction::Add {
+                rd: Register::X0,
+                rn: Register::SP,
+                rm: Operand::Immediate(8),
+            },
+            Instruction::Sub {
+                rd: Register::X0,
+                rn: Register::SP,
+                rm: Operand::Immediate(8),
+            },
+        ] {
+            let bytes = assembler
+                .assemble_instructions(&[instr], 0)
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "Expected SP-as-rn to encode, got Err({}) for {:?}",
+                        e, instr
+                    )
+                });
+            assert_eq!(bytes.len(), 4);
+        }
+    }
+
+    #[test]
+    fn test_add_imm_sp_rn_roundtrip() {
+        let mut assembler = AArch64Assembler::new();
+        let bytes = assembler
+            .assemble_instructions(
+                &[Instruction::Add {
+                    rd: Register::X0,
+                    rn: Register::SP,
+                    rm: Operand::Immediate(8),
+                }],
+                0,
+            )
+            .expect("ADD imm with SP rn should encode");
+        disassemble_and_verify(&bytes, "add", &["x0", "sp", "#8"]);
+    }
+
+    #[test]
+    fn test_sub_imm_sp_rn_roundtrip() {
+        let mut assembler = AArch64Assembler::new();
+        let bytes = assembler
+            .assemble_instructions(
+                &[Instruction::Sub {
+                    rd: Register::X0,
+                    rn: Register::SP,
+                    rm: Operand::Immediate(8),
+                }],
+                0,
+            )
+            .expect("SUB imm with SP rn should encode");
+        disassemble_and_verify(&bytes, "sub", &["x0", "sp", "#8"]);
+    }
+
     /// Capstone round-trip for ADDS with SP as `rn` — guards against silent
     /// off-by-one in the encoded slot. Capstone must disassemble back to
     /// `adds` with `sp` in the rn position.
@@ -3098,6 +3163,54 @@ mod tests {
             0,
         );
         assert!(ok.is_ok(), "register-form ADDS with XZR should encode");
+    }
+
+    /// ADD/SUB immediate-form `rn` is also `Xn|SP`, so XZR must be rejected
+    /// instead of being encoded as SP.
+    #[test]
+    fn test_add_sub_imm_reject_xzr_rn() {
+        let mut assembler = AArch64Assembler::new();
+        for instr in [
+            Instruction::Add {
+                rd: Register::X0,
+                rn: Register::XZR,
+                rm: Operand::Immediate(1),
+            },
+            Instruction::Sub {
+                rd: Register::X0,
+                rn: Register::XZR,
+                rm: Operand::Immediate(1),
+            },
+        ] {
+            let result = assembler.assemble_instructions(&[instr], 0);
+            assert!(
+                result.is_err(),
+                "Expected encoder to reject {:?}, got {:?}",
+                instr,
+                result
+            );
+        }
+        // Register-form ADD/SUB with XZR as rn must still succeed — the
+        // register-form encoding decodes 31 as XZR correctly.
+        for instr in [
+            Instruction::Add {
+                rd: Register::X0,
+                rn: Register::XZR,
+                rm: Operand::Register(Register::X1),
+            },
+            Instruction::Sub {
+                rd: Register::X0,
+                rn: Register::XZR,
+                rm: Operand::Register(Register::X1),
+            },
+        ] {
+            let result = assembler.assemble_instructions(&[instr], 0);
+            assert!(
+                result.is_ok(),
+                "register-form ADD/SUB with XZR should encode: {:?}",
+                result
+            );
+        }
     }
 
     /// Defense-in-depth: assembler must refuse CSET/CSETM with AL or NV,

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -670,10 +670,14 @@ impl AArch64Assembler {
                 Ok(())
             }
             Instruction::Add { rd, rn, rm } => {
-                let rd_reg = register_to_dynasm(*rd)?;
-
+                // rd resolution depends on the rm operand shape: the immediate
+                // and extended-register forms encode Rd in the Xn|SP slot
+                // (accept SP, reject XZR), while the register and
+                // shifted-register forms use the plain Xn slot. Resolve rd
+                // inside each arm so the correct encoder gates it.
                 match rm {
                     Operand::Register(rm_reg) => {
+                        let rd_reg = register_to_dynasm(*rd)?;
                         let rn_reg = register_to_dynasm(*rn)?;
                         let rm_reg_num = register_to_dynasm(*rm_reg)?;
                         dynasm!(ops
@@ -686,9 +690,12 @@ impl AArch64Assembler {
                         if *imm < 0 || *imm > 0xFFF {
                             return Err(format!("Immediate {} out of range for ADD", imm));
                         }
-                        // ADD immediate requires XSP register type (Xn|SP format) per AArch64 spec.
-                        // The X register type only works for register operands, not immediates.
-                        // XSP allows both general-purpose X registers and SP in this encoding.
+                        // ADD immediate uses the Xn|SP register type for both rd
+                        // and rn per AArch64 spec (`ADD <Xd|SP>, <Xn|SP>, #imm`).
+                        // register_to_dynasm_xsp accepts SP (so `ADD SP, SP, #imm`
+                        // encodes) and rejects XZR, which shares index 31 and
+                        // would otherwise silently alias to SP.
+                        let rd_reg = register_to_dynasm_xsp(*rd)?;
                         let rn_reg = register_to_dynasm_xsp(*rn)?;
                         dynasm!(ops
                             ; .arch aarch64
@@ -697,6 +704,7 @@ impl AArch64Assembler {
                         Ok(())
                     }
                     Operand::ShiftedRegister { reg, kind, amount } => {
+                        let rd_reg = register_to_dynasm(*rd)?;
                         let rn_reg = register_to_dynasm(*rn)?;
                         let rm_reg_num = register_to_dynasm(*reg)?;
                         emit_shifted_reg_3op_arith!(
@@ -720,10 +728,12 @@ impl AArch64Assembler {
                 }
             }
             Instruction::Sub { rd, rn, rm } => {
-                let rd_reg = register_to_dynasm(*rd)?;
-
+                // See the ADD arm: rd is resolved inside each operand branch so
+                // the immediate/extended forms gate it through the Xn|SP encoder
+                // and the register/shifted forms through the plain Xn encoder.
                 match rm {
                     Operand::Register(rm_reg) => {
+                        let rd_reg = register_to_dynasm(*rd)?;
                         let rn_reg = register_to_dynasm(*rn)?;
                         let rm_reg_num = register_to_dynasm(*rm_reg)?;
                         dynasm!(ops
@@ -736,7 +746,11 @@ impl AArch64Assembler {
                         if *imm < 0 || *imm > 0xFFF {
                             return Err(format!("Immediate {} out of range for SUB", imm));
                         }
-                        // SUB immediate also requires XSP register type (Xn|SP format)
+                        // SUB immediate uses the Xn|SP register type for both rd
+                        // and rn (`SUB <Xd|SP>, <Xn|SP>, #imm`). register_to_dynasm_xsp
+                        // accepts SP (so `SUB SP, SP, #imm` encodes) and rejects
+                        // XZR, which would otherwise alias to SP via index 31.
+                        let rd_reg = register_to_dynasm_xsp(*rd)?;
                         let rn_reg = register_to_dynasm_xsp(*rn)?;
                         dynasm!(ops
                             ; .arch aarch64
@@ -745,6 +759,7 @@ impl AArch64Assembler {
                         Ok(())
                     }
                     Operand::ShiftedRegister { reg, kind, amount } => {
+                        let rd_reg = register_to_dynasm(*rd)?;
                         let rn_reg = register_to_dynasm(*rn)?;
                         let rm_reg_num = register_to_dynasm(*reg)?;
                         emit_shifted_reg_3op_arith!(
@@ -3208,6 +3223,93 @@ mod tests {
             assert!(
                 result.is_ok(),
                 "register-form ADD/SUB with XZR should encode: {:?}",
+                result
+            );
+        }
+    }
+
+    /// ADD/SUB immediate-form `rd` is `Xd|SP`, so SP must be accepted as the
+    /// destination: `ADD SP, SP, #imm` / `SUB SP, SP, #imm` are the canonical
+    /// stack-pointer adjusts. Round-trip through Capstone to pin the slot
+    /// (both rd and rn must decode back to `sp`).
+    #[test]
+    fn test_add_imm_sp_rd_roundtrip() {
+        let mut assembler = AArch64Assembler::new();
+        let bytes = assembler
+            .assemble_instructions(
+                &[Instruction::Add {
+                    rd: Register::SP,
+                    rn: Register::SP,
+                    rm: Operand::Immediate(16),
+                }],
+                0,
+            )
+            .expect("ADD imm with SP as rd and rn should encode");
+        disassemble_and_verify(&bytes, "add", &["sp, sp", "0x10"]);
+    }
+
+    #[test]
+    fn test_sub_imm_sp_rd_roundtrip() {
+        let mut assembler = AArch64Assembler::new();
+        let bytes = assembler
+            .assemble_instructions(
+                &[Instruction::Sub {
+                    rd: Register::SP,
+                    rn: Register::SP,
+                    rm: Operand::Immediate(16),
+                }],
+                0,
+            )
+            .expect("SUB imm with SP as rd and rn should encode");
+        disassemble_and_verify(&bytes, "sub", &["sp, sp", "0x10"]);
+    }
+
+    /// ADD/SUB immediate-form `rd` is `Xd|SP` (register 31 decodes as SP, not
+    /// XZR), so XZR as the destination must be rejected rather than silently
+    /// encoded as SP. `register_to_dynasm(XZR) == Some(31)` previously made the
+    /// shared top-of-arm `rd_reg` binding alias XZR to SP; resolving `rd` via
+    /// `register_to_dynasm_xsp` inside the immediate arm guards against that.
+    #[test]
+    fn test_add_sub_imm_reject_xzr_rd() {
+        let mut assembler = AArch64Assembler::new();
+        for instr in [
+            Instruction::Add {
+                rd: Register::XZR,
+                rn: Register::X0,
+                rm: Operand::Immediate(1),
+            },
+            Instruction::Sub {
+                rd: Register::XZR,
+                rn: Register::X0,
+                rm: Operand::Immediate(1),
+            },
+        ] {
+            let result = assembler.assemble_instructions(&[instr], 0);
+            assert!(
+                result.is_err(),
+                "Expected encoder to reject XZR as rd, got {:?} for {:?}",
+                result,
+                instr
+            );
+        }
+        // Register-form ADD/SUB with XZR as rd must still succeed — the
+        // register-form encoding decodes 31 as XZR correctly.
+        for instr in [
+            Instruction::Add {
+                rd: Register::XZR,
+                rn: Register::X0,
+                rm: Operand::Register(Register::X1),
+            },
+            Instruction::Sub {
+                rd: Register::XZR,
+                rn: Register::X0,
+                rm: Operand::Register(Register::X1),
+            },
+        ] {
+            let result = assembler.assemble_instructions(&[instr], 0);
+            assert!(
+                result.is_ok(),
+                "register-form ADD/SUB with XZR as rd should encode: {:?}",
                 result
             );
         }

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -703,7 +703,7 @@ impl Instruction {
     ///
     /// This validates immediate operand ranges against AArch64 encoding constraints:
     /// - MOV immediate: 0 to 0xFFFF (16-bit)
-    /// - ADD/SUB immediate: 0 to 0xFFF (12-bit unsigned)
+    /// - ADD/SUB immediate: 0 to 0xFFF (12-bit unsigned); rd/rn ≠ XZR (Xn|SP slot, SP allowed)
     /// - CMP/CMN immediate: 0 to 0xFFF (12-bit unsigned)
     /// - LSL/LSR/ASR immediate: 0 to 63
     /// - AND/ORR/EOR immediate: register, or encodable bitmask immediate
@@ -722,7 +722,13 @@ impl Instruction {
             // Shifted-register form forbids SP for any operand (ARM v8 spec).
             Instruction::Add { rd, rn, rm } | Instruction::Sub { rd, rn, rm } => match rm {
                 Operand::Register(_) => true,
-                Operand::Immediate(imm) => *imm >= 0 && *imm <= 0xFFF,
+                // Immediate form: rd and rn occupy the Xn|SP slot, so SP is
+                // permitted but XZR (also reg 31) must be rejected — it would
+                // alias to SP. Mirrors the assembler's register_to_dynasm_xsp
+                // so can_assemble() stays consistent with the real encoder.
+                Operand::Immediate(imm) => {
+                    *imm >= 0 && *imm <= 0xFFF && *rd != Register::XZR && *rn != Register::XZR
+                }
                 Operand::ShiftedRegister { reg, kind, amount } => {
                     *kind != ShiftKind::Ror
                         && *amount <= 63
@@ -2314,6 +2320,54 @@ mod tests {
         };
         assert!(mk_cmp(ShiftKind::Lsl).is_encodable_aarch64());
         assert!(!mk_cmp(ShiftKind::Ror).is_encodable_aarch64());
+    }
+
+    #[test]
+    fn test_is_encodable_add_sub_immediate_rejects_xzr_allows_sp() {
+        // ADD/SUB immediate Rd/Rn occupy the Xn|SP slot: SP is encodable,
+        // XZR is not (it would alias to SP). The predicate must stay in
+        // lockstep with the assembler's register_to_dynasm_xsp behaviour so
+        // can_assemble() never admits candidates the encoder rejects.
+        let add = |rd, rn| Instruction::Add {
+            rd,
+            rn,
+            rm: Operand::Immediate(8),
+        };
+        let sub = |rd, rn| Instruction::Sub {
+            rd,
+            rn,
+            rm: Operand::Immediate(8),
+        };
+
+        // SP as rd and/or rn is encodable.
+        assert!(add(Register::SP, Register::SP).is_encodable_aarch64());
+        assert!(sub(Register::SP, Register::SP).is_encodable_aarch64());
+        assert!(add(Register::X0, Register::SP).is_encodable_aarch64());
+        assert!(sub(Register::X0, Register::SP).is_encodable_aarch64());
+
+        // XZR in either slot is rejected for the immediate form.
+        assert!(!add(Register::XZR, Register::X0).is_encodable_aarch64());
+        assert!(!add(Register::X0, Register::XZR).is_encodable_aarch64());
+        assert!(!sub(Register::XZR, Register::X0).is_encodable_aarch64());
+        assert!(!sub(Register::X0, Register::XZR).is_encodable_aarch64());
+
+        // Register form with XZR stays encodable (plain Xn slot, 31 = XZR).
+        assert!(
+            Instruction::Add {
+                rd: Register::XZR,
+                rn: Register::XZR,
+                rm: Operand::Register(Register::X1),
+            }
+            .is_encodable_aarch64()
+        );
+        assert!(
+            Instruction::Sub {
+                rd: Register::XZR,
+                rn: Register::XZR,
+                rm: Operand::Register(Register::X1),
+            }
+            .is_encodable_aarch64()
+        );
     }
 
     #[test]

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -333,11 +333,12 @@ mod tests {
 
     #[test]
     fn statistics_aggregate_smt_elapsed() {
-        // Reuse the same length-3 target as `finds_length_two_rewrite` —
-        // proven to drive at least one SMT equivalence check during the
-        // length-2 sweep. After the search returns, the cumulative SMT
-        // wall time must be non-zero, and it must be <= the overall search
-        // elapsed (sanity check on aggregation correctness).
+        // Reuse the same length-2 target as `collapses_mov_add_into_single_add`:
+        // it reaches the equivalent `add x0, x1, #1` candidate promptly while
+        // still driving at least one SMT equivalence check. After the search
+        // returns, the cumulative SMT wall time must be non-zero, and it must
+        // be <= the overall search elapsed (sanity check on aggregation
+        // correctness).
         //
         // `cores = Some(1)` is required for the upper-bound assertion: the
         // global rayon pool would let multiple worker threads each spend
@@ -351,23 +352,14 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
             },
-            Instruction::Eor {
+            Instruction::Add {
                 rd: Register::X0,
                 rn: Register::X0,
-                rm: Operand::Register(Register::X0),
-            },
-            Instruction::Eor {
-                rd: Register::X2,
-                rn: Register::X2,
-                rm: Operand::Register(Register::X2),
+                rm: Operand::Immediate(1),
             },
         ];
-        let live_out = LiveOut::from_registers(vec![Register::X0, Register::X2]);
-        let config = SearchConfig::default()
-            .with_registers(vec![Register::X0, Register::X1, Register::X2])
-            .with_immediates(vec![0, 1])
-            .with_timeout(std::time::Duration::from_secs(30))
-            .with_cores(Some(1));
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
+        let config = small_config().with_cores(Some(1));
 
         let mut search = EnumerativeSearch::new();
         let result = search.search(&target, &live_out, &config);


### PR DESCRIPTION
Summary:
- Defer ADD/SUB rn encoding until the operand branch so immediate-form rn uses register_to_dynasm_xsp.
- Add ADD/SUB regressions for SP-as-rn, Capstone round-trips, and XZR-as-rn rejection.
- Stabilize the enumerative SMT elapsed regression so the full test gate no longer times out before SMT under suite contention.

Tests:
- cargo fmt --all
- cargo clippy --all -- -D warnings
- ./build_tests.sh
- cargo test --all
- ./ci_check.sh
- scripts/full_test.sh not present in this s11 repo

Closes #102

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**