### PR TITLE
test(stochastic): cover move-wide opcode peers

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,46 +1,43 @@
-# Plan - issue #181: Pin reversed-order `--live-out` error
+# Plan - issue #114: Targeted swap_opcode move-wide peer tests
 
 ## 1. Problem Restated
 
-Issue #181 asks for a narrow regression test documenting the current malformed-order behavior for `--live-out "nzcv;x0"`. The accepted grammar is `<regs>` or `<regs>;<flags>` with `nzcv` valid only in the flags half, so the reversed input currently splits into register half `nzcv` and flag half `x0`, then fails through the register parser with `invalid register name: 'nzcv'`. The PR should pin that exact diagnostic so future parser-message changes fail with an actionable test failure, without changing parser behavior.
+Issue #114 asks for targeted unit coverage of the AArch64 stochastic opcode-mutator topology added around the move-wide family: `MOVN`, `MOVZ`, and `MOVK` should be able to propose their declared peer opcodes, and `MOVZ` should be the only direct bridge to `MovImm`. The current MCMC integration tests exercise these arms indirectly, but they do not fail loudly if an individual `mutate_opcode` arm loses a peer, gains the wrong bridge, or stops producing the documented self/peer distribution.
 
 ## 2. Files To Touch
 
-- `src/validation/live_out.rs` - add one unit test in the existing `#[cfg(test)] mod tests`, near the `parse_live_out_contract` malformed-input tests around lines 677-727.
+- `src/search/stochastic/mutation.rs` - add test-only helper code and a focused unit test in the existing `#[cfg(test)] mod tests`; the relevant implementation arms are `Mutator::mutate_opcode` lines 738-775, and nearby opcode-mutator tests start around lines 1457 and 1622.
+- `src/search/stochastic/mutation.rs` - production code should change only if the new tests expose drift from the intended topology; any such fix should stay inside the `Instruction::MovN`, `Instruction::MovZ`, and `Instruction::MovK` `mutate_opcode` arms at lines 750-775.
 
-No production files should change. There are no `crates/` or `compiler/` directories in this repository, so this is not a Rust-stage/self-hosted compiler cross-cutting change. There is no `docs/spec/` tree in this checkout; the relevant accepted design source is `docs/adr/0006-live-out-cli-grammar.md`, and no ADR/spec update is needed because the grammar and behavior stay unchanged.
+No `crates/` or `compiler/` paths exist in this repository, so there is no Rust-stage/self-hosted compiler split to update. No `docs/spec/` tree exists in this checkout. The issue is test-only for AArch64 stochastic search, so `docs/capability.md` and `docs/adr/*.md` do not need updates.
 
 ## 3. TDD Slices
 
-1. Add a focused regression test in `src/validation/live_out.rs`, immediately after `test_parse_live_out_contract_bareword_nzcv_rejected` or before `test_parse_live_out_contract_unknown_flag_rejected`. Name it `test_parse_live_out_contract_reversed_order_nzcv_x0_error`.
+1. Add a test-local opcode classifier in `src/search/stochastic/mutation.rs` inside the existing tests module near `default_mutator()` at lines 1270-1275. The helper should classify only `Instruction::MovN`, `Instruction::MovZ`, `Instruction::MovK`, and `Instruction::MovImm`; all other opcodes should panic or return an explicit unexpected marker so accidental non-move-wide outputs are visible.
 
-2. In that test, call `let err = parse_live_out_contract("nzcv;x0").unwrap_err();` and assert the exact rendered message:
-   ```rust
-   assert_eq!(err.to_string(), "invalid register name: 'nzcv'");
-   ```
-   Prefer `err.to_string()` over substring matching so the test pins the user-visible `Display` body already covered by `display_renders_message_without_type_prefix` at `src/validation/live_out.rs:267-271`.
+2. Add a small deterministic histogram helper in the same test module. It should create `let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(<fixed seed>);`, call `default_mutator().mutate_opcode(&mut rng, &mut seq)` 5000 times from a one-instruction sequence, and count opcode classes. Use fixed-size counters or a deterministic `BTreeMap`, not a `HashMap`, so failure output is stable. Assert reachability only: every expected class has count greater than zero, and every observed class is in the expected set. Do not assert exact frequencies.
 
