### PR TITLE
perf(smt): reduce clz formula depth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,7 @@ harness = false
 [[bench]]
 name = "algebraic_fusion"
 harness = false
+
+[[bench]]
+name = "smt_clz"
+harness = false

--- a/Justfile
+++ b/Justfile
@@ -96,6 +96,10 @@ bench-phase1: build
     @mkdir -p benches/results
     cargo bench --bench hackers_delight
 
+# Direct SMT CLZ/CLS formula timing for issue #112; does not write JSONL.
+bench-smt-clz: build
+    cargo bench --bench smt_clz
+
 # Wipe criterion HTML reports and the JSONL accumulator.
 bench-clean:
     rm -rf target/criterion benches/results
@@ -123,6 +127,7 @@ help:
     @echo "  test          - Run tests"
     @echo "  build-tests   - Build AArch64 test binaries"
     @echo "  test-all      - Run complete test suite"
+    @echo "  bench-smt-clz - Time direct CLZ/CLS SMT equivalence queries"
     @echo "  mutants       - Run cargo-mutants locally (slow; informational)"
     @echo "  coverage      - Generate HTML coverage report via cargo-llvm-cov"
     @echo "  coverage-lcov - Generate LCOV coverage report (CI format)"

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,66 +1,99 @@
-# Plan - issue #181: Pin reversed-order `--live-out` error
+# Plan - issue #112: Replace `bv_clz` ITE chain with binary-search decomposition
 
 ## 1. Problem Restated
 
-Issue #181 asks for a narrow regression test documenting the current malformed-order behavior for `--live-out "nzcv;x0"`. The accepted grammar is `<regs>` or `<regs>;<flags>` with `nzcv` valid only in the flags half, so the reversed input currently splits into register half `nzcv` and flag half `x0`, then fails through the register parser with `invalid register name: 'nzcv'`. The PR should pin that exact diagnostic so future parser-message changes fail with an actionable test failure, without changing parser behavior.
+The AArch64 SMT lowering currently computes CLZ with a width-deep nested ITE chain in `src/semantics/smt.rs::bv_clz`, so each symbolic `CLZ` contributes up to 64 dependent ITE levels, and each `CLS` reaches the same helper through the sign-fold expression `x ^ (x ASR 63)`. The goal is to keep the existing semantics exactly the same while changing the symbolic encoding to a binary-search decomposition over top halves (32, 16, 8, 4, 2, 1) so Z3 sees logarithmic ITE depth and lower solve time on CLZ/CLS-heavy equivalence queries.
 
 ## 2. Files To Touch
 
-- `src/validation/live_out.rs` - add one unit test in the existing `#[cfg(test)] mod tests`, near the `parse_live_out_contract` malformed-input tests around lines 677-727.
+- `src/semantics/smt.rs` - replace the current `bv_clz` helper at lines 61-79, keep `Instruction::Clz` and `Instruction::Cls` call sites at lines 780-797 using the same helper, and add/extend unit tests in the existing `#[cfg(test)] mod tests` near the CLZ/CLS tests at lines 1578-1652 and concrete/SMT parity tests at lines 2777-2815.
+- `benches/smt_clz.rs` [new] - add a narrow Criterion benchmark that times equivalent CLZ/CLS SMT queries directly through `check_equivalence_with_config_metrics`, separate from the search-oriented benchmark phases.
+- `Cargo.toml` - add a `[[bench]]` entry for `smt_clz` next to the existing benchmark entries at lines 44-54.
+- `benches/README.md` - document the new direct SMT benchmark command and make clear it is for before/after CLZ formula timing, not part of the phase 1/2/3 search fixture schema.
+- `Justfile` [optional, only if keeping a project recipe useful] - add a `bench-smt-clz` recipe for `cargo bench --bench smt_clz`; do not silently fold this into long CI-like checks.
 
-No production files should change. There are no `crates/` or `compiler/` directories in this repository, so this is not a Rust-stage/self-hosted compiler cross-cutting change. There is no `docs/spec/` tree in this checkout; the relevant accepted design source is `docs/adr/0006-live-out-cli-grammar.md`, and no ADR/spec update is needed because the grammar and behavior stay unchanged.
+There are no `crates/`, `compiler/`, or `docs/spec/` directories in this s11 checkout. This is not a Vow compiler cross-cutting change, and no `docs/spec/*.md` update is required. The public AArch64 instruction set, parser grammar, CLI flags, and documented semantics do not change, so `docs/capability.md` and the ADRs should not change for this PR.
 
 ## 3. TDD Slices
 
