### PR TITLE
fix(search): rebalance AArch64 bit-op sampling

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,66 +1,57 @@
-# Plan - issue #181: Pin reversed-order `--live-out` error
+# Plan - issue #115: Re-balance AArch64 MCMC bit-manipulation sampling
 
 ## 1. Problem Restated
 
-Issue #181 asks for a narrow regression test documenting the current malformed-order behavior for `--live-out "nzcv;x0"`. The accepted grammar is `<regs>` or `<regs>;<flags>` with `nzcv` valid only in the flags half, so the reversed input currently splits into register half `nzcv` and flag half `x0`, then fails through the register parser with `invalid register name: 'nzcv'`. The PR should pin that exact diagnostic so future parser-message changes fail with an actionable test failure, without changing parser behavior.
+The current AArch64 random candidate tables still route `CLZ`, `CLS`, `RBIT`, `REV`, `REV32`, and `REV16` through one shared random-generation slot in both `AArch64InstructionGenerator::generate_random` and `search::candidate::generate_random_instruction`. In the current 33-slot tree each bit-manipulation opcode is sampled at roughly `1 / (33 * 6)`, while singleton top-level opcodes are sampled at `1 / 33`; this preserves the original issue's 6x starvation even though later issues grew the table. The minimal fix is to give each of the six single-source bit-manipulation ops its own top-level slot in both samplers, without changing opcode IDs, semantics, parsing, assembler output, or `opcode_count()`.
 
 ## 2. Files To Touch
 
-- `src/validation/live_out.rs` - add one unit test in the existing `#[cfg(test)] mod tests`, near the `parse_live_out_contract` malformed-input tests around lines 677-727.
+- `src/isa/aarch64.rs` - add a distribution regression test near `slot_23_sub_multiplexer_removed_for_issue_93`, promote the bit-manipulation arm in `AArch64InstructionGenerator::generate_random`, update the random-slot comments, and update the `opcode_count()` doc comment that currently says the bit ops are folded behind slot 26.
+- `src/search/candidate.rs` - add the matching distribution regression test in the existing candidate-generator tests, promote the bit-manipulation arm in `generate_random_instruction`, and update the random-slot comments.
+- `src/search/stochastic/mutation.rs` - update the stale comment that points at `candidate.rs::generate_random_instruction` "case 27" for `CCMP`/`CCMN` after candidate slots shift.
 
-No production files should change. There are no `crates/` or `compiler/` directories in this repository, so this is not a Rust-stage/self-hosted compiler cross-cutting change. There is no `docs/spec/` tree in this checkout; the relevant accepted design source is `docs/adr/0006-live-out-cli-grammar.md`, and no ADR/spec update is needed because the grammar and behavior stay unchanged.
+There are no `crates/`, `compiler/`, or `docs/spec/` directories in this repository, so this is not a cross-compiler or Vow-spec change. `docs/capability.md` does not need an update because the supported mnemonic set is unchanged; this PR changes only stochastic sampling weights.
 
 ## 3. TDD Slices
 
-1. Add a focused regression test in `src/validation/live_out.rs`, immediately after `test_parse_live_out_contract_bareword_nzcv_rejected` or before `test_parse_live_out_contract_unknown_flag_rejected`. Name it `test_parse_live_out_contract_reversed_order_nzcv_x0_error`.
+1. Add a red distribution test for the stochastic search candidate generator in `src/search/candidate.rs::tests`, near the existing random reachability tests around `random_opcode_ids`. Use `ChaCha8Rng`, `default_registers()`, `default_immediates()`, and `opcode_id` to count 30,000 calls to `generate_random_instruction`. Assert each representative `Instruction::{Clz, Cls, Rbit, Rev, Rev32, Rev16}` opcode ID appears at least 500 times. The current code should fail because each opcode is expected near 152 hits; the promoted 38-slot table should put each near 789 hits.
 
