### PR TITLE
refactor(aarch64): share logical immediate helper

### DIFF
--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -1,5 +1,6 @@
 pub mod x86;
 
+use crate::ir::aarch64_encoding::logical_imm64_encodable;
 use crate::ir::types::{
     AccessWidth, AddressOperand, Condition, ExtendKind, IndexMode, LabelId, ShiftKind,
 };
@@ -798,7 +799,7 @@ impl AArch64Assembler {
                     }
                     Operand::Immediate(imm) => {
                         let val = *imm as u64;
-                        if dynasmrt::aarch64::encode_logical_immediate_64bit(val).is_none() {
+                        if !logical_imm64_encodable(*imm) {
                             return Err(format!(
                                 "AND immediate 0x{:x} is not a valid AArch64 logical immediate",
                                 val
@@ -839,7 +840,7 @@ impl AArch64Assembler {
                     }
                     Operand::Immediate(imm) => {
                         let val = *imm as u64;
-                        if dynasmrt::aarch64::encode_logical_immediate_64bit(val).is_none() {
+                        if !logical_imm64_encodable(*imm) {
                             return Err(format!(
                                 "ORR immediate 0x{:x} is not a valid AArch64 logical immediate",
                                 val
@@ -879,7 +880,7 @@ impl AArch64Assembler {
                     }
                     Operand::Immediate(imm) => {
                         let val = *imm as u64;
-                        if dynasmrt::aarch64::encode_logical_immediate_64bit(val).is_none() {
+                        if !logical_imm64_encodable(*imm) {
                             return Err(format!(
                                 "EOR immediate 0x{:x} is not a valid AArch64 logical immediate",
                                 val
@@ -1183,7 +1184,7 @@ impl AArch64Assembler {
                     }
                     Operand::Immediate(imm) => {
                         let val = *imm as u64;
-                        if dynasmrt::aarch64::encode_logical_immediate_64bit(val).is_none() {
+                        if !logical_imm64_encodable(*imm) {
                             return Err(format!(
                                 "TST immediate 0x{:x} is not a valid AArch64 logical immediate",
                                 val
@@ -1559,7 +1560,7 @@ impl AArch64Assembler {
                     }
                     Operand::Immediate(imm) => {
                         let val = *imm as u64;
-                        if dynasmrt::aarch64::encode_logical_immediate_64bit(val).is_none() {
+                        if !logical_imm64_encodable(*imm) {
                             return Err(format!(
                                 "ANDS immediate 0x{:x} is not a valid AArch64 logical immediate",
                                 val

--- a/src/ir/aarch64_encoding.rs
+++ b/src/ir/aarch64_encoding.rs
@@ -1,0 +1,41 @@
+//! AArch64 encoding predicates shared by IR validation and assembly lowering.
+
+/// True iff `imm` (reinterpreted as `u64`) is representable as an AArch64
+/// 64-bit logical bitmask immediate (the `N:immr:imms` encoding used by
+/// AND/ORR/EOR/TST/ANDS immediate forms).
+pub(crate) fn logical_imm64_encodable(imm: i64) -> bool {
+    dynasmrt::aarch64::encode_logical_immediate_64bit(imm as u64).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::logical_imm64_encodable;
+
+    #[test]
+    fn logical_imm64_encodable_accepts_valid_bitmasks() {
+        for imm in [
+            0xff,
+            0xffff,
+            0xf0f0_f0f0_f0f0_f0f0_u64 as i64,
+            0x5555_5555_5555_5555,
+            i64::MIN,
+        ] {
+            assert!(
+                logical_imm64_encodable(imm),
+                "expected 0x{:x} to be encodable",
+                imm as u64
+            );
+        }
+    }
+
+    #[test]
+    fn logical_imm64_encodable_rejects_invalid_bitmasks() {
+        for imm in [0_i64, -1, 5] {
+            assert!(
+                !logical_imm64_encodable(imm),
+                "expected 0x{:x} to be rejected",
+                imm as u64
+            );
+        }
+    }
+}

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -1,5 +1,6 @@
 //! AArch64 instruction definitions for the IR
 
+use crate::ir::aarch64_encoding::logical_imm64_encodable;
 use crate::ir::types::{
     AccessWidth, AddressOperand, Condition, IndexMode, LabelId, Operand, Register, ShiftKind,
 };
@@ -10,13 +11,6 @@ use std::fmt;
 /// every random-generation / mutation site so the four positions cannot drift
 /// out of sync across the codebase.
 pub const MOVW_LEGAL_SHIFTS: [u8; 4] = [0, 16, 32, 48];
-
-/// True iff `imm` (reinterpreted as `u64`) is representable as an AArch64
-/// 64-bit logical bitmask immediate (the `N:immr:imms` encoding used by
-/// AND/ORR/EOR/TST/ANDS immediate forms). Delegates to dynasmrt's encoder.
-fn logical_imm64_encodable(imm: i64) -> bool {
-    dynasmrt::aarch64::encode_logical_immediate_64bit(imm as u64).is_some()
-}
 
 /// Helper for `Instruction::destinations` on single-register memory ops: the
 /// data register is always written, and PreIndex/PostIndex modes additionally

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -1,5 +1,6 @@
 //! Intermediate Representation (IR) for AArch64 instructions
 
+pub(crate) mod aarch64_encoding;
 pub mod instructions;
 pub mod types;
 


### PR DESCRIPTION
Summary:
- Add a crate-internal AArch64 encoding helper for 64-bit logical immediates.
- Route IR encodability and assembler immediate validation through the shared helper.
- Preserve existing assembler diagnostics and edge-case behavior for AND/ORR/EOR/TST/ANDS.

Validation:
- cargo fmt --all
- cargo clippy --all -- -D warnings
- ./build_tests.sh
- cargo test --all
- ./ci_check.sh

Note: scripts/full_test.sh is not present in this repository; ./ci_check.sh runs the available full test_all.sh gate.

Closes #176