-1. Add a focused regression test in `src/validation/live_out.rs`, immediately after `test_parse_live_out_contract_bareword_nzcv_rejected` or before `test_parse_live_out_contract_unknown_flag_rejected`. Name it `test_parse_live_out_contract_reversed_order_nzcv_x0_error`.
+1. Add a formula-shape regression test in `src/semantics/smt.rs`.
+   - Test location: the existing SMT test module near `test_clz_of_one_is_63` at lines 1578-1598.
+   - Behavior under test: a symbolic `bv_clz(&BV::new_const("x", 64), 64)` must not render as a width-deep ITE chain. Use a small test-only scanner over the SMT string to compute maximum nested `ite` depth, and assert a generous logarithmic bound such as `<= 16` rather than an exact count.
+   - Red expectation: the current loop-based helper should fail because it nests one ITE per bit.
+   - Production code to make it pass: replace `bv_clz` with a binary-search selected-half decomposition.
 
-2. In that test, call `let err = parse_live_out_contract("nzcv;x0").unwrap_err();` and assert the exact rendered message:
-   ```rust
-   assert_eq!(err.to_string(), "invalid register name: 'nzcv'");
-   ```
-   Prefer `err.to_string()` over substring matching so the test pins the user-visible `Display` body already covered by `display_renders_message_without_type_prefix` at `src/validation/live_out.rs:267-271`.
+2. Implement the binary-search CLZ helper in `src/semantics/smt.rs`.
+   - Production change: keep the public helper signature `fn bv_clz(value: &BV, width: u32) -> BV`.
+   - Algorithm: maintain a selected chunk and a width-bit count. For each half size, test whether the upper half is zero; if yes, add the half size to the count and continue with the lower half, otherwise continue with the upper half. At the final one-bit chunk, add one only if that bit is zero.
+   - Important shape: both branches of each `ite` must have the same bit width. The running count stays `width` bits; the selected chunk shrinks from 64 to 32 to 16 to 8 to 4 to 2 to 1 bits.
+   - Guardrails: use `debug_assert!(width > 0)` and `debug_assert!(width.is_power_of_two())` because the current AArch64 path calls this with 64, and the halving logic assumes exact halves.
 
-3. Red-check the guard without committing sabotage: temporarily change the expected string in the new test, or temporarily mutate the local parser diagnostic at `src/validation/live_out.rs:49-50`, then run:
-   ```bash
-   cargo test validation::live_out::tests::test_parse_live_out_contract_reversed_order_nzcv_x0_error -- --exact
-   ```
-   Confirm the test fails on the message mismatch, then immediately revert the temporary mutation.
+3. Extend CLZ semantic boundary coverage in `src/semantics/smt.rs`.
+   - Test location: extend or split out from `test_clz_concrete_smt_parity` at lines 2777-2795.
+   - Behavior under test: CLZ matches the concrete interpreter at split boundaries and edge cases: `0`, `1`, `2`, `3`, `0x10`, `1 << 31`, `1 << 32`, `1 << 63`, `u64::MAX`, and a mixed value such as `0x0000_0000_FFFF_FFFF`.
+   - Production code that should make it pass: the new `bv_clz` helper used by `Instruction::Clz`.
 
-4. Green-check against the real code. The production path that should satisfy the test already exists: `parse_live_out_contract` counts one semicolon at `src/validation/live_out.rs:94-115`, parses `regs_part` via `RegisterSet::<Register>::from_str`, and `parse_register` emits `invalid register name: 'nzcv'` at `src/validation/live_out.rs:49-50`. No production code should be edited.
+4. Extend CLS transitive coverage in `src/semantics/smt.rs`.
+   - Test location: extend `test_cls_concrete_smt_parity` at lines 2797-2815 and keep `test_cls_equivalent_to_clz_of_signfold` at lines 1413-1459 passing.
+   - Behavior under test: CLS still matches concrete semantics for all-zero/all-one inputs, sign-bit-only inputs, opposite-sign-leading inputs, and boundary values whose sign-folded form crosses the same 32/16/8/4/2/1 CLZ splits.
+   - Production code that should make it pass: the unchanged CLS lowering at lines 791-797 calling the new `bv_clz` helper.
 
