### PR TITLE
docs(semantics): explain exhaustive NZCV variant count

### DIFF
--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -311,6 +311,8 @@ fn fast_path_initial_nzcv_variants(
 ) -> Vec<ConcreteMachineState> {
     use crate::semantics::state::ConditionFlags;
     let variant_regs_config = RandomInputConfig {
+        // 16 == 2^4 NZCV bit patterns; this pass is exhaustive over initial
+        // flags rather than governed by config.random_test_count.
         count: 16,
         registers: input_regs.to_vec(),
         memory_seed_size: 0,


### PR DESCRIPTION
Adds an inline comment explaining that the hardcoded `count: 16` in `fast_path_initial_nzcv_variants` covers all 2^4 initial NZCV bit patterns, rather than following `config.random_test_count`.

Verification:
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test semantics::equivalence::tests::fast_only`
- `cargo test --all` after `./build_tests.sh` generated required integration fixtures
- `./ci_check.sh`
- `scripts/full_test.sh` was requested by the generic run contract but is not present in this repo

Closes #186

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**