-3. Red-check the guard without committing sabotage: temporarily change the expected string in the new test, or temporarily mutate the local parser diagnostic at `src/validation/live_out.rs:49-50`, then run:
-   ```bash
-   cargo test validation::live_out::tests::test_parse_live_out_contract_reversed_order_nzcv_x0_error -- --exact
-   ```
-   Confirm the test fails on the message mismatch, then immediately revert the temporary mutation.
+3. Red slice for `MOVN`: add a table row or dedicated test case named from `test_move_wide_opcode_mutation_reaches_declared_peers`, starting with `Instruction::MovN { rd: Register::X0, imm: 0x1234, shift: 16 }`. Expected reachable classes are `MovN`, `MovZ`, and `MovK`; `MovImm` must not appear directly. Red-check by temporarily deleting or mis-expecting one peer locally, then revert the temporary change.
 
-4. Green-check against the real code. The production path that should satisfy the test already exists: `parse_live_out_contract` counts one semicolon at `src/validation/live_out.rs:94-115`, parses `regs_part` via `RegisterSet::<Register>::from_str`, and `parse_register` emits `invalid register name: 'nzcv'` at `src/validation/live_out.rs:49-50`. No production code should be edited.
+4. Red slice for `MOVZ`: extend the same test with `Instruction::MovZ { rd: Register::X0, imm: 0x1234, shift: 16 }`. Expected reachable classes are `MovZ`, `MovN`, `MovK`, and `MovImm`. When classifying a `MovImm` bridge, also assert it preserves `rd` and uses the raw `u16` immediate as `imm as i64`, not `imm << shift`, matching the current bridge comment at lines 758-768.
 
-5. Refactor only if formatting requires it. Keep the test local and explicit; do not introduce helper functions or convert the surrounding parse-live-out tests to table-driven form for this small coverage addition.
+5. Red slice for `MOVK`: extend the same test with `Instruction::MovK { rd: Register::X0, imm: 0x1234, shift: 16 }`. Expected reachable classes are `MovK`, `MovN`, and `MovZ`; `MovImm` must not appear directly.
+
+6. Green/fix slice: if any row fails against current code, edit only the corresponding `mutate_opcode` move-wide arm at `src/search/stochastic/mutation.rs:750-775` to restore the documented topology: `MovN -> {MovN, MovZ, MovK}`, `MovZ -> {MovZ, MovN, MovK, MovImm}`, and `MovK -> {MovK, MovN, MovZ}`. Do not change mutation weights, MCMC acceptance, candidate generation, parsing, semantics, or encodability rules.
+
+7. Refactor slice: keep helper names local and narrow, remove any temporary red-check edits, and run formatting only if the added test code needs it. Avoid broad table-driven rewrites of unrelated opcode-mutator tests.
 
 ## 4. Verification Surface
 
-- No ESBMC proof work is needed. This change does not touch contracts, codegen, the C model, SMT lowering, concrete semantics, assembler output, or binary patching.
+- No ESBMC proof work is needed. This repository does not have the Vow C-model/codegen surface referenced by the generic run template, and this issue does not touch contracts, codegen, SMT lowering, concrete semantics, assembler output, or binary patching.
 - No fixtures under `tests/run/`, `tests/asm/`, `tests/integration/`, `examples/`, or benchmark directories should grow.
-- Minimum verification:
+- Minimum targeted verification:
   ```bash
-  cargo test validation::live_out::tests::test_parse_live_out_contract_reversed_order_nzcv_x0_error -- --exact
+  cargo test search::stochastic::mutation::tests::test_move_wide_opcode_mutation_reaches_declared_peers -- --exact
   ```
-- Broader local verification before PR/commit:
+- Broader local verification for the touched module:
   ```bash
-  cargo test validation::live_out
+  cargo test search::stochastic::mutation
   cargo fmt -- --check
   ```
 - Full pre-push verification remains the repository gate from `CLAUDE.md`:
