### PR TITLE
docs: fix mutants summary unittest command

### DIFF
--- a/scripts/test_mutants_summary.py
+++ b/scripts/test_mutants_summary.py
@@ -1,6 +1,6 @@
 """Tests for scripts/mutants_summary.py.
 
-Run with: python3 -m unittest scripts/test_mutants_summary.py
+Run with: python3 -m unittest discover -s scripts -p 'test_*.py'
 """
 
 import contextlib


### PR DESCRIPTION
Fixes #204.

The documented unittest invocation in `scripts/test_mutants_summary.py` currently fails from the repository root because `scripts/` is not placed on `sys.path` for `python -m unittest scripts/test_mutants_summary.py`.

This updates the file header to the working unittest discovery command.

Validation:

```text
python -m unittest scripts/test_mutants_summary.py
# fails before this change with ModuleNotFoundError: No module named 'mutants_summary'

python -m unittest discover -s scripts -p 'test_*.py'
# Ran 28 tests in 0.319s - OK
```