### PR TITLE
refactor(aarch64): consolidate candidate opcode ids

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,66 +1,65 @@
-# Plan - issue #181: Pin reversed-order `--live-out` error
+# Plan: Consolidate AArch64 opcode IDs
 
 ## 1. Problem Restated
 
-Issue #181 asks for a narrow regression test documenting the current malformed-order behavior for `--live-out "nzcv;x0"`. The accepted grammar is `<regs>` or `<regs>;<flags>` with `nzcv` valid only in the flags half, so the reversed input currently splits into register half `nzcv` and flag half `x0`, then fails through the register parser with `invalid register name: 'nzcv'`. The PR should pin that exact diagnostic so future parser-message changes fail with an actionable test failure, without changing parser behavior.
+`src/search/candidate.rs` defines a free `opcode_id(&Instruction) -> u8` match table that mirrors the canonical `InstructionType::opcode_id` implementation for `Instruction` in `src/isa/aarch64.rs`. This hand-synchronised duplicate makes each new AArch64 IR variant a two-site update and required an extra drift test. The implementation should remove the search-layer copy and route every `candidate.rs` opcode-ID use through the existing `InstructionType` trait method.
 
 ## 2. Files To Touch
 
-- `src/validation/live_out.rs` - add one unit test in the existing `#[cfg(test)] mod tests`, near the `parse_live_out_contract` malformed-input tests around lines 677-727.
-
-No production files should change. There are no `crates/` or `compiler/` directories in this repository, so this is not a Rust-stage/self-hosted compiler cross-cutting change. There is no `docs/spec/` tree in this checkout; the relevant accepted design source is `docs/adr/0006-live-out-cli-grammar.md`, and no ADR/spec update is needed because the grammar and behavior stay unchanged.
+- `src/search/candidate.rs`: update same-file test/helper call sites from the free `opcode_id` function to `InstructionType::opcode_id` or `.opcode_id()`, remove the free function at lines 999-1081, and remove or rewrite the now-obsolete drift test at lines 1690-1742.
+- `src/isa/aarch64.rs`: no production change expected; this remains the canonical opcode-ID table in `impl InstructionType for Instruction` at lines 182-270. Use existing tests here as the backend safety net.
+- `src/isa/traits.rs`: no change expected; `InstructionType::opcode_id` already exists at lines 112-113.
+- No `crates/` or `compiler/` paths exist in this repository, so there is no cross-compiler update.
+- No `docs/spec/*.md` updates are required because this is an internal Rust refactor with no syntax, semantics, builtin, operator, effect, or CLI behavior change. This repository also has no `docs/spec/` directory.
 
 ## 3. TDD Slices
 
-1. Add a focused regression test in `src/validation/live_out.rs`, immediately after `test_parse_live_out_contract_bareword_nzcv_rejected` or before `test_parse_live_out_contract_unknown_flag_rejected`. Name it `test_parse_live_out_contract_reversed_order_nzcv_x0_error`.
+1. **Compile-fail consumer audit**
+   - Test/location: `src/search/candidate.rs` unit tests that currently call the free function, especially `test_generate_all_instructions_covers_issue_66_opcodes` at lines 1201-1221, `random_opcode_ids` at lines 1223-1232, `test_opcode_id_unique` at lines 1630-1688, and `test_bitfield_opcode_id_matches_isa_backend` at lines 1690-1742.
+   - Red: remove or temporarily hide `candidate::opcode_id`; `cargo test candidate::` should fail at every remaining free-function call.
+   - Green: update those call sites to use `InstructionType::opcode_id` or `.opcode_id()`. Keep stable literal checks such as `10u8..=19`; only change the source of the ID value.
+   - Production code: no behavior change yet beyond call-site routing.
 