@@ -50,17 +47,18 @@ No production files should change. There are no `crates/` or `compiler/` directo
 
 ## 5. Risk Areas
 
-- Error-message coupling is intentional here: use an exact assertion because the issue specifically asks to pin the diagnostic text for `nzcv;x0`.
-- Test placement should stay in the parser/error-test cluster so future maintainers understand this as CLI grammar coverage, not live-in/live-out dataflow coverage.
-- Do not change `parse_live_out_contract` to special-case reversed order unless a separate issue asks for a friendlier diagnostic; that would widen the behavioral scope and may require ADR/help-text updates.
-- `parse -> print -> parse` idempotency is unaffected because this is a CLI live-out contract parser test, not assembly IR parsing or formatting.
-- Binary fixed-point risks are absent: no `compiler/` tree exists here, and the plan does not touch codegen ordering, map iteration, stack-slot layout, assembler encoding, or `vow-clif-shim`-style components.
-- The `cargo clippy --all -- -D warnings` gate should be unaffected; the added test must avoid unused imports or dead helper functions.
+- Deterministic sampling can create false negatives if the chosen seed/sample count misses a valid low-probability arm. With the current 1-in-3 and 1-in-4 arms, 5000 samples makes that practically impossible, but the implementation stage should run the exact test after choosing the seed and keep the seed fixed in the test.
+- The test should not assert exact frequencies; doing so would overfit implementation detail and make harmless future weight changes painful.
+- `mutate_opcode` is private, but the existing unit tests live in the same module and already call it directly. Do not widen visibility or add new public API for this test.
+- `MovZ -> MovImm` intentionally discards `shift`. The test should protect this payload behavior only for the bridge output, while keeping the main assertion about opcode reachability.
+- `parse -> print -> parse` idempotency is unaffected because no parser/display code changes are planned.
+- Binary fixed-point risks are absent: there is no `compiler/` tree here, and this plan does not touch codegen ordering, map iteration in production, stack-slot layout, or any `vow-clif-shim`-style component.
+- The `cargo clippy --all -- -D warnings` gate should remain clean; avoid unused imports such as `ChaCha8Rng` if the final test uses `StdRng` instead, and avoid dead helper functions.
 
 ## 6. Out Of Scope
 
