### PR TITLE
docs(search): document issue-66 opcode range

### DIFF
--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -1117,6 +1117,10 @@ mod tests {
         // isn't in scope here.
         let instrs = generate_all_instructions(&default_registers(), &default_immediates());
         let ids: std::collections::BTreeSet<u8> = instrs.iter().map(opcode_id).collect();
+        // Keep this literal range: 10..=19 is the stable issue-66 opcode_id
+        // contract for Mul through Csneg. Deriving it from representative
+        // Instruction values would hide accidental renumbering, unlike the
+        // random-reach tests where that indirection is deliberate.
         for id in 10u8..=19 {
             assert!(
                 ids.contains(&id),


### PR DESCRIPTION
Summary:
- Document that opcode_id range 10..=19 is the stable issue-66 contract for Mul through Csneg.
- Clarify why the exhaustive generator guard keeps the literal range instead of deriving IDs from Instruction values.

Verification:
- cargo test search::candidate::tests::test_generate_all_instructions_covers_issue_66_opcodes -- --exact
- cargo fmt --all
- cargo clippy --all -- -D warnings
- ./build_tests.sh
- cargo test --all
- ./ci_check.sh

Note: scripts/full_test.sh from the orchestration prompt is not present in this repository; the repository-local full gate is ./ci_check.sh.

Closes #174

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**