-2. In that test, call `let err = parse_live_out_contract("nzcv;x0").unwrap_err();` and assert the exact rendered message:
-   ```rust
-   assert_eq!(err.to_string(), "invalid register name: 'nzcv'");
-   ```
-   Prefer `err.to_string()` over substring matching so the test pins the user-visible `Display` body already covered by `display_renders_message_without_type_prefix` at `src/validation/live_out.rs:267-271`.
+2. **Remove the duplicated table**
+   - Test/location: same `src/search/candidate.rs` unit test module plus repository search.
+   - Red: after deleting the free function at lines 999-1081, `rg -n "map\\(opcode_id\\)|opcode_id\\(&|candidate::opcode_id|fn opcode_id" src/search` should show no AArch64 candidate helper references.
+   - Green: rely on `InstructionType::opcode_id` from the existing import at `src/search/candidate.rs:5`; add a local `use crate::isa::InstructionType;` inside the test module only if method resolution stops being obvious after edits.
+   - Production code: delete `pub fn opcode_id` entirely, including `#[allow(dead_code)]` and comments that say the table mirrors `src/isa/aarch64.rs`.
 
-3. Red-check the guard without committing sabotage: temporarily change the expected string in the new test, or temporarily mutate the local parser diagnostic at `src/validation/live_out.rs:49-50`, then run:
-   ```bash
-   cargo test validation::live_out::tests::test_parse_live_out_contract_reversed_order_nzcv_x0_error -- --exact
-   ```
-   Confirm the test fails on the message mismatch, then immediately revert the temporary mutation.
+3. **Retire the drift test without losing useful coverage**
+   - Test/location: `src/search/candidate.rs::test_bitfield_opcode_id_matches_isa_backend` at lines 1690-1742.
+   - Red: once the free function is gone, the old assertion would become `instr.opcode_id() == instr.opcode_id()` and no longer catches anything.
+   - Green: either delete this sync test as redundant, or convert it into a stable-value guard for the bitfield aliases using literal expected IDs `49..=54`. Prefer deletion if `src/isa/aarch64.rs::all_instruction_families_cover_trait_methods` and candidate bitfield generation tests already give enough coverage.
+   - Production code: none.
 
-4. Green-check against the real code. The production path that should satisfy the test already exists: `parse_live_out_contract` counts one semicolon at `src/validation/live_out.rs:94-115`, parses `regs_part` via `RegisterSet::<Register>::from_str`, and `parse_register` emits `invalid register name: 'nzcv'` at `src/validation/live_out.rs:49-50`. No production code should be edited.
-
-5. Refactor only if formatting requires it. Keep the test local and explicit; do not introduce helper functions or convert the surrounding parse-live-out tests to table-driven form for this small coverage addition.
+4. **Regression and formatting pass**
+   - Test/location: affected unit tests in `src/search/candidate.rs` and `src/isa/aarch64.rs`.
+   - Red: run the narrow tests before and after cleanup to catch accidental ID or import changes.
+   - Green: run `cargo test candidate::`, `cargo test isa::aarch64::tests::all_instruction_families_cover_trait_methods`, and `cargo fmt -- --check`. If time permits in implementation, run `just check` or the full `./ci_check.sh` before opening the PR.
+   - Production code: only formatting required by Rustfmt.
 
 ## 4. Verification Surface
 
-- No ESBMC proof work is needed. This change does not touch contracts, codegen, the C model, SMT lowering, concrete semantics, assembler output, or binary patching.
-- No fixtures under `tests/run/`, `tests/asm/`, `tests/integration/`, `examples/`, or benchmark directories should grow.
-- Minimum verification:
-  ```bash
-  cargo test validation::live_out::tests::test_parse_live_out_contract_reversed_order_nzcv_x0_error -- --exact
-  ```
-- Broader local verification before PR/commit:
-  ```bash
-  cargo test validation::live_out
-  cargo fmt -- --check
-  ```
-- Full pre-push verification remains the repository gate from `CLAUDE.md`:
-  ```bash
-  ./ci_check.sh
-  ```
+- Contracts, codegen, the C model, and ESBMC properties are not touched. No Vow `.vow` contracts or ESBMC proofs apply to this s11 Rust refactor.
+- No `tests/run/` or `examples/` fixtures need to grow; this does not affect parse, print, assembly, disassembly, equivalence, or CLI output.
+- Verification should focus on Rust compile/test coverage and static search:
+  - `rg -n "opcode_id" src/search/` should show only legitimate trait test method calls or comments, not a search-layer helper table.
+  - `cargo test candidate::` should keep candidate generator behavior intact.
+  - `cargo test isa::aarch64::tests::all_instruction_families_cover_trait_methods` should keep the canonical opcode-count invariant intact.
 
 ## 5. Risk Areas
 
