### PR TITLE
feat(aarch64): support W logical immediates

### DIFF
--- a/docs/capability.md
+++ b/docs/capability.md
@@ -22,6 +22,8 @@ Rewritable straight-line mnemonics accepted by the parser and Capstone bridge:
 - Arithmetic and flag-setting arithmetic: `add`, `sub`, `adds`, `subs`
 - Logical and inverted-logical forms: `and`, `ands`, `orr`, `eor`, `bic`,
   `bics`, `orn`, `eon`
+  - Logical-immediate forms for `and`, `ands`, `orr`, `eor`, and `tst`
+    support both 64-bit `X` registers and 32-bit `W` registers.
 - Shifts and rotate: `lsl`, `lsr`, `asr`, `ror`
 - Multiply/divide and multiply-accumulate: `mul`, `madd`, `msub`, `mneg`,
   `smulh`, `umulh`, `sdiv`, `udiv`

--- a/docs/capability.md
+++ b/docs/capability.md
@@ -24,6 +24,8 @@ Rewritable straight-line mnemonics accepted by the parser and Capstone bridge:
   `bics`, `orn`, `eon`
   - Logical-immediate forms for `and`, `ands`, `orr`, `eor`, and `tst`
     support both 64-bit `X` registers and 32-bit `W` registers.
+    Capstone `mov Wd|WSP, #imm` bitmask aliases are accepted for the
+    `orr Wd|WSP, wzr, #imm` form.
 - Shifts and rotate: `lsl`, `lsr`, `asr`, `ror`
 - Multiply/divide and multiply-accumulate: `mul`, `madd`, `msub`, `mneg`,
   `smulh`, `umulh`, `sdiv`, `udiv`

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -1,9 +1,10 @@
 pub mod x86;
 
+use crate::ir::instructions::logical_imm32_value;
 use crate::ir::types::{
     AccessWidth, AddressOperand, Condition, ExtendKind, IndexMode, LabelId, ShiftKind,
 };
-use crate::ir::{Instruction, Operand, Register};
+use crate::ir::{Instruction, Operand, Register, RegisterWidth};
 use dynasmrt::{DynasmApi, dynasm};
 
 /// Emits one of the four CSEL-family mnemonics with the given register
