### PR TITLE
refactor(smt): drop needless generic borrows

### DIFF
--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -1185,7 +1185,7 @@ mod tests {
         let state2 = apply_sequence(initial_state, &seq2);
 
         // Assert states are not equal
-        solver.assert(&states_not_equal(&state1, &state2));
+        solver.assert(states_not_equal(&state1, &state2));
 
         // If UNSAT, states are always equal
         assert_eq!(solver.check(), SatResult::Unsat);
@@ -1295,7 +1295,7 @@ mod tests {
         let expected = BV::from_i64(15, 64);
 
         let solver = Solver::new();
-        solver.assert(&x0_val.eq(&expected).not());
+        solver.assert(x0_val.eq(&expected).not());
         assert_eq!(solver.check(), SatResult::Unsat);
     }
 
@@ -1322,7 +1322,7 @@ mod tests {
         let final_x0 = final_state.get_register(Register::X0);
 
         let solver = Solver::new();
-        solver.assert(&final_x0.eq(&initial_x1).not());
+        solver.assert(final_x0.eq(&initial_x1).not());
         assert_eq!(
             solver.check(),
             SatResult::Unsat,
@@ -1361,7 +1361,7 @@ mod tests {
         //                       ⇒ the two sequences are NOT proved equivalent
         // states_not_equal UNSAT ⇒ they are always equal ⇒ unsound for CSEL
         let solver = Solver::new();
-        solver.assert(&states_not_equal(&state_csel, &state_mov));
+        solver.assert(states_not_equal(&state_csel, &state_mov));
         assert_eq!(
             solver.check(),
             SatResult::Sat,
@@ -1380,7 +1380,7 @@ mod tests {
         let final_x0 = final_state.get_register(Register::X0);
 
         let solver = Solver::new();
-        solver.assert(&final_x0.eq(&initial_x1).not());
+        solver.assert(final_x0.eq(&initial_x1).not());
         assert_eq!(
             solver.check(),
             SatResult::Unsat,
@@ -1593,7 +1593,7 @@ mod tests {
         let final_state = apply_sequence(initial, &seq);
         let final_x0 = final_state.get_register(Register::X0);
         let solver = Solver::new();
-        solver.assert(&final_x0.eq(&BV::from_u64(63, 64)).not());
+        solver.assert(final_x0.eq(BV::from_u64(63, 64)).not());
         assert_eq!(solver.check(), SatResult::Unsat, "CLZ(1) must be 63");
     }
 
@@ -1664,10 +1664,10 @@ mod tests {
         let (n2, z2, c2, v2) = s2.get_flags();
 
         let solver = Solver::new();
-        solver.assert(&n1.eq(n2).not());
-        solver.assert(&z1.eq(z2).not());
-        solver.assert(&c1.eq(c2).not());
-        solver.assert(&v1.eq(v2).not());
+        solver.assert(n1.eq(n2).not());
+        solver.assert(z1.eq(z2).not());
+        solver.assert(c1.eq(c2).not());
+        solver.assert(v1.eq(v2).not());
         assert_eq!(solver.check(), SatResult::Sat);
     }
 
@@ -1714,7 +1714,7 @@ mod tests {
 
     fn assert_register_eq(state: &MachineState, reg: Register, expected: &BV, ctx: &str) {
         let solver = Solver::new();
-        solver.assert(&state.get_register(reg).eq(expected).not());
+        solver.assert(state.get_register(reg).eq(expected).not());
         assert_eq!(solver.check(), SatResult::Unsat, "{}", ctx);
     }
 
@@ -1742,7 +1742,7 @@ mod tests {
         force_flags(&mut s2, 0, 0, 0, 0);
 
         let solver = Solver::new();
-        solver.assert(&states_not_equal(&s1, &s2));
+        solver.assert(states_not_equal(&s1, &s2));
         assert_eq!(solver.check(), SatResult::Sat);
     }
 
@@ -2021,7 +2021,7 @@ mod tests {
                     rn: Register::X0,
                     rm: rm_reg.clone(),
                 },
-                compute_flags_logical(&x0.bvand(&x1.bvnot()), 64),
+                compute_flags_logical(&x0.bvand(x1.bvnot()), 64),
                 "BICS x2, x0, x1",
             ),
         ];
@@ -2149,7 +2149,7 @@ mod tests {
                 let smt = condition_to_smt(cond, &n_bv, &z_bv, &c_bv, &v_bv);
                 let solver = Solver::new();
                 let expected_bv = BV::from_u64(expected as u64, 1);
-                solver.assert(&smt.eq(&expected_bv).not());
+                solver.assert(smt.eq(&expected_bv).not());
                 assert_eq!(
                     solver.check(),
                     SatResult::Unsat,
@@ -2210,13 +2210,13 @@ mod tests {
         let symbolic_pre = MachineState::new_symbolic("pre");
         let solver = Solver::new();
         for &(reg, val) in pre_values {
-            solver.assert(&symbolic_pre.get_register(reg).eq(&BV::from_u64(val, 64)));
+            solver.assert(symbolic_pre.get_register(reg).eq(BV::from_u64(val, 64)));
         }
         let symbolic_post = apply_instruction(symbolic_pre, instr);
         solver.assert(
-            &symbolic_post
+            symbolic_post
                 .get_register(dest)
-                .eq(&BV::from_u64(concrete_dest, 64))
+                .eq(BV::from_u64(concrete_dest, 64))
                 .not(),
         );
 
@@ -2258,13 +2258,13 @@ mod tests {
         let symbolic_pre = MachineState::new_symbolic("pre");
         let solver = Solver::new();
         for &(reg, val) in pre_values {
-            solver.assert(&symbolic_pre.get_register(reg).eq(&BV::from_u64(val, 64)));
+            solver.assert(symbolic_pre.get_register(reg).eq(BV::from_u64(val, 64)));
         }
         if let Some(flags) = &pre_flags {
-            solver.assert(&symbolic_pre.n.eq(&BV::from_u64(flags.n as u64, 1)));
-            solver.assert(&symbolic_pre.z.eq(&BV::from_u64(flags.z as u64, 1)));
-            solver.assert(&symbolic_pre.c.eq(&BV::from_u64(flags.c as u64, 1)));
-            solver.assert(&symbolic_pre.v.eq(&BV::from_u64(flags.v as u64, 1)));
+            solver.assert(symbolic_pre.n.eq(BV::from_u64(flags.n as u64, 1)));
+            solver.assert(symbolic_pre.z.eq(BV::from_u64(flags.z as u64, 1)));
+            solver.assert(symbolic_pre.c.eq(BV::from_u64(flags.c as u64, 1)));
+            solver.assert(symbolic_pre.v.eq(BV::from_u64(flags.v as u64, 1)));
         }
         let symbolic_post = apply_instruction(symbolic_pre, instr);
 
@@ -2275,17 +2275,17 @@ mod tests {
         }
         if check_post_flags {
             let cf = concrete_post.get_flags();
-            disagreements.push(symbolic_post.n.eq(&BV::from_u64(cf.n as u64, 1)).not());
-            disagreements.push(symbolic_post.z.eq(&BV::from_u64(cf.z as u64, 1)).not());
-            disagreements.push(symbolic_post.c.eq(&BV::from_u64(cf.c as u64, 1)).not());
-            disagreements.push(symbolic_post.v.eq(&BV::from_u64(cf.v as u64, 1)).not());
+            disagreements.push(symbolic_post.n.eq(BV::from_u64(cf.n as u64, 1)).not());
+            disagreements.push(symbolic_post.z.eq(BV::from_u64(cf.z as u64, 1)).not());
+            disagreements.push(symbolic_post.c.eq(BV::from_u64(cf.c as u64, 1)).not());
+            disagreements.push(symbolic_post.v.eq(BV::from_u64(cf.v as u64, 1)).not());
         }
         assert!(
             !disagreements.is_empty(),
             "assert_concrete_smt_parity_full needs either dest or check_post_flags"
         );
         let refs: Vec<&z3::ast::Bool> = disagreements.iter().collect();
-        solver.assert(&z3::ast::Bool::or(&refs));
+        solver.assert(z3::ast::Bool::or(&refs));
 
         assert_eq!(
             solver.check(),


### PR DESCRIPTION
Summary:
- Removes redundant generic-argument borrows from AArch64 SMT Z3 assertions and helpers flagged by Clippy.
- Keeps the cleanup scoped to src/semantics/smt.rs with no semantic changes.

Verification:
- cargo clippy --all-features --all-targets -- -D clippy::needless_borrows_for_generic_args
- cargo test semantics::smt
- cargo fmt --all -- --check
- cargo clippy --all -- -D warnings
- ./build_tests.sh
- cargo test --all
- ./ci_check.sh

Note: scripts/full_test.sh from the autonomous contract is not present in this repository; ./ci_check.sh is the repo-documented gate and runs test_all.sh after building fixtures.

Closes #111

**Merge with \`gh pr merge --merge\` (merge commit, not squash) per CLAUDE.md.**