-- Error-message coupling is intentional here: use an exact assertion because the issue specifically asks to pin the diagnostic text for `nzcv;x0`.
-- Test placement should stay in the parser/error-test cluster so future maintainers understand this as CLI grammar coverage, not live-in/live-out dataflow coverage.
-- Do not change `parse_live_out_contract` to special-case reversed order unless a separate issue asks for a friendlier diagnostic; that would widen the behavioral scope and may require ADR/help-text updates.
-- `parse -> print -> parse` idempotency is unaffected because this is a CLI live-out contract parser test, not assembly IR parsing or formatting.
-- Binary fixed-point risks are absent: no `compiler/` tree exists here, and the plan does not touch codegen ordering, map iteration, stack-slot layout, assembler encoding, or `vow-clif-shim`-style components.
-- The `cargo clippy --all -- -D warnings` gate should be unaffected; the added test must avoid unused imports or dead helper functions.
+- Method-call trait resolution: `.opcode_id()` requires `InstructionType` in scope; `candidate.rs` already imports it at line 5, but tests should be checked after deleting the helper.
+- Test tautology: the old drift test must not survive as a self-comparison after the free function is removed.
+- Stable opcode ID expectations: tests around issue #66 intentionally use literal range `10..=19`; do not rewrite these to derive the values from representatives, because that would hide renumbering.
+- Search comments: remove or update comments that claim `candidate.rs` owns or mirrors an opcode table so future contributors do not reintroduce the duplicate.
+- `cargo clippy --all -- -D warnings`: deleting the free function should remove one `#[allow(dead_code)]`, but new imports must not be unused.
+- Binary fixed point, parse-print-parse idempotency, codegen ordering, map ordering, and stack-slot layout are not involved.
 
 ## 6. Out Of Scope
 
-- Changing the grammar for reversed-order input or adding a bespoke "wrong order" diagnostic.
-- Changing any `run_equiv` or `run_llm_opt` error-prefix behavior in `src/main.rs`.
-- Adding docs/spec/ADR updates; this PR documents existing behavior through a regression test only.
-- Refactoring `ParseRegisterSetError`, `parse_register`, or the surrounding `parse_live_out_contract` tests.
-- Running benchmarks, mutation tests, x86/RISC-V flows, LLM search, assembler tests, or integration fixtures for this unit-test-only issue.
+- Renumbering opcode IDs or changing `AArch64InstructionGenerator::opcode_count`.
+- Consolidating `generate_all_instructions` with `AArch64InstructionGenerator::generate_all`; those are broader duplicated candidate-generation paths.
+- Refactoring x86, RISC-V, symbolic sketch opcode constants, or stochastic mutation opcode-selection tables.
+- Changing instruction semantics, parser behavior, assembler encodability, CLI flags, docs capability tables, or benchmark fixtures.
+- Running `sudo`, modifying `symphony/` if present, or editing anything under gitignored `build/`.

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -996,90 +996,6 @@ pub fn generate_random_sequence<R: rand::RngExt>(
         .collect()
 }
 