-- Changing the grammar for reversed-order input or adding a bespoke "wrong order" diagnostic.
-- Changing any `run_equiv` or `run_llm_opt` error-prefix behavior in `src/main.rs`.
-- Adding docs/spec/ADR updates; this PR documents existing behavior through a regression test only.
-- Refactoring `ParseRegisterSetError`, `parse_register`, or the surrounding `parse_live_out_contract` tests.
-- Running benchmarks, mutation tests, x86/RISC-V flows, LLM search, assembler tests, or integration fixtures for this unit-test-only issue.
+- Changing the stochastic proposal topology beyond restoring the documented move-wide peers if drift is found.
+- Adding exact statistical/frequency assertions, chi-squared checks, or acceptance-rate tests.
+- Adding integration, MCMC end-to-end, parser, encoder, concrete-semantics, SMT, or capability-matrix tests.
+- Refactoring the full `mutate_opcode` match, moving tests out of `mutation.rs`, or replacing existing stochastic test patterns.
+- Updating docs or ADRs for a test-only coverage addition.

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -1266,6 +1266,8 @@ mod tests {
     use proptest::prelude::*;
     use rand::SeedableRng;
     use rand::rngs::StdRng;
+    use rand_chacha::ChaCha8Rng;
+    use std::collections::BTreeMap;
 
     fn default_mutator() -> Mutator {
         Mutator::new(
@@ -1273,6 +1275,74 @@ mod tests {
             vec![-1, 0, 1, 2],
             MutationWeights::default(),
         )
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    enum MoveWideOpcode {
+        MovImm,
+        MovK,
+        MovN,
+        MovZ,
+    }
+
+    fn classify_move_wide_opcode(instr: Instruction) -> MoveWideOpcode {
+        match instr {
+            Instruction::MovImm { .. } => MoveWideOpcode::MovImm,
+            Instruction::MovK { .. } => MoveWideOpcode::MovK,
+            Instruction::MovN { .. } => MoveWideOpcode::MovN,
+            Instruction::MovZ { .. } => MoveWideOpcode::MovZ,
+            other => panic!("unexpected move-wide opcode mutation output: {other:?}"),
+        }
+    }
+
+    fn move_wide_opcode_mutation_counts(
+        start: Instruction,
+        expected_mov_imm_payload: Option<(Register, i64)>,
+    ) -> BTreeMap<MoveWideOpcode, usize> {
+        let mutator = default_mutator();
+        let mut rng = ChaCha8Rng::seed_from_u64(0x114);
+        let mut counts = BTreeMap::new();
+
+        for _ in 0..5000 {
+            let mut seq = vec![start];
+            mutator.mutate_opcode(&mut rng, &mut seq);
+
+            if let Instruction::MovImm { rd, imm } = seq[0]
+                && let Some((expected_rd, expected_imm)) = expected_mov_imm_payload
+            {
+                assert_eq!(rd, expected_rd, "MovZ -> MovImm must preserve rd");
+                assert_eq!(
+                    imm, expected_imm,
+                    "MovZ -> MovImm must use the raw u16 immediate"
+                );
+            }
+
+            *counts.entry(classify_move_wide_opcode(seq[0])).or_insert(0) += 1;
+        }
+
+        counts
+    }
+
+    fn assert_move_wide_opcode_peers(
+        start: Instruction,
+        expected: &[MoveWideOpcode],
+        expected_mov_imm_payload: Option<(Register, i64)>,
+    ) {
+        let counts = move_wide_opcode_mutation_counts(start, expected_mov_imm_payload);
+
+        for observed in counts.keys() {
+            assert!(
+                expected.contains(observed),
+                "unexpected move-wide opcode {observed:?} from {start:?}; counts: {counts:?}"
+            );
+        }
+
+        for expected_opcode in expected {
+            assert!(
+                counts.get(expected_opcode).copied().unwrap_or(0) > 0,
+                "missing move-wide opcode {expected_opcode:?} from {start:?}; counts: {counts:?}"
+            );
+        }
     }
 
     #[test]
@@ -1494,6 +1564,39 @@ mod tests {
         assert!(
             saw_arith_after_bridge,
             "expected the bridge to occasionally produce Add/Sub from And"
+        );
+    }
+
+    #[test]
+    fn test_move_wide_opcode_mutation_reaches_declared_peers() {
+        use MoveWideOpcode::{MovImm, MovK, MovN, MovZ};
+
+        assert_move_wide_opcode_peers(
+            Instruction::MovN {
+                rd: Register::X0,
+                imm: 0x1234,
+                shift: 16,
+            },
+            &[MovN, MovZ, MovK],
+            None,
+        );
+        assert_move_wide_opcode_peers(
+            Instruction::MovZ {
+                rd: Register::X0,
+                imm: 0x1234,
+                shift: 16,
+            },
+            &[MovZ, MovN, MovK, MovImm],
+            Some((Register::X0, 0x1234)),
+        );
+        assert_move_wide_opcode_peers(
+            Instruction::MovK {
+                rd: Register::X0,
+                imm: 0x1234,
+                shift: 16,
+            },
+            &[MovK, MovN, MovZ],
+            None,
         );
     }
 


### PR DESCRIPTION
Summary:
- add deterministic histogram coverage for MOVN/MOVZ/MOVK mutate_opcode peer reachability
- assert the MOVZ -> MovImm bridge preserves rd and uses the raw u16 immediate
- update PLAN.md for issue #114

Verification:
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test search::stochastic::mutation::tests::test_move_wide_opcode_mutation_reaches_declared_peers -- --exact
- cargo test search::stochastic::mutation
- ./ci_check.sh
- cargo test --all

Closes #114

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**