### PR TITLE
docs(search): document stochastic proposal asymmetry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ src/
 │   ├── candidate.rs     # AArch64 candidate generation
 │   ├── candidate_x86.rs # x86 candidate generation
 │   ├── enumerative/     # Exhaustive search up to target.len()-1 (rayon-parallel; AArch64)
-│   ├── stochastic/      # MCMC with Metropolis-Hastings (AArch64)
+│   ├── stochastic/      # MCMC-style search with Metropolis acceptance (AArch64)
 │   ├── symbolic/        # SMT-based synthesis (AArch64)
 │   ├── parallel/        # Multi-threaded coordination (AArch64)
 │   └── llm/             # LLM-assisted search via Codex CLI (AArch64)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ sequence that is provably equivalent under SMT.
 - Reads an ELF binary, disassembles it with [Capstone], and lifts a window
   into an internal IR.
 - Searches for a cheaper instruction sequence using one of four
-  algorithms: enumerative, stochastic (MCMC / Metropolis–Hastings),
+  algorithms: enumerative, stochastic (MCMC-style Metropolis cost acceptance),
   symbolic (SMT synthesis with Z3), or a hybrid of the symbolic and
   stochastic workers running in parallel.
 - Verifies each candidate first with random-input testing for a quick

--- a/src/search/config.rs
+++ b/src/search/config.rs
@@ -14,7 +14,7 @@ pub enum Algorithm {
     /// Exhaustive enumeration over all possible sequences
     #[default]
     Enumerative,
-    /// Stochastic MCMC search using Metropolis-Hastings
+    /// Stochastic MCMC-style search using heuristic proposals and Metropolis acceptance
     Stochastic,
     /// SMT-based symbolic synthesis
     Symbolic,
@@ -89,7 +89,7 @@ impl std::str::FromStr for CostMetricConfig {
 /// Configuration for stochastic (MCMC) search
 #[derive(Debug, Clone)]
 pub struct StochasticConfig {
-    /// Inverse temperature parameter for Metropolis-Hastings (higher = more greedy)
+    /// Inverse temperature parameter for Metropolis acceptance (higher = more greedy)
     pub beta: f64,
     /// Maximum number of MCMC iterations
     pub iterations: u64,

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides multiple search algorithms for superoptimization:
 //! - Enumerative: exhaustive search over instruction sequences
-//! - Stochastic: MCMC-based search using Metropolis-Hastings acceptance
+//! - Stochastic: MCMC-style search using heuristic proposals and Metropolis acceptance
 //! - Symbolic: SMT-based synthesis using Z3
 //! - Hybrid: parallel execution combining symbolic + multiple stochastic workers
 

--- a/src/search/stochastic/acceptance.rs
+++ b/src/search/stochastic/acceptance.rs
@@ -1,6 +1,8 @@
-//! Metropolis-Hastings acceptance criterion for MCMC
+//! Metropolis acceptance criterion for stochastic search
 //!
-//! Implements the acceptance decision for stochastic search.
+//! Implements the cost-only acceptance decision for stochastic search. This
+//! module does not receive proposal probabilities and therefore does not apply
+//! a Hastings correction for asymmetric mutation proposals.
 //! A proposal is accepted if:
 //!   proposal_cost < current_cost - ln(random) / beta
 //!
@@ -12,7 +14,7 @@
 
 use rand::RngExt;
 
-/// Acceptance criterion for Metropolis-Hastings MCMC
+/// Cost-only Metropolis acceptance criterion.
 pub struct AcceptanceCriterion {
     /// Inverse temperature (higher = more greedy)
     beta: f64,

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -1,6 +1,8 @@
 //! Markov Chain Monte Carlo (MCMC) search implementation
 //!
-//! Implements stochastic superoptimization using Metropolis-Hastings MCMC.
+//! Implements stochastic superoptimization using MCMC-style mutation plus
+//! Metropolis cost acceptance. Proposal probabilities are heuristic and no
+//! Hastings ratio is computed.
 //! The algorithm:
 //! 1. Generate test cases for fast validation
 //! 2. Start with a random initial program (or copy of target)
@@ -8,10 +10,10 @@
 //!    a. Mutate current program
 //!    b. Evaluate on tests (fast rejection if fails)
 //!    c. If passes tests with zero cost → verify with SMT
+//!    d. Accept/reject based on Metropolis cost acceptance
+//! 4. Return best found optimization
 
 #![allow(dead_code)]
-//!    d. Accept/reject based on Metropolis-Hastings criterion
-//! 4. Return best found optimization
 
 use crate::ir::{Instruction, Register};
 use crate::isa::{ISA, ISAMutator};
@@ -30,7 +32,8 @@ use std::marker::PhantomData;
 use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
 
-/// Stochastic search using Metropolis-Hastings MCMC, generic over ISA.
+/// Stochastic search using MCMC-style proposals and Metropolis cost
+/// acceptance, generic over ISA.
 ///
 /// The body routes through the `StochasticBackend<I>` dispatch trait
 /// (`src/search/stochastic/backend.rs`) for every ISA-specific

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -3,6 +3,7 @@
 //! Implements stochastic superoptimization using MCMC-style mutation plus
 //! Metropolis cost acceptance. Proposal probabilities are heuristic and no
 //! Hastings ratio is computed.
+//!
 //! The algorithm:
 //! 1. Generate test cases for fast validation
 //! 2. Start with a random initial program (or copy of target)

--- a/src/search/stochastic/mod.rs
+++ b/src/search/stochastic/mod.rs
@@ -1,8 +1,10 @@
 //! Stochastic (MCMC) search for superoptimization
 //!
-//! Implements Metropolis-Hastings MCMC search for finding shorter equivalent
-//! instruction sequences. The algorithm randomly mutates candidate programs
-//! and accepts/rejects mutations based on their cost using a temperature parameter.
+//! Implements MCMC-style search for finding shorter equivalent instruction
+//! sequences. The algorithm randomly mutates candidate programs with heuristic
+//! proposals and accepts/rejects mutations based on their cost using a
+//! Metropolis temperature parameter. It does not compute a Hastings ratio for
+//! proposal asymmetry.
 
 pub mod acceptance;
 pub mod backend;

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -5,6 +5,12 @@
 //! 2. Opcode mutation (16%): Change the opcode while keeping operand structure
 //! 3. Swap mutation (16%): Swap two instructions
 //! 4. Instruction mutation (18%): Replace an entire instruction
+//!
+//! These operators are heuristic proposal generators. In particular,
+//! opcode peer clusters are not required to have equal forward/reverse
+//! transition probabilities, and the stochastic search does not apply a
+//! Hastings ratio to correct that asymmetry. The search is intended as an
+//! optimization heuristic, not as a detailed-balance sampler.
 
 #![allow(dead_code)]
 
@@ -446,7 +452,12 @@ impl Mutator {
         }
     }
 
-    /// Opcode mutation: change the opcode while keeping operand structure
+    /// Opcode mutation: change the opcode while keeping operand structure.
+    ///
+    /// The match arms below are intentionally heuristic. Some clusters are
+    /// asymmetric because certain instructions have extra bridges or
+    /// encodability clamps; acceptance uses only the Metropolis cost rule, not
+    /// a Hastings correction for the proposal probabilities.
     fn mutate_opcode<R: RngExt>(&self, rng: &mut R, sequence: &mut [Instruction]) {
         if sequence.is_empty() {
             return;
@@ -738,6 +749,10 @@ impl Mutator {
             // Move-wide cluster: MOVN ↔ MOVZ ↔ MOVK (all share rd/imm/shift),
             // plus a single MovImm bridge anchored at MOVZ.
             //
+            // This is not a symmetric proposal table: MOVZ has one more
+            // outgoing arm than MOVN/MOVK. The top-level search accepts it as
+            // a heuristic proposal without a Hastings correction.
+            //
             // Topology note: before this PR, MOVN had a direct MOVN ↔ MovImm
             // edge. We removed it so MOVN now reaches MovImm via two hops
             // (MOVN → MOVZ → MovImm). Ergodicity is preserved — every move
@@ -773,7 +788,9 @@ impl Mutator {
                 1 => Instruction::MovZ { rd, imm, shift },
                 _ => Instruction::MovK { rd, imm, shift },
             },
-            // Inverted-logical join the AND/ORR/EOR cluster.
+            // Inverted-logical instructions join the AND/ORR/EOR cluster.
+            // The peer counts differ across BIC/BICS/ORN/EON, so these arms
+            // are also heuristic rather than detailed-balance transitions.
             Instruction::Bic { rd, rn, rm } => match rng.random_range(0..7) {
                 0 => Instruction::And {
                     rd,
@@ -861,6 +878,8 @@ impl Mutator {
                 _ => Instruction::Eon { rd, rn, rm },
             },
             // Flag-setting cluster: ADDS↔SUBS↔ANDS, and into/out of ADD/SUB/AND.
+            // The ADD/SUB/AND bridges make this another intentionally
+            // asymmetric proposal family.
             //
             // Note: ADDS/SUBS accept `Operand::Immediate` (12-bit). ANDS and
             // AND now accept *bitmask* immediates (issue #65), but the table


### PR DESCRIPTION
Summary:
- Document that stochastic opcode mutation proposals are heuristic and may be asymmetric.
- Reword stochastic search and acceptance docs away from strict Metropolis-Hastings terminology.
- Update README and CLAUDE.md so public guidance matches the code contract.

Tests:
- rg -n "Metropolis-Hastings|Hastings" src/search
- cargo test search::stochastic
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test --all (after ./build_tests.sh generated integration binaries)
- ./ci_check.sh

Closes #119

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**