-/// Get the opcode type as a numeric identifier (for mutation)
-#[allow(dead_code)]
-pub fn opcode_id(instr: &Instruction) -> u8 {
-    match instr {
-        Instruction::MovReg { .. } => 0,
-        Instruction::MovImm { .. } => 1,
-        Instruction::Add { .. } => 2,
-        Instruction::Sub { .. } => 3,
-        Instruction::And { .. } => 4,
-        Instruction::Orr { .. } => 5,
-        Instruction::Eor { .. } => 6,
-        Instruction::Lsl { .. } => 7,
-        Instruction::Lsr { .. } => 8,
-        Instruction::Asr { .. } => 9,
-        Instruction::Mul { .. } => 10,
-        Instruction::Sdiv { .. } => 11,
-        Instruction::Udiv { .. } => 12,
-        Instruction::Cmp { .. } => 13,
-        Instruction::Cmn { .. } => 14,
-        Instruction::Tst { .. } => 15,
-        Instruction::Csel { .. } => 16,
-        Instruction::Csinc { .. } => 17,
-        Instruction::Csinv { .. } => 18,
-        Instruction::Csneg { .. } => 19,
-        Instruction::Mvn { .. } => 20,
-        Instruction::Neg { .. } => 21,
-        Instruction::Negs { .. } => 22,
-        Instruction::MovN { .. } => 23,
-        Instruction::Bic { .. } => 24,
-        Instruction::Bics { .. } => 25,
-        Instruction::Orn { .. } => 26,
-        Instruction::Eon { .. } => 27,
-        Instruction::Adds { .. } => 28,
-        Instruction::Subs { .. } => 29,
-        Instruction::Ands { .. } => 30,
-        Instruction::Cset { .. } => 31,
-        Instruction::Csetm { .. } => 32,
-        Instruction::Ror { .. } => 33,
-        Instruction::MovZ { .. } => 34,
-        Instruction::MovK { .. } => 35,
-        Instruction::Clz { .. } => 36,
-        Instruction::Cls { .. } => 37,
-        Instruction::Rbit { .. } => 38,
-        Instruction::Rev { .. } => 39,
-        Instruction::Rev32 { .. } => 40,
-        Instruction::Rev16 { .. } => 41,
-        Instruction::Madd { .. } => 42,
-        Instruction::Msub { .. } => 43,
-        Instruction::Mneg { .. } => 44,
-        Instruction::Smulh { .. } => 45,
-        Instruction::Umulh { .. } => 46,
-        Instruction::Ccmp { .. } => 47,
-        Instruction::Ccmn { .. } => 48,
-        Instruction::Sxtb { .. } => 49,
-        Instruction::Sxth { .. } => 50,
-        Instruction::Sxtw { .. } => 51,
-        Instruction::Uxtb { .. } => 52,
-        Instruction::Uxth { .. } => 53,
-        Instruction::Ubfx { .. } => 49,
-        Instruction::Sbfx { .. } => 50,
-        Instruction::Bfi { .. } => 51,
-        Instruction::Bfxil { .. } => 52,
-        Instruction::Ubfiz { .. } => 53,
-        Instruction::Sbfiz { .. } => 54,
-        // Branches / terminators (issue #69)
-        Instruction::B { .. } => 55,
-        Instruction::BCond { .. } => 56,
-        Instruction::Ret { .. } => 57,
-        Instruction::Cbz { .. } => 58,
-        Instruction::Cbnz { .. } => 59,
-        Instruction::Tbz { .. } => 60,
-        Instruction::Tbnz { .. } => 61,
-        Instruction::Bl { .. } => 62,
-        Instruction::Br { .. } => 63,
-        // Memory ops (issue #68). Mirrors `src/isa/aarch64.rs` so the two
-        // tables stay aligned. See ADR-0007.
-        Instruction::Ldr { .. } => 64,
-        Instruction::Ldrs { .. } => 65,
-        Instruction::Str { .. } => 66,
-        Instruction::Ldp { .. } => 67,
-        Instruction::Stp { .. } => 68,
-    }
-}
-
 /// Check if an instruction has immediate operand support
 #[allow(dead_code)]
 pub fn supports_immediate(instr: &Instruction) -> bool {
@@ -1206,7 +1122,8 @@ mod tests {
         // opcode_id collision between Sxt* and Ubfx/Sbfx/Bfi/Bfxil/Ubfiz that
         // isn't in scope here.
         let instrs = generate_all_instructions(&default_registers(), &default_immediates());
-        let ids: std::collections::BTreeSet<u8> = instrs.iter().map(opcode_id).collect();
+        let ids: std::collections::BTreeSet<u8> =
+            instrs.iter().map(InstructionType::opcode_id).collect();
         // Keep this literal range: 10..=19 is the stable issue-66 opcode_id
         // contract for Mul through Csneg. Deriving it from representative
         // Instruction values would hide accidental renumbering, unlike the
@@ -1227,7 +1144,7 @@ mod tests {
         let imms = default_immediates();
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
         (0..draws)
-            .map(|_| opcode_id(&generate_random_instruction(&mut rng, &regs, &imms)))
+            .map(|_| generate_random_instruction(&mut rng, &regs, &imms).opcode_id())
             .collect()
     }
 
@@ -1261,7 +1178,7 @@ mod tests {
             ),
         ] {
             assert!(
-                ids.contains(&opcode_id(&instr)),
+                ids.contains(&instr.opcode_id()),
                 "random never produced {}",
                 label
             );
@@ -1296,7 +1213,7 @@ mod tests {
             ),
         ] {
             assert!(
-                ids.contains(&opcode_id(&instr)),
+                ids.contains(&instr.opcode_id()),
                 "random never produced {}",
                 label
             );
@@ -1345,7 +1262,7 @@ mod tests {
             ),
         ] {
             assert!(
-                ids.contains(&opcode_id(&instr)),
+                ids.contains(&instr.opcode_id()),
                 "random never produced {}",
                 label
             );
@@ -1400,7 +1317,7 @@ mod tests {
             ),
         ] {
             assert!(
-                ids.contains(&opcode_id(&instr)),
+                ids.contains(&instr.opcode_id()),
                 "random never produced {}",
                 label
             );
@@ -1682,63 +1599,9 @@ mod tests {
             },
         ];
 
-        let ids: Vec<_> = instrs.iter().map(opcode_id).collect();
+        let ids: Vec<_> = instrs.iter().map(InstructionType::opcode_id).collect();
         let unique: std::collections::HashSet<_> = ids.iter().collect();
         assert_eq!(ids.len(), unique.len());
-    }
-
-    /// Sync test: opcode_id in candidate.rs must agree with
-    /// AArch64InstructionInfo::opcode_id in isa/aarch64.rs for every bitfield
-    /// variant. Catches drift between the two definitions.
-    #[test]
-    fn test_bitfield_opcode_id_matches_isa_backend() {
-        use crate::isa::InstructionType;
-        let instrs = vec![
-            Instruction::Ubfx {
-                rd: Register::X0,
-                rn: Register::X1,
-                lsb: 0,
-                width: 1,
-            },
-            Instruction::Sbfx {
-                rd: Register::X0,
-                rn: Register::X1,
-                lsb: 0,
-                width: 1,
-            },
-            Instruction::Bfi {
-                rd: Register::X0,
-                rn: Register::X1,
-                lsb: 0,
-                width: 1,
-            },
-            Instruction::Bfxil {
-                rd: Register::X0,
-                rn: Register::X1,
-                lsb: 0,
-                width: 1,
-            },
-            Instruction::Ubfiz {
-                rd: Register::X0,
-                rn: Register::X1,
-                lsb: 0,
-                width: 1,
-            },
-            Instruction::Sbfiz {
-                rd: Register::X0,
-                rn: Register::X1,
-                lsb: 0,
-                width: 1,
-            },
-        ];
-        for instr in &instrs {
-            assert_eq!(
-                opcode_id(instr),
-                instr.opcode_id(),
-                "opcode_id drift for {}",
-                instr
-            );
-        }
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- Removed the duplicated `candidate::opcode_id` AArch64 match table.
- Routed candidate coverage helpers/tests through `InstructionType::opcode_id()` from the ISA backend.
- Deleted the now-tautological candidate-vs-ISA opcode drift test.

Validation:
- `cargo test candidate::` (includes red/green cycle after deleting the helper)
- `cargo test isa::aarch64::tests::all_instruction_families_cover_trait_methods`
- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`
- `cargo test --all` (initially failed because fixture binaries were absent; passed after `./build_tests.sh`)
- `./ci_check.sh`

Closes #116

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**
