### PR TITLE
docs(smt): clarify overlapping store test comment

### DIFF
--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -3617,9 +3617,9 @@ mod tests {
         let zero = BV::from_u64(0, 64);
         solver.assert(x0_pre.eq(BV::from_u64(0xDEADBEEF_CAFEBABE, 64)));
         solver.assert(pre.get_register(Register::X1).eq(&zero));
-        // Expected: low 2 bytes of x2 from x0 low 2 bytes = 0xBABE
-        // Then bytes 2..3 from x0 low 2 bytes (re-stored) = 0xBABE
-        // Then bytes 4..7 from x0 high 4 bytes = 0xDEADBEEF
+        // Expected: bytes 0..1 from the original 64-bit STR of x0 = 0xBABE
+        // Then bytes 2..3 from the low 16 bits of x0 stored by STRH at offset 2 = 0xBABE
+        // Then bytes 4..7 from the original 64-bit STR of x0 = 0xDEADBEEF
         let x2_post = post.get_register(Register::X2);
         let expected = BV::from_u64(0xDEAD_BEEF_BABE_BABE, 64);
         solver.assert(x2_post.eq(&expected));

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -3617,9 +3617,9 @@ mod tests {
         let zero = BV::from_u64(0, 64);
         solver.assert(x0_pre.eq(BV::from_u64(0xDEADBEEF_CAFEBABE, 64)));
         solver.assert(pre.get_register(Register::X1).eq(&zero));
-        // Expected: bytes 0..1 from the original 64-bit STR of x0 = 0xBABE
-        // Then bytes 2..3 from the low 16 bits of x0 stored by STRH at offset 2 = 0xBABE
-        // Then bytes 4..7 from the original 64-bit STR of x0 = 0xDEADBEEF
+        // Expected: bytes 0..=1 from the original 64-bit STR of x0 = 0xBABE
+        // Then bytes 2..=3 from the low 16 bits of x0 stored by STRH at offset 2 = 0xBABE
+        // Then bytes 4..=7 from the original 64-bit STR of x0 = 0xDEADBEEF
         let x2_post = post.get_register(Register::X2);
         let expected = BV::from_u64(0xDEAD_BEEF_BABE_BABE, 64);
         solver.assert(x2_post.eq(&expected));


### PR DESCRIPTION
Summary:
- Clarifies the `overlapping_stores_resolve_per_byte_in_smt` expected-byte comment so bytes 2..3 are attributed to the low 16 bits stored by `STRH` at offset 2.
- Leaves the SMT assertions and expected value unchanged.

Validation:
- `cargo test overlapping_stores_resolve_per_byte_in_smt`
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `./build_tests.sh`
- `cargo test --all`
- `./ci_check.sh`

Closes #291

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**