-2. In that test, call `let err = parse_live_out_contract("nzcv;x0").unwrap_err();` and assert the exact rendered message:
-   ```rust
-   assert_eq!(err.to_string(), "invalid register name: 'nzcv'");
-   ```
-   Prefer `err.to_string()` over substring matching so the test pins the user-visible `Display` body already covered by `display_renders_message_without_type_prefix` at `src/validation/live_out.rs:267-271`.
+2. Make the candidate-generator test pass by changing `src/search/candidate.rs::generate_random_instruction`: grow `rng.random_range(0..33)` to `0..38`, replace the slot-26 six-way sub-multiplexer with slots `26` through `31` for `Clz`, `Cls`, `Rbit`, `Rev`, `Rev32`, and `Rev16`, then shift the existing later arms to `32` through `37` while preserving their internal sub-multiplexers.
 
-3. Red-check the guard without committing sabotage: temporarily change the expected string in the new test, or temporarily mutate the local parser diagnostic at `src/validation/live_out.rs:49-50`, then run:
+3. Add the analogous red distribution test in `src/isa/aarch64.rs::tests`, near `slot_23_sub_multiplexer_removed_for_issue_93`. Use `AArch64InstructionGenerator::generate_random`, the same 30,000 fixed-seed draw count, and the same `>= 500` threshold for the six bit-manipulation opcode IDs. The current generator should fail for the same 6x-starvation reason.
+
+4. Make the trait-generator test pass by changing `src/isa/aarch64.rs::AArch64InstructionGenerator::generate_random`: grow `rng.random_range(0..33)` to `0..38`, replace the slot-26 six-way sub-multiplexer with slots `26` through `31`, and shift `MADD` family, `CCMP`/`CCMN`, bit-field aliases, `CSET`, `CSETM`, and `ROR` to slots `32` through `37`. Keep `opcode_count()` at `55`; it counts stable opcode IDs, not random slots.
+
+5. Refactor only the comments needed to keep contracts honest. In `src/isa/aarch64.rs`, update the top-of-table comment and the `opcode_count()` doc comment so they say the random table has 38 slots and no longer name the bit-manipulation ops as a folded family. In `src/search/stochastic/mutation.rs`, change the `candidate.rs` case-number comment to either the new slot number or a case-number-free phrase.
+
+6. Run the focused green checks, then the normal repository gate:
    ```bash
-   cargo test validation::live_out::tests::test_parse_live_out_contract_reversed_order_nzcv_x0_error -- --exact
+   cargo test generate_random_instruction_promotes_single_source_bit_ops_to_top_level_slots
+   cargo test aarch64_random_generation_promotes_single_source_bit_ops_to_top_level_slots
+   cargo test slot_23_sub_multiplexer_removed_for_issue_93
+   cargo fmt -- --check
+   cargo test
+   ./ci_check.sh
    ```
-   Confirm the test fails on the message mismatch, then immediately revert the temporary mutation.
-
-4. Green-check against the real code. The production path that should satisfy the test already exists: `parse_live_out_contract` counts one semicolon at `src/validation/live_out.rs:94-115`, parses `regs_part` via `RegisterSet::<Register>::from_str`, and `parse_register` emits `invalid register name: 'nzcv'` at `src/validation/live_out.rs:49-50`. No production code should be edited.
-
-5. Refactor only if formatting requires it. Keep the test local and explicit; do not introduce helper functions or convert the surrounding parse-live-out tests to table-driven form for this small coverage addition.
 
 ## 4. Verification Surface
 
-- No ESBMC proof work is needed. This change does not touch contracts, codegen, the C model, SMT lowering, concrete semantics, assembler output, or binary patching.
-- No fixtures under `tests/run/`, `tests/asm/`, `tests/integration/`, `examples/`, or benchmark directories should grow.
-- Minimum verification:
-  ```bash
-  cargo test validation::live_out::tests::test_parse_live_out_contract_reversed_order_nzcv_x0_error -- --exact
-  ```
-- Broader local verification before PR/commit:
-  ```bash
-  cargo test validation::live_out
-  cargo fmt -- --check
-  ```
-- Full pre-push verification remains the repository gate from `CLAUDE.md`:
-  ```bash
-  ./ci_check.sh
-  ```
+- No ESBMC work is needed. This change does not touch contracts, codegen, the C model, SMT lowering, concrete semantics, parser grammar, assembler encoding, ELF patching, or binary output.
+- No fixtures under `tests/run/` or `examples/` need to grow; neither directory exists in this checkout. No `tests/asm/`, `tests/integration/`, or benchmark fixture is required because the observable change is the random sampler distribution, not accepted syntax or end-to-end optimization behavior.
+- The key proof-by-test is statistical but deterministic: fixed-seed 30,000-draw tests distinguish the current `~152` hits per bit opcode from the promoted `~789` hits per bit opcode with a wide threshold.
 
 ## 5. Risk Areas
 
