### PR TITLE
fix(search): make x86-32 backend width architectural

### DIFF
--- a/src/search/stochastic/backend.rs
+++ b/src/search/stochastic/backend.rs
@@ -110,6 +110,8 @@ pub trait StochasticBackend<I: ISA>: Sized {
 
     /// Width parameter for cost + state masking. Architecture markers own
     /// this width so a mismatched config cannot silently change semantics.
+    /// `config` is retained only for API symmetry; implementations are
+    /// expected to return an architectural constant and must not read it.
     fn width(config: &SearchConfig) -> u32;
 }
 
@@ -449,6 +451,8 @@ mod tests {
             32
         );
 
+        // X86_64 was already correct; this cross-check guards against a
+        // future regression and is not part of the x86-32 bug being fixed.
         assert_eq!(
             <crate::isa::X86_64 as StochasticBackend<crate::isa::X86_64>>::width(
                 &SearchConfig::default().with_x86_width(32),

--- a/src/search/stochastic/backend.rs
+++ b/src/search/stochastic/backend.rs
@@ -108,8 +108,8 @@ pub trait StochasticBackend<I: ISA>: Sized {
         None
     }
 
-    /// Width parameter for cost + state masking. AArch64 returns 64;
-    /// x86 reads `SearchConfig::x86_width` (32 or 64).
+    /// Width parameter for cost + state masking. Architecture markers own
+    /// this width so a mismatched config cannot silently change semantics.
     fn width(config: &SearchConfig) -> u32;
 }
 
@@ -420,8 +420,8 @@ impl StochasticBackend<crate::isa::X86_32> for crate::isa::X86_32 {
             .copied()
     }
 
-    fn width(config: &SearchConfig) -> u32 {
-        config.x86_width
+    fn width(_config: &SearchConfig) -> u32 {
+        crate::isa::X86_32.register_width()
     }
 }
 
@@ -438,6 +438,24 @@ mod tests {
     use super::*;
     use crate::isa::x86::{X86Instruction, X86Register};
     use crate::semantics::state::X86LiveOutMask;
+
+    #[test]
+    fn x86_32_stochastic_width_is_architectural_even_with_default_config() {
+        let config = SearchConfig::default();
+        assert_eq!(config.x86_width, 64);
+
+        assert_eq!(
+            <crate::isa::X86_32 as StochasticBackend<crate::isa::X86_32>>::width(&config),
+            32
+        );
+
+        assert_eq!(
+            <crate::isa::X86_64 as StochasticBackend<crate::isa::X86_64>>::width(
+                &SearchConfig::default().with_x86_width(32),
+            ),
+            64
+        );
+    }
 
     #[test]
     fn x86_check_equivalence_helper_handles_width64() {

--- a/src/search/symbolic/backend.rs
+++ b/src/search/symbolic/backend.rs
@@ -53,6 +53,8 @@ pub trait SymbolicBackend<I: ISA>: Sized {
 
     /// Width parameter for cost + state masking. Architecture markers own
     /// this width so a mismatched config cannot silently change semantics.
+    /// `config` is retained only for API symmetry; implementations are
+    /// expected to return an architectural constant and must not read it.
     fn width(config: &SearchConfig) -> u32;
 }
 
@@ -233,6 +235,8 @@ mod tests {
             32
         );
 
+        // X86_64 was already correct; this cross-check guards against a
+        // future regression and is not part of the x86-32 bug being fixed.
         assert_eq!(
             <crate::isa::X86_64 as SymbolicBackend<crate::isa::X86_64>>::width(
                 &SearchConfig::default().with_x86_width(32),

--- a/src/search/symbolic/backend.rs
+++ b/src/search/symbolic/backend.rs
@@ -51,8 +51,8 @@ pub trait SymbolicBackend<I: ISA>: Sized {
         timeout: Duration,
     ) -> (EquivalenceResult, EquivalenceMetrics);
 
-    /// Width parameter for cost + state masking. AArch64 returns 64;
-    /// x86 reads `SearchConfig::x86_width` (32 or 64).
+    /// Width parameter for cost + state masking. Architecture markers own
+    /// this width so a mismatched config cannot silently change semantics.
     fn width(config: &SearchConfig) -> u32;
 }
 
@@ -214,7 +214,30 @@ impl SymbolicBackend<crate::isa::X86_32> for crate::isa::X86_32 {
         (result, EquivalenceMetrics::default())
     }
 
-    fn width(config: &SearchConfig) -> u32 {
-        config.x86_width
+    fn width(_config: &SearchConfig) -> u32 {
+        crate::isa::X86_32.register_width()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn x86_32_symbolic_width_is_architectural_even_with_default_config() {
+        let config = SearchConfig::default();
+        assert_eq!(config.x86_width, 64);
+
+        assert_eq!(
+            <crate::isa::X86_32 as SymbolicBackend<crate::isa::X86_32>>::width(&config),
+            32
+        );
+
+        assert_eq!(
+            <crate::isa::X86_64 as SymbolicBackend<crate::isa::X86_64>>::width(
+                &SearchConfig::default().with_x86_width(32),
+            ),
+            64
+        );
     }
 }

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -963,8 +963,7 @@ mod tests {
 
     /// Mirror of `x86_symbolic_runs_end_to_end` for x86-32. Covers the
     /// `SymbolicBackend<X86_32>` impl methods, including the width-32
-    /// branch in `x86_check_equivalence` and the `width()` accessor
-    /// reading `config.x86_width`.
+    /// backend path through cost and equivalence checking.
     #[test]
     fn x86_symbolic_mode32_runs_end_to_end() {
         use crate::isa::X86_32;


### PR DESCRIPTION
## Summary
- Make x86-32 stochastic and symbolic backend width accessors return the ISA marker width instead of SearchConfig::x86_width
- Add regression coverage proving default SearchConfig cannot silently widen X86_32 search to 64 bits
- Update the x86-32 symbolic end-to-end test comment to describe the new invariant

## Verification
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test --all (after ./build_tests.sh; initial run failed only because fixture binaries were absent)
- ./ci_check.sh
- scripts/full_test.sh is not present in this s11 repository; used ./ci_check.sh per CLAUDE.md

Closes #192

**Merge with  (merge commit, not squash) per CLAUDE.md.**