-5. Refactor only if formatting requires it. Keep the test local and explicit; do not introduce helper functions or convert the surrounding parse-live-out tests to table-driven form for this small coverage addition.
+5. Add direct before/after benchmark evidence.
+   - Benchmark location: `benches/smt_clz.rs` [new].
+   - Behavior under measurement: build equivalent sequence pairs such as one CLZ, four independent CLZs, one CLS, and four independent CLSs; compare each sequence with itself or with an equivalent temp-register form so `check_equivalence_with_config_metrics` reaches SMT and returns `Equivalent`.
+   - Implementation detail: use `EquivalenceConfig::with_live_out(RegisterSet::from_registers(...)).random_tests(0).timeout(Duration::from_secs(30))` to reduce non-SMT noise, and let Criterion measure full wall time while recording `metrics.smt_elapsed`/`metrics.smt_formula_bytes` inside the benchmark if useful for `black_box`.
+   - Baseline workflow: after adding only the benchmark file and Cargo entry, run `cargo bench --bench smt_clz -- --quick` on the old helper and save the output in the PR body or a local evidence note; rerun the same command after the `bv_clz` rewrite.
+
+6. Refactor only after green.
+   - Remove the stale TODO at lines 67-68 once the helper is rewritten.
+   - Keep comments focused on the binary-search invariant and width choices.
+   - Do not introduce a new public API unless the private helper becomes hard to read; all consumers should continue calling `bv_clz` through the existing CLZ/CLS instruction lowering.
 
 ## 4. Verification Surface
 
-- No ESBMC proof work is needed. This change does not touch contracts, codegen, the C model, SMT lowering, concrete semantics, assembler output, or binary patching.
-- No fixtures under `tests/run/`, `tests/asm/`, `tests/integration/`, `examples/`, or benchmark directories should grow.
-- Minimum verification:
+- ESBMC, Vow contracts, the C model, self-hosted compiler codegen, and `tests/run/` fixtures are not applicable in this repository. No contract should be weakened, and no function needs to be marked unverifiable.
+- No `examples/`, `tests/asm/`, or `tests/integration/` fixtures need to grow because there is no parser, CLI, assembler, or machine-code behavior change.
+- Focused tests:
   ```bash
-  cargo test validation::live_out::tests::test_parse_live_out_contract_reversed_order_nzcv_x0_error -- --exact
+  cargo test semantics::smt::tests::test_bv_clz_formula_has_logarithmic_ite_depth -- --exact
+  cargo test semantics::smt::tests::test_clz_concrete_smt_parity -- --exact
+  cargo test semantics::smt::tests::test_cls_concrete_smt_parity -- --exact
+  cargo test semantics::smt::tests::test_clz_floor_log2_pattern -- --exact
   ```
-- Broader local verification before PR/commit:
+- Broader local verification:
   ```bash
-  cargo test validation::live_out
+  cargo test semantics::smt
   cargo fmt -- --check
+  cargo clippy --all-targets -- -D warnings
   ```
-- Full pre-push verification remains the repository gate from `CLAUDE.md`:
+- Repository gate before commit/push:
   ```bash
   ./ci_check.sh
   ```
+- Performance evidence:
+  ```bash
+  cargo bench --bench smt_clz -- --quick
+  ```
+  Capture before/after Criterion summaries plus `smt_elapsed`/formula-size observations if the benchmark prints them. Do not gate CI on timing thresholds; Z3 timings are noisy.
 
 ## 5. Risk Areas
 
-- Error-message coupling is intentional here: use an exact assertion because the issue specifically asks to pin the diagnostic text for `nzcv;x0`.
-- Test placement should stay in the parser/error-test cluster so future maintainers understand this as CLI grammar coverage, not live-in/live-out dataflow coverage.
-- Do not change `parse_live_out_contract` to special-case reversed order unless a separate issue asks for a friendlier diagnostic; that would widen the behavioral scope and may require ADR/help-text updates.
-- `parse -> print -> parse` idempotency is unaffected because this is a CLI live-out contract parser test, not assembly IR parsing or formatting.
-- Binary fixed-point risks are absent: no `compiler/` tree exists here, and the plan does not touch codegen ordering, map iteration, stack-slot layout, assembler encoding, or `vow-clif-shim`-style components.
-- The `cargo clippy --all -- -D warnings` gate should be unaffected; the added test must avoid unused imports or dead helper functions.
+- A naive recursive implementation can still build a large eager AST because both ITE branches are constructed before the parent ITE. Prefer the iterative selected-half decomposition so the selected chunk narrows each step and the term shape stays compact.
+- Bit-vector width mismatches are the main correctness risk. The CLZ result must remain a `width`-bit BV because it is written into a 64-bit register and CLS subtracts a width-bit `1`; the selected chunk is the only term that shrinks.
+- The zero input must return `width` (64 today), not `width - 1`. The final one-bit step must distinguish zero from one after all upper-zero decisions have been accumulated.
+- `BV::extract(half - 1, 0)` and `BV::from_u64(half as u64, width)` need careful loop bounds to avoid underflow and branch sort mismatches.
+- The formula-depth regression test will inspect Z3's printed term shape. Keep it deliberately coarse and do not assert exact formula bytes or exact ITE counts.
+- Binary fixed-point risks are absent: there is no `compiler/` tree here, and this plan does not touch codegen ordering, `BTreeMap`/`HashMap` determinism, stack-slot layout, or any `vow-clif-shim`-style component.
+- `parse -> print -> parse` idempotency is unaffected because no parser, formatter, or IR display code changes.
+- The `cargo clippy --all-targets -- -D warnings` gate can fail on unused imports/helpers in the new benchmark or test-only scanner; keep helper functions local and used.
+- Benchmark results can vary by host load and Z3 version. Treat them as supporting evidence, not a hard correctness criterion.
 
 ## 6. Out Of Scope
 
-- Changing the grammar for reversed-order input or adding a bespoke "wrong order" diagnostic.
-- Changing any `run_equiv` or `run_llm_opt` error-prefix behavior in `src/main.rs`.
-- Adding docs/spec/ADR updates; this PR documents existing behavior through a regression test only.
-- Refactoring `ParseRegisterSetError`, `parse_register`, or the surrounding `parse_live_out_contract` tests.
-- Running benchmarks, mutation tests, x86/RISC-V flows, LLM search, assembler tests, or integration fixtures for this unit-test-only issue.
+- Changing concrete CLZ/CLS semantics in `src/semantics/concrete.rs`.
+- Changing the CLS sign-fold lowering beyond its use of the rewritten `bv_clz`.
+- Adding or removing AArch64 mnemonics, parser rules, Capstone conversion behavior, assembler encodings, or `docs/capability.md` rows.
+- Generalizing this work to x86 or RISC-V SMT helpers.
+- Introducing an uninterpreted CLZ function, solver-specific tactics, or a new dependency to model CLZ.
+- Refactoring `MachineState`, equivalence configuration, search algorithms, or the existing phase 1/2/3 benchmark JSON schema.
+- Adding timing thresholds to unit tests or CI.

--- a/benches/README.md
+++ b/benches/README.md
@@ -9,6 +9,7 @@ shared JSON-Lines report.
 just bench           # all three phases
 just bench-phase1    # Hacker's Delight only
 cargo bench --bench hackers_delight -- max --quick   # one fixture, fast smoke run
+cargo bench --bench smt_clz -- --quick   # direct CLZ/CLS SMT formula timing
 ```
 
 Output:
@@ -21,6 +22,11 @@ Output:
 The harness is **not wired into CI**. Full sweeps are tens of minutes,
 which would burn through GitHub Actions budget.
 
+`smt_clz` is a narrow direct-SMT benchmark for comparing CLZ/CLS formula
+encodings. It calls the equivalence checker on equivalent CLZ/CLS-heavy
+sequences and consumes the SMT metrics, but it is intentionally separate
+from the phase 1/2/3 fixture harness and does not append JSON Lines.
+
 ## Layout
 
 ```
@@ -31,6 +37,7 @@ benches/
 ├── llvm_codegen/          # Phase 2 fixtures — populated by the harvester
 ├── algebraic_fusion.rs    # Phase 3 driver
 ├── algebraic_fusion/*.s   # Phase 3 fixtures (~15, textbook identities)
+├── smt_clz.rs             # Direct CLZ/CLS SMT formula timing
 ├── results/results.jsonl  # JSONL accumulator (gitignored)
 └── README.md              # you are here
 ```

--- a/benches/smt_clz.rs
+++ b/benches/smt_clz.rs
@@ -1,0 +1,117 @@
+//! Direct SMT CLZ/CLS formula benchmark for issue #112.
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use s11::ir::{Instruction, Register};
+use s11::semantics::{
+    EquivalenceConfig, EquivalenceResult, RegisterSet, check_equivalence_with_config_metrics,
+};
+use std::hint::black_box;
+use std::time::Duration;
+
+struct SmtClzCase {
+    name: &'static str,
+    sequence: Vec<Instruction>,
+    live_out: RegisterSet<Register>,
+}
+
+fn smt_clz_cases() -> Vec<SmtClzCase> {
+    vec![
+        SmtClzCase {
+            name: "one_clz",
+            sequence: vec![Instruction::Clz {
+                rd: Register::X0,
+                rn: Register::X1,
+            }],
+            live_out: RegisterSet::from_registers(vec![Register::X0]),
+        },
+        SmtClzCase {
+            name: "four_clz",
+            sequence: vec![
+                Instruction::Clz {
+                    rd: Register::X0,
+                    rn: Register::X4,
+                },
+                Instruction::Clz {
+                    rd: Register::X1,
+                    rn: Register::X5,
+                },
+                Instruction::Clz {
+                    rd: Register::X2,
+                    rn: Register::X6,
+                },
+                Instruction::Clz {
+                    rd: Register::X3,
+                    rn: Register::X7,
+                },
+            ],
+            live_out: RegisterSet::from_registers(vec![
+                Register::X0,
+                Register::X1,
+                Register::X2,
+                Register::X3,
+            ]),
+        },
+        SmtClzCase {
+            name: "one_cls",
+            sequence: vec![Instruction::Cls {
+                rd: Register::X0,
+                rn: Register::X1,
+            }],
+            live_out: RegisterSet::from_registers(vec![Register::X0]),
+        },
+        SmtClzCase {
+            name: "four_cls",
+            sequence: vec![
+                Instruction::Cls {
+                    rd: Register::X0,
+                    rn: Register::X4,
+                },
+                Instruction::Cls {
+                    rd: Register::X1,
+                    rn: Register::X5,
+                },
+                Instruction::Cls {
+                    rd: Register::X2,
+                    rn: Register::X6,
+                },
+                Instruction::Cls {
+                    rd: Register::X3,
+                    rn: Register::X7,
+                },
+            ],
+            live_out: RegisterSet::from_registers(vec![
+                Register::X0,
+                Register::X1,
+                Register::X2,
+                Register::X3,
+            ]),
+        },
+    ]
+}
+
+fn smt_clz(c: &mut Criterion) {
+    let mut group = c.benchmark_group("smt_clz");
+    group.sample_size(10);
+
+    for case in smt_clz_cases() {
+        group.bench_function(case.name, |b| {
+            b.iter(|| {
+                let config = EquivalenceConfig::with_live_out(case.live_out.clone())
+                    .random_tests(0)
+                    .timeout(Duration::from_secs(30));
+                let (result, metrics) = check_equivalence_with_config_metrics(
+                    black_box(&case.sequence),
+                    black_box(&case.sequence),
+                    &config,
+                );
+                assert_eq!(result, EquivalenceResult::Equivalent);
+                black_box((metrics.smt_elapsed, metrics.smt_formula_bytes));
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, smt_clz);
+criterion_main!(benches);

--- a/benches/smt_clz.rs
+++ b/benches/smt_clz.rs
@@ -99,6 +99,10 @@ fn smt_clz(c: &mut Criterion) {
                 let config = EquivalenceConfig::with_live_out(case.live_out.clone())
                     .random_tests(0)
                     .timeout(Duration::from_secs(30));
+                // Each case is compared against itself: `random_tests(0)` forces the
+                // SMT path, and Z3 still builds the full CLZ/CLS formula to prove
+                // f(x) == f(x), so self-comparison isolates the encoding/solve cost
+                // under test rather than the cost of finding a distinct equivalent.
                 let (result, metrics) = check_equivalence_with_config_metrics(
                     black_box(&case.sequence),
                     black_box(&case.sequence),

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -58,24 +58,37 @@ fn bv_reverse_bits(value: &BV, width: u32) -> BV {
     result
 }
 
-/// Count leading zeros of a `width`-bit BV using a nested ITE chain.
-/// Iterates bit positions from LSB upward; later iterations overwrite the
-/// result when their bit is set, so the final result is the CLZ of the
-/// input — the number of leading zeros — derived from the highest-set-bit
-/// position found (or `width` if no bit is set).
-//
-// TODO(#112): replace this width-deep ITE chain with an O(log n) binary-search
-// decomposition (top-W/2 / top-W/4 / … / top-1) to reduce Z3 formula depth.
+/// Count leading zeros of a `width`-bit BV with a binary-search decomposition.
+///
+/// The result remains `width` bits wide, while the selected chunk halves on
+/// each step. If the upper half is zero, add its width to the count and
+/// continue with the lower half; otherwise continue with the upper half.
 fn bv_clz(value: &BV, width: u32) -> BV {
-    let mut result = BV::from_u64(width as u64, width);
-    let one_bit = BV::from_u64(1, 1);
-    for pos in 0..width {
-        let bit = value.extract(pos, pos);
-        let is_set = bit.eq(&one_bit);
-        let clz_if_top = BV::from_u64((width - 1 - pos) as u64, width);
-        result = is_set.ite(&clz_if_top, &result);
+    debug_assert!(width > 0, "bv_clz requires a nonzero width");
+    debug_assert!(
+        width.is_power_of_two(),
+        "bv_clz binary-search decomposition requires power-of-two width"
+    );
+
+    let mut chunk = value.clone();
+    let mut chunk_width = width;
+    let mut count = BV::from_u64(0, width);
+
+    while chunk_width > 1 {
+        let half = chunk_width / 2;
+        let upper = chunk.extract(chunk_width - 1, half);
+        let lower = chunk.extract(half - 1, 0);
+        let upper_is_zero = upper.eq(BV::from_u64(0, half));
+
+        let incremented = count.bvadd(BV::from_u64(half as u64, width));
+        count = upper_is_zero.ite(&incremented, &count);
+        chunk = upper_is_zero.ite(&lower, &upper);
+        chunk_width = half;
     }
-    result
+
+    let bit_is_zero = chunk.eq(BV::from_u64(0, 1));
+    let incremented = count.bvadd(BV::from_u64(1, width));
+    bit_is_zero.ite(&incremented, &count)
 }
 
 /// Configuration for the SMT solver
@@ -1162,6 +1175,44 @@ mod tests {
     use super::*;
     use z3::{SatResult, Solver};
 
+    fn max_nested_ite_depth(smt: &str) -> usize {
+        let bytes = smt.as_bytes();
+        let mut paren_depth = 0usize;
+        let mut ite_paren_depths = Vec::new();
+        let mut max_depth = 0usize;
+        let mut i = 0usize;
+
+        while i < bytes.len() {
+            match bytes[i] {
+                b'(' => {
+                    paren_depth += 1;
+                    if is_ite_head(bytes, i) {
+                        ite_paren_depths.push(paren_depth);
+                        max_depth = max_depth.max(ite_paren_depths.len());
+                    }
+                    i += 1;
+                }
+                b')' => {
+                    while ite_paren_depths.last().copied() == Some(paren_depth) {
+                        ite_paren_depths.pop();
+                    }
+                    paren_depth = paren_depth.saturating_sub(1);
+                    i += 1;
+                }
+                _ => i += 1,
+            }
+        }
+
+        max_depth
+    }
+
+    fn is_ite_head(bytes: &[u8], open_paren: usize) -> bool {
+        matches!(bytes.get(open_paren + 1..open_paren + 4), Some(b"ite"))
+            && bytes
+                .get(open_paren + 4)
+                .is_some_and(|b| b.is_ascii_whitespace() || *b == b')')
+    }
+
     #[test]
     fn test_mov_zero_equivalence() {
         let solver = Solver::new();
@@ -1595,6 +1646,19 @@ mod tests {
         let solver = Solver::new();
         solver.assert(&final_x0.eq(&BV::from_u64(63, 64)).not());
         assert_eq!(solver.check(), SatResult::Unsat, "CLZ(1) must be 63");
+    }
+
+    #[test]
+    fn test_bv_clz_formula_has_logarithmic_ite_depth() {
+        let value = BV::new_const("x", 64);
+        let clz = bv_clz(&value, 64);
+        let smt = clz.to_string();
+
+        assert!(
+            max_nested_ite_depth(&smt) <= 16,
+            "CLZ SMT term should be logarithmic-depth, got nested ite depth {}",
+            max_nested_ite_depth(&smt)
+        );
     }
 
     /// Floor-log2 acceptance test (issue #58): for nonzero `x1`, the sequence
@@ -2784,7 +2848,12 @@ mod tests {
         let values: &[u64] = &[
             0,
             1,
-            0x8000_0000_0000_0000,
+            2,
+            3,
+            0x10,
+            1 << 31,
+            1 << 32,
+            1 << 63,
             0x0000_0000_0000_0080,
             0x0000_0000_FFFF_FFFF,
             0xFFFF_FFFF_FFFF_FFFF,
@@ -2806,7 +2875,20 @@ mod tests {
             0,                     // all zero -> 63
             0xFFFF_FFFF_FFFF_FFFF, // all one -> 63
             0x8000_0000_0000_0000, // sign-bit only -> 0
-            0x4000_0000_0000_0000, // alternate sign -> 0
+            0x4000_0000_0000_0000, // opposite sign after sign bit -> 0
+            0xBFFF_FFFF_FFFF_FFFF, // negative opposite sign after sign bit -> 0
+            0xC000_0000_0000_0000, // one leading sign replica -> 1
+            1,                     // positive sign-fold boundary -> 62
+            2,                     // positive sign-fold boundary -> 61
+            3,                     // positive sign-fold boundary -> 61
+            0x10,                  // positive sign-fold nibble boundary -> 59
+            1 << 31,               // positive sign-fold 32-bit boundary -> 31
+            1 << 32,               // positive sign-fold 32-bit boundary -> 30
+            0xFFFF_FFFF_FFFF_FFFE, // negative sign-fold boundary -> 62
+            0xFFFF_FFFF_FFFF_FFFD, // negative sign-fold boundary -> 61
+            0xFFFF_FFFF_FFFF_FFEF, // negative sign-fold nibble boundary -> 59
+            0xFFFF_FFFF_7FFF_FFFF, // negative sign-fold 32-bit boundary -> 31
+            0xFFFF_FFFE_FFFF_FFFF, // negative sign-fold 32-bit boundary -> 30
             0x0000_0000_FFFF_FFFF, // mid run -> 31
         ];
         for &v1 in values {


### PR DESCRIPTION
Summary:
- Replace the 64-step `bv_clz` nested ITE chain with a binary-search decomposition over 32/16/8/4/2/1-bit halves.
- Add a formula-shape regression test plus expanded CLZ/CLS concrete/SMT boundary coverage.
- Add a direct `smt_clz` Criterion benchmark and `just bench-smt-clz` recipe for CLZ/CLS SMT timing.

Benchmark evidence (`cargo bench --bench smt_clz -- --quick`, Criterion middle estimate; old helper measured by temporarily reversing only `src/semantics/smt.rs`):
- old: one_clz 2.5672 ms, four_clz 8.6741 ms, one_cls 3.3232 ms, four_cls 11.422 ms
- new: one_clz 875.73 us, four_clz 3.2310 ms, one_cls 897.27 us, four_cls 3.3663 ms

Verification:
- `cargo test semantics::smt::tests::test_bv_clz_formula_has_logarithmic_ite_depth -- --exact` (red on old helper with nested ite depth 64; green after rewrite)
- `cargo test semantics::smt::tests::test_clz_concrete_smt_parity -- --exact`
- `cargo test semantics::smt::tests::test_cls_concrete_smt_parity -- --exact`
- `cargo test semantics::smt::tests::test_clz_floor_log2_pattern -- --exact`
- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`
- `cargo clippy --bench smt_clz -- -D warnings`
- `./build_tests.sh`
- `cargo test --all`
- `./ci_check.sh`

Closes #112

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**