-- Error-message coupling is intentional here: use an exact assertion because the issue specifically asks to pin the diagnostic text for `nzcv;x0`.
-- Test placement should stay in the parser/error-test cluster so future maintainers understand this as CLI grammar coverage, not live-in/live-out dataflow coverage.
-- Do not change `parse_live_out_contract` to special-case reversed order unless a separate issue asks for a friendlier diagnostic; that would widen the behavioral scope and may require ADR/help-text updates.
-- `parse -> print -> parse` idempotency is unaffected because this is a CLI live-out contract parser test, not assembly IR parsing or formatting.
-- Binary fixed-point risks are absent: no `compiler/` tree exists here, and the plan does not touch codegen ordering, map iteration, stack-slot layout, assembler encoding, or `vow-clif-shim`-style components.
-- The `cargo clippy --all -- -D warnings` gate should be unaffected; the added test must avoid unused imports or dead helper functions.
+- `opcode_count()` must not be bumped as part of this change. In the current tree it is explicitly the upper bound for `Instruction::opcode_id()`, not the random slot count; changing it would break the stable opcode-family contract and the existing `all_instruction_families_cover_trait_methods` test.
+- The two random tables are parallel but not numerically identical today. Do not copy one table wholesale into the other; promote only the six bit-manipulation opcodes and shift each table's existing later arms in place.
+- Distribution tests can become flaky if thresholds are too tight. Keep the fixed seed and a deliberately loose threshold that fails the current clustered table but sits far below the promoted table's expected count.
+- Slot shifts can leave stale comments, especially the `CCMP`/`CCMN` case-number comment in `src/search/stochastic/mutation.rs`; use `rg "slot 26|slot 27|0\\.\\.33|6-way sub-multiplexer|case 27"` after the edit.
+- The change slightly reduces every former top-level opcode's absolute probability from `1/33` to `1/38`; that is the intentional tradeoff for making the six bit ops first-class slots. Existing sub-multiplexed families such as multiply-accumulate and bit-field aliases remain out of scope.
+- `parse -> print -> parse` idempotency and binary fixed-point concerns are absent because parsing, formatting, assembler/codegen ordering, map iteration, stack-slot layout, and `vow-clif-shim`-style components are not touched. The `cargo clippy --all -- -D warnings` gate should only be at risk from unused imports in the new tests.
 
 ## 6. Out Of Scope
 
