### PR TITLE
fix(ir): display AArch64 extends with architectural widths

### DIFF
--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -1431,11 +1431,36 @@ impl fmt::Display for Instruction {
             Instruction::Rev { rd, rn } => write!(f, "rev {}, {}", rd, rn),
             Instruction::Rev32 { rd, rn } => write!(f, "rev32 {}, {}", rd, rn),
             Instruction::Rev16 { rd, rn } => write!(f, "rev16 {}, {}", rd, rn),
-            Instruction::Sxtb { rd, rn } => write!(f, "sxtb {}, {}", rd, rn),
-            Instruction::Sxth { rd, rn } => write!(f, "sxth {}, {}", rd, rn),
-            Instruction::Sxtw { rd, rn } => write!(f, "sxtw {}, {}", rd, rn),
-            Instruction::Uxtb { rd, rn } => write!(f, "uxtb {}, {}", rd, rn),
-            Instruction::Uxth { rd, rn } => write!(f, "uxth {}, {}", rd, rn),
+            Instruction::Sxtb { rd, rn } => write!(
+                f,
+                "sxtb {}, {}",
+                RegisterWidth::X64.register_name(*rd),
+                RegisterWidth::W32.register_name(*rn)
+            ),
+            Instruction::Sxth { rd, rn } => write!(
+                f,
+                "sxth {}, {}",
+                RegisterWidth::X64.register_name(*rd),
+                RegisterWidth::W32.register_name(*rn)
+            ),
+            Instruction::Sxtw { rd, rn } => write!(
+                f,
+                "sxtw {}, {}",
+                RegisterWidth::X64.register_name(*rd),
+                RegisterWidth::W32.register_name(*rn)
+            ),
+            Instruction::Uxtb { rd, rn } => write!(
+                f,
+                "uxtb {}, {}",
+                RegisterWidth::W32.register_name(*rd),
+                RegisterWidth::W32.register_name(*rn)
+            ),
+            Instruction::Uxth { rd, rn } => write!(
+                f,
+                "uxth {}, {}",
+                RegisterWidth::W32.register_name(*rd),
+                RegisterWidth::W32.register_name(*rn)
+            ),
             Instruction::Ubfx { rd, rn, lsb, width } => {
                 write!(f, "ubfx {}, {}, #{}, #{}", rd, rn, lsb, width)
             }
@@ -3411,7 +3436,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X1,
         };
-        assert_eq!(ok.to_string(), "sxtw x0, x1");
+        assert_eq!(ok.to_string(), "sxtw x0, w1");
         assert_eq!(ok.destination(), Some(Register::X0));
         assert_eq!(ok.source_registers(), vec![Register::X1]);
         assert!(!ok.modifies_flags());
@@ -3438,7 +3463,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X1,
         };
-        assert_eq!(ok.to_string(), "sxth x0, x1");
+        assert_eq!(ok.to_string(), "sxth x0, w1");
         assert_eq!(ok.destination(), Some(Register::X0));
         assert_eq!(ok.source_registers(), vec![Register::X1]);
         assert!(!ok.modifies_flags());
@@ -3465,7 +3490,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X1,
         };
-        assert_eq!(ok.to_string(), "uxth x0, x1");
+        assert_eq!(ok.to_string(), "uxth w0, w1");
         assert_eq!(ok.destination(), Some(Register::X0));
         assert_eq!(ok.source_registers(), vec![Register::X1]);
         assert!(!ok.modifies_flags());
@@ -3494,7 +3519,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X1,
         };
-        assert_eq!(ok.to_string(), "sxtb x0, x1");
+        assert_eq!(ok.to_string(), "sxtb x0, w1");
         assert_eq!(ok.destination(), Some(Register::X0));
         assert_eq!(ok.source_registers(), vec![Register::X1]);
         assert!(!ok.modifies_flags());
@@ -3523,7 +3548,7 @@ mod tests {
             rd: Register::X0,
             rn: Register::X1,
         };
-        assert_eq!(ok.to_string(), "uxtb x0, x1");
+        assert_eq!(ok.to_string(), "uxtb w0, w1");
         assert_eq!(ok.destination(), Some(Register::X0));
         assert_eq!(ok.source_registers(), vec![Register::X1]);
         assert!(!ok.modifies_flags());

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2449,6 +2449,26 @@ mod tests {
                 rn: Register::X1,
                 shift: Operand::Register(Register::X2),
             },
+            Instruction::Uxtb {
+                rd: Register::X0,
+                rn: Register::X1,
+            },
+            Instruction::Uxth {
+                rd: Register::X0,
+                rn: Register::X1,
+            },
+            Instruction::Sxtb {
+                rd: Register::X0,
+                rn: Register::X1,
+            },
+            Instruction::Sxth {
+                rd: Register::X0,
+                rn: Register::X1,
+            },
+            Instruction::Sxtw {
+                rd: Register::X0,
+                rn: Register::X1,
+            },
         ];
         for instr in cases {
             let printed = format!("{}", instr);
@@ -2835,8 +2855,8 @@ mod tests {
             };
             assert_eq!(parsed, expected, "round-trip failed for {}", line);
         }
-        // The legacy X-form spelling we use internally for Display still
-        // parses correctly (e.g. `uxtb x0, x1` from older tests).
+        // Legacy X-form input remains accepted for compatibility even though
+        // Display now canonicalizes these aliases to architectural widths.
         assert!(parse_line("uxtb x0, x1").is_ok());
         assert!(parse_line("sxtw x0, x1").is_ok());
     }
@@ -2887,7 +2907,7 @@ mod tests {
                 rn: Register::X1,
             }
         );
-        assert_eq!(format!("{}", parsed), "sxtw x0, x1");
+        assert_eq!(format!("{}", parsed), "sxtw x0, w1");
     }
 
     #[test]
@@ -2903,7 +2923,7 @@ mod tests {
                 rn: Register::X1,
             }
         );
-        assert_eq!(format!("{}", parsed), "sxth x0, x1");
+        assert_eq!(format!("{}", parsed), "sxth x0, w1");
     }
 
     #[test]
@@ -2919,7 +2939,7 @@ mod tests {
                 rn: Register::X1,
             }
         );
-        assert_eq!(format!("{}", parsed), "uxth x0, x1");
+        assert_eq!(format!("{}", parsed), "uxth w0, w1");
     }
 
     #[test]
@@ -2935,7 +2955,7 @@ mod tests {
                 rn: Register::X1,
             }
         );
-        assert_eq!(format!("{}", parsed), "sxtb x0, x1");
+        assert_eq!(format!("{}", parsed), "sxtb x0, w1");
     }
 
     #[test]
@@ -2952,7 +2972,7 @@ mod tests {
                 rn: Register::X1,
             }
         );
-        assert_eq!(format!("{}", parsed), "uxtb x0, x1");
+        assert_eq!(format!("{}", parsed), "uxtb w0, w1");
     }
 
     // ===== Issue #69: branch / control-flow parsing =====


### PR DESCRIPTION
## Summary
- Project standalone SXTB/SXTH/SXTW sources through W register names in IR Display.
- Project UXTB/UXTH destinations and sources through W register names while preserving legacy X-form parser acceptance.
- Add display-parser roundtrip coverage for the five standalone extend aliases.

## Validation
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test --all
- ./ci_check.sh

Closes #150

**Merge with \`gh pr merge --merge\` (merge commit, not squash) per CLAUDE.md.**