### PR TITLE
fix(ir): print zero-shift movz as mov alias

### DIFF
--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -1337,7 +1337,7 @@ impl fmt::Display for Instruction {
             }
             Instruction::MovZ { rd, imm, shift } => {
                 if *shift == 0 {
-                    write!(f, "movz {}, #{}", rd, imm)
+                    write!(f, "mov {}, #{}", rd, imm)
                 } else {
                     write!(f, "movz {}, #{}, lsl #{}", rd, imm, shift)
                 }
@@ -1494,6 +1494,23 @@ mod tests {
             rm: Operand::Register(Register::X0),
         };
         assert_eq!(format!("{}", eor), "eor x0, x0, x0");
+    }
+
+    #[test]
+    fn movz_shift0_display_uses_mov_alias() {
+        let shift0 = Instruction::MovZ {
+            rd: Register::X0,
+            imm: 0x1234,
+            shift: 0,
+        };
+        assert_eq!(shift0.to_string(), "mov x0, #4660");
+
+        let shift16 = Instruction::MovZ {
+            rd: Register::X0,
+            imm: 0x1234,
+            shift: 16,
+        };
+        assert_eq!(shift16.to_string(), "movz x0, #4660, lsl #16");
     }
 
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2456,7 +2456,7 @@ mod tests {
     #[test]
     fn parse_movz_and_movk_accept_canonical_forms() {
         let cases = [
-            ("movz x0, #0x1234", "movz x0, #4660"),
+            ("movz x0, #0x1234", "mov x0, #4660"),
             ("movz x0, #0xFFFF, lsl #48", "movz x0, #65535, lsl #48"),
             ("movk x1, #0", "movk x1, #0"),
             ("movk x1, #0x5678, lsl #16", "movk x1, #22136, lsl #16"),
@@ -2468,6 +2468,38 @@ mod tests {
             };
             assert_eq!(format!("{}", parsed), display);
         }
+    }
+
+    #[test]
+    fn parse_movz_shift0_display_normalizes_to_mov_alias() {
+        let parsed = match parse_line("movz x0, #0x1234").unwrap() {
+            LineResult::Instruction(instr) => instr,
+            LineResult::Skip => panic!("unexpected skip for movz"),
+        };
+        assert_eq!(
+            parsed,
+            Instruction::MovZ {
+                rd: Register::X0,
+                imm: 0x1234,
+                shift: 0,
+            }
+        );
+
+        let printed = parsed.to_string();
+        assert_eq!(printed, "mov x0, #4660");
+
+        let reparsed = match parse_line(&printed).unwrap() {
+            LineResult::Instruction(instr) => instr,
+            LineResult::Skip => panic!("unexpected skip for {}", printed),
+        };
+        assert_eq!(
+            reparsed,
+            Instruction::MovImm {
+                rd: Register::X0,
+                imm: 4660,
+            }
+        );
+        assert_eq!(reparsed.to_string(), printed);
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- Print `Instruction::MovZ { shift: 0 }` with the canonical `mov` mnemonic.
- Keep shifted `movz` display unchanged.
- Add parser/display coverage documenting that explicit zero-shift `movz` normalizes to `mov` text and then reparses as `MovImm`.

Verification:
- `cargo test ir::instructions::tests::movz_shift0_display_uses_mov_alias -- --exact`
- `cargo test parser::tests::parse_movz_shift0_display_normalizes_to_mov_alias -- --exact`
- `cargo test parser::tests::parse_movz_and_movk_accept_canonical_forms -- --exact`
- `cargo test parser::tests::test_tier1_display_parser_roundtrip -- --exact`
- `cargo test movz`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`
- `./ci_check.sh`

Note: the requested `scripts/full_test.sh` path does not exist in this repository; `./ci_check.sh` ran the repo-present `./test_all.sh`.

Closes #113

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**