@@ -783,11 +784,14 @@ impl AArch64Assembler {
             // rejects XZR), while the register and shifted-register forms use
             // the plain Xn slot (rejects SP). Resolving rd inside each arm
             // avoids prematurely rejecting `<op> sp, xn, #imm`.
-            Instruction::And { rd, rn, rm } => {
+            Instruction::And { rd, rn, rm, width } => {
                 let rn_reg = register_to_dynasm(*rn)?;
 
                 match rm {
                     Operand::Register(rm_reg) => {
+                        if *width != RegisterWidth::X64 {
+                            return Err("AND W-register form supports immediates only".to_string());
+                        }
                         let rd_reg = register_to_dynasm(*rd)?;
                         let rm_reg_num = register_to_dynasm(*rm_reg)?;
                         dynasm!(ops
@@ -797,22 +801,38 @@ impl AArch64Assembler {
                         Ok(())
                     }
                     Operand::Immediate(imm) => {
-                        let val = *imm as u64;
-                        if dynasmrt::aarch64::encode_logical_immediate_64bit(val).is_none() {
-                            return Err(format!(
-                                "AND immediate 0x{:x} is not a valid AArch64 logical immediate",
-                                val
-                            ));
+                        match width {
+                            RegisterWidth::X64 => {
+                                let val = *imm as u64;
+                                if dynasmrt::aarch64::encode_logical_immediate_64bit(val).is_none()
+                                {
+                                    return Err(format!(
+                                        "AND immediate 0x{:x} is not a valid AArch64 logical immediate",
+                                        val
+                                    ));
+                                }
+                                // AND (immediate) encodes Rd in the Xn|SP slot.
+                                let rd_reg_xsp = register_to_dynasm_xsp(*rd)?;
+                                dynasm!(ops
+                                    ; .arch aarch64
+                                    ; and XSP(rd_reg_xsp), X(rn_reg), #val
+                                );
+                            }
+                            RegisterWidth::W32 => {
+                                let val = logical_imm32_for_assembler("AND", *imm)?;
+                                let rd_reg_wsp = register_to_dynasm_wsp(*rd)?;
+                                dynasm!(ops
+                                    ; .arch aarch64
+                                    ; and WSP(rd_reg_wsp), W(rn_reg), #val
+                                );
+                            }
                         }
-                        // AND (immediate) encodes Rd in the Xn|SP slot.
-                        let rd_reg_xsp = register_to_dynasm_xsp(*rd)?;
-                        dynasm!(ops
-                            ; .arch aarch64
-                            ; and XSP(rd_reg_xsp), X(rn_reg), #val
-                        );
                         Ok(())
                     }
                     Operand::ShiftedRegister { reg, kind, amount } => {
+                        if *width != RegisterWidth::X64 {
+                            return Err("AND W-register form supports immediates only".to_string());
+                        }
                         let rd_reg = register_to_dynasm(*rd)?;
                         let rm_reg_num = register_to_dynasm(*reg)?;
                         emit_shifted_reg_3op_logical!(
@@ -824,11 +844,14 @@ impl AArch64Assembler {
                     }
                 }
             }
-            Instruction::Orr { rd, rn, rm } => {
+            Instruction::Orr { rd, rn, rm, width } => {
                 let rn_reg = register_to_dynasm(*rn)?;
 
                 match rm {
                     Operand::Register(rm_reg) => {
+                        if *width != RegisterWidth::X64 {
+                            return Err("ORR W-register form supports immediates only".to_string());
+                        }
                         let rd_reg = register_to_dynasm(*rd)?;
                         let rm_reg_num = register_to_dynasm(*rm_reg)?;
                         dynasm!(ops
@@ -838,21 +861,37 @@ impl AArch64Assembler {
                         Ok(())
                     }
                     Operand::Immediate(imm) => {
-                        let val = *imm as u64;
-                        if dynasmrt::aarch64::encode_logical_immediate_64bit(val).is_none() {
-                            return Err(format!(
-                                "ORR immediate 0x{:x} is not a valid AArch64 logical immediate",
-                                val
-                            ));
+                        match width {
+                            RegisterWidth::X64 => {
+                                let val = *imm as u64;
+                                if dynasmrt::aarch64::encode_logical_immediate_64bit(val).is_none()
+                                {
+                                    return Err(format!(
+                                        "ORR immediate 0x{:x} is not a valid AArch64 logical immediate",
+                                        val
+                                    ));
+                                }
+                                let rd_reg_xsp = register_to_dynasm_xsp(*rd)?;
+                                dynasm!(ops
+                                    ; .arch aarch64
+                                    ; orr XSP(rd_reg_xsp), X(rn_reg), #val
+                                );
+                            }
+                            RegisterWidth::W32 => {
+                                let val = logical_imm32_for_assembler("ORR", *imm)?;
+                                let rd_reg_wsp = register_to_dynasm_wsp(*rd)?;
+                                dynasm!(ops
+                                    ; .arch aarch64
+                                    ; orr WSP(rd_reg_wsp), W(rn_reg), #val
+                                );
+                            }
                         }
-                        let rd_reg_xsp = register_to_dynasm_xsp(*rd)?;
-                        dynasm!(ops
-                            ; .arch aarch64
-                            ; orr XSP(rd_reg_xsp), X(rn_reg), #val
-                        );
                         Ok(())
                     }
                     Operand::ShiftedRegister { reg, kind, amount } => {
+                        if *width != RegisterWidth::X64 {
+                            return Err("ORR W-register form supports immediates only".to_string());
+                        }
                         let rd_reg = register_to_dynasm(*rd)?;
                         let rm_reg_num = register_to_dynasm(*reg)?;
                         emit_shifted_reg_3op_logical!(
@@ -864,11 +903,14 @@ impl AArch64Assembler {
                     }
                 }
             }
-            Instruction::Eor { rd, rn, rm } => {
+            Instruction::Eor { rd, rn, rm, width } => {
                 let rn_reg = register_to_dynasm(*rn)?;
 
                 match rm {
                     Operand::Register(rm_reg) => {
+                        if *width != RegisterWidth::X64 {
+                            return Err("EOR W-register form supports immediates only".to_string());
+                        }
                         let rd_reg = register_to_dynasm(*rd)?;
                         let rm_reg_num = register_to_dynasm(*rm_reg)?;
                         dynasm!(ops
@@ -878,21 +920,37 @@ impl AArch64Assembler {
                         Ok(())
                     }
                     Operand::Immediate(imm) => {
-                        let val = *imm as u64;
-                        if dynasmrt::aarch64::encode_logical_immediate_64bit(val).is_none() {
-                            return Err(format!(
-                                "EOR immediate 0x{:x} is not a valid AArch64 logical immediate",
-                                val
-                            ));
+                        match width {
+                            RegisterWidth::X64 => {
+                                let val = *imm as u64;
+                                if dynasmrt::aarch64::encode_logical_immediate_64bit(val).is_none()
+                                {
+                                    return Err(format!(
+                                        "EOR immediate 0x{:x} is not a valid AArch64 logical immediate",
+                                        val
+                                    ));
+                                }
+                                let rd_reg_xsp = register_to_dynasm_xsp(*rd)?;
+                                dynasm!(ops
+                                    ; .arch aarch64
+                                    ; eor XSP(rd_reg_xsp), X(rn_reg), #val
+                                );
+                            }
+                            RegisterWidth::W32 => {
+                                let val = logical_imm32_for_assembler("EOR", *imm)?;
+                                let rd_reg_wsp = register_to_dynasm_wsp(*rd)?;
+                                dynasm!(ops
+                                    ; .arch aarch64
+                                    ; eor WSP(rd_reg_wsp), W(rn_reg), #val
+                                );
+                            }
                         }
-                        let rd_reg_xsp = register_to_dynasm_xsp(*rd)?;
-                        dynasm!(ops
-                            ; .arch aarch64
-                            ; eor XSP(rd_reg_xsp), X(rn_reg), #val
-                        );
                         Ok(())
                     }
                     Operand::ShiftedRegister { reg, kind, amount } => {
+                        if *width != RegisterWidth::X64 {
+                            return Err("EOR W-register form supports immediates only".to_string());
+                        }
                         let rd_reg = register_to_dynasm(*rd)?;
                         let rm_reg_num = register_to_dynasm(*reg)?;
                         emit_shifted_reg_3op_logical!(
@@ -1169,11 +1227,14 @@ impl AArch64Assembler {
                     }
                 }
             }
-            Instruction::Tst { rn, rm } => {
+            Instruction::Tst { rn, rm, width } => {
                 let rn_reg = register_to_dynasm(*rn)?;
 
                 match rm {
                     Operand::Register(rm_reg) => {
+                        if *width != RegisterWidth::X64 {
+                            return Err("TST W-register form supports immediates only".to_string());
+                        }
                         let rm_reg_num = register_to_dynasm(*rm_reg)?;
                         dynasm!(ops
                             ; .arch aarch64
@@ -1182,20 +1243,35 @@ impl AArch64Assembler {
                         Ok(())
                     }
                     Operand::Immediate(imm) => {
-                        let val = *imm as u64;
-                        if dynasmrt::aarch64::encode_logical_immediate_64bit(val).is_none() {
-                            return Err(format!(
-                                "TST immediate 0x{:x} is not a valid AArch64 logical immediate",
-                                val
-                            ));
+                        match width {
+                            RegisterWidth::X64 => {
+                                let val = *imm as u64;
+                                if dynasmrt::aarch64::encode_logical_immediate_64bit(val).is_none()
+                                {
+                                    return Err(format!(
+                                        "TST immediate 0x{:x} is not a valid AArch64 logical immediate",
+                                        val
+                                    ));
+                                }
+                                dynasm!(ops
+                                    ; .arch aarch64
+                                    ; tst X(rn_reg), #val
+                                );
+                            }
+                            RegisterWidth::W32 => {
+                                let val = logical_imm32_for_assembler("TST", *imm)?;
+                                dynasm!(ops
+                                    ; .arch aarch64
+                                    ; tst W(rn_reg), #val
+                                );
+                            }
                         }
-                        dynasm!(ops
-                            ; .arch aarch64
-                            ; tst X(rn_reg), #val
-                        );
                         Ok(())
                     }
                     Operand::ShiftedRegister { reg, kind, amount } => {
+                        if *width != RegisterWidth::X64 {
+                            return Err("TST W-register form supports immediates only".to_string());
+                        }
                         let rm_reg_num = register_to_dynasm(*reg)?;
                         emit_shifted_reg_2op_logical!(ops, tst, rn_reg, rm_reg_num, kind, *amount)
                     }
@@ -1548,27 +1624,42 @@ impl AArch64Assembler {
                     }
                 }
             }
-            Instruction::Ands { rd, rn, rm } => {
+            Instruction::Ands { rd, rn, rm, width } => {
                 let rd_reg = register_to_dynasm(*rd)?;
                 let rn_reg = register_to_dynasm(*rn)?;
                 match rm {
                     Operand::Register(r) => {
+                        if *width != RegisterWidth::X64 {
+                            return Err("ANDS W-register form supports immediates only".to_string());
+                        }
                         let rm_reg = register_to_dynasm(*r)?;
                         dynasm!(ops ; .arch aarch64 ; ands X(rd_reg), X(rn_reg), X(rm_reg));
                         Ok(())
                     }
                     Operand::Immediate(imm) => {
-                        let val = *imm as u64;
-                        if dynasmrt::aarch64::encode_logical_immediate_64bit(val).is_none() {
-                            return Err(format!(
-                                "ANDS immediate 0x{:x} is not a valid AArch64 logical immediate",
-                                val
-                            ));
+                        match width {
+                            RegisterWidth::X64 => {
+                                let val = *imm as u64;
+                                if dynasmrt::aarch64::encode_logical_immediate_64bit(val).is_none()
+                                {
+                                    return Err(format!(
+                                        "ANDS immediate 0x{:x} is not a valid AArch64 logical immediate",
+                                        val
+                                    ));
+                                }
+                                dynasm!(ops
+                                    ; .arch aarch64
+                                    ; ands X(rd_reg), X(rn_reg), #val
+                                );
+                            }
+                            RegisterWidth::W32 => {
+                                let val = logical_imm32_for_assembler("ANDS", *imm)?;
+                                dynasm!(ops
+                                    ; .arch aarch64
+                                    ; ands W(rd_reg), W(rn_reg), #val
+                                );
+                            }
                         }
-                        dynasm!(ops
-                            ; .arch aarch64
-                            ; ands X(rd_reg), X(rn_reg), #val
-                        );
                         Ok(())
                     }
                     Operand::ShiftedRegister { .. } => {
@@ -1975,6 +2066,40 @@ fn register_to_dynasm_xsp(reg: Register) -> Result<u8, String> {
     }
 }
 
+/// Map a register to the `Wn|WSP` encoding slot. Returns Err for WZR — this
+/// IR represents WZR as `Register::XZR`, whose register number 31 would decode
+/// as WSP in this slot.
+fn register_to_dynasm_wsp(reg: Register) -> Result<u8, String> {
+    match reg {
+        Register::XZR => Err(
+            "WZR is not encodable in the Wn|WSP register slot (would decode as WSP)".to_string(),
+        ),
+        Register::SP => Ok(31),
+        other => other.index().ok_or_else(|| {
+            format!(
+                "Register {:?} not supported in dynasm Wn|WSP encoding",
+                other
+            )
+        }),
+    }
+}
+
+fn logical_imm32_for_assembler(mnemonic: &str, imm: i64) -> Result<u32, String> {
+    let val = logical_imm32_value(imm).ok_or_else(|| {
+        format!(
+            "{} immediate {} is out of range for a 32-bit logical immediate",
+            mnemonic, imm
+        )
+    })?;
+    if dynasmrt::aarch64::encode_logical_immediate_32bit(val).is_none() {
+        return Err(format!(
+            "{} immediate 0x{:x} is not a valid AArch64 32-bit logical immediate",
+            mnemonic, val
+        ));
+    }
+    Ok(val)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2209,6 +2334,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X1,
             rm: Operand::Register(Register::X2),
+            width: crate::ir::RegisterWidth::X64,
         }];
 
         let bytes = assembler
@@ -2224,6 +2350,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X1,
             rm: Operand::Register(Register::X2),
+            width: crate::ir::RegisterWidth::X64,
         }];
 
         let bytes = assembler
@@ -2239,6 +2366,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X0,
             rm: Operand::Register(Register::X0),
+            width: crate::ir::RegisterWidth::X64,
         }];
 
         let bytes = assembler
@@ -2254,6 +2382,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X1,
             rm: Operand::Immediate(0xFF),
+            width: crate::ir::RegisterWidth::X64,
         }];
 
         let bytes = assembler
@@ -2269,6 +2398,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X1,
             rm: Operand::Immediate(0xFFFF),
+            width: crate::ir::RegisterWidth::X64,
         }];
 
         let bytes = assembler
@@ -2284,6 +2414,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X1,
             rm: Operand::Immediate(0xF0F0F0F0F0F0F0F0_u64 as i64),
+            width: crate::ir::RegisterWidth::X64,
         }];
 
         let bytes = assembler
@@ -2298,6 +2429,7 @@ mod tests {
         let instructions = vec![Instruction::Tst {
             rn: Register::X1,
             rm: Operand::Immediate(0xFF),
+            width: crate::ir::RegisterWidth::X64,
         }];
 
         let bytes = assembler
@@ -2313,6 +2445,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X1,
             rm: Operand::Immediate(0xFF),
+            width: crate::ir::RegisterWidth::X64,
         }];
 
         let bytes = assembler
@@ -2331,6 +2464,7 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Immediate(0),
+                width: crate::ir::RegisterWidth::X64,
             }],
             0,
         );
@@ -2346,6 +2480,7 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Immediate(-1),
+                width: crate::ir::RegisterWidth::X64,
             }],
             0,
         );
@@ -2360,6 +2495,7 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Immediate(5),
+                width: crate::ir::RegisterWidth::X64,
             }],
             0,
         );
@@ -2373,6 +2509,7 @@ mod tests {
             &[Instruction::Tst {
                 rn: Register::X1,
                 rm: Operand::Immediate(0),
+                width: crate::ir::RegisterWidth::X64,
             }],
             0,
         );
@@ -2391,6 +2528,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X1,
             rm: Operand::Immediate(0x8000_0000_0000_0000_u64 as i64),
+            width: crate::ir::RegisterWidth::X64,
         }];
 
         let bytes = assembler
@@ -2410,6 +2548,7 @@ mod tests {
             rd: Register::SP,
             rn: Register::X1,
             rm: Operand::Immediate(0xFF),
+            width: crate::ir::RegisterWidth::X64,
         }];
 
         let bytes = assembler
@@ -2429,6 +2568,7 @@ mod tests {
             rd: Register::XZR,
             rn: Register::X1,
             rm: Operand::Immediate(0xFF),
+            width: crate::ir::RegisterWidth::X64,
         }];
 
         let bytes = assembler
@@ -2436,6 +2576,144 @@ mod tests {
             .expect("ANDS with XZR destination (immediate form) should encode");
         // Capstone canonicalises ANDS XZR ..., #imm → TST X..., #imm.
         disassemble_and_verify(&bytes, "tst", &["x1", "0xff"]);
+    }
+
+    #[test]
+    fn test_w32_logical_immediates_roundtrip() {
+        let cases: Vec<(Instruction, &str, Vec<&str>)> = vec![
+            (
+                Instruction::And {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::Immediate(0xFF),
+                    width: RegisterWidth::W32,
+                },
+                "and",
+                vec!["w0", "w1", "0xff"],
+            ),
+            (
+                Instruction::Orr {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::Immediate(0xFF),
+                    width: RegisterWidth::W32,
+                },
+                "orr",
+                vec!["w0", "w1", "0xff"],
+            ),
+            (
+                Instruction::Eor {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::Immediate(0xFF),
+                    width: RegisterWidth::W32,
+                },
+                "eor",
+                vec!["w0", "w1", "0xff"],
+            ),
+            (
+                Instruction::Tst {
+                    rn: Register::X1,
+                    rm: Operand::Immediate(0xFF),
+                    width: RegisterWidth::W32,
+                },
+                "tst",
+                vec!["w1", "0xff"],
+            ),
+            (
+                Instruction::Ands {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::Immediate(0xFF),
+                    width: RegisterWidth::W32,
+                },
+                "ands",
+                vec!["w0", "w1", "0xff"],
+            ),
+            (
+                Instruction::And {
+                    rd: Register::SP,
+                    rn: Register::X1,
+                    rm: Operand::Immediate(0xFF),
+                    width: RegisterWidth::W32,
+                },
+                "and",
+                vec!["wsp", "w1", "0xff"],
+            ),
+        ];
+
+        for (instr, mnemonic, operands) in cases {
+            let mut assembler = AArch64Assembler::new();
+            let bytes = assembler
+                .assemble_instructions(&[instr], 0)
+                .expect("W32 logical immediate should encode");
+            disassemble_and_verify(&bytes, mnemonic, &operands);
+        }
+    }
+
+    #[test]
+    fn test_w32_logical_immediates_reject_invalid_masks_and_slots() {
+        let mut assembler = AArch64Assembler::new();
+
+        for imm in [0, -1, 5, 0x1_0000_00FF] {
+            let err = assembler
+                .assemble_instructions(
+                    &[Instruction::And {
+                        rd: Register::X0,
+                        rn: Register::X1,
+                        rm: Operand::Immediate(imm),
+                        width: RegisterWidth::W32,
+                    }],
+                    0,
+                )
+                .expect_err("invalid W32 logical immediate must be rejected");
+            assert!(
+                err.contains("32-bit logical immediate"),
+                "unexpected error for imm {imm}: {err}"
+            );
+        }
+
+        assert!(
+            assembler
+                .assemble_instructions(
+                    &[Instruction::And {
+                        rd: Register::XZR,
+                        rn: Register::X1,
+                        rm: Operand::Immediate(0xFF),
+                        width: RegisterWidth::W32,
+                    }],
+                    0,
+                )
+                .is_err(),
+            "AND WZR, Wn, #imm would alias to WSP and must be rejected"
+        );
+        assert!(
+            assembler
+                .assemble_instructions(
+                    &[Instruction::Ands {
+                        rd: Register::SP,
+                        rn: Register::X1,
+                        rm: Operand::Immediate(0xFF),
+                        width: RegisterWidth::W32,
+                    }],
+                    0,
+                )
+                .is_err(),
+            "ANDS WSP, Wn, #imm is not encodable"
+        );
+        assert!(
+            assembler
+                .assemble_instructions(
+                    &[Instruction::Tst {
+                        rn: Register::SP,
+                        rm: Operand::Immediate(0xFF),
+                        width: RegisterWidth::W32,
+                    }],
+                    0,
+                )
+                .is_err(),
+            "TST WSP, #imm is not encodable"
+        );
     }
 
     #[test]
@@ -3422,16 +3700,19 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Register(Register::X2),
+                width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Orr {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Register(Register::X2),
+                width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Eor {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Register(Register::X2),
+                width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Lsl {
                 rd: Register::X0,
@@ -3482,6 +3763,7 @@ mod tests {
             Instruction::Tst {
                 rn: Register::X1,
                 rm: Operand::Register(Register::X2),
+                width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Mvn {
                 rd: Register::X0,
@@ -3589,6 +3871,7 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Register(Register::X2),
+                width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Ror {
                 rd: Register::X0,
@@ -3629,16 +3912,19 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Immediate(5),
+                width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Orr {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Immediate(5),
+                width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Eor {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Immediate(5),
+                width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Lsl {
                 rd: Register::X0,
@@ -3666,6 +3952,7 @@ mod tests {
             Instruction::Tst {
                 rn: Register::X1,
                 rm: Operand::Immediate(5),
+                width: crate::ir::RegisterWidth::X64,
             },
             Instruction::MovN {
                 rd: Register::X0,
@@ -3726,6 +4013,7 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Immediate(5),
+                width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Ror {
                 rd: Register::X0,
@@ -3997,6 +4285,7 @@ mod tests {
                         kind: ShiftKind::Asr,
                         amount: 7,
                     },
+                    width: crate::ir::RegisterWidth::X64,
                 },
                 "and",
                 vec!["x6".into(), "x7".into(), "x8".into(), "asr #7".into()],
@@ -4010,6 +4299,7 @@ mod tests {
                         kind: ShiftKind::Ror,
                         amount: 1,
                     },
+                    width: crate::ir::RegisterWidth::X64,
                 },
                 "orr",
                 vec!["x9".into(), "x10".into(), "x11".into(), "ror #1".into()],
@@ -4023,6 +4313,7 @@ mod tests {
                         kind: ShiftKind::Lsl,
                         amount: 2,
                     },
+                    width: crate::ir::RegisterWidth::X64,
                 },
                 "eor",
                 vec!["x12".into(), "x13".into(), "x14".into(), "lsl #2".into()],
@@ -4059,6 +4350,7 @@ mod tests {
                         kind: ShiftKind::Ror,
                         amount: 16,
                     },
+                    width: crate::ir::RegisterWidth::X64,
                 },
                 "tst",
                 vec!["x19".into(), "x20".into(), "ror #16".into()],

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -790,7 +790,7 @@ impl AArch64Assembler {
                 match rm {
                     Operand::Register(rm_reg) => {
                         if *width != RegisterWidth::X64 {
-                            return Err("AND W-register form supports immediates only".to_string());
+                            return Err("AND with W registers supports immediate operands only; register and shifted-register forms require X registers".to_string());
                         }
                         let rd_reg = register_to_dynasm(*rd)?;
                         let rm_reg_num = register_to_dynasm(*rm_reg)?;
@@ -831,7 +831,7 @@ impl AArch64Assembler {
                     }
                     Operand::ShiftedRegister { reg, kind, amount } => {
                         if *width != RegisterWidth::X64 {
-                            return Err("AND W-register form supports immediates only".to_string());
+                            return Err("AND with W registers supports immediate operands only; register and shifted-register forms require X registers".to_string());
                         }
                         let rd_reg = register_to_dynasm(*rd)?;
                         let rm_reg_num = register_to_dynasm(*reg)?;
@@ -850,7 +850,7 @@ impl AArch64Assembler {
                 match rm {
                     Operand::Register(rm_reg) => {
                         if *width != RegisterWidth::X64 {
-                            return Err("ORR W-register form supports immediates only".to_string());
+                            return Err("ORR with W registers supports immediate operands only; register and shifted-register forms require X registers".to_string());
                         }
                         let rd_reg = register_to_dynasm(*rd)?;
                         let rm_reg_num = register_to_dynasm(*rm_reg)?;
@@ -890,7 +890,7 @@ impl AArch64Assembler {
                     }
                     Operand::ShiftedRegister { reg, kind, amount } => {
                         if *width != RegisterWidth::X64 {
-                            return Err("ORR W-register form supports immediates only".to_string());
+                            return Err("ORR with W registers supports immediate operands only; register and shifted-register forms require X registers".to_string());
                         }
                         let rd_reg = register_to_dynasm(*rd)?;
                         let rm_reg_num = register_to_dynasm(*reg)?;
@@ -909,7 +909,7 @@ impl AArch64Assembler {
                 match rm {
                     Operand::Register(rm_reg) => {
                         if *width != RegisterWidth::X64 {
-                            return Err("EOR W-register form supports immediates only".to_string());
+                            return Err("EOR with W registers supports immediate operands only; register and shifted-register forms require X registers".to_string());
                         }
                         let rd_reg = register_to_dynasm(*rd)?;
                         let rm_reg_num = register_to_dynasm(*rm_reg)?;
@@ -949,7 +949,7 @@ impl AArch64Assembler {
                     }
                     Operand::ShiftedRegister { reg, kind, amount } => {
                         if *width != RegisterWidth::X64 {
-                            return Err("EOR W-register form supports immediates only".to_string());
+                            return Err("EOR with W registers supports immediate operands only; register and shifted-register forms require X registers".to_string());
                         }
                         let rd_reg = register_to_dynasm(*rd)?;
                         let rm_reg_num = register_to_dynasm(*reg)?;
@@ -1233,7 +1233,7 @@ impl AArch64Assembler {
                 match rm {
                     Operand::Register(rm_reg) => {
                         if *width != RegisterWidth::X64 {
-                            return Err("TST W-register form supports immediates only".to_string());
+                            return Err("TST with W registers supports immediate operands only; register and shifted-register forms require X registers".to_string());
                         }
                         let rm_reg_num = register_to_dynasm(*rm_reg)?;
                         dynasm!(ops
@@ -1270,7 +1270,7 @@ impl AArch64Assembler {
                     }
                     Operand::ShiftedRegister { reg, kind, amount } => {
                         if *width != RegisterWidth::X64 {
-                            return Err("TST W-register form supports immediates only".to_string());
+                            return Err("TST with W registers supports immediate operands only; register and shifted-register forms require X registers".to_string());
                         }
                         let rm_reg_num = register_to_dynasm(*reg)?;
                         emit_shifted_reg_2op_logical!(ops, tst, rn_reg, rm_reg_num, kind, *amount)
@@ -1630,7 +1630,7 @@ impl AArch64Assembler {
                 match rm {
                     Operand::Register(r) => {
                         if *width != RegisterWidth::X64 {
-                            return Err("ANDS W-register form supports immediates only".to_string());
+                            return Err("ANDS with W registers supports immediate operands only; register and shifted-register forms require X registers".to_string());
                         }
                         let rm_reg = register_to_dynasm(*r)?;
                         dynasm!(ops ; .arch aarch64 ; ands X(rd_reg), X(rn_reg), X(rm_reg));

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -1,7 +1,8 @@
 //! AArch64 instruction definitions for the IR
 
 use crate::ir::types::{
-    AccessWidth, AddressOperand, Condition, IndexMode, LabelId, Operand, Register, ShiftKind,
+    AccessWidth, AddressOperand, Condition, IndexMode, LabelId, Operand, Register, RegisterWidth,
+    ShiftKind,
 };
 use std::fmt;
 
@@ -16,6 +17,23 @@ pub const MOVW_LEGAL_SHIFTS: [u8; 4] = [0, 16, 32, 48];
 /// AND/ORR/EOR/TST/ANDS immediate forms). Delegates to dynasmrt's encoder.
 fn logical_imm64_encodable(imm: i64) -> bool {
     dynasmrt::aarch64::encode_logical_immediate_64bit(imm as u64).is_some()
+}
+
+pub(crate) fn logical_imm32_value(imm: i64) -> Option<u32> {
+    if imm >= 0 {
+        u32::try_from(imm).ok()
+    } else {
+        Some(imm as u32)
+    }
+}
+
+/// True iff `imm` is representable as an AArch64 32-bit logical bitmask
+/// immediate. Positive literals must fit in 32 bits; negative literals are
+/// interpreted as two's-complement W-width masks.
+pub(crate) fn logical_imm32_encodable(imm: i64) -> bool {
+    logical_imm32_value(imm)
+        .and_then(dynasmrt::aarch64::encode_logical_immediate_32bit)
+        .is_some()
 }
 
 /// Helper for `Instruction::destinations` on single-register memory ops: the
@@ -108,16 +126,19 @@ pub enum Instruction {
         rd: Register,
         rn: Register,
         rm: Operand,
+        width: RegisterWidth,
     },
     Orr {
         rd: Register,
         rn: Register,
         rm: Operand,
+        width: RegisterWidth,
     },
     Eor {
         rd: Register,
         rn: Register,
         rm: Operand,
+        width: RegisterWidth,
     },
 
     // Shifts
@@ -195,6 +216,7 @@ pub enum Instruction {
     Tst {
         rn: Register,
         rm: Operand,
+        width: RegisterWidth,
     },
 
     // Conditional select
@@ -313,6 +335,7 @@ pub enum Instruction {
         rd: Register,
         rn: Register,
         rm: Operand,
+        width: RegisterWidth,
     },
 
     // Conditional set: rd = (cond holds) ? 1 : 0
@@ -758,17 +781,23 @@ impl Instruction {
             // forbids SP for any operand). The immediate form encodes Rd in
             // the Xn|SP slot, which forbids XZR (would alias to SP and
             // silently miscompile).
-            Instruction::And { rd, rn, rm }
-            | Instruction::Orr { rd, rn, rm }
-            | Instruction::Eor { rd, rn, rm } => match rm {
-                Operand::Register(_) => true,
+            Instruction::And { rd, rn, rm, width }
+            | Instruction::Orr { rd, rn, rm, width }
+            | Instruction::Eor { rd, rn, rm, width } => match rm {
+                Operand::Register(_) => *width == RegisterWidth::X64,
                 // rd in the Xn|SP slot (SP allowed, XZR forbidden); rn in the
                 // plain Xn slot (XZR allowed via reg 31, SP forbidden).
-                Operand::Immediate(imm) => {
-                    *rd != Register::XZR && *rn != Register::SP && logical_imm64_encodable(*imm)
-                }
+                Operand::Immediate(imm) => match width {
+                    RegisterWidth::X64 => {
+                        *rd != Register::XZR && *rn != Register::SP && logical_imm64_encodable(*imm)
+                    }
+                    RegisterWidth::W32 => {
+                        *rd != Register::XZR && *rn != Register::SP && logical_imm32_encodable(*imm)
+                    }
+                },
                 Operand::ShiftedRegister { reg, amount, .. } => {
-                    *amount <= 63
+                    *width == RegisterWidth::X64
+                        && *amount <= 63
                         && *reg != Register::SP
                         && *rd != Register::SP
                         && *rn != Register::SP
@@ -826,11 +855,17 @@ impl Instruction {
             // shifted-register (all 4 kinds incl. ROR). No rd, so no XZR-slot
             // guard needed for the immediate form — but rn is the plain Xn slot
             // (rejects SP).
-            Instruction::Tst { rn, rm } => match rm {
-                Operand::Register(_) => true,
-                Operand::Immediate(imm) => *rn != Register::SP && logical_imm64_encodable(*imm),
+            Instruction::Tst { rn, rm, width } => match rm {
+                Operand::Register(_) => *width == RegisterWidth::X64,
+                Operand::Immediate(imm) => match width {
+                    RegisterWidth::X64 => *rn != Register::SP && logical_imm64_encodable(*imm),
+                    RegisterWidth::W32 => *rn != Register::SP && logical_imm32_encodable(*imm),
+                },
                 Operand::ShiftedRegister { reg, amount, .. } => {
-                    *amount <= 63 && *reg != Register::SP && *rn != Register::SP
+                    *width == RegisterWidth::X64
+                        && *amount <= 63
+                        && *reg != Register::SP
+                        && *rn != Register::SP
                 }
                 Operand::ExtendedRegister { .. } => false,
             },
@@ -868,11 +903,16 @@ impl Instruction {
             // ShiftedRegister out of scope (#59). The immediate form uses the
             // plain X slot for both rd and rn (rejects SP); XZR is fine for rd
             // (encodes as the TST shape).
-            Instruction::Ands { rd, rn, rm } => match rm {
-                Operand::Register(_) => true,
-                Operand::Immediate(imm) => {
-                    *rd != Register::SP && *rn != Register::SP && logical_imm64_encodable(*imm)
-                }
+            Instruction::Ands { rd, rn, rm, width } => match rm {
+                Operand::Register(_) => *width == RegisterWidth::X64,
+                Operand::Immediate(imm) => match width {
+                    RegisterWidth::X64 => {
+                        *rd != Register::SP && *rn != Register::SP && logical_imm64_encodable(*imm)
+                    }
+                    RegisterWidth::W32 => {
+                        *rd != Register::SP && *rn != Register::SP && logical_imm32_encodable(*imm)
+                    }
+                },
                 Operand::ShiftedRegister { .. } => false,
                 Operand::ExtendedRegister { .. } => false,
             },
@@ -1033,7 +1073,7 @@ impl Instruction {
             // including the shifted-register form's inner register).
             Instruction::Cmp { rn, rm }
             | Instruction::Cmn { rn, rm }
-            | Instruction::Tst { rn, rm } => {
+            | Instruction::Tst { rn, rm, .. } => {
                 let mut regs = vec![*rn];
                 match rm {
                     Operand::Register(r) => regs.push(*r),
@@ -1290,9 +1330,27 @@ impl fmt::Display for Instruction {
             Instruction::MovImm { rd, imm } => write!(f, "mov {}, #{}", rd, imm),
             Instruction::Add { rd, rn, rm } => write!(f, "add {}, {}, {}", rd, rn, rm),
             Instruction::Sub { rd, rn, rm } => write!(f, "sub {}, {}, {}", rd, rn, rm),
-            Instruction::And { rd, rn, rm } => write!(f, "and {}, {}, {}", rd, rn, rm),
-            Instruction::Orr { rd, rn, rm } => write!(f, "orr {}, {}, {}", rd, rn, rm),
-            Instruction::Eor { rd, rn, rm } => write!(f, "eor {}, {}, {}", rd, rn, rm),
+            Instruction::And { rd, rn, rm, width } => write!(
+                f,
+                "and {}, {}, {}",
+                width.register_name(*rd),
+                width.register_name(*rn),
+                rm
+            ),
+            Instruction::Orr { rd, rn, rm, width } => write!(
+                f,
+                "orr {}, {}, {}",
+                width.register_name(*rd),
+                width.register_name(*rn),
+                rm
+            ),
+            Instruction::Eor { rd, rn, rm, width } => write!(
+                f,
+                "eor {}, {}, {}",
+                width.register_name(*rd),
+                width.register_name(*rn),
+                rm
+            ),
             Instruction::Lsl { rd, rn, shift } => write!(f, "lsl {}, {}, {}", rd, rn, shift),
             Instruction::Lsr { rd, rn, shift } => write!(f, "lsr {}, {}, {}", rd, rn, shift),
             Instruction::Asr { rd, rn, shift } => write!(f, "asr {}, {}, {}", rd, rn, shift),
@@ -1311,7 +1369,9 @@ impl fmt::Display for Instruction {
             // Comparison instructions
             Instruction::Cmp { rn, rm } => write!(f, "cmp {}, {}", rn, rm),
             Instruction::Cmn { rn, rm } => write!(f, "cmn {}, {}", rn, rm),
-            Instruction::Tst { rn, rm } => write!(f, "tst {}, {}", rn, rm),
+            Instruction::Tst { rn, rm, width } => {
+                write!(f, "tst {}, {}", width.register_name(*rn), rm)
+            }
             // Conditional select instructions
             Instruction::Csel { rd, rn, rm, cond } => {
                 write!(f, "csel {}, {}, {}, {}", rd, rn, rm, cond)
@@ -1361,7 +1421,13 @@ impl fmt::Display for Instruction {
             Instruction::Eon { rd, rn, rm } => write!(f, "eon {}, {}, {}", rd, rn, rm),
             Instruction::Adds { rd, rn, rm } => write!(f, "adds {}, {}, {}", rd, rn, rm),
             Instruction::Subs { rd, rn, rm } => write!(f, "subs {}, {}, {}", rd, rn, rm),
-            Instruction::Ands { rd, rn, rm } => write!(f, "ands {}, {}, {}", rd, rn, rm),
+            Instruction::Ands { rd, rn, rm, width } => write!(
+                f,
+                "ands {}, {}, {}",
+                width.register_name(*rd),
+                width.register_name(*rn),
+                rm
+            ),
             Instruction::Cset { rd, cond } => write!(f, "cset {}, {}", rd, cond),
             Instruction::Csetm { rd, cond } => write!(f, "csetm {}, {}", rd, cond),
             Instruction::Ror { rd, rn, shift } => write!(f, "ror {}, {}, {}", rd, rn, shift),
@@ -1498,6 +1564,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X0,
             rm: Operand::Register(Register::X0),
+            width: crate::ir::RegisterWidth::X64,
         };
         assert_eq!(format!("{}", eor), "eor x0, x0, x0");
     }
@@ -2212,16 +2279,19 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: shifted,
+                width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Orr {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: shifted,
+                width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Eor {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: shifted,
+                width: crate::ir::RegisterWidth::X64,
             },
         ] {
             assert_eq!(
@@ -2243,6 +2313,7 @@ mod tests {
             Instruction::Tst {
                 rn: Register::X1,
                 rm: shifted,
+                width: crate::ir::RegisterWidth::X64,
             },
         ] {
             assert_eq!(instr.source_registers(), vec![Register::X1, Register::X3]);
@@ -2388,6 +2459,7 @@ mod tests {
                         kind,
                         amount: 5
                     },
+                    width: crate::ir::RegisterWidth::X64,
                 }
                 .is_encodable_aarch64(),
                 "ORR with {:?} must be encodable",
@@ -2401,6 +2473,7 @@ mod tests {
                         kind,
                         amount: 5
                     },
+                    width: crate::ir::RegisterWidth::X64,
                 }
                 .is_encodable_aarch64(),
                 "TST with {:?} must be encodable",
@@ -2538,7 +2611,8 @@ mod tests {
             Instruction::And {
                 rd: Register::X0,
                 rn: Register::X1,
-                rm: Operand::Register(Register::X2)
+                rm: Operand::Register(Register::X2),
+                width: crate::ir::RegisterWidth::X64,
             }
             .is_encodable_aarch64()
         );
@@ -2548,7 +2622,8 @@ mod tests {
             Instruction::And {
                 rd: Register::X0,
                 rn: Register::X1,
-                rm: Operand::Immediate(0xFF)
+                rm: Operand::Immediate(0xFF),
+                width: crate::ir::RegisterWidth::X64,
             }
             .is_encodable_aarch64()
         );
@@ -2556,7 +2631,8 @@ mod tests {
             Instruction::Orr {
                 rd: Register::X0,
                 rn: Register::X1,
-                rm: Operand::Immediate(1)
+                rm: Operand::Immediate(1),
+                width: crate::ir::RegisterWidth::X64,
             }
             .is_encodable_aarch64()
         );
@@ -2566,7 +2642,8 @@ mod tests {
             !Instruction::Eor {
                 rd: Register::X0,
                 rn: Register::X1,
-                rm: Operand::Immediate(0)
+                rm: Operand::Immediate(0),
+                width: crate::ir::RegisterWidth::X64,
             }
             .is_encodable_aarch64()
         );
@@ -2808,14 +2885,16 @@ mod tests {
         assert!(
             Instruction::Tst {
                 rn: Register::X0,
-                rm: Operand::Register(Register::X1)
+                rm: Operand::Register(Register::X1),
+                width: crate::ir::RegisterWidth::X64,
             }
             .is_encodable_aarch64()
         );
         assert!(
             Instruction::Tst {
                 rn: Register::X0,
-                rm: Operand::Immediate(1)
+                rm: Operand::Immediate(1),
+                width: crate::ir::RegisterWidth::X64,
             }
             .is_encodable_aarch64()
         );
@@ -2823,7 +2902,8 @@ mod tests {
         assert!(
             !Instruction::Tst {
                 rn: Register::X0,
-                rm: Operand::Immediate(5)
+                rm: Operand::Immediate(5),
+                width: crate::ir::RegisterWidth::X64,
             }
             .is_encodable_aarch64()
         );
@@ -2854,16 +2934,19 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Register(Register::X2),
+                width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Orr {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Register(Register::X2),
+                width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Eor {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Register(Register::X2),
+                width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Lsl {
                 rd: Register::X0,
@@ -2933,6 +3016,7 @@ mod tests {
             Instruction::Tst {
                 rn: Register::X1,
                 rm: Operand::Register(Register::X2),
+                width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Csel {
                 rd: Register::X0,
@@ -3019,6 +3103,7 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Register(Register::X2),
+                width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Cset {
                 rd: Register::X0,
@@ -3277,6 +3362,7 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: er,
+                width: crate::ir::RegisterWidth::X64,
             }
             .is_encodable_aarch64()
         );
@@ -3285,6 +3371,7 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: er,
+                width: crate::ir::RegisterWidth::X64,
             }
             .is_encodable_aarch64()
         );
@@ -3293,6 +3380,7 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: er,
+                width: crate::ir::RegisterWidth::X64,
             }
             .is_encodable_aarch64()
         );
@@ -3300,6 +3388,7 @@ mod tests {
             !Instruction::Tst {
                 rn: Register::X1,
                 rm: er,
+                width: crate::ir::RegisterWidth::X64,
             }
             .is_encodable_aarch64()
         );
@@ -3559,6 +3648,7 @@ mod tests {
                     rd: Register::X0,
                     rn: Register::X1,
                     rm: Operand::Immediate(imm),
+                    width: crate::ir::RegisterWidth::X64,
                 }
                 .is_encodable_aarch64(),
                 "AND with valid imm 0x{:x} should be encodable",
@@ -3569,6 +3659,7 @@ mod tests {
                     rd: Register::X0,
                     rn: Register::X1,
                     rm: Operand::Immediate(imm),
+                    width: crate::ir::RegisterWidth::X64,
                 }
                 .is_encodable_aarch64(),
                 "ORR with valid imm 0x{:x} should be encodable",
@@ -3579,6 +3670,7 @@ mod tests {
                     rd: Register::X0,
                     rn: Register::X1,
                     rm: Operand::Immediate(imm),
+                    width: crate::ir::RegisterWidth::X64,
                 }
                 .is_encodable_aarch64(),
                 "EOR with valid imm 0x{:x} should be encodable",
@@ -3588,6 +3680,7 @@ mod tests {
                 Instruction::Tst {
                     rn: Register::X1,
                     rm: Operand::Immediate(imm),
+                    width: crate::ir::RegisterWidth::X64,
                 }
                 .is_encodable_aarch64(),
                 "TST with valid imm 0x{:x} should be encodable",
@@ -3598,6 +3691,7 @@ mod tests {
                     rd: Register::X0,
                     rn: Register::X1,
                     rm: Operand::Immediate(imm),
+                    width: crate::ir::RegisterWidth::X64,
                 }
                 .is_encodable_aarch64(),
                 "ANDS with valid imm 0x{:x} should be encodable",
@@ -3615,25 +3709,30 @@ mod tests {
                     rd: Register::X0,
                     rn: Register::X1,
                     rm: Operand::Immediate(r),
+                    width: crate::ir::RegisterWidth::X64,
                 },
                 |r| Instruction::Orr {
                     rd: Register::X0,
                     rn: Register::X1,
                     rm: Operand::Immediate(r),
+                    width: crate::ir::RegisterWidth::X64,
                 },
                 |r| Instruction::Eor {
                     rd: Register::X0,
                     rn: Register::X1,
                     rm: Operand::Immediate(r),
+                    width: crate::ir::RegisterWidth::X64,
                 },
                 |r| Instruction::Tst {
                     rn: Register::X1,
                     rm: Operand::Immediate(r),
+                    width: crate::ir::RegisterWidth::X64,
                 },
                 |r| Instruction::Ands {
                     rd: Register::X0,
                     rn: Register::X1,
                     rm: Operand::Immediate(r),
+                    width: crate::ir::RegisterWidth::X64,
                 },
             ] {
                 let instr = ctor(imm);
@@ -3647,6 +3746,121 @@ mod tests {
         }
     }
 
+    fn w32_logical_immediate_instrs(imm: i64) -> [Instruction; 5] {
+        [
+            Instruction::And {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Immediate(imm),
+                width: RegisterWidth::W32,
+            },
+            Instruction::Orr {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Immediate(imm),
+                width: RegisterWidth::W32,
+            },
+            Instruction::Eor {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Immediate(imm),
+                width: RegisterWidth::W32,
+            },
+            Instruction::Tst {
+                rn: Register::X1,
+                rm: Operand::Immediate(imm),
+                width: RegisterWidth::W32,
+            },
+            Instruction::Ands {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Immediate(imm),
+                width: RegisterWidth::W32,
+            },
+        ]
+    }
+
+    #[test]
+    fn test_is_encodable_aarch64_logical_imm32_accepts_valid_masks() {
+        for imm in [0xFF_i64, 0x8000_0000, 0x5555_5555, -256] {
+            for instr in w32_logical_immediate_instrs(imm) {
+                assert!(
+                    instr.is_encodable_aarch64(),
+                    "{} with W32 imm 0x{:x} should be encodable",
+                    instr,
+                    imm as u64
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_is_encodable_aarch64_logical_imm32_rejects_invalid_masks() {
+        for imm in [0_i64, -1, 0xFFFF_FFFF, 5, 0x1_0000_00FF] {
+            for instr in w32_logical_immediate_instrs(imm) {
+                assert!(
+                    !instr.is_encodable_aarch64(),
+                    "{} with W32 imm 0x{:x} must NOT be encodable",
+                    instr,
+                    imm as u64
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_is_encodable_aarch64_logical_imm32_enforces_wsp_wzr_slots() {
+        assert!(
+            Instruction::And {
+                rd: Register::SP,
+                rn: Register::X1,
+                rm: Operand::Immediate(0xFF),
+                width: RegisterWidth::W32,
+            }
+            .is_encodable_aarch64(),
+            "AND WSP, Wn, #imm uses the Wn|WSP destination slot"
+        );
+        assert!(
+            !Instruction::And {
+                rd: Register::XZR,
+                rn: Register::X1,
+                rm: Operand::Immediate(0xFF),
+                width: RegisterWidth::W32,
+            }
+            .is_encodable_aarch64(),
+            "AND WZR, Wn, #imm would alias to WSP in the destination slot"
+        );
+        assert!(
+            Instruction::Ands {
+                rd: Register::XZR,
+                rn: Register::X1,
+                rm: Operand::Immediate(0xFF),
+                width: RegisterWidth::W32,
+            }
+            .is_encodable_aarch64(),
+            "ANDS WZR, Wn, #imm uses a plain W destination slot"
+        );
+        assert!(
+            !Instruction::Ands {
+                rd: Register::SP,
+                rn: Register::X1,
+                rm: Operand::Immediate(0xFF),
+                width: RegisterWidth::W32,
+            }
+            .is_encodable_aarch64(),
+            "ANDS WSP, Wn, #imm is not a plain W-register destination"
+        );
+        assert!(
+            !Instruction::Tst {
+                rn: Register::SP,
+                rm: Operand::Immediate(0xFF),
+                width: RegisterWidth::W32,
+            }
+            .is_encodable_aarch64(),
+            "TST WSP, #imm is not a plain W-register source"
+        );
+    }
+
     #[test]
     fn test_is_encodable_aarch64_rejects_xzr_dest_for_and_orr_eor_imm() {
         // AND/ORR/EOR (immediate) put Rd in the Xn|SP slot — XZR aliases to SP
@@ -3656,16 +3870,19 @@ mod tests {
                 rd,
                 rn: Register::X1,
                 rm: Operand::Immediate(imm),
+                width: crate::ir::RegisterWidth::X64,
             },
             |rd, imm| Instruction::Orr {
                 rd,
                 rn: Register::X1,
                 rm: Operand::Immediate(imm),
+                width: crate::ir::RegisterWidth::X64,
             },
             |rd, imm| Instruction::Eor {
                 rd,
                 rn: Register::X1,
                 rm: Operand::Immediate(imm),
+                width: crate::ir::RegisterWidth::X64,
             },
         ] {
             // Same encoder accepts 0xFF for X0…
@@ -3680,6 +3897,7 @@ mod tests {
                 rd: Register::XZR,
                 rn: Register::X1,
                 rm: Operand::Immediate(0xFF),
+                width: crate::ir::RegisterWidth::X64,
             }
             .is_encodable_aarch64()
         );
@@ -3694,16 +3912,19 @@ mod tests {
                 rd: Register::X0,
                 rn,
                 rm: Operand::Immediate(0xFF),
+                width: crate::ir::RegisterWidth::X64,
             },
             |rn| Instruction::Orr {
                 rd: Register::X0,
                 rn,
                 rm: Operand::Immediate(0xFF),
+                width: crate::ir::RegisterWidth::X64,
             },
             |rn| Instruction::Eor {
                 rd: Register::X0,
                 rn,
                 rm: Operand::Immediate(0xFF),
+                width: crate::ir::RegisterWidth::X64,
             },
         ] {
             assert!(
@@ -3722,6 +3943,7 @@ mod tests {
                 rd: Register::SP,
                 rn: Register::X1,
                 rm: Operand::Immediate(0xFF),
+                width: crate::ir::RegisterWidth::X64,
             }
             .is_encodable_aarch64()
         );
@@ -3731,6 +3953,7 @@ mod tests {
             !Instruction::Tst {
                 rn: Register::SP,
                 rm: Operand::Immediate(0xFF),
+                width: crate::ir::RegisterWidth::X64,
             }
             .is_encodable_aarch64()
         );
@@ -3741,6 +3964,7 @@ mod tests {
                 rd: Register::SP,
                 rn: Register::X1,
                 rm: Operand::Immediate(0xFF),
+                width: crate::ir::RegisterWidth::X64,
             }
             .is_encodable_aarch64()
         );
@@ -3749,6 +3973,7 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::SP,
                 rm: Operand::Immediate(0xFF),
+                width: crate::ir::RegisterWidth::X64,
             }
             .is_encodable_aarch64()
         );

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -5,4 +5,4 @@ pub mod types;
 
 // Re-export commonly used types
 pub use instructions::Instruction;
-pub use types::{Condition, ExtendKind, LabelId, Operand, Register, ShiftKind};
+pub use types::{Condition, ExtendKind, LabelId, Operand, Register, RegisterWidth, ShiftKind};

--- a/src/ir/types.rs
+++ b/src/ir/types.rs
@@ -164,6 +164,45 @@ impl fmt::Display for Register {
     }
 }
 
+/// Register width for the narrow set of AArch64 instructions that this IR
+/// models in both architectural X and W forms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RegisterWidth {
+    W32,
+    X64,
+}
+
+impl RegisterWidth {
+    pub fn bit_width(self) -> u8 {
+        match self {
+            RegisterWidth::W32 => 32,
+            RegisterWidth::X64 => 64,
+        }
+    }
+
+    pub fn register_name(self, register: Register) -> &'static str {
+        const X_NAMES: [&str; 31] = [
+            "x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11", "x12", "x13",
+            "x14", "x15", "x16", "x17", "x18", "x19", "x20", "x21", "x22", "x23", "x24", "x25",
+            "x26", "x27", "x28", "x29", "x30",
+        ];
+        const W_NAMES: [&str; 31] = [
+            "w0", "w1", "w2", "w3", "w4", "w5", "w6", "w7", "w8", "w9", "w10", "w11", "w12", "w13",
+            "w14", "w15", "w16", "w17", "w18", "w19", "w20", "w21", "w22", "w23", "w24", "w25",
+            "w26", "w27", "w28", "w29", "w30",
+        ];
+
+        match (self, register) {
+            (RegisterWidth::X64, Register::XZR) => "xzr",
+            (RegisterWidth::X64, Register::SP) => "sp",
+            (RegisterWidth::X64, reg) => X_NAMES[reg.index().expect("x register index") as usize],
+            (RegisterWidth::W32, Register::XZR) => "wzr",
+            (RegisterWidth::W32, Register::SP) => "wsp",
+            (RegisterWidth::W32, reg) => W_NAMES[reg.index().expect("w register index") as usize],
+        }
+    }
+}
+
 /// AArch64 shift kind for the shifted-register operand form
 /// (`add x0, x1, x2, lsl #3` etc.). Issue #59.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -6,7 +6,7 @@
 
 use crate::ir::instructions::MOVW_LEGAL_SHIFTS;
 use crate::ir::types::Condition;
-use crate::ir::{Instruction, Operand, Register};
+use crate::ir::{Instruction, Operand, Register, RegisterWidth};
 use crate::isa::traits::{ISA, InstructionGenerator, InstructionType, OperandType, RegisterType};
 
 use rand::RngExt;
@@ -423,9 +423,24 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     let rm_op = Operand::Register(rm);
                     instructions.push(Instruction::Add { rd, rn, rm: rm_op });
                     instructions.push(Instruction::Sub { rd, rn, rm: rm_op });
-                    instructions.push(Instruction::And { rd, rn, rm: rm_op });
-                    instructions.push(Instruction::Orr { rd, rn, rm: rm_op });
-                    instructions.push(Instruction::Eor { rd, rn, rm: rm_op });
+                    instructions.push(Instruction::And {
+                        rd,
+                        rn,
+                        rm: rm_op,
+                        width: RegisterWidth::X64,
+                    });
+                    instructions.push(Instruction::Orr {
+                        rd,
+                        rn,
+                        rm: rm_op,
+                        width: RegisterWidth::X64,
+                    });
+                    instructions.push(Instruction::Eor {
+                        rd,
+                        rn,
+                        rm: rm_op,
+                        width: RegisterWidth::X64,
+                    });
                 }
             }
         }
@@ -571,7 +586,12 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     instructions.push(Instruction::Eon { rd, rn, rm: rm_op });
                     instructions.push(Instruction::Adds { rd, rn, rm: rm_op });
                     instructions.push(Instruction::Subs { rd, rn, rm: rm_op });
-                    instructions.push(Instruction::Ands { rd, rn, rm: rm_op });
+                    instructions.push(Instruction::Ands {
+                        rd,
+                        rn,
+                        rm: rm_op,
+                        width: RegisterWidth::X64,
+                    });
                 }
                 // ADDS / SUBS immediate forms (ANDS is register-only).
                 for &imm in immediates {
@@ -705,9 +725,24 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                 match opcode {
                     2 => Instruction::Add { rd, rn, rm },
                     3 => Instruction::Sub { rd, rn, rm },
-                    4 => Instruction::And { rd, rn, rm },
-                    5 => Instruction::Orr { rd, rn, rm },
-                    6 => Instruction::Eor { rd, rn, rm },
+                    4 => Instruction::And {
+                        rd,
+                        rn,
+                        rm,
+                        width: RegisterWidth::X64,
+                    },
+                    5 => Instruction::Orr {
+                        rd,
+                        rn,
+                        rm,
+                        width: RegisterWidth::X64,
+                    },
+                    6 => Instruction::Eor {
+                        rd,
+                        rn,
+                        rm,
+                        width: RegisterWidth::X64,
+                    },
                     _ => unreachable!(),
                 }
             }
@@ -799,6 +834,7 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                 rd,
                 rn,
                 rm: Operand::Register(pick_reg(rng)),
+                width: RegisterWidth::X64,
             },
             24 => {
                 let imm = (rng.random::<u32>() & 0xFFFF) as u16;
@@ -998,9 +1034,24 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     Instruction::MovImm { imm, .. } => Instruction::MovImm { rd: new_rd, imm },
                     Instruction::Add { rn, rm, .. } => Instruction::Add { rd: new_rd, rn, rm },
                     Instruction::Sub { rn, rm, .. } => Instruction::Sub { rd: new_rd, rn, rm },
-                    Instruction::And { rn, rm, .. } => Instruction::And { rd: new_rd, rn, rm },
-                    Instruction::Orr { rn, rm, .. } => Instruction::Orr { rd: new_rd, rn, rm },
-                    Instruction::Eor { rn, rm, .. } => Instruction::Eor { rd: new_rd, rn, rm },
+                    Instruction::And { rn, rm, width, .. } => Instruction::And {
+                        rd: new_rd,
+                        rn,
+                        rm,
+                        width,
+                    },
+                    Instruction::Orr { rn, rm, width, .. } => Instruction::Orr {
+                        rd: new_rd,
+                        rn,
+                        rm,
+                        width,
+                    },
+                    Instruction::Eor { rn, rm, width, .. } => Instruction::Eor {
+                        rd: new_rd,
+                        rn,
+                        rm,
+                        width,
+                    },
                     Instruction::Lsl { rn, shift, .. } => Instruction::Lsl {
                         rd: new_rd,
                         rn,
@@ -1089,7 +1140,12 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     Instruction::Eon { rn, rm, .. } => Instruction::Eon { rd: new_rd, rn, rm },
                     Instruction::Adds { rn, rm, .. } => Instruction::Adds { rd: new_rd, rn, rm },
                     Instruction::Subs { rn, rm, .. } => Instruction::Subs { rd: new_rd, rn, rm },
-                    Instruction::Ands { rn, rm, .. } => Instruction::Ands { rd: new_rd, rn, rm },
+                    Instruction::Ands { rn, rm, width, .. } => Instruction::Ands {
+                        rd: new_rd,
+                        rn,
+                        rm,
+                        width,
+                    },
                     Instruction::Cset { cond, .. } => Instruction::Cset { rd: new_rd, cond },
                     Instruction::Csetm { cond, .. } => Instruction::Csetm { rd: new_rd, cond },
                     Instruction::Ror { rn, shift, .. } => Instruction::Ror {
@@ -1183,21 +1239,51 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                         let new_rm = mutate_operand(rng, rm, registers, immediates, 0xFFF);
                         Instruction::Sub { rd, rn, rm: new_rm }
                     }
-                    Instruction::And { rd, rn, rm: _ } => {
+                    Instruction::And {
+                        rd,
+                        rn,
+                        rm: _,
+                        width,
+                    } => {
                         // AND doesn't support immediates, so only change register
                         let new_rm =
                             Operand::Register(registers[rng.random_range(0..registers.len())]);
-                        Instruction::And { rd, rn, rm: new_rm }
+                        Instruction::And {
+                            rd,
+                            rn,
+                            rm: new_rm,
+                            width,
+                        }
                     }
-                    Instruction::Orr { rd, rn, rm: _ } => {
+                    Instruction::Orr {
+                        rd,
+                        rn,
+                        rm: _,
+                        width,
+                    } => {
                         let new_rm =
                             Operand::Register(registers[rng.random_range(0..registers.len())]);
-                        Instruction::Orr { rd, rn, rm: new_rm }
+                        Instruction::Orr {
+                            rd,
+                            rn,
+                            rm: new_rm,
+                            width,
+                        }
                     }
-                    Instruction::Eor { rd, rn, rm: _ } => {
+                    Instruction::Eor {
+                        rd,
+                        rn,
+                        rm: _,
+                        width,
+                    } => {
                         let new_rm =
                             Operand::Register(registers[rng.random_range(0..registers.len())]);
-                        Instruction::Eor { rd, rn, rm: new_rm }
+                        Instruction::Eor {
+                            rd,
+                            rn,
+                            rm: new_rm,
+                            width,
+                        }
                     }
                     Instruction::Lsl { rd, rn, shift } => {
                         let new_shift = mutate_shift_operand(rng, shift, registers);
@@ -1296,10 +1382,14 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                         let new_rm = mutate_operand(rng, rm, registers, immediates, 0xFFF);
                         Instruction::Cmn { rn, rm: new_rm }
                     }
-                    Instruction::Tst { rn, rm: _ } => {
+                    Instruction::Tst { rn, rm: _, width } => {
                         let new_rm =
                             Operand::Register(registers[rng.random_range(0..registers.len())]);
-                        Instruction::Tst { rn, rm: new_rm }
+                        Instruction::Tst {
+                            rn,
+                            rm: new_rm,
+                            width,
+                        }
                     }
                     // CCMP / CCMN: pick a new rm (register or imm5). The
                     // dedicated mutate_operand path in
@@ -1438,10 +1528,20 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                         let new_rm = mutate_operand(rng, rm, registers, immediates, 0xFFF);
                         Instruction::Subs { rd, rn, rm: new_rm }
                     }
-                    Instruction::Ands { rd, rn, rm: _ } => {
+                    Instruction::Ands {
+                        rd,
+                        rn,
+                        rm: _,
+                        width,
+                    } => {
                         let new_rm =
                             Operand::Register(registers[rng.random_range(0..registers.len())]);
-                        Instruction::Ands { rd, rn, rm: new_rm }
+                        Instruction::Ands {
+                            rd,
+                            rn,
+                            rm: new_rm,
+                            width,
+                        }
                     }
                     // CSET / CSETM: only thing to "change as operand" is the cond.
                     // Pick from the 14 sensible conditions (skip AL/NV).
@@ -1677,16 +1777,19 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Register(Register::X2),
+                width: RegisterWidth::X64,
             },
             Instruction::Orr {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Register(Register::X2),
+                width: RegisterWidth::X64,
             },
             Instruction::Eor {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Register(Register::X2),
+                width: RegisterWidth::X64,
             },
             Instruction::Lsl {
                 rd: Register::X0,
@@ -1729,6 +1832,7 @@ mod tests {
             Instruction::Tst {
                 rn: Register::X1,
                 rm: Operand::Register(Register::X2),
+                width: RegisterWidth::X64,
             },
             Instruction::Csel {
                 rd: Register::X0,
@@ -1815,6 +1919,7 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Register(Register::X2),
+                width: RegisterWidth::X64,
             },
             Instruction::Cset {
                 rd: Register::X0,
@@ -2394,6 +2499,7 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Register(Register::X2),
+                width: RegisterWidth::X64,
             },
             Instruction::Cset {
                 rd: Register::X0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1953,9 +1953,13 @@ mod cli_helper_tests {
             ("adds", "x0, x1, #1"),
             ("subs", "x0, x1, x2"),
             ("and", "x0, x1, x2"),
+            ("and", "w0, w1, #0xff"),
             ("ands", "x0, x1, x2"),
+            ("ands", "w0, w1, #0xff"),
             ("orr", "x0, x1, x2"),
+            ("orr", "w0, w1, #0xff"),
             ("eor", "x0, x1, x2"),
+            ("eor", "w0, w1, #0xff"),
             ("bic", "x0, x1, x2"),
             ("bics", "x0, x1, x2"),
             ("orn", "x0, x1, x2"),
@@ -1976,6 +1980,7 @@ mod cli_helper_tests {
             ("cmp", "x1, x2, lsl #4"),
             ("cmn", "x1, x2"),
             ("tst", "x1, x2"),
+            ("tst", "w1, #0xff"),
             ("ccmp", "x1, x2, #5, eq"),
             ("ccmn", "x1, #15, #3, ne"),
             ("csel", "x0, x1, x2, eq"),
@@ -2099,7 +2104,7 @@ mod cli_helper_tests {
         // Tripwire: bump in lockstep when adding/removing rows. Catches
         // accidental row deletion and forces a re-read when adding a parser
         // mnemonic without a matching test row.
-        assert_eq!(cases.len(), 132);
+        assert_eq!(cases.len(), 137);
 
         fn docs_mnemonic(mnemonic: &'static str) -> &'static str {
             if mnemonic.starts_with("b.") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1940,6 +1940,8 @@ mod cli_helper_tests {
         let cases = [
             ("mov", "x0, x1"),
             ("mov", "x0, #5"),
+            ("mov", "w0, #0xff"),
+            ("mov", "wsp, #0xff"),
             ("mvn", "x0, x1"),
             ("neg", "x0, x1"),
             ("negs", "x0, x1"),
@@ -2104,7 +2106,7 @@ mod cli_helper_tests {
         // Tripwire: bump in lockstep when adding/removing rows. Catches
         // accidental row deletion and forces a re-read when adding a parser
         // mnemonic without a matching test row.
-        assert_eq!(cases.len(), 137);
+        assert_eq!(cases.len(), 139);
 
         fn docs_mnemonic(mnemonic: &'static str) -> &'static str {
             if mnemonic.starts_with("b.") {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -17,7 +17,7 @@ use std::path::Path;
 
 use crate::ir::instructions::MOVW_LEGAL_SHIFTS;
 use crate::ir::types::NORMAL_CONDITIONS;
-use crate::ir::{Condition, Instruction, LabelId, Operand, Register, ShiftKind};
+use crate::ir::{Condition, Instruction, LabelId, Operand, Register, RegisterWidth, ShiftKind};
 
 pub mod x86;
 
@@ -196,6 +196,42 @@ pub fn parse_w_or_x_register(s: &str) -> Result<Register, String> {
         "wsp" => Ok(Register::SP),
         _ => Err(format!("unknown register: {}", s)),
     }
+}
+
+fn parse_sized_register(s: &str) -> Result<(Register, RegisterWidth), String> {
+    let lower = s.to_lowercase();
+    match lower.as_str() {
+        "wzr" => return Ok((Register::XZR, RegisterWidth::W32)),
+        "wsp" => return Ok((Register::SP, RegisterWidth::W32)),
+        _ => {}
+    }
+
+    if let Some(raw_index) = lower.strip_prefix('w')
+        && let Ok(index) = raw_index.parse::<u8>()
+        && index <= 30
+    {
+        return Ok((
+            Register::from_index(index).expect("valid W register index"),
+            RegisterWidth::W32,
+        ));
+    }
+
+    parse_register(s).map(|register| (register, RegisterWidth::X64))
+}
+
+fn parse_same_width_registers(
+    mnem: &str,
+    operands: &[&str],
+) -> Result<(Register, Register, RegisterWidth), String> {
+    let (rd, rd_width) = parse_sized_register(operands[0])?;
+    let (rn, rn_width) = parse_sized_register(operands[1])?;
+    if rd_width != rn_width {
+        return Err(format!(
+            "{} operands must use matching register widths",
+            mnem
+        ));
+    }
+    Ok((rd, rn, rd_width))
 }
 
 /// Parse an immediate value (with or without # prefix, hex or decimal)
@@ -515,10 +551,24 @@ fn parse_subs(operands: &[&str]) -> Result<Instruction, String> {
 
 /// Parse ANDS instruction (register-only rm)
 fn parse_ands(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() == 3 {
+        let (rd, rn, width) = parse_same_width_registers("ands", operands)?;
+        let rm = match width {
+            RegisterWidth::W32 => Operand::Immediate(parse_immediate(operands[2])?),
+            RegisterWidth::X64 => parse_operand(operands[2])?,
+        };
+        return Ok(Instruction::Ands { rd, rn, rm, width });
+    }
+
     let rm = parse_rm_3op("ands", operands)?;
     let rd = parse_register(operands[0])?;
     let rn = parse_register(operands[1])?;
-    Ok(Instruction::Ands { rd, rn, rm })
+    Ok(Instruction::Ands {
+        rd,
+        rn,
+        rm,
+        width: RegisterWidth::X64,
+    })
 }
 
 /// Parse CSET instruction: `cset rd, cond`
@@ -1090,26 +1140,68 @@ fn parse_sub(operands: &[&str]) -> Result<Instruction, String> {
 
 /// Parse AND instruction
 fn parse_and(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() == 3 {
+        let (rd, rn, width) = parse_same_width_registers("and", operands)?;
+        let rm = match width {
+            RegisterWidth::W32 => Operand::Immediate(parse_immediate(operands[2])?),
+            RegisterWidth::X64 => parse_operand(operands[2])?,
+        };
+        return Ok(Instruction::And { rd, rn, rm, width });
+    }
+
     let rm = parse_rm_3op("and", operands)?;
     let rd = parse_register(operands[0])?;
     let rn = parse_register(operands[1])?;
-    Ok(Instruction::And { rd, rn, rm })
+    Ok(Instruction::And {
+        rd,
+        rn,
+        rm,
+        width: RegisterWidth::X64,
+    })
 }
 
 /// Parse ORR instruction
 fn parse_orr(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() == 3 {
+        let (rd, rn, width) = parse_same_width_registers("orr", operands)?;
+        let rm = match width {
+            RegisterWidth::W32 => Operand::Immediate(parse_immediate(operands[2])?),
+            RegisterWidth::X64 => parse_operand(operands[2])?,
+        };
+        return Ok(Instruction::Orr { rd, rn, rm, width });
+    }
+
     let rm = parse_rm_3op("orr", operands)?;
     let rd = parse_register(operands[0])?;
     let rn = parse_register(operands[1])?;
-    Ok(Instruction::Orr { rd, rn, rm })
+    Ok(Instruction::Orr {
+        rd,
+        rn,
+        rm,
+        width: RegisterWidth::X64,
+    })
 }
 
 /// Parse EOR instruction
 fn parse_eor(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() == 3 {
+        let (rd, rn, width) = parse_same_width_registers("eor", operands)?;
+        let rm = match width {
+            RegisterWidth::W32 => Operand::Immediate(parse_immediate(operands[2])?),
+            RegisterWidth::X64 => parse_operand(operands[2])?,
+        };
+        return Ok(Instruction::Eor { rd, rn, rm, width });
+    }
+
     let rm = parse_rm_3op("eor", operands)?;
     let rd = parse_register(operands[0])?;
     let rn = parse_register(operands[1])?;
-    Ok(Instruction::Eor { rd, rn, rm })
+    Ok(Instruction::Eor {
+        rd,
+        rn,
+        rm,
+        width: RegisterWidth::X64,
+    })
 }
 
 /// Parse LSL instruction
@@ -1300,9 +1392,22 @@ fn parse_cmn(operands: &[&str]) -> Result<Instruction, String> {
 
 /// Parse TST instruction
 fn parse_tst(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() == 2 {
+        let (rn, width) = parse_sized_register(operands[0])?;
+        let rm = match width {
+            RegisterWidth::W32 => Operand::Immediate(parse_immediate(operands[1])?),
+            RegisterWidth::X64 => parse_operand(operands[1])?,
+        };
+        return Ok(Instruction::Tst { rn, rm, width });
+    }
+
     let rm = parse_rm_2op("tst", operands)?;
     let rn = parse_register(operands[0])?;
-    Ok(Instruction::Tst { rn, rm })
+    Ok(Instruction::Tst {
+        rn,
+        rm,
+        width: RegisterWidth::X64,
+    })
 }
 
 /// Parse CCMP instruction: `ccmp Xn, <Xm | #imm5>, #nzcv, cond`.
@@ -1973,6 +2078,7 @@ mod tests {
                     kind: ShiftKind::Ror,
                     amount: 8,
                 },
+                width: RegisterWidth::X64,
             }
         );
     }
@@ -2162,6 +2268,35 @@ mod tests {
         assert!(parse_line("tst x1, #0x8000000000000000").is_ok());
     }
 
+    #[test]
+    fn test_parse_w_logical_immediates_roundtrip() {
+        for text in [
+            "and w0, w1, #255",
+            "orr w0, w1, #255",
+            "eor w0, w1, #255",
+            "tst w1, #255",
+            "ands w0, w1, #255",
+            "and wsp, w1, #255",
+            "ands wzr, w1, #255",
+        ] {
+            let instr = parse_one(text);
+            assert_eq!(format!("{}", instr), text);
+        }
+    }
+
+    #[test]
+    fn test_parse_w_logical_immediates_reject_invalid_slots_and_forms() {
+        for text in [
+            "and wzr, w1, #255",
+            "ands wsp, w1, #255",
+            "tst wsp, #255",
+            "and w0, x1, #255",
+            "and w0, w1, w2",
+        ] {
+            assert!(parse_line(text).is_err(), "{text} should be rejected");
+        }
+    }
+
     // Full assembly parsing tests
     #[test]
     fn test_parse_assembly_string() {
@@ -2247,6 +2382,7 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Register(Register::X2),
+                width: RegisterWidth::X64,
             },
             Instruction::Cset {
                 rd: Register::X0,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -366,6 +366,23 @@ fn parse_mov(operands: &[&str]) -> Result<Instruction, String> {
         return Err(format!("mov requires 2 operands, got {}", operands.len()));
     }
 
+    if let Ok((rd, RegisterWidth::W32)) = parse_sized_register(operands[0]) {
+        let src = parse_operand(operands[1])?;
+        return match src {
+            Operand::Immediate(imm) => Ok(Instruction::Orr {
+                rd,
+                rn: Register::XZR,
+                rm: Operand::Immediate(imm),
+                width: RegisterWidth::W32,
+            }),
+            Operand::Register(_)
+            | Operand::ShiftedRegister { .. }
+            | Operand::ExtendedRegister { .. } => {
+                Err("mov W-register form only supports logical-immediate aliases".to_string())
+            }
+        };
+    }
+
     let rd = parse_register(operands[0])?;
     let src = parse_operand(operands[1])?;
 
@@ -2285,6 +2302,33 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_mov_w_logical_immediate_aliases() {
+        let instr = parse_one("mov w0, #0xff");
+        assert_eq!(
+            instr,
+            Instruction::Orr {
+                rd: Register::X0,
+                rn: Register::XZR,
+                rm: Operand::Immediate(255),
+                width: RegisterWidth::W32,
+            }
+        );
+        assert_eq!(format!("{}", instr), "orr w0, wzr, #255");
+
+        let instr = parse_one("mov wsp, #0xff");
+        assert_eq!(
+            instr,
+            Instruction::Orr {
+                rd: Register::SP,
+                rn: Register::XZR,
+                rm: Operand::Immediate(255),
+                width: RegisterWidth::W32,
+            }
+        );
+        assert_eq!(format!("{}", instr), "orr wsp, wzr, #255");
+    }
+
+    #[test]
     fn test_parse_w_logical_immediates_reject_invalid_slots_and_forms() {
         for text in [
             "and wzr, w1, #255",
@@ -2292,6 +2336,9 @@ mod tests {
             "tst wsp, #255",
             "and w0, x1, #255",
             "and w0, w1, w2",
+            "mov wzr, #0xff",
+            "mov w0, #5",
+            "mov w0, w1",
         ] {
             assert!(parse_line(text).is_err(), "{text} should be rejected");
         }

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -1,7 +1,7 @@
 //! Instruction generation utilities for search algorithms
 
 use crate::ir::instructions::MOVW_LEGAL_SHIFTS;
-use crate::ir::{Instruction, Operand, Register};
+use crate::ir::{Instruction, Operand, Register, RegisterWidth};
 use crate::isa::{AArch64, Assembler, InstructionType};
 
 /// Generic encodability check: for any `<I: InstructionType, A: Assembler<I>>`,
@@ -66,9 +66,24 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
 
                 instrs.push(Instruction::Add { rd, rn, rm: rm_op });
                 instrs.push(Instruction::Sub { rd, rn, rm: rm_op });
-                instrs.push(Instruction::And { rd, rn, rm: rm_op });
-                instrs.push(Instruction::Orr { rd, rn, rm: rm_op });
-                instrs.push(Instruction::Eor { rd, rn, rm: rm_op });
+                instrs.push(Instruction::And {
+                    rd,
+                    rn,
+                    rm: rm_op,
+                    width: RegisterWidth::X64,
+                });
+                instrs.push(Instruction::Orr {
+                    rd,
+                    rn,
+                    rm: rm_op,
+                    width: RegisterWidth::X64,
+                });
+                instrs.push(Instruction::Eor {
+                    rd,
+                    rn,
+                    rm: rm_op,
+                    width: RegisterWidth::X64,
+                });
                 instrs.push(Instruction::Lsl {
                     rd,
                     rn,
@@ -92,9 +107,24 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
 
                 instrs.push(Instruction::Add { rd, rn, rm: imm_op });
                 instrs.push(Instruction::Sub { rd, rn, rm: imm_op });
-                instrs.push(Instruction::And { rd, rn, rm: imm_op });
-                instrs.push(Instruction::Orr { rd, rn, rm: imm_op });
-                instrs.push(Instruction::Eor { rd, rn, rm: imm_op });
+                instrs.push(Instruction::And {
+                    rd,
+                    rn,
+                    rm: imm_op,
+                    width: RegisterWidth::X64,
+                });
+                instrs.push(Instruction::Orr {
+                    rd,
+                    rn,
+                    rm: imm_op,
+                    width: RegisterWidth::X64,
+                });
+                instrs.push(Instruction::Eor {
+                    rd,
+                    rn,
+                    rm: imm_op,
+                    width: RegisterWidth::X64,
+                });
             }
 
             // Shifted-register form (issue #59):
@@ -113,9 +143,24 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
                         };
                         instrs.push(Instruction::Add { rd, rn, rm: sr });
                         instrs.push(Instruction::Sub { rd, rn, rm: sr });
-                        instrs.push(Instruction::And { rd, rn, rm: sr });
-                        instrs.push(Instruction::Orr { rd, rn, rm: sr });
-                        instrs.push(Instruction::Eor { rd, rn, rm: sr });
+                        instrs.push(Instruction::And {
+                            rd,
+                            rn,
+                            rm: sr,
+                            width: RegisterWidth::X64,
+                        });
+                        instrs.push(Instruction::Orr {
+                            rd,
+                            rn,
+                            rm: sr,
+                            width: RegisterWidth::X64,
+                        });
+                        instrs.push(Instruction::Eor {
+                            rd,
+                            rn,
+                            rm: sr,
+                            width: RegisterWidth::X64,
+                        });
                     }
                     // ROR — logical only.
                     let sr_ror = Operand::ShiftedRegister {
@@ -123,9 +168,24 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
                         kind: ShiftKind::Ror,
                         amount,
                     };
-                    instrs.push(Instruction::And { rd, rn, rm: sr_ror });
-                    instrs.push(Instruction::Orr { rd, rn, rm: sr_ror });
-                    instrs.push(Instruction::Eor { rd, rn, rm: sr_ror });
+                    instrs.push(Instruction::And {
+                        rd,
+                        rn,
+                        rm: sr_ror,
+                        width: RegisterWidth::X64,
+                    });
+                    instrs.push(Instruction::Orr {
+                        rd,
+                        rn,
+                        rm: sr_ror,
+                        width: RegisterWidth::X64,
+                    });
+                    instrs.push(Instruction::Eor {
+                        rd,
+                        rn,
+                        rm: sr_ror,
+                        width: RegisterWidth::X64,
+                    });
                 }
                 // Issue #60: extended-register form for ADD/SUB. Cmp/Cmn
                 // are produced once-per-(rn,rm,kind,shift) further below
@@ -200,7 +260,12 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
                 instrs.push(Instruction::Eon { rd, rn, rm: rm_op });
                 instrs.push(Instruction::Adds { rd, rn, rm: rm_op });
                 instrs.push(Instruction::Subs { rd, rn, rm: rm_op });
-                instrs.push(Instruction::Ands { rd, rn, rm: rm_op });
+                instrs.push(Instruction::Ands {
+                    rd,
+                    rn,
+                    rm: rm_op,
+                    width: RegisterWidth::X64,
+                });
             }
             // ADDS / SUBS also accept the same 12-bit-class immediate table
             // ADD / SUB does — keep them in sync. ANDS accepts bitmask
@@ -359,7 +424,11 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
             let rm_op = Operand::Register(rm);
             instrs.push(Instruction::Cmp { rn, rm: rm_op });
             instrs.push(Instruction::Cmn { rn, rm: rm_op });
-            instrs.push(Instruction::Tst { rn, rm: rm_op });
+            instrs.push(Instruction::Tst {
+                rn,
+                rm: rm_op,
+                width: RegisterWidth::X64,
+            });
         }
         for &imm in immediates {
             let imm_op = Operand::Immediate(imm);
@@ -582,17 +651,32 @@ pub fn generate_random_instruction<R: rand::RngExt>(
         4 => {
             let rn = pick_reg(rng);
             let rm = Operand::Register(pick_reg(rng));
-            Instruction::And { rd, rn, rm }
+            Instruction::And {
+                rd,
+                rn,
+                rm,
+                width: RegisterWidth::X64,
+            }
         }
         5 => {
             let rn = pick_reg(rng);
             let rm = Operand::Register(pick_reg(rng));
-            Instruction::Orr { rd, rn, rm }
+            Instruction::Orr {
+                rd,
+                rn,
+                rm,
+                width: RegisterWidth::X64,
+            }
         }
         6 => {
             let rn = pick_reg(rng);
             let rm = Operand::Register(pick_reg(rng));
-            Instruction::Eor { rd, rn, rm }
+            Instruction::Eor {
+                rd,
+                rn,
+                rm,
+                width: RegisterWidth::X64,
+            }
         }
         7 => {
             let rn = pick_reg(rng);
@@ -661,7 +745,12 @@ pub fn generate_random_instruction<R: rand::RngExt>(
         20 => {
             let rn = pick_reg(rng);
             let rm = Operand::Register(pick_reg(rng));
-            Instruction::Ands { rd, rn, rm }
+            Instruction::Ands {
+                rd,
+                rn,
+                rm,
+                width: RegisterWidth::X64,
+            }
         }
         21 => Instruction::Cset {
             rd,
@@ -845,6 +934,7 @@ pub fn generate_random_instruction<R: rand::RngExt>(
                 _ => Instruction::Tst {
                     rn,
                     rm: Operand::Register(pick_reg(rng)),
+                    width: RegisterWidth::X64,
                 },
             }
         }
@@ -1197,6 +1287,7 @@ mod tests {
                 Instruction::Tst {
                     rn: Register::X0,
                     rm: Operand::Register(Register::X1),
+                    width: RegisterWidth::X64,
                 },
             ),
         ] {
@@ -1556,16 +1647,19 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Immediate(0),
+                width: RegisterWidth::X64,
             },
             Instruction::Orr {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Immediate(0),
+                width: RegisterWidth::X64,
             },
             Instruction::Eor {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Immediate(0),
+                width: RegisterWidth::X64,
             },
             Instruction::Lsl {
                 rd: Register::X0,

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -424,11 +424,13 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X0,
                 rm: Operand::Register(Register::X0),
+                width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Eor {
                 rd: Register::X2,
                 rn: Register::X2,
                 rm: Operand::Register(Register::X2),
+                width: crate::ir::RegisterWidth::X64,
             },
         ];
         let live_out = LiveOut::from_registers(vec![Register::X0, Register::X2]);

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -443,6 +443,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X0,
             rm: Operand::Register(Register::X0),
+            width: crate::ir::RegisterWidth::X64,
         }];
 
         let input = ConcreteMachineState::new_zeroed();

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -10,7 +10,7 @@
 
 use crate::ir::instructions::MOVW_LEGAL_SHIFTS;
 use crate::ir::types::Condition;
-use crate::ir::{Instruction, Operand, Register};
+use crate::ir::{Instruction, Operand, Register, RegisterWidth};
 use crate::search::candidate::generate_random_instruction;
 use crate::search::config::MutationWeights;
 use rand::RngExt;
@@ -161,15 +161,21 @@ impl Mutator {
                     _ => *rm = Self::clamp_imm12(self.random_operand_3op(rng, false)),
                 }
             }
-            Instruction::And { rd, rn, rm }
-            | Instruction::Orr { rd, rn, rm }
-            | Instruction::Eor { rd, rn, rm } => {
+            Instruction::And { rd, rn, rm, width }
+            | Instruction::Orr { rd, rn, rm, width }
+            | Instruction::Eor { rd, rn, rm, width } => {
                 let choice = rng.random_range(0..3);
                 match choice {
                     0 => *rd = self.random_register(rng),
                     1 => *rn = self.random_register(rng),
                     // Logical ops accept ROR in the shifted-register form.
-                    _ => *rm = self.random_operand_3op(rng, true),
+                    _ => {
+                        *rm = if *width == RegisterWidth::W32 {
+                            Operand::Immediate(self.random_immediate(rng))
+                        } else {
+                            self.random_operand_3op(rng, true)
+                        }
+                    }
                 }
             }
             Instruction::Lsl { rd, rn, shift }
@@ -223,9 +229,11 @@ impl Mutator {
                     *rm = Self::clamp_imm12(self.random_operand_3op(rng, false));
                 }
             }
-            Instruction::Tst { rn, rm } => {
+            Instruction::Tst { rn, rm, width } => {
                 if rng.random_bool(0.5) {
                     *rn = self.random_register(rng);
+                } else if *width == RegisterWidth::W32 {
+                    *rm = Operand::Immediate(self.random_immediate(rng));
                 } else {
                     // Tst is register-only for non-shifted form. Use the 3op
                     // helper but force the non-shifted fallback to a Register
@@ -340,12 +348,18 @@ impl Mutator {
                     _ => *rm = Self::clamp_imm12(self.random_operand(rng)),
                 }
             }
-            Instruction::Ands { rd, rn, rm } => {
+            Instruction::Ands { rd, rn, rm, width } => {
                 let choice = rng.random_range(0..3);
                 match choice {
                     0 => *rd = self.random_register(rng),
                     1 => *rn = self.random_register(rng),
-                    _ => *rm = Operand::Register(self.random_register(rng)),
+                    _ => {
+                        *rm = if *width == RegisterWidth::W32 {
+                            Operand::Immediate(self.random_immediate(rng))
+                        } else {
+                            Operand::Register(self.random_register(rng))
+                        }
+                    }
                 }
             }
             // CSET / CSETM: only rd and cond can change; cond from the 14
@@ -471,19 +485,49 @@ impl Mutator {
             }
             Instruction::Add { rd, rn, rm } => match rng.random_range(0..5) {
                 0 => Instruction::Sub { rd, rn, rm },
-                1 => Instruction::And { rd, rn, rm },
-                2 => Instruction::Orr { rd, rn, rm },
-                3 => Instruction::Eor { rd, rn, rm },
+                1 => Instruction::And {
+                    rd,
+                    rn,
+                    rm,
+                    width: RegisterWidth::X64,
+                },
+                2 => Instruction::Orr {
+                    rd,
+                    rn,
+                    rm,
+                    width: RegisterWidth::X64,
+                },
+                3 => Instruction::Eor {
+                    rd,
+                    rn,
+                    rm,
+                    width: RegisterWidth::X64,
+                },
                 _ => Instruction::Add { rd, rn, rm },
             },
             Instruction::Sub { rd, rn, rm } => match rng.random_range(0..5) {
                 0 => Instruction::Add { rd, rn, rm },
-                1 => Instruction::And { rd, rn, rm },
-                2 => Instruction::Orr { rd, rn, rm },
-                3 => Instruction::Eor { rd, rn, rm },
+                1 => Instruction::And {
+                    rd,
+                    rn,
+                    rm,
+                    width: RegisterWidth::X64,
+                },
+                2 => Instruction::Orr {
+                    rd,
+                    rn,
+                    rm,
+                    width: RegisterWidth::X64,
+                },
+                3 => Instruction::Eor {
+                    rd,
+                    rn,
+                    rm,
+                    width: RegisterWidth::X64,
+                },
                 _ => Instruction::Sub { rd, rn, rm },
             },
-            Instruction::And { rd, rn, rm } => match rng.random_range(0..5) {
+            Instruction::And { rd, rn, rm, width } => match rng.random_range(0..5) {
                 // Logical -> arithmetic: drop ROR from the shifted-register form.
                 0 => Instruction::Add {
                     rd,
@@ -495,11 +539,11 @@ impl Mutator {
                     rn,
                     rm: strip_ror_for_arith(rm),
                 },
-                2 => Instruction::Orr { rd, rn, rm },
-                3 => Instruction::Eor { rd, rn, rm },
-                _ => Instruction::And { rd, rn, rm },
+                2 => Instruction::Orr { rd, rn, rm, width },
+                3 => Instruction::Eor { rd, rn, rm, width },
+                _ => Instruction::And { rd, rn, rm, width },
             },
-            Instruction::Orr { rd, rn, rm } => match rng.random_range(0..5) {
+            Instruction::Orr { rd, rn, rm, width } => match rng.random_range(0..5) {
                 0 => Instruction::Add {
                     rd,
                     rn,
@@ -510,11 +554,11 @@ impl Mutator {
                     rn,
                     rm: strip_ror_for_arith(rm),
                 },
-                2 => Instruction::And { rd, rn, rm },
-                3 => Instruction::Eor { rd, rn, rm },
-                _ => Instruction::Orr { rd, rn, rm },
+                2 => Instruction::And { rd, rn, rm, width },
+                3 => Instruction::Eor { rd, rn, rm, width },
+                _ => Instruction::Orr { rd, rn, rm, width },
             },
-            Instruction::Eor { rd, rn, rm } => match rng.random_range(0..5) {
+            Instruction::Eor { rd, rn, rm, width } => match rng.random_range(0..5) {
                 0 => Instruction::Add {
                     rd,
                     rn,
@@ -525,9 +569,9 @@ impl Mutator {
                     rn,
                     rm: strip_ror_for_arith(rm),
                 },
-                2 => Instruction::And { rd, rn, rm },
-                3 => Instruction::Orr { rd, rn, rm },
-                _ => Instruction::Eor { rd, rn, rm },
+                2 => Instruction::And { rd, rn, rm, width },
+                3 => Instruction::Orr { rd, rn, rm, width },
+                _ => Instruction::Eor { rd, rn, rm, width },
             },
             Instruction::Lsl { rd, rn, shift } => match rng.random_range(0..3) {
                 0 => Instruction::Lsr { rd, rn, shift },
@@ -563,15 +607,23 @@ impl Mutator {
             // Comparison instructions can mutate between each other
             Instruction::Cmp { rn, rm } => match rng.random_range(0..3) {
                 0 => Instruction::Cmn { rn, rm },
-                1 => Instruction::Tst { rn, rm },
+                1 => Instruction::Tst {
+                    rn,
+                    rm,
+                    width: RegisterWidth::X64,
+                },
                 _ => Instruction::Cmp { rn, rm },
             },
             Instruction::Cmn { rn, rm } => match rng.random_range(0..3) {
                 0 => Instruction::Cmp { rn, rm },
-                1 => Instruction::Tst { rn, rm },
+                1 => Instruction::Tst {
+                    rn,
+                    rm,
+                    width: RegisterWidth::X64,
+                },
                 _ => Instruction::Cmn { rn, rm },
             },
-            Instruction::Tst { rn, rm } => match rng.random_range(0..3) {
+            Instruction::Tst { rn, rm, width } => match rng.random_range(0..3) {
                 // Tst (logical) -> Cmp/Cmn (arithmetic): drop ROR.
                 0 => Instruction::Cmp {
                     rn,
@@ -581,7 +633,7 @@ impl Mutator {
                     rn,
                     rm: strip_ror_for_arith(rm),
                 },
-                _ => Instruction::Tst { rn, rm },
+                _ => Instruction::Tst { rn, rm, width },
             },
             // CCMP ↔ CCMN swap (both share (rn, rm, nzcv, cond)).
             Instruction::Ccmp { rn, rm, nzcv, cond } => Instruction::Ccmn { rn, rm, nzcv, cond },
@@ -723,9 +775,24 @@ impl Mutator {
             },
             // Inverted-logical join the AND/ORR/EOR cluster.
             Instruction::Bic { rd, rn, rm } => match rng.random_range(0..7) {
-                0 => Instruction::And { rd, rn, rm },
-                1 => Instruction::Orr { rd, rn, rm },
-                2 => Instruction::Eor { rd, rn, rm },
+                0 => Instruction::And {
+                    rd,
+                    rn,
+                    rm,
+                    width: RegisterWidth::X64,
+                },
+                1 => Instruction::Orr {
+                    rd,
+                    rn,
+                    rm,
+                    width: RegisterWidth::X64,
+                },
+                2 => Instruction::Eor {
+                    rd,
+                    rn,
+                    rm,
+                    width: RegisterWidth::X64,
+                },
                 3 => Instruction::Bics { rd, rn, rm },
                 4 => Instruction::Orn { rd, rn, rm },
                 5 => Instruction::Eon { rd, rn, rm },
@@ -736,24 +803,59 @@ impl Mutator {
             // BIC. The original 1-peer version made BICS effectively a
             // dead-end neighbour, slowing convergence.
             Instruction::Bics { rd, rn, rm } => match rng.random_range(0..7) {
-                0 => Instruction::And { rd, rn, rm },
-                1 => Instruction::Orr { rd, rn, rm },
-                2 => Instruction::Eor { rd, rn, rm },
+                0 => Instruction::And {
+                    rd,
+                    rn,
+                    rm,
+                    width: RegisterWidth::X64,
+                },
+                1 => Instruction::Orr {
+                    rd,
+                    rn,
+                    rm,
+                    width: RegisterWidth::X64,
+                },
+                2 => Instruction::Eor {
+                    rd,
+                    rn,
+                    rm,
+                    width: RegisterWidth::X64,
+                },
                 3 => Instruction::Bic { rd, rn, rm },
                 4 => Instruction::Orn { rd, rn, rm },
                 5 => Instruction::Eon { rd, rn, rm },
                 _ => Instruction::Bics { rd, rn, rm },
             },
             Instruction::Orn { rd, rn, rm } => match rng.random_range(0..5) {
-                0 => Instruction::And { rd, rn, rm },
-                1 => Instruction::Orr { rd, rn, rm },
+                0 => Instruction::And {
+                    rd,
+                    rn,
+                    rm,
+                    width: RegisterWidth::X64,
+                },
+                1 => Instruction::Orr {
+                    rd,
+                    rn,
+                    rm,
+                    width: RegisterWidth::X64,
+                },
                 2 => Instruction::Bic { rd, rn, rm },
                 3 => Instruction::Eon { rd, rn, rm },
                 _ => Instruction::Orn { rd, rn, rm },
             },
             Instruction::Eon { rd, rn, rm } => match rng.random_range(0..5) {
-                0 => Instruction::And { rd, rn, rm },
-                1 => Instruction::Eor { rd, rn, rm },
+                0 => Instruction::And {
+                    rd,
+                    rn,
+                    rm,
+                    width: RegisterWidth::X64,
+                },
+                1 => Instruction::Eor {
+                    rd,
+                    rn,
+                    rm,
+                    width: RegisterWidth::X64,
+                },
                 2 => Instruction::Bic { rd, rn, rm },
                 3 => Instruction::Orn { rd, rn, rm },
                 _ => Instruction::Eon { rd, rn, rm },
@@ -773,6 +875,7 @@ impl Mutator {
                     rd,
                     rn,
                     rm: clamp_to_register(rm, &self.registers, rng),
+                    width: RegisterWidth::X64,
                 },
                 _ => Instruction::Adds { rd, rn, rm },
             },
@@ -783,14 +886,15 @@ impl Mutator {
                     rd,
                     rn,
                     rm: clamp_to_register(rm, &self.registers, rng),
+                    width: RegisterWidth::X64,
                 },
                 _ => Instruction::Subs { rd, rn, rm },
             },
-            Instruction::Ands { rd, rn, rm } => match rng.random_range(0..4) {
-                0 => Instruction::And { rd, rn, rm },
+            Instruction::Ands { rd, rn, rm, width } => match rng.random_range(0..4) {
+                0 => Instruction::And { rd, rn, rm, width },
                 1 => Instruction::Adds { rd, rn, rm },
                 2 => Instruction::Subs { rd, rn, rm },
-                _ => Instruction::Ands { rd, rn, rm },
+                _ => Instruction::Ands { rd, rn, rm, width },
             },
             // CSET ↔ CSETM
             Instruction::Cset { rd, cond } => match rng.random_range(0..2) {
@@ -1367,6 +1471,7 @@ mod tests {
                 kind: crate::ir::ShiftKind::Ror,
                 amount: 4,
             },
+            width: RegisterWidth::X64,
         };
         let mut saw_arith_after_bridge = false;
         for _ in 0..2000 {
@@ -1816,6 +1921,7 @@ mod tests {
                         kind: crate::ir::ShiftKind::Ror,
                         amount: 4,
                     },
+                    width: RegisterWidth::X64,
                 }],
             ];
 

--- a/src/search/symbolic/sketch.rs
+++ b/src/search/symbolic/sketch.rs
@@ -95,9 +95,24 @@ impl SymbolicInstruction {
             }
             2 => Some(Instruction::Add { rd, rn, rm }),
             3 => Some(Instruction::Sub { rd, rn, rm }),
-            4 => Some(Instruction::And { rd, rn, rm }),
-            5 => Some(Instruction::Orr { rd, rn, rm }),
-            6 => Some(Instruction::Eor { rd, rn, rm }),
+            4 => Some(Instruction::And {
+                rd,
+                rn,
+                rm,
+                width: crate::ir::RegisterWidth::X64,
+            }),
+            5 => Some(Instruction::Orr {
+                rd,
+                rn,
+                rm,
+                width: crate::ir::RegisterWidth::X64,
+            }),
+            6 => Some(Instruction::Eor {
+                rd,
+                rn,
+                rm,
+                width: crate::ir::RegisterWidth::X64,
+            }),
             7 => Some(Instruction::Lsl { rd, rn, shift: rm }),
             8 => Some(Instruction::Lsr { rd, rn, shift: rm }),
             9 => Some(Instruction::Asr { rd, rn, shift: rm }),

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -894,6 +894,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X0,
             rm: Operand::Register(Register::X0),
+            width: crate::ir::RegisterWidth::X64,
         }];
 
         assert!(search.verify_equivalence(&target, &candidate, &live_out, &config));

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -1,7 +1,7 @@
 //! Concrete interpreter for fast validation of instruction sequences
 
 use crate::ir::types::{AccessWidth, AddressOperand, IndexMode};
-use crate::ir::{Condition, Instruction, Operand, Register, ShiftKind};
+use crate::ir::{Condition, Instruction, Operand, Register, RegisterWidth, ShiftKind};
 use crate::semantics::live_out::RegisterSet;
 use crate::semantics::state::{ConcreteMachineState, ConcreteValue, ConditionFlags};
 
@@ -38,6 +38,34 @@ fn eval_operand(state: &ConcreteMachineState, operand: &Operand) -> ConcreteValu
     }
 }
 
+fn mask_for_register_width(width: RegisterWidth) -> u64 {
+    match width {
+        RegisterWidth::W32 => u32::MAX as u64,
+        RegisterWidth::X64 => u64::MAX,
+    }
+}
+
+fn eval_logical_operand(
+    state: &ConcreteMachineState,
+    operand: &Operand,
+    width: RegisterWidth,
+) -> u64 {
+    eval_operand(state, operand).as_u64() & mask_for_register_width(width)
+}
+
+fn logical_flags(result: u64, width: RegisterWidth) -> ConditionFlags {
+    let sign_bit = match width {
+        RegisterWidth::W32 => 1u64 << 31,
+        RegisterWidth::X64 => 1u64 << 63,
+    };
+    ConditionFlags {
+        n: (result & sign_bit) != 0,
+        z: (result & mask_for_register_width(width)) == 0,
+        c: false,
+        v: false,
+    }
+}
+
 /// Apply a single instruction to a concrete machine state
 pub fn apply_instruction_concrete(
     mut state: ConcreteMachineState,
@@ -64,22 +92,22 @@ pub fn apply_instruction_concrete(
             let result = lhs.wrapping_sub(rhs);
             state.set_register(*rd, ConcreteValue::new(result));
         }
-        Instruction::And { rd, rn, rm } => {
-            let lhs = state.get_register(*rn).as_u64();
-            let rhs = eval_operand(&state, rm).as_u64();
-            let result = lhs & rhs;
+        Instruction::And { rd, rn, rm, width } => {
+            let lhs = state.get_register(*rn).as_u64() & mask_for_register_width(*width);
+            let rhs = eval_logical_operand(&state, rm, *width);
+            let result = (lhs & rhs) & mask_for_register_width(*width);
             state.set_register(*rd, ConcreteValue::new(result));
         }
-        Instruction::Orr { rd, rn, rm } => {
-            let lhs = state.get_register(*rn).as_u64();
-            let rhs = eval_operand(&state, rm).as_u64();
-            let result = lhs | rhs;
+        Instruction::Orr { rd, rn, rm, width } => {
+            let lhs = state.get_register(*rn).as_u64() & mask_for_register_width(*width);
+            let rhs = eval_logical_operand(&state, rm, *width);
+            let result = (lhs | rhs) & mask_for_register_width(*width);
             state.set_register(*rd, ConcreteValue::new(result));
         }
-        Instruction::Eor { rd, rn, rm } => {
-            let lhs = state.get_register(*rn).as_u64();
-            let rhs = eval_operand(&state, rm).as_u64();
-            let result = lhs ^ rhs;
+        Instruction::Eor { rd, rn, rm, width } => {
+            let lhs = state.get_register(*rn).as_u64() & mask_for_register_width(*width);
+            let rhs = eval_logical_operand(&state, rm, *width);
+            let result = (lhs ^ rhs) & mask_for_register_width(*width);
             state.set_register(*rd, ConcreteValue::new(result));
         }
         Instruction::Lsl { rd, rn, shift } => {
@@ -172,18 +200,11 @@ pub fn apply_instruction_concrete(
             state.set_flags(flags);
         }
         // TST: Test (AND and set flags, discard result)
-        Instruction::Tst { rn, rm } => {
-            let lhs = state.get_register(*rn).as_u64();
-            let rhs = eval_operand(&state, rm).as_u64();
-            let result = lhs & rhs;
-            // TST sets N and Z based on result, clears C and V
-            let flags = ConditionFlags {
-                n: (result as i64) < 0,
-                z: result == 0,
-                c: false,
-                v: false,
-            };
-            state.set_flags(flags);
+        Instruction::Tst { rn, rm, width } => {
+            let lhs = state.get_register(*rn).as_u64() & mask_for_register_width(*width);
+            let rhs = eval_logical_operand(&state, rm, *width);
+            let result = (lhs & rhs) & mask_for_register_width(*width);
+            state.set_flags(logical_flags(result, *width));
         }
         // CCMP: conditional compare (subtract). If `cond` holds at runtime,
         // set NZCV from `rn - operand(rm)` exactly like CMP; otherwise force
@@ -329,12 +350,12 @@ pub fn apply_instruction_concrete(
             state.set_register(*rd, ConcreteValue::new(result));
             state.set_flags(ConditionFlags::from_sub(lhs, rhs, result));
         }
-        Instruction::Ands { rd, rn, rm } => {
-            let lhs = state.get_register(*rn).as_u64();
-            let rhs = eval_operand(&state, rm).as_u64();
-            let result = lhs & rhs;
+        Instruction::Ands { rd, rn, rm, width } => {
+            let lhs = state.get_register(*rn).as_u64() & mask_for_register_width(*width);
+            let rhs = eval_logical_operand(&state, rm, *width);
+            let result = (lhs & rhs) & mask_for_register_width(*width);
             state.set_register(*rd, ConcreteValue::new(result));
-            state.set_flags(ConditionFlags::from_logical(result));
+            state.set_flags(logical_flags(result, *width));
         }
         // CSET / CSETM: AArch64-spec defines them as aliases of CSINC/CSINV
         // with XZR sources and inverted condition. The observable result is
@@ -886,6 +907,7 @@ mod tests {
                 kind: ShiftKind::Asr,
                 amount: 1,
             },
+            width: RegisterWidth::X64,
         };
         let new_state = apply_instruction_concrete(state, &instr);
         assert_eq!(
@@ -906,6 +928,7 @@ mod tests {
                 kind: ShiftKind::Ror,
                 amount: 4,
             },
+            width: RegisterWidth::X64,
         };
         let new_state = apply_instruction_concrete(state, &instr);
         // 0xF rotated right by 4 in 64 bits == 0xF000_0000_0000_0000
@@ -975,6 +998,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X1,
             rm: Operand::Register(Register::X2),
+            width: RegisterWidth::X64,
         };
         let new_state = apply_instruction_concrete(state, &instr);
         assert_eq!(new_state.get_register(Register::X0).as_u64(), 0x0F00);
@@ -987,6 +1011,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X1,
             rm: Operand::Register(Register::X2),
+            width: RegisterWidth::X64,
         };
         let new_state = apply_instruction_concrete(state, &instr);
         assert_eq!(new_state.get_register(Register::X0).as_u64(), 0xFF);
@@ -999,6 +1024,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X1,
             rm: Operand::Register(Register::X2),
+            width: RegisterWidth::X64,
         };
         let new_state = apply_instruction_concrete(state, &instr);
         assert_eq!(new_state.get_register(Register::X0).as_u64(), 0xF0);
@@ -1011,9 +1037,90 @@ mod tests {
             rd: Register::X0,
             rn: Register::X0,
             rm: Operand::Register(Register::X0),
+            width: RegisterWidth::X64,
         };
         let new_state = apply_instruction_concrete(state, &instr);
         assert_eq!(new_state.get_register(Register::X0).as_u64(), 0);
+    }
+
+    #[test]
+    fn test_w32_logical_immediates_zero_extend_results() {
+        let state = state_with(vec![(Register::X1, 0xFFFF_FFFF_1234_00FF)]);
+        let instr = Instruction::And {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Immediate(0xFF),
+            width: RegisterWidth::W32,
+        };
+        let new_state = apply_instruction_concrete(state, &instr);
+        assert_eq!(new_state.get_register(Register::X0).as_u64(), 0xFF);
+
+        let state = state_with(vec![(Register::X1, 0xFFFF_FFFF_0000_00F0)]);
+        let instr = Instruction::Orr {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Immediate(0x0F),
+            width: RegisterWidth::W32,
+        };
+        let new_state = apply_instruction_concrete(state, &instr);
+        assert_eq!(new_state.get_register(Register::X0).as_u64(), 0xFF);
+
+        let state = state_with(vec![(Register::X1, 0xFFFF_FFFF_FFFF_00FF)]);
+        let instr = Instruction::Eor {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Immediate(0xFF),
+            width: RegisterWidth::W32,
+        };
+        let new_state = apply_instruction_concrete(state, &instr);
+        assert_eq!(new_state.get_register(Register::X0).as_u64(), 0xFFFF_0000);
+    }
+
+    #[test]
+    fn test_w32_tst_uses_32_bit_flags() {
+        let instr = Instruction::Tst {
+            rn: Register::X1,
+            rm: Operand::Immediate(0x8000_0000),
+            width: RegisterWidth::W32,
+        };
+        let state = state_with(vec![(Register::X1, 0x8000_0000)]);
+        let new_state = apply_instruction_concrete(state, &instr);
+        let flags = new_state.get_flags();
+        assert_eq!(
+            (flags.n, flags.z, flags.c, flags.v),
+            (true, false, false, false)
+        );
+
+        let instr = Instruction::Tst {
+            rn: Register::X1,
+            rm: Operand::Immediate(0xFF),
+            width: RegisterWidth::W32,
+        };
+        let state = state_with(vec![(Register::X1, 0xFFFF_FFFF_0000_0000)]);
+        let new_state = apply_instruction_concrete(state, &instr);
+        let flags = new_state.get_flags();
+        assert_eq!(
+            (flags.n, flags.z, flags.c, flags.v),
+            (false, true, false, false)
+        );
+    }
+
+    #[test]
+    fn test_w32_ands_zero_extends_and_uses_32_bit_flags() {
+        let state = state_with(vec![(Register::X1, 0xFFFF_FFFF_8000_0000)]);
+        let instr = Instruction::Ands {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Immediate(0x8000_0000),
+            width: RegisterWidth::W32,
+        };
+        let new_state = apply_instruction_concrete(state, &instr);
+        assert_eq!(new_state.get_register(Register::X0).as_u64(), 0x8000_0000);
+        let flags = new_state.get_flags();
+        assert_eq!(
+            (flags.n, flags.z, flags.c, flags.v),
+            (true, false, false, false)
+        );
     }
 
     #[test]
@@ -1181,6 +1288,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X0,
             rm: Operand::Register(Register::X0),
+            width: RegisterWidth::X64,
         }];
         let state2 = apply_sequence_concrete(state, &seq2);
 
@@ -1564,6 +1672,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X1,
             rm: Operand::Register(Register::X2),
+            width: RegisterWidth::X64,
         };
         let new_state = apply_instruction_concrete(state, &instr);
         assert_eq!(new_state.get_register(Register::X0).as_u64(), 0);

--- a/src/semantics/cost.rs
+++ b/src/semantics/cost.rs
@@ -298,16 +298,19 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Immediate(1),
+                width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Orr {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Immediate(1),
+                width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Eor {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Immediate(1),
+                width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Lsl {
                 rd: Register::X0,

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -1420,6 +1420,7 @@ mod tests {
                 rd: Register::X3,
                 rn: Register::X3,
                 rm: Operand::Register(Register::X4),
+                width: crate::ir::RegisterWidth::X64,
             },
         ];
         // Deliberately omit `.with_flags(true)`: the two forms produce
@@ -1603,6 +1604,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X0,
             rm: Operand::Register(Register::X0),
+            width: crate::ir::RegisterWidth::X64,
         }];
 
         assert_eq!(
@@ -1686,6 +1688,7 @@ mod tests {
                 rd: reg,
                 rn: reg,
                 rm: Operand::Register(reg),
+                width: crate::ir::RegisterWidth::X64,
             }];
 
             assert_eq!(
@@ -1701,6 +1704,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X1,
             rm: Operand::Immediate(0),
+            width: crate::ir::RegisterWidth::X64,
         }];
 
         let seq2 = vec![Instruction::MovImm {
@@ -1720,6 +1724,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X1,
             rm: Operand::Immediate(0),
+            width: crate::ir::RegisterWidth::X64,
         }];
 
         let seq2 = vec![Instruction::MovReg {
@@ -1765,6 +1770,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X0,
             rm: Operand::Register(Register::X0),
+            width: crate::ir::RegisterWidth::X64,
         }];
 
         let config = EquivalenceConfig::default();
@@ -1858,6 +1864,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X0,
             rm: Operand::Register(Register::X0),
+            width: crate::ir::RegisterWidth::X64,
         }];
         let seq2 = vec![Instruction::Bic {
             rd: Register::X0,
@@ -2042,6 +2049,7 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Register(Register::X3),
+                width: crate::ir::RegisterWidth::X64,
             },
         ];
         let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
@@ -2068,6 +2076,7 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Register(Register::X3),
+                width: crate::ir::RegisterWidth::X64,
             },
         ];
         let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
@@ -2094,6 +2103,7 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Register(Register::X3),
+                width: crate::ir::RegisterWidth::X64,
             },
         ];
         let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
@@ -2429,6 +2439,7 @@ mod tests {
                 rd: Register::X2,
                 rn: Register::X1,
                 rm: Operand::Immediate(low_mask),
+                width: crate::ir::RegisterWidth::X64,
             },
             // tmp_shift (X2) = tmp_field << lsb
             Instruction::Lsl {
@@ -2441,12 +2452,14 @@ mod tests {
                 rd: Register::X3,
                 rn: Register::X0,
                 rm: Operand::Immediate(clear_mask),
+                width: crate::ir::RegisterWidth::X64,
             },
             // rd = tmp_clear | tmp_shift
             Instruction::Orr {
                 rd: Register::X0,
                 rn: Register::X3,
                 rm: Operand::Register(Register::X2),
+                width: crate::ir::RegisterWidth::X64,
             },
         ];
 
@@ -2482,6 +2495,7 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X2,
                 rm: Operand::Immediate(mask),
+                width: crate::ir::RegisterWidth::X64,
             },
         ];
 
@@ -2717,10 +2731,12 @@ mod tests {
         let seq1 = vec![Instruction::Tst {
             rn: Register::X1,
             rm: Operand::Immediate(1),
+            width: crate::ir::RegisterWidth::X64,
         }];
         let seq2 = vec![Instruction::Tst {
             rn: Register::X1,
             rm: Operand::Immediate(2),
+            width: crate::ir::RegisterWidth::X64,
         }];
         let config = EquivalenceConfig::fast_only()
             .live_out(LiveOut::from_registers(vec![]))
@@ -2815,6 +2831,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X0,
             rm: Operand::Register(Register::X0),
+            width: crate::ir::RegisterWidth::X64,
         }];
         let cfg =
             EquivalenceConfig::default().live_out(LiveOut::from_registers(vec![Register::X0]));

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -3,7 +3,7 @@
 #![allow(dead_code)]
 
 use crate::ir::types::{AccessWidth, AddressOperand, IndexMode};
-use crate::ir::{ExtendKind, Instruction, Operand, Register};
+use crate::ir::{ExtendKind, Instruction, Operand, Register, RegisterWidth};
 use crate::semantics::live_out::RegisterSet;
 use std::collections::HashMap;
 use std::time::Duration;
@@ -56,6 +56,37 @@ fn bv_reverse_bits(value: &BV, width: u32) -> BV {
         result = result.concat(value.extract(i, i));
     }
     result
+}
+
+fn logical_smt_width(width: RegisterWidth, state_width: u32) -> u32 {
+    match width {
+        RegisterWidth::W32 => 32,
+        RegisterWidth::X64 => state_width,
+    }
+}
+
+fn register_logical_value(state: &MachineState, reg: Register, width: RegisterWidth) -> BV {
+    let value = state.get_register(reg).clone();
+    match width {
+        RegisterWidth::W32 => value.extract(31, 0),
+        RegisterWidth::X64 => value,
+    }
+}
+
+fn eval_logical_operand(state: &MachineState, operand: &Operand, width: RegisterWidth) -> BV {
+    let value = state.eval_operand(operand);
+    match width {
+        RegisterWidth::W32 => value.extract(31, 0),
+        RegisterWidth::X64 => value,
+    }
+}
+
+fn zero_extend_to_state_width(value: BV, value_width: u32, state_width: u32) -> BV {
+    if value_width == state_width {
+        value
+    } else {
+        value.zero_ext(state_width - value_width)
+    }
 }
 
 /// Count leading zeros of a `width`-bit BV using a nested ITE chain.
@@ -495,23 +526,41 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let result = lhs.bvsub(&rhs);
             state.set_register(*rd, result);
         }
-        Instruction::And { rd, rn, rm } => {
-            let lhs = state.get_register(*rn).clone();
-            let rhs = state.eval_operand(rm);
+        Instruction::And {
+            rd,
+            rn,
+            rm,
+            width: reg_width,
+        } => {
+            let op_width = logical_smt_width(*reg_width, width);
+            let lhs = register_logical_value(&state, *rn, *reg_width);
+            let rhs = eval_logical_operand(&state, rm, *reg_width);
             let result = lhs.bvand(&rhs);
-            state.set_register(*rd, result);
+            state.set_register(*rd, zero_extend_to_state_width(result, op_width, width));
         }
-        Instruction::Orr { rd, rn, rm } => {
-            let lhs = state.get_register(*rn).clone();
-            let rhs = state.eval_operand(rm);
+        Instruction::Orr {
+            rd,
+            rn,
+            rm,
+            width: reg_width,
+        } => {
+            let op_width = logical_smt_width(*reg_width, width);
+            let lhs = register_logical_value(&state, *rn, *reg_width);
+            let rhs = eval_logical_operand(&state, rm, *reg_width);
             let result = lhs.bvor(&rhs);
-            state.set_register(*rd, result);
+            state.set_register(*rd, zero_extend_to_state_width(result, op_width, width));
         }
-        Instruction::Eor { rd, rn, rm } => {
-            let lhs = state.get_register(*rn).clone();
-            let rhs = state.eval_operand(rm);
+        Instruction::Eor {
+            rd,
+            rn,
+            rm,
+            width: reg_width,
+        } => {
+            let op_width = logical_smt_width(*reg_width, width);
+            let lhs = register_logical_value(&state, *rn, *reg_width);
+            let rhs = eval_logical_operand(&state, rm, *reg_width);
             let result = lhs.bvxor(&rhs);
-            state.set_register(*rd, result);
+            state.set_register(*rd, zero_extend_to_state_width(result, op_width, width));
         }
         Instruction::Lsl { rd, rn, shift } => {
             let value = state.get_register(*rn).clone();
@@ -609,11 +658,16 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let (n, z, c, v) = compute_flags_add(&lhs, &rhs, width);
             state.set_flags(n, z, c, v);
         }
-        Instruction::Tst { rn, rm } => {
-            let lhs = state.get_register(*rn).clone();
-            let rhs = state.eval_operand(rm);
+        Instruction::Tst {
+            rn,
+            rm,
+            width: reg_width,
+        } => {
+            let op_width = logical_smt_width(*reg_width, width);
+            let lhs = register_logical_value(&state, *rn, *reg_width);
+            let rhs = eval_logical_operand(&state, rm, *reg_width);
             let result = lhs.bvand(&rhs);
-            let (n, z, c, v) = compute_flags_logical(&result, width);
+            let (n, z, c, v) = compute_flags_logical(&result, op_width);
             state.set_flags(n, z, c, v);
         }
         // CCMP / CCMN: ITE between freshly-computed sub/add NZCV (true branch)
@@ -750,12 +804,18 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             state.set_register(*rd, lhs.bvsub(&rhs));
             state.set_flags(n, z, c, v);
         }
-        Instruction::Ands { rd, rn, rm } => {
-            let lhs = state.get_register(*rn).clone();
-            let rhs = state.eval_operand(rm);
+        Instruction::Ands {
+            rd,
+            rn,
+            rm,
+            width: reg_width,
+        } => {
+            let op_width = logical_smt_width(*reg_width, width);
+            let lhs = register_logical_value(&state, *rn, *reg_width);
+            let rhs = eval_logical_operand(&state, rm, *reg_width);
             let result = lhs.bvand(&rhs);
-            let (n, z, c, v) = compute_flags_logical(&result, width);
-            state.set_register(*rd, result);
+            let (n, z, c, v) = compute_flags_logical(&result, op_width);
+            state.set_register(*rd, zero_extend_to_state_width(result, op_width, width));
             state.set_flags(n, z, c, v);
         }
         // CSET / CSETM: rd = cond ? 1 : 0 (or all-ones for CSETM).
@@ -1181,6 +1241,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X0,
             rm: Operand::Register(Register::X0),
+            width: crate::ir::RegisterWidth::X64,
         }];
         let state2 = apply_sequence(initial_state, &seq2);
 
@@ -1250,6 +1311,7 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Register(Register::X10),
+                width: crate::ir::RegisterWidth::X64,
             },
         ];
         let seq_fused = vec![Instruction::And {
@@ -1260,6 +1322,7 @@ mod tests {
                 kind: crate::ir::ShiftKind::Ror,
                 amount: 4,
             },
+            width: crate::ir::RegisterWidth::X64,
         }];
 
         let s1 = apply_sequence(initial.clone(), &seq_split);
@@ -1427,6 +1490,7 @@ mod tests {
                 rd: Register::X0,
                 rn: Register::X1,
                 rm: Operand::Register(Register::X10),
+                width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Clz {
                 rd: Register::X0,
@@ -1976,6 +2040,7 @@ mod tests {
                 Instruction::Tst {
                     rn: Register::X0,
                     rm: rm_reg.clone(),
+                    width: crate::ir::RegisterWidth::X64,
                 },
                 compute_flags_logical(&x0.bvand(&x1), 64),
                 "TST x0, x1",
@@ -2003,6 +2068,7 @@ mod tests {
                     rd: Register::X2,
                     rn: Register::X0,
                     rm: rm_reg.clone(),
+                    width: crate::ir::RegisterWidth::X64,
                 },
                 compute_flags_logical(&x0.bvand(&x1), 64),
                 "ANDS x2, x0, x1",
@@ -2368,6 +2434,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X1,
             rm: Operand::Register(Register::X2),
+            width: crate::ir::RegisterWidth::X64,
         };
         let samples: &[(u64, u64)] = &[
             (0, 0xFFFF_FFFF_FFFF_FFFF),
@@ -2390,6 +2457,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X1,
             rm: Operand::Register(Register::X2),
+            width: crate::ir::RegisterWidth::X64,
         };
         let samples: &[(u64, u64)] = &[
             (0, 0),
@@ -2412,6 +2480,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X1,
             rm: Operand::Register(Register::X2),
+            width: crate::ir::RegisterWidth::X64,
         };
         let samples: &[(u64, u64)] = &[
             (0, 0),
@@ -2425,6 +2494,41 @@ mod tests {
                 &[(Register::X1, v1), (Register::X2, v2)],
                 Register::X0,
             );
+        }
+    }
+
+    #[test]
+    fn test_w32_logical_immediate_concrete_smt_parity() {
+        for (instr, pre) in [
+            (
+                Instruction::And {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::Immediate(0xFF),
+                    width: RegisterWidth::W32,
+                },
+                0xFFFF_FFFF_1234_00FF,
+            ),
+            (
+                Instruction::Orr {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::Immediate(0x0F),
+                    width: RegisterWidth::W32,
+                },
+                0xFFFF_FFFF_0000_00F0,
+            ),
+            (
+                Instruction::Eor {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::Immediate(0xFF),
+                    width: RegisterWidth::W32,
+                },
+                0xFFFF_FFFF_FFFF_00FF,
+            ),
+        ] {
+            assert_concrete_smt_parity(&instr, &[(Register::X1, pre)], Register::X0);
         }
     }
 
@@ -3181,6 +3285,7 @@ mod tests {
         let instr = Instruction::Tst {
             rn: Register::X1,
             rm: Operand::Register(Register::X2),
+            width: crate::ir::RegisterWidth::X64,
         };
         let samples: &[(u64, u64)] = &[
             (0, 0xFFFF_FFFF_FFFF_FFFF),                     // result=0 -> Z=1
@@ -3251,6 +3356,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X1,
             rm: Operand::Register(Register::X2),
+            width: crate::ir::RegisterWidth::X64,
         };
         let samples: &[(u64, u64)] = &[
             (0, 0xFFFF_FFFF_FFFF_FFFF),
@@ -3267,6 +3373,51 @@ mod tests {
                 true,
             );
         }
+    }
+
+    #[test]
+    fn test_w32_logical_flag_immediates_concrete_smt_parity() {
+        use crate::semantics::state::ConditionFlags;
+
+        let tst_n = Instruction::Tst {
+            rn: Register::X1,
+            rm: Operand::Immediate(0x8000_0000),
+            width: RegisterWidth::W32,
+        };
+        assert_concrete_smt_parity_full(
+            &tst_n,
+            &[(Register::X1, 0x8000_0000)],
+            Some(ConditionFlags::default()),
+            None,
+            true,
+        );
+
+        let tst_z = Instruction::Tst {
+            rn: Register::X1,
+            rm: Operand::Immediate(0xFF),
+            width: RegisterWidth::W32,
+        };
+        assert_concrete_smt_parity_full(
+            &tst_z,
+            &[(Register::X1, 0xFFFF_FFFF_0000_0000)],
+            Some(ConditionFlags::default()),
+            None,
+            true,
+        );
+
+        let ands = Instruction::Ands {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Immediate(0x8000_0000),
+            width: RegisterWidth::W32,
+        };
+        assert_concrete_smt_parity_full(
+            &ands,
+            &[(Register::X1, 0xFFFF_FFFF_8000_0000)],
+            Some(ConditionFlags::default()),
+            Some(Register::X0),
+            true,
+        );
     }
 
     #[test]

--- a/tests/integration/docs_capability.rs
+++ b/tests/integration/docs_capability.rs
@@ -69,6 +69,12 @@ fn docs_capability_documents_w_logical_immediates() {
         ),
         "docs/capability.md must document W-register logical-immediate support"
     );
+    assert!(
+        matrix.contains(
+            "capstone `mov wd|wsp, #imm` bitmask aliases are accepted for the `orr wd|wsp, wzr, #imm` form"
+        ),
+        "docs/capability.md must document Capstone MOV aliases for W logical-immediate ORR"
+    );
 }
 
 #[test]

--- a/tests/integration/docs_capability.rs
+++ b/tests/integration/docs_capability.rs
@@ -61,6 +61,17 @@ fn docs_capability_lists_every_checked_in_aarch64_mnemonic() {
 }
 
 #[test]
+fn docs_capability_documents_w_logical_immediates() {
+    let matrix = normalized_doc("docs/capability.md");
+    assert!(
+        matrix.contains(
+            "logical-immediate forms for `and`, `ands`, `orr`, `eor`, and `tst` support both 64-bit `x` registers and 32-bit `w` registers"
+        ),
+        "docs/capability.md must document W-register logical-immediate support"
+    );
+}
+
+#[test]
 fn memory_operations_are_consistently_documented_with_known_gaps() {
     let matrix = normalized_doc("docs/capability.md");
     assert!(


### PR DESCRIPTION
Adds 32-bit W-register logical-immediate support for AArch64 AND/ORR/EOR/TST/ANDS across parser, IR encodability, assembler emission, and concrete/SMT semantics. Also accepts Capstone's `mov Wd|WSP, #imm` bitmask alias by lowering it to the existing W32 `orr Wd|WSP, wzr, #imm` path.

Validation:
- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`
- `./ci_check.sh`

Closes #177

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**