-- Changing the grammar for reversed-order input or adding a bespoke "wrong order" diagnostic.
-- Changing any `run_equiv` or `run_llm_opt` error-prefix behavior in `src/main.rs`.
-- Adding docs/spec/ADR updates; this PR documents existing behavior through a regression test only.
-- Refactoring `ParseRegisterSetError`, `parse_register`, or the surrounding `parse_live_out_contract` tests.
-- Running benchmarks, mutation tests, x86/RISC-V flows, LLM search, assembler tests, or integration fixtures for this unit-test-only issue.
+- Adding or tuning a full Criterion stochastic-convergence benchmark for a CLZ-shaped target. The existing bench harness is not CI-gated and fixture sweeps are costly; this PR should close the sampler-policy issue with deterministic distribution regressions.
+- Rebalancing other shared random slots such as multiply-accumulate, conditional compare, bit-field aliases, compare, multiply/divide, or conditional-select families.
+- Refactoring the duplicated AArch64 random tables into a shared abstraction or introducing a global random-slot constant.
+- Changing opcode IDs, `opcode_count()`, instruction semantics, encodability rules, parser support, docs/capability mnemonic inventories, CLI flags, or benchmark JSON schema.

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -692,18 +692,15 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
         registers: &[Register],
         immediates: &[i64],
     ) -> Instruction {
-        // 33 opcode slots: 0..13 original, 13..23 Tier 1, 23 = ANDS,
-        // 24 = MOVZ, 25 = MOVK, 26 = single-source bit-manipulation
-        // (CLZ/CLS/RBIT/REV*) 6-way sub-multiplexer, 27 = multiply-
-        // accumulate family (issue #56: 5-way sub-multiplexer for
-        // MADD/MSUB/MNEG/SMULH/UMULH), 28 = conditional-compare family
-        // (issue #57: 2-way sub-multiplexer for CCMP/CCMN), 29 =
-        // bit-field aliases (issue #61: 6-way sub-multiplexer for
-        // UBFX/SBFX/BFI/BFXIL/UBFIZ/SBFIZ), 30 = CSET, 31 = CSETM,
-        // 32 = ROR (issue #93: each of these four held the old slot 23
-        // sub-multiplexer; promoted to top-level slots so their sampling
-        // probability matches the rest of the table).
-        let opcode = rng.random_range(0..33);
+        // 38 opcode slots: 0..=12 original, 13..=23 Tier 1, 24 = MOVZ,
+        // 25 = MOVK, 26..=31 = CLZ/CLS/RBIT/REV/REV32/REV16 as separate
+        // top-level slots, 32 = multiply-accumulate family (issue #56:
+        // 5-way sub-multiplexer for MADD/MSUB/MNEG/SMULH/UMULH), 33 =
+        // conditional-compare family (issue #57: 2-way sub-multiplexer
+        // for CCMP/CCMN), 34 = bit-field aliases (issue #61: 6-way
+        // sub-multiplexer for UBFX/SBFX/BFI/BFXIL/UBFIZ/SBFIZ), 35 = CSET,
+        // 36 = CSETM, 37 = ROR.
+        let opcode = rng.random_range(0..38);
         let rd = registers[rng.random_range(0..registers.len())];
         let rn = registers[rng.random_range(0..registers.len())];
         let pick_reg = |rng: &mut R| registers[rng.random_range(0..registers.len())];
@@ -854,20 +851,34 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     shift: shifts[rng.random_range(0..shifts.len())],
                 }
             }
-            // Single-source bit-manipulation: CLZ / CLS / RBIT / REV / REV32 / REV16.
-            26 => {
-                let rn = pick_reg(rng);
-                match rng.random_range(0..6) {
-                    0 => Instruction::Clz { rd, rn },
-                    1 => Instruction::Cls { rd, rn },
-                    2 => Instruction::Rbit { rd, rn },
-                    3 => Instruction::Rev { rd, rn },
-                    4 => Instruction::Rev32 { rd, rn },
-                    _ => Instruction::Rev16 { rd, rn },
-                }
-            }
+            // Single-source bit-manipulation opcodes each keep a top-level slot
+            // so stochastic search does not starve CLZ/RBIT/REV-shaped targets.
+            26 => Instruction::Clz {
+                rd,
+                rn: pick_reg(rng),
+            },
+            27 => Instruction::Cls {
+                rd,
+                rn: pick_reg(rng),
+            },
+            28 => Instruction::Rbit {
+                rd,
+                rn: pick_reg(rng),
+            },
+            29 => Instruction::Rev {
+                rd,
+                rn: pick_reg(rng),
+            },
+            30 => Instruction::Rev32 {
+                rd,
+                rn: pick_reg(rng),
+            },
+            31 => Instruction::Rev16 {
+                rd,
+                rn: pick_reg(rng),
+            },
             // Multiply-accumulate family.
