### PR TITLE
test(equivalence): pin preserved CSET flag sharing

### DIFF
--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -1475,6 +1475,31 @@ mod tests {
     }
 
     #[test]
+    fn preserved_cset_after_dead_mov_is_equivalent() {
+        let target = vec![
+            Instruction::MovImm {
+                rd: Register::X1,
+                imm: 0,
+            },
+            Instruction::Cset {
+                rd: Register::X0,
+                cond: crate::ir::types::Condition::NE,
+            },
+        ];
+        let candidate = vec![Instruction::Cset {
+            rd: Register::X0,
+            cond: crate::ir::types::Condition::NE,
+        }];
+        let cfg =
+            EquivalenceConfig::default().live_out(LiveOut::from_registers(vec![Register::X0]));
+        assert_eq!(
+            check_equivalence_with_config(&target, &candidate, &cfg),
+            EquivalenceResult::Equivalent,
+            "preserved CSET must share the incoming symbolic flags across both sequences"
+        );
+    }
+
+    #[test]
     fn csinc_wraps_on_max_input() {
         // CSINC x0, x1, x2, EQ with EQ=false sets x0 = x2 + 1 (wrapping).
         // Pin x1 = 0 and x2 = u64::MAX, then CMP x1, #1 leaves Z=0 so the

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -1476,6 +1476,10 @@ mod tests {
 
     #[test]
     fn preserved_cset_after_dead_mov_is_equivalent() {
+        // Regression for issue #99: dropping a dead `MOV X1, #0` that writes an
+        // unobserved register before a `CSET X0, NE` must not change the result.
+        // `MOV` leaves NZCV untouched, so both sequences read the same incoming
+        // flags into the CSET and stay equivalent with only X0 live.
         let target = vec![
             Instruction::MovImm {
                 rd: Register::X1,
@@ -1495,7 +1499,7 @@ mod tests {
         assert_eq!(
             check_equivalence_with_config(&target, &candidate, &cfg),
             EquivalenceResult::Equivalent,
-            "preserved CSET must share the incoming symbolic flags across both sequences"
+            "removing a dead MOV before CSET must not change the result: both sequences read the same incoming flags"
         );
     }
 


### PR DESCRIPTION
Adds a regression test for the issue #99 CSET preservation case: removing a dead `mov x1, #0` before an unchanged `cset x0, ne` remains equivalent with `x0` live. This keeps the existing precise symbolic NZCV model rather than replacing it with the older opaque uninterpreted-function shim.

Validation:
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --all` after `./build_tests.sh` generated integration fixtures
- `./ci_check.sh`

Note: `scripts/full_test.sh` is not present in this repository; `./ci_check.sh` ran the repository-native `test_all.sh` gate.

Closes #99

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**