### PR TITLE
test(validation): cover space-separated live-out contract regs

### DIFF
--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -617,6 +617,14 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_live_out_contract_space_separated_regs_and_flags() {
+        let live_out = parse_live_out_contract("x0 x1;nzcv").unwrap();
+        assert!(live_out.contains_register(Register::X0));
+        assert!(live_out.contains_register(Register::X1));
+        assert!(live_out.flags_live());
+    }
+
+    #[test]
     fn test_parse_live_out_contract_regs_only_flags_off() {
         let live_out = parse_live_out_contract("x0,x1").unwrap();
         assert!(live_out.contains_register(Register::X0));


### PR DESCRIPTION
Adds a focused regression test proving parse_live_out_contract accepts a space-separated register half together with the nzcv flag suffix, e.g. `x0 x1;nzcv`.

Verification:
- cargo test validation::live_out::tests::test_parse_live_out_contract_space_separated_regs_and_flags -- --exact
- cargo test validation::live_out
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test --all
- ./ci_check.sh

Closes #188

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**