### PR TITLE
docs(search): document enumerative candidate pool growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ Useful flags on `opt`:
 | `--search-mode linear\|binary`, `--solver-timeout SECS` | SMT synthesis tuning |
 | `--no-symbolic` | run hybrid as all-stochastic workers |
 
+Note: enumerative search scales with the generated instruction families in its
+candidate pool. At the default AArch64 8-register CLI scope,
+multiply-accumulate and high-half multiply add 9,728 candidates per length
+bucket; use `--timeout` or smaller optimization windows to bound runtime.
+
 `equiv` — check whether two assembly files are semantically equivalent
 on a chosen live-out set:
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -303,6 +303,11 @@ Exhaustively searches all possible instruction sequences up to a given length. G
 
 **Best for:** Small windows (1-3 instructions) where exhaustive search is feasible.
 
+Note: enumerative search scales with the generated instruction families in its
+candidate pool. At the default AArch64 8-register CLI scope,
+multiply-accumulate and high-half multiply add 9,728 candidates per length
+bucket; use `--timeout` or smaller optimization windows to bound runtime.
+
 ### 2. Stochastic Search (MCMC)
 
 Uses Markov Chain Monte Carlo to randomly explore the search space. Can handle larger windows but may not find optimal solutions.

--- a/docs/capability.md
+++ b/docs/capability.md
@@ -13,6 +13,11 @@ a region; supported control-flow terminators are parsed and then held fixed.
 Algorithms:
 - Enumerative, stochastic, symbolic, hybrid, and LLM-assisted search are
   available for AArch64.
+- Enumerative search scales with the generated instruction families in its
+  candidate pool. At the default AArch64 8-register CLI scope, `madd`/`msub`
+  contribute `2 * 8^4` and `mneg`/`smulh`/`umulh` contribute `3 * 8^3`, or
+  9,728 extra candidates per length bucket; use `--timeout` or smaller
+  optimization windows to bound runtime.
 - Hybrid and LLM remain AArch64-only.
 
 Rewritable straight-line mnemonics accepted by the parser and Capstone bridge:

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,6 +142,9 @@ enum Commands {
         arch: Option<CliArch>,
     },
     /// Optimize a window of instructions in an ELF binary
+    #[command(
+        after_help = "Note: enumerative search scales with the generated instruction families in its candidate pool. At the default AArch64 8-register CLI scope, multiply-accumulate and high-half multiply add 9,728 candidates per length bucket; use --timeout or smaller windows to bound runtime."
+    )]
     Opt {
         /// Path to ELF binary to optimize
         binary: PathBuf,
@@ -1918,6 +1921,27 @@ mod cli_helper_tests {
             llm_max_calls: 0,
             llm_model: "test-model".to_string(),
         }
+    }
+
+    #[test]
+    fn opt_help_mentions_enumerative_candidate_pool_growth() {
+        use clap::CommandFactory;
+
+        let mut command = Args::command();
+        let opt_help = command
+            .find_subcommand_mut("opt")
+            .expect("opt subcommand should be registered")
+            .render_long_help()
+            .to_string();
+
+        assert!(
+            opt_help.contains("enumerative search scales with the generated instruction families"),
+            "opt help should explain enumerative candidate pool growth:\n{opt_help}"
+        );
+        assert!(
+            opt_help.contains("9,728"),
+            "opt help should mention the default AArch64 multiply candidate growth:\n{opt_help}"
+        );
     }
 
     #[test]

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -313,6 +313,10 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
 
         // Multiply-accumulate family. MADD/MSUB take a 4th register slot
         // (`ra`); MNEG/SMULH/UMULH are 3-operand register-only.
+        // At the default 8-register scope this block emits
+        // `2 * 8^4 + 3 * 8^3` = 9,728 candidates per length bucket; keep
+        // docs/capability.md (and the README/TUTORIAL notes) in sync if the
+        // instruction mix here changes.
         for &rn in registers {
             for &rm in registers {
                 instrs.push(Instruction::Mneg { rd, rn, rm });

--- a/tests/integration/docs_capability.rs
+++ b/tests/integration/docs_capability.rs
@@ -78,6 +78,27 @@ fn docs_capability_documents_w_logical_immediates() {
 }
 
 #[test]
+fn enumerative_candidate_growth_visible_in_public_docs() {
+    for doc in ["README.md", "TUTORIAL.md", "docs/capability.md"] {
+        let body = normalized_doc(doc);
+        assert!(
+            body.contains("enumerative search scales with the generated instruction families"),
+            "{doc} must document enumerative candidate-pool growth"
+        );
+        assert!(
+            body.contains("candidate pool") && body.contains("length bucket"),
+            "{doc} must use candidate-pool and length-bucket wording"
+        );
+    }
+
+    let matrix = read_doc("docs/capability.md");
+    assert!(
+        matrix.contains("9,728") && matrix.contains("8^4") && matrix.contains("8^3"),
+        "docs/capability.md must keep the default AArch64 multiply-candidate budget visible"
+    );
+}
+
+#[test]
 fn memory_operations_are_consistently_documented_with_known_gaps() {
     let matrix = normalized_doc("docs/capability.md");
     assert!(


### PR DESCRIPTION
Summary
- Add an `s11 opt --help` note that enumerative search scales with generated instruction families and calls out the default AArch64 multiply/high-half multiply growth.
- Document the same caveat in README.md, TUTORIAL.md, and docs/capability.md, with the detailed 8^4/8^3 formula kept in the capability matrix.
- Add regressions for CLI help and public docs visibility.

Verification
- cargo fmt --all -- --check
- cargo clippy --all -- -D warnings
- ./build_tests.sh
- cargo test --all
- ./ci_check.sh
- scripts/full_test.sh: not present in this repository

Opt-out note
- Did not add `--disable-instruction` or an allow-list in this slice. A filter needs a shared design across the free-function candidate generators, AArch64InstructionGenerator::generate_all, and search paths that consume those pools; measuring representative wall-clock impact first keeps that tuning surface honest.

Closes #126

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**