### PR TITLE
fix(search): bound non-sp random operand selection

### DIFF
--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -1156,6 +1156,9 @@ mod tests {
         }
     }
 
+    // Inverts `random_range`'s Lemire mapping: returns the smallest 32-bit
+    // word `w` such that `(w * range) >> 32 == value`, so a `BudgetedRng` can
+    // be primed to force a specific `random_range(0..range)` outcome.
     fn word_for_range(range: u32, value: u32) -> u32 {
         assert!(range > 0);
         assert!(value < range);
@@ -1165,6 +1168,11 @@ mod tests {
         word
     }
 
+    // Primes a `BudgetedRng` to steer `generate_random_instruction` down a
+    // chosen opcode arm: the first draw is the `rd` index (`random_range(0..2)`
+    // for these 2-register pools), the second is the opcode slot
+    // (`random_range(0..38)`). Slot 32 = CCMP/CCMN arm, slot 33 = bit-field arm
+    // — keep these in sync with the match in `generate_random_instruction`.
     fn rng_for_opcode_slot(slot: u32, rd_index: u32) -> BudgetedRng {
         BudgetedRng::new(vec![word_for_range(2, rd_index), word_for_range(38, slot)])
     }

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -812,19 +812,21 @@ pub fn generate_random_instruction<R: rand::RngExt>(
             // (encoded in the Xn slot, not XSP). `generate_all_instructions`
             // filters SP at enumeration time; mirror that here so the
             // mutator does not bleed avoidable is_encodable_aarch64
-            // rejections. The debug_assert guards against a degenerate
-            // `registers = [SP]` caller, which would otherwise spin
-            // forever in the retry loop below.
-            debug_assert!(
-                registers.iter().any(|r| *r != Register::SP),
-                "CCMP/CCMN random generator requires at least one non-SP register",
-            );
-            let pick_non_sp = |rng: &mut R| loop {
-                let r = pick_reg(rng);
-                if r != Register::SP {
-                    break r;
-                }
-            };
+            // rejections. Build a filtered pool up front so pathological
+            // SP-only inputs fall back finitely instead of retrying forever.
+            let non_sp: Vec<Register> = registers
+                .iter()
+                .copied()
+                .filter(|r| *r != Register::SP)
+                .collect();
+            if non_sp.is_empty() {
+                return Instruction::Mneg {
+                    rd,
+                    rn: pick_reg(rng),
+                    rm: pick_reg(rng),
+                };
+            }
+            let pick_non_sp = |rng: &mut R| non_sp[rng.random_range(0..non_sp.len())];
             let rn = pick_non_sp(rng);
             let rm = match random_operand(rng, registers, immediates) {
                 Operand::Register(Register::SP) => Operand::Register(pick_non_sp(rng)),
@@ -833,8 +835,13 @@ pub fn generate_random_instruction<R: rand::RngExt>(
                 // random_operand only returns Register/Immediate, but the
                 // compiler can't prove that — drop ShiftedRegister/Extended-
                 // Register to a plain register (CCMP rejects both forms).
-                Operand::ShiftedRegister { reg, .. } | Operand::ExtendedRegister { reg, .. } => {
+                Operand::ShiftedRegister { reg, .. } | Operand::ExtendedRegister { reg, .. }
+                    if reg != Register::SP =>
+                {
                     Operand::Register(reg)
+                }
+                Operand::ShiftedRegister { .. } | Operand::ExtendedRegister { .. } => {
+                    Operand::Register(pick_non_sp(rng))
                 }
             };
             let nzcv = (rng.random::<u32>() & 0x0F) as u8;
@@ -850,16 +857,19 @@ pub fn generate_random_instruction<R: rand::RngExt>(
         // `is_encodable_aarch64`); 2D constraint on (lsb, width) enforced by
         // sampling width AFTER lsb so width is bounded by `64-lsb`.
         33 => {
-            debug_assert!(
-                registers.iter().any(|r| *r != Register::SP),
-                "bit-field random generator requires at least one non-SP register",
-            );
-            let pick_non_sp = |rng: &mut R| loop {
-                let r = pick_reg(rng);
-                if r != Register::SP {
-                    break r;
-                }
-            };
+            let non_sp: Vec<Register> = registers
+                .iter()
+                .copied()
+                .filter(|r| *r != Register::SP)
+                .collect();
+            if non_sp.is_empty() {
+                return Instruction::Mneg {
+                    rd,
+                    rn: pick_reg(rng),
+                    rm: pick_reg(rng),
+                };
+            }
+            let pick_non_sp = |rng: &mut R| non_sp[rng.random_range(0..non_sp.len())];
             let rd_local = pick_non_sp(rng);
             let rn = pick_non_sp(rng);
             let lsb = (rng.random::<u32>() & 0x3F) as u8;
@@ -1081,6 +1091,7 @@ pub fn is_move_op(instr: &Instruction) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::convert::Infallible;
 
     fn default_registers() -> Vec<Register> {
         vec![Register::X0, Register::X1, Register::X2]
@@ -1088,6 +1099,74 @@ mod tests {
 
     fn default_immediates() -> Vec<i64> {
         vec![-1, 0, 1, 2]
+    }
+
+    struct BudgetedRng {
+        words: Vec<u32>,
+        next_word: usize,
+        fallback: u32,
+        remaining_draws: usize,
+    }
+
+    impl BudgetedRng {
+        fn new(words: Vec<u32>) -> Self {
+            Self {
+                words,
+                next_word: 0,
+                fallback: 0,
+                remaining_draws: 64,
+            }
+        }
+
+        fn draw_word(&mut self) -> u32 {
+            assert!(
+                self.remaining_draws > 0,
+                "random generator exceeded its draw budget"
+            );
+            self.remaining_draws -= 1;
+            let word = self
+                .words
+                .get(self.next_word)
+                .copied()
+                .unwrap_or(self.fallback);
+            self.next_word += 1;
+            word
+        }
+    }
+
+    impl rand::TryRng for BudgetedRng {
+        type Error = Infallible;
+
+        fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+            Ok(self.draw_word())
+        }
+
+        fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+            let low = u64::from(self.draw_word());
+            let high = u64::from(self.draw_word());
+            Ok(low | (high << 32))
+        }
+
+        fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
+            for chunk in dst.chunks_mut(4) {
+                let bytes = self.draw_word().to_le_bytes();
+                chunk.copy_from_slice(&bytes[..chunk.len()]);
+            }
+            Ok(())
+        }
+    }
+
+    fn word_for_range(range: u32, value: u32) -> u32 {
+        assert!(range > 0);
+        assert!(value < range);
+        let numerator = (u128::from(value)) << 32;
+        let word = numerator.div_ceil(u128::from(range)) as u32;
+        debug_assert_eq!(((u64::from(word) * u64::from(range)) >> 32) as u32, value);
+        word
+    }
+
+    fn rng_for_opcode_slot(slot: u32, rd_index: u32) -> BudgetedRng {
+        BudgetedRng::new(vec![word_for_range(2, rd_index), word_for_range(38, slot)])
     }
 
     #[test]
@@ -1558,6 +1637,68 @@ mod tests {
             if let Some(dest) = instr.destination() {
                 assert!(regs.contains(&dest));
             }
+        }
+    }
+
+    #[test]
+    fn generate_random_instruction_handles_sp_only_ccmp_and_bitfield_slots() {
+        let regs = [Register::SP];
+        let imms = default_immediates();
+
+        for slot in [32, 33] {
+            let mut rng = rng_for_opcode_slot(slot, 0);
+            let instr = generate_random_instruction(&mut rng, &regs, &imms);
+            assert!(
+                matches!(
+                    instr,
+                    Instruction::Mneg {
+                        rd: Register::SP,
+                        rn: Register::SP,
+                        rm: Register::SP,
+                    }
+                ),
+                "slot {slot} should fall back finitely for an SP-only pool, got {instr:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn generate_random_instruction_filters_sp_from_ccmp_and_bitfield_operands() {
+        let regs = [Register::SP, Register::X0];
+        let imms = default_immediates();
+
+        let mut ccmp_rng = rng_for_opcode_slot(32, 0);
+        let ccmp = generate_random_instruction(&mut ccmp_rng, &regs, &imms);
+        match ccmp {
+            Instruction::Ccmp {
+                rn,
+                rm: Operand::Register(rm),
+                ..
+            }
+            | Instruction::Ccmn {
+                rn,
+                rm: Operand::Register(rm),
+                ..
+            } => {
+                assert_eq!(rn, Register::X0);
+                assert_eq!(rm, Register::X0);
+            }
+            other => panic!("expected register-form CCMP/CCMN, got {other:?}"),
+        }
+
+        let mut bitfield_rng = rng_for_opcode_slot(33, 0);
+        let bitfield = generate_random_instruction(&mut bitfield_rng, &regs, &imms);
+        match bitfield {
+            Instruction::Ubfx { rd, rn, .. }
+            | Instruction::Sbfx { rd, rn, .. }
+            | Instruction::Bfi { rd, rn, .. }
+            | Instruction::Bfxil { rd, rn, .. }
+            | Instruction::Ubfiz { rd, rn, .. }
+            | Instruction::Sbfiz { rd, rn, .. } => {
+                assert_eq!(rd, Register::X0);
+                assert_eq!(rn, Register::X0);
+            }
+            other => panic!("expected bit-field instruction, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Summary
- filter SP out of the CCMP/CCMN and bit-field random candidate pools before operand sampling
- fall back finitely to the existing MNEG-shaped random candidate pattern when a pathological pool contains only SP
- add budgeted RNG regressions for forced CCMP/CCMN and bit-field slots with SP-only and mixed SP/non-SP pools

## Decision Notes
I used the existing finite fallback pattern already present in `src/isa/aarch64.rs` instead of adding retry limits or changing opcode probabilities. This keeps the random slot mapping unchanged while removing the release-build infinite-loop path.

## Verification
- `cargo test generate_random_instruction_` (red before the fix, green after)
- `cargo test search::candidate::tests`
- `cargo clippy --all -- -D warnings`
- `./build_tests.sh`
- `cargo test --all`
- `./test_all.sh`
- `./ci_check.sh`

Note: the requested `scripts/full_test.sh` path does not exist in this repository; `test_all.sh` and `ci_check.sh` are the repo-local equivalents.

Closes #147

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**