-            27 => {
+            32 => {
                 let rm = pick_reg(rng);
                 match rng.random_range(0..5) {
                     0 => {
@@ -890,7 +901,7 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
             // bounded sample (no retry loop, no infinite-spin risk in
             // release builds on a degenerate `[SP]`-only pool — that
             // case falls back to the next opcode).
-            28 => {
+            33 => {
                 let non_sp: Vec<Register> = registers
                     .iter()
                     .copied()
@@ -935,7 +946,7 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
             // family (which tolerates any register). The 2D constraint
             // `lsb + width <= 64` is enforced by sampling width AFTER lsb so
             // width is bounded by `64 - lsb`.
-            29 => {
+            34 => {
                 let non_sp: Vec<Register> = registers
                     .iter()
                     .copied()
@@ -990,15 +1001,15 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     },
                 }
             }
-            30 => Instruction::Cset {
+            35 => Instruction::Cset {
                 rd,
                 cond: Condition::random_normal(rng),
             },
-            31 => Instruction::Csetm {
+            36 => Instruction::Csetm {
                 rd,
                 cond: Condition::random_normal(rng),
             },
-            32 => {
+            37 => {
                 let shift = if rng.random_bool(0.5) {
                     let amounts = [0i64, 1, 2, 4, 8, 16, 32];
                     Operand::Immediate(amounts[rng.random_range(0..amounts.len())])
@@ -1666,11 +1677,9 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
 
     /// Total number of distinct opcode *families* (the upper bound on
     /// `opcode_id()`). Not the same as `generate_random`'s slot count —
-    /// `generate_random` samples 33 top-level slots and folds several
-    /// families into sub-multiplexers (e.g. CLZ/CLS/RBIT/REV*/REV16 on
-    /// slot 26, the five multiply-accumulate ops on slot 27, the two
-    /// conditional-compare ops on slot 28, and the six bit-field aliases
-    /// on slot 29) — keeping the slot table small. So
+    /// `generate_random` samples 38 top-level slots and still folds several
+    /// families into sub-multiplexers (e.g. the five multiply-accumulate ops,
+    /// the two conditional-compare ops, and the six bit-field aliases). So
     /// `opcode_id < opcode_count` always holds, but the random-generation
     /// distribution is not uniform across all 55 IDs.
     fn opcode_count(&self) -> u8 {
@@ -2454,9 +2463,9 @@ mod tests {
     /// pool. The current code collects the non-SP registers up front
     /// and falls back to `Mneg` when the filter yields an empty slice,
     /// so every call must return a valid `Instruction` in finite time.
-    /// Not asserting which opcode comes back — both slot 27 (the
-    /// multiply-accumulate sub-multiplexer) and slot 28's fallback can
-    /// emit Mneg, so any "did slot 28 fire?" proxy gives false
+    /// Not asserting which opcode comes back — both slot 32 (the
+    /// multiply-accumulate sub-multiplexer) and slot 33's fallback can
+    /// emit Mneg, so any "did the conditional-compare slot fire?" proxy gives false
     /// confidence. The 10000 samples + bounded loop is the contract:
     /// completing the loop without panicking or hanging is the test.
     #[test]
@@ -2468,6 +2477,81 @@ mod tests {
         for _ in 0..10_000 {
             let instr = generator.generate_random(&mut rng, &regs, &imms);
             assert!(instr.opcode_id() < generator.opcode_count());
+        }
+    }
+
+    #[test]
+    fn aarch64_random_generation_promotes_single_source_bit_ops_to_top_level_slots() {
+        use std::collections::HashMap;
+
+        let generator = AArch64InstructionGenerator;
+        let regs = vec![Register::X0, Register::X1, Register::X2];
+        let imms = vec![0, 1, 2, 16, 32];
+        let mut rng = ChaCha8Rng::seed_from_u64(0x115);
+        let mut counts: HashMap<u8, u32> = HashMap::new();
+        const N: u32 = 30_000;
+
+        for _ in 0..N {
+            let id = generator
+                .generate_random(&mut rng, &regs, &imms)
+                .opcode_id();
+            *counts.entry(id).or_default() += 1;
+        }
+
+        for (label, instr) in [
+            (
+                "Clz",
+                Instruction::Clz {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                },
+            ),
+            (
+                "Cls",
+                Instruction::Cls {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                },
+            ),
+            (
+                "Rbit",
+                Instruction::Rbit {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                },
+            ),
+            (
+                "Rev",
+                Instruction::Rev {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                },
+            ),
+            (
+                "Rev32",
+                Instruction::Rev32 {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                },
+            ),
+            (
+                "Rev16",
+                Instruction::Rev16 {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                },
+            ),
+        ] {
+            let id = instr.opcode_id();
+            let count = counts.get(&id).copied().unwrap_or(0);
+            assert!(
+                count >= 500,
+                "expected >= 500 samples for {} (id {}) in {} draws, got {}",
+                label,
+                id,
+                N,
+                count
+            );
         }
     }
 

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -617,7 +617,7 @@ pub fn generate_random_instruction<R: rand::RngExt>(
     let rd = registers[rng.random_range(0..registers.len())];
     let pick_reg = |rng: &mut R| registers[rng.random_range(0..registers.len())];
 
-    match rng.random_range(0..33) {
+    match rng.random_range(0..38) {
         0 => {
             let imm = if immediates.is_empty() {
                 0
@@ -777,23 +777,37 @@ pub fn generate_random_instruction<R: rand::RngExt>(
             let shift = shifts[rng.random_range(0..shifts.len())];
             Instruction::MovK { rd, imm, shift }
         }
-        // Single-source bit-manipulation: CLZ / CLS / RBIT / REV / REV32 / REV16.
-        26 => {
-            let rn = pick_reg(rng);
-            match rng.random_range(0..6) {
-                0 => Instruction::Clz { rd, rn },
-                1 => Instruction::Cls { rd, rn },
-                2 => Instruction::Rbit { rd, rn },
-                3 => Instruction::Rev { rd, rn },
-                4 => Instruction::Rev32 { rd, rn },
-                _ => Instruction::Rev16 { rd, rn },
-            }
-        }
+        // Single-source bit-manipulation opcodes each keep a top-level slot
+        // so stochastic search does not starve CLZ/RBIT/REV-shaped targets.
+        26 => Instruction::Clz {
+            rd,
+            rn: pick_reg(rng),
+        },
+        27 => Instruction::Cls {
+            rd,
+            rn: pick_reg(rng),
+        },
+        28 => Instruction::Rbit {
+            rd,
+            rn: pick_reg(rng),
+        },
+        29 => Instruction::Rev {
+            rd,
+            rn: pick_reg(rng),
+        },
+        30 => Instruction::Rev32 {
+            rd,
+            rn: pick_reg(rng),
+        },
+        31 => Instruction::Rev16 {
+            rd,
+            rn: pick_reg(rng),
+        },
         // CCMP / CCMN: conditional compare. The dispatch picks Ccmp or Ccmn
         // uniformly; the rm operand is sampled via random_operand and then
         // clamped/coerced to a valid 5-bit immediate if it lands on the
         // immediate side. nzcv is a 4-bit literal; cond from NORMAL_CONDITIONS.
-        27 => {
+        32 => {
             // CCMP/CCMN forbid SP in `rn` and in the register form of `rm`
             // (encoded in the Xn slot, not XSP). `generate_all_instructions`
             // filters SP at enumeration time; mirror that here so the
@@ -835,7 +849,7 @@ pub fn generate_random_instruction<R: rand::RngExt>(
         // SP rejected in rd and rn (matches `generate_all_instructions` and
         // `is_encodable_aarch64`); 2D constraint on (lsb, width) enforced by
         // sampling width AFTER lsb so width is bounded by `64-lsb`.
-        28 => {
+        33 => {
             debug_assert!(
                 registers.iter().any(|r| *r != Register::SP),
                 "bit-field random generator requires at least one non-SP register",
@@ -891,7 +905,7 @@ pub fn generate_random_instruction<R: rand::RngExt>(
             }
         }
         // Multiply-accumulate family: MADD/MSUB (4-operand) and MNEG/SMULH/UMULH (3-operand).
-        29 => {
+        34 => {
             let rn = pick_reg(rng);
             let rm = pick_reg(rng);
             match rng.random_range(0..5) {
@@ -909,7 +923,7 @@ pub fn generate_random_instruction<R: rand::RngExt>(
             }
         }
         // Issue #66 multiply / divide: MUL/SDIV/UDIV. All register-only.
-        30 => {
+        35 => {
             let rn = pick_reg(rng);
             let rm = pick_reg(rng);
             match rng.random_range(0..3) {
@@ -920,7 +934,7 @@ pub fn generate_random_instruction<R: rand::RngExt>(
         }
         // Issue #66 compares: CMP/CMN accept reg or imm; TST is register-only
         // at the encoder, so its `rm` is clamped to a register draw.
-        31 => {
+        36 => {
             let rn = pick_reg(rng);
             match rng.random_range(0..3) {
                 0 => Instruction::Cmp {
@@ -941,7 +955,7 @@ pub fn generate_random_instruction<R: rand::RngExt>(
         // Issue #66 conditional selects: CSEL/CSINC/CSINV/CSNEG. Register-only,
         // condition sampled from NORMAL_CONDITIONS (AL/NV excluded — AL
         // collapses to MOV rd,rn and NV is reserved).
-        32 => {
+        37 => {
             let rn = pick_reg(rng);
             let rm = pick_reg(rng);
             let cond = crate::ir::types::Condition::random_normal(rng);
@@ -1229,6 +1243,80 @@ mod tests {
         (0..draws)
             .map(|_| opcode_id(&generate_random_instruction(&mut rng, &regs, &imms)))
             .collect()
+    }
+
+    #[test]
+    fn generate_random_instruction_promotes_single_source_bit_ops_to_top_level_slots() {
+        use rand::SeedableRng;
+        use rand_chacha::ChaCha8Rng;
+        use std::collections::HashMap;
+
+        let regs = default_registers();
+        let imms = default_immediates();
+        let mut rng = ChaCha8Rng::seed_from_u64(0x115);
+        let mut counts: HashMap<u8, u32> = HashMap::new();
+        const N: u32 = 30_000;
+
+        for _ in 0..N {
+            let id = opcode_id(&generate_random_instruction(&mut rng, &regs, &imms));
+            *counts.entry(id).or_default() += 1;
+        }
+
+        for (label, instr) in [
+            (
+                "Clz",
+                Instruction::Clz {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                },
+            ),
+            (
+                "Cls",
+                Instruction::Cls {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                },
+            ),
+            (
+                "Rbit",
+                Instruction::Rbit {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                },
+            ),
+            (
+                "Rev",
+                Instruction::Rev {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                },
+            ),
+            (
+                "Rev32",
+                Instruction::Rev32 {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                },
+            ),
+            (
+                "Rev16",
+                Instruction::Rev16 {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                },
+            ),
+        ] {
+            let id = opcode_id(&instr);
+            let count = counts.get(&id).copied().unwrap_or(0);
+            assert!(
+                count >= 500,
+                "expected >= 500 samples for {} (id {}) in {} draws, got {}",
+                label,
+                id,
+                N,
+                count
+            );
+        }
     }
 
     #[test]

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -262,7 +262,7 @@ impl Mutator {
                             // CCMP/CCMN reject shifted-register or extended-
                             // register operands; collapse to a plain register
                             // (consistent with candidate::generate_random_-
-                            // instruction case 27).
+                            // instruction's conditional-compare arm).
                             Operand::ShiftedRegister { reg, .. }
                             | Operand::ExtendedRegister { reg, .. } => Operand::Register(reg),
                         };

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -596,14 +596,13 @@ mod tests {
             _timeout: Duration,
         ) -> (EquivalenceResult, EquivalenceMetrics) {
             let checks = TEST_EQUIVALENCE_CHECKS.fetch_add(1, Ordering::SeqCst) + 1;
-            if checks == 1 {
-                if let Some(flag) = TEST_STOP_FLAG
+            if checks == 1
+                && let Some(flag) = TEST_STOP_FLAG
                     .lock()
                     .expect("test stop flag lock poisoned")
                     .as_ref()
-                {
-                    flag.store(true, Ordering::SeqCst);
-                }
+            {
+                flag.store(true, Ordering::SeqCst);
             }
             std::thread::sleep(Duration::from_millis(1));
             (

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -406,12 +406,26 @@ mod tests {
     use crate::semantics::EquivalenceMetrics;
     use crate::semantics::cost::CostMetric;
     use crate::semantics::live_out::LiveOut;
-    use std::sync::Mutex;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
     static TEST_EQUIVALENCE_CHECKS: AtomicUsize = AtomicUsize::new(0);
+    static TEST_STOP_FLAG: Mutex<Option<Arc<AtomicBool>>> = Mutex::new(None);
     static SYMBOLIC_INNER_LOOP_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    struct TestStopFlagGuard;
+
+    impl Drop for TestStopFlagGuard {
+        fn drop(&mut self) {
+            *TEST_STOP_FLAG.lock().expect("test stop flag lock poisoned") = None;
+        }
+    }
+
+    fn stop_after_first_test_equivalence_check(flag: &Arc<AtomicBool>) -> TestStopFlagGuard {
+        *TEST_STOP_FLAG.lock().expect("test stop flag lock poisoned") = Some(Arc::clone(flag));
+        TestStopFlagGuard
+    }
 
     #[derive(Clone)]
     struct TestIsa;
@@ -581,7 +595,16 @@ mod tests {
             _width: u32,
             _timeout: Duration,
         ) -> (EquivalenceResult, EquivalenceMetrics) {
-            TEST_EQUIVALENCE_CHECKS.fetch_add(1, Ordering::SeqCst);
+            let checks = TEST_EQUIVALENCE_CHECKS.fetch_add(1, Ordering::SeqCst) + 1;
+            if checks == 1 {
+                if let Some(flag) = TEST_STOP_FLAG
+                    .lock()
+                    .expect("test stop flag lock poisoned")
+                    .as_ref()
+                {
+                    flag.store(true, Ordering::SeqCst);
+                }
+            }
             std::thread::sleep(Duration::from_millis(1));
             (
                 EquivalenceResult::NotEquivalent,
@@ -772,9 +795,6 @@ mod tests {
 
     #[test]
     fn symbolic_length_two_inner_loop_respects_cooperative_stop_flag() {
-        use std::sync::Arc;
-        use std::sync::atomic::AtomicBool;
-        use std::thread;
         use std::time::Instant;
 
         let _guard = SYMBOLIC_INNER_LOOP_TEST_LOCK
@@ -783,14 +803,7 @@ mod tests {
         TEST_EQUIVALENCE_CHECKS.store(0, Ordering::SeqCst);
 
         let flag = Arc::new(AtomicBool::new(false));
-        let flag_for_stop = Arc::clone(&flag);
-
-        let stopper = thread::spawn(move || {
-            while TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst) == 0 {
-                thread::yield_now();
-            }
-            flag_for_stop.store(true, Ordering::SeqCst);
-        });
+        let _stop_guard = stop_after_first_test_equivalence_check(&flag);
 
         let mut search: SymbolicSearch<TestIsa> = SymbolicSearch::new();
         let config = SearchConfig::default()
@@ -814,8 +827,6 @@ mod tests {
             Instant::now(),
         );
 
-        stopper.join().expect("stopper thread panicked");
-
         let checks = TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst);
         assert_eq!(result, None);
         assert!(
@@ -826,9 +837,6 @@ mod tests {
 
     #[test]
     fn symbolic_length_three_inner_loops_respect_cooperative_stop_flag() {
-        use std::sync::Arc;
-        use std::sync::atomic::AtomicBool;
-        use std::thread;
         use std::time::Instant;
 
         let _guard = SYMBOLIC_INNER_LOOP_TEST_LOCK
@@ -837,14 +845,7 @@ mod tests {
         TEST_EQUIVALENCE_CHECKS.store(0, Ordering::SeqCst);
 
         let flag = Arc::new(AtomicBool::new(false));
-        let flag_for_stop = Arc::clone(&flag);
-
-        let stopper = thread::spawn(move || {
-            while TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst) == 0 {
-                thread::yield_now();
-            }
-            flag_for_stop.store(true, Ordering::SeqCst);
-        });
+        let _stop_guard = stop_after_first_test_equivalence_check(&flag);
 
         let mut search: SymbolicSearch<TestIsa> = SymbolicSearch::new();
         let config = SearchConfig::default()
@@ -868,8 +869,6 @@ mod tests {
             &mut best_cost,
             Instant::now(),
         );
-
-        stopper.join().expect("stopper thread panicked");
 
         let checks = TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst);
         assert_eq!(result, None);


### PR DESCRIPTION
## Summary
- Promote CLZ, CLS, RBIT, REV, REV32, and REV16 to separate top-level random sampler slots in both AArch64 generators.
- Add deterministic distribution regressions for both random-generation paths and refresh stale slot-count comments.
- Stabilize the symbolic cancellation test harness so the local gate no longer depends on helper-thread scheduling.

## Verification
- `cargo test generate_random_instruction_promotes_single_source_bit_ops_to_top_level_slots`
- `cargo test aarch64_random_generation_promotes_single_source_bit_ops_to_top_level_slots`
- `cargo test slot_23_sub_multiplexer_removed_for_issue_93`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`
- `./ci_check.sh`

Closes #115

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**
