### PR TITLE
docs(isa): cross-reference opcode-id drift guards

### DIFF
--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -180,6 +180,10 @@ impl InstructionType for Instruction {
         Instruction::source_registers(self)
     }
 
+    // Canonical AArch64 opcode-id table. Candidate generation calls this through
+    // `InstructionType::opcode_id`; drift is guarded by this module's
+    // `all_instruction_families_cover_trait_methods` test and candidate coverage
+    // tests in `src/search/candidate.rs`.
     fn opcode_id(&self) -> u8 {
         match self {
             Instruction::MovReg { .. } => 0,

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -182,8 +182,9 @@ impl InstructionType for Instruction {
 
     // Canonical AArch64 opcode-id table. Candidate generation calls this through
     // `InstructionType::opcode_id`; drift is guarded by this module's
-    // `all_instruction_families_cover_trait_methods` test and candidate coverage
-    // tests in `src/search/candidate.rs`.
+    // `all_instruction_families_cover_trait_methods` test and
+    // `test_generate_all_instructions_covers_issue_66_opcodes` in
+    // `src/search/candidate.rs`.
     fn opcode_id(&self) -> u8 {
         match self {
             Instruction::MovReg { .. } => 0,

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -1129,6 +1129,9 @@ mod tests {
 
     #[test]
     fn test_generate_all_instructions_covers_issue_66_opcodes() {
+        // Candidate generation intentionally uses `InstructionType::opcode_id`
+        // from `src/isa/aarch64.rs`; add a sync guard beside any future
+        // candidate-local table instead of letting the two drift silently.
         // Regression guard: every IR opcode family enumerated by issue #66
         // (Mul/Sdiv/Udiv/Cmp/Cmn/Tst/Csel/Csinc/Csinv/Csneg, opcode_ids
         // 10..=19) must appear in the exhaustive enumeration. Narrower scope


### PR DESCRIPTION
Summary:
- Add a comment above the canonical AArch64 opcode-id table pointing to the drift guard tests.
- Add a candidate-side comment noting that candidate generation uses `InstructionType::opcode_id` and should not grow an unguarded local table.

Tests:
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test all_instruction_families_cover_trait_methods
- cargo test test_generate_all_instructions_covers_issue_66_opcodes
- ./build_tests.sh
- cargo test --all
- ./ci_check.sh

Closes #149

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**