### PR TITLE
fix(symbolic): honor timeout before SMT verification

### DIFF
--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -1074,7 +1074,7 @@ mod tests {
     }
 
     #[test]
-    fn symbolic_timeout_returns_best_at_length() {
+    fn symbolic_early_stop_returns_best_at_length() {
         use std::time::Instant;
 
         let _guard = SYMBOLIC_INNER_LOOP_TEST_LOCK
@@ -1084,8 +1084,18 @@ mod tests {
         TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK.store(1, Ordering::SeqCst);
         TEST_SEQUENCE_COST_DELAY_MS.store(0, Ordering::SeqCst);
 
+        // The fake check_equivalence trips the installed stop flag on the first
+        // check, so candidate (0, 0) is recorded as best_at_length and the very
+        // next should_stop poll bails out. This drives the early-return path
+        // deterministically, with no dependence on a 1 ms timeout firing inside
+        // a precise scheduler window (which is racy on an oversubscribed runner).
+        let flag = Arc::new(AtomicBool::new(false));
+        let _stop_guard = install_test_stop_flag(Arc::clone(&flag));
+
         let mut search: SymbolicSearch<TestIsa> = SymbolicSearch::new();
-        let config = SearchConfig::default().with_timeout(Duration::from_millis(1));
+        let config = SearchConfig::default()
+            .with_timeout_option(None)
+            .with_stop_flag(flag);
         let all_instructions: Vec<_> = (0..64).map(TestInstruction).collect();
         let target = [
             TestInstruction(100),
@@ -1109,11 +1119,11 @@ mod tests {
         assert_eq!(
             result,
             Some(vec![TestInstruction(0), TestInstruction(0)]),
-            "timeout should return the best equivalent candidate found at this length",
+            "an early stop should return the best equivalent candidate found at this length",
         );
         assert!(
             TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst) < 8,
-            "timeout should stop promptly after preserving the best candidate",
+            "search should stop promptly after preserving the best candidate",
         );
     }
 

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -153,6 +153,9 @@ where
                     &config.cost_metric,
                     width,
                 );
+                if should_stop(config, start_time) {
+                    return best_at_length;
+                }
 
                 if candidate_cost >= *best_cost {
                     continue;
@@ -189,6 +192,9 @@ where
                         &config.cost_metric,
                         width,
                     );
+                    if should_stop(config, start_time) {
+                        return best_at_length;
+                    }
 
                     if candidate_cost >= *best_cost {
                         continue;
@@ -256,6 +262,9 @@ where
                             &config.cost_metric,
                             width,
                         );
+                        if should_stop(config, start_time) {
+                            return best_at_length;
+                        }
 
                         if candidate_cost >= *best_cost {
                             count += 1;
@@ -406,11 +415,13 @@ mod tests {
     use crate::semantics::EquivalenceMetrics;
     use crate::semantics::cost::CostMetric;
     use crate::semantics::live_out::LiveOut;
-    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
     static TEST_EQUIVALENCE_CHECKS: AtomicUsize = AtomicUsize::new(0);
+    static TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK: AtomicUsize = AtomicUsize::new(0);
+    static TEST_SEQUENCE_COST_DELAY_MS: AtomicU64 = AtomicU64::new(0);
     static TEST_STOP_FLAG: Mutex<Option<Arc<AtomicBool>>> = Mutex::new(None);
     static SYMBOLIC_INNER_LOOP_TEST_LOCK: Mutex<()> = Mutex::new(());
 
@@ -588,6 +599,10 @@ mod tests {
         }
 
         fn sequence_cost(seq: &[TestInstruction], _metric: &CostMetric, _width: u32) -> u64 {
+            let delay_ms = TEST_SEQUENCE_COST_DELAY_MS.load(Ordering::SeqCst);
+            if delay_ms > 0 {
+                std::thread::sleep(Duration::from_millis(delay_ms));
+            }
             seq.len() as u64
         }
 
@@ -606,6 +621,9 @@ mod tests {
                 }
             }
             std::thread::sleep(Duration::from_millis(1));
+            if check_number == TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK.load(Ordering::SeqCst) {
+                return (EquivalenceResult::Equivalent, EquivalenceMetrics::default());
+            }
             (
                 EquivalenceResult::NotEquivalent,
                 EquivalenceMetrics::default(),
@@ -839,6 +857,8 @@ mod tests {
             .lock()
             .expect("symbolic inner-loop test lock poisoned");
         TEST_EQUIVALENCE_CHECKS.store(0, Ordering::SeqCst);
+        TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK.store(0, Ordering::SeqCst);
+        TEST_SEQUENCE_COST_DELAY_MS.store(0, Ordering::SeqCst);
 
         let flag = Arc::new(AtomicBool::new(false));
         let _stop_guard = install_test_stop_flag(Arc::clone(&flag));
@@ -874,6 +894,96 @@ mod tests {
     }
 
     #[test]
+    fn symbolic_length_two_inner_loop_respects_overall_timeout() {
+        use std::time::Instant;
+
+        let _guard = SYMBOLIC_INNER_LOOP_TEST_LOCK
+            .lock()
+            .expect("symbolic inner-loop test lock poisoned");
+        TEST_EQUIVALENCE_CHECKS.store(0, Ordering::SeqCst);
+        TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK.store(0, Ordering::SeqCst);
+        TEST_SEQUENCE_COST_DELAY_MS.store(0, Ordering::SeqCst);
+
+        let mut search: SymbolicSearch<TestIsa> = SymbolicSearch::new();
+        let config = SearchConfig::default().with_timeout(Duration::from_millis(1));
+        let all_instructions: Vec<_> = (0..64).map(TestInstruction).collect();
+        let target = [
+            TestInstruction(100),
+            TestInstruction(101),
+            TestInstruction(102),
+        ];
+        let mut best_cost = u64::MAX;
+
+        let result = search.search_at_length(
+            &target,
+            &(),
+            &config,
+            &all_instructions,
+            2,
+            &mut best_cost,
+            Instant::now(),
+        );
+
+        let checks = TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst);
+        assert_eq!(result, None);
+        assert!(
+            checks < 8,
+            "length-2 search should poll timeout inside the instr2 loop; ran {checks} checks",
+        );
+        assert!(
+            search.statistics().candidates_evaluated < 8,
+            "length-2 search should stop counting candidates promptly after timeout; evaluated {}",
+            search.statistics().candidates_evaluated,
+        );
+    }
+
+    #[test]
+    fn symbolic_length_two_timeout_is_checked_before_verification() {
+        use std::time::Instant;
+
+        let _guard = SYMBOLIC_INNER_LOOP_TEST_LOCK
+            .lock()
+            .expect("symbolic inner-loop test lock poisoned");
+        TEST_EQUIVALENCE_CHECKS.store(0, Ordering::SeqCst);
+        TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK.store(0, Ordering::SeqCst);
+        TEST_SEQUENCE_COST_DELAY_MS.store(2, Ordering::SeqCst);
+
+        let mut search: SymbolicSearch<TestIsa> = SymbolicSearch::new();
+        let config = SearchConfig::default().with_timeout(Duration::from_millis(1));
+        let all_instructions: Vec<_> = (0..64).map(TestInstruction).collect();
+        let target = [
+            TestInstruction(100),
+            TestInstruction(101),
+            TestInstruction(102),
+        ];
+        let mut best_cost = u64::MAX;
+
+        let result = search.search_at_length(
+            &target,
+            &(),
+            &config,
+            &all_instructions,
+            2,
+            &mut best_cost,
+            Instant::now(),
+        );
+
+        TEST_SEQUENCE_COST_DELAY_MS.store(0, Ordering::SeqCst);
+
+        assert_eq!(result, None);
+        assert_eq!(
+            TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst),
+            0,
+            "timeout expired during candidate costing, so no SMT verification should run",
+        );
+        assert_eq!(
+            search.statistics().candidates_evaluated,
+            0,
+            "timed-out candidates must not be counted as evaluated",
+        );
+    }
+
+    #[test]
     fn symbolic_length_three_inner_loops_respect_cooperative_stop_flag() {
         use std::time::Instant;
 
@@ -881,6 +991,8 @@ mod tests {
             .lock()
             .expect("symbolic inner-loop test lock poisoned");
         TEST_EQUIVALENCE_CHECKS.store(0, Ordering::SeqCst);
+        TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK.store(0, Ordering::SeqCst);
+        TEST_SEQUENCE_COST_DELAY_MS.store(0, Ordering::SeqCst);
 
         let flag = Arc::new(AtomicBool::new(false));
         let _stop_guard = install_test_stop_flag(Arc::clone(&flag));
@@ -913,6 +1025,95 @@ mod tests {
         assert!(
             checks < 8,
             "length-3 search should poll cancellation inside the instr2/instr3 loops; ran {checks} checks",
+        );
+    }
+
+    #[test]
+    fn symbolic_length_three_inner_loops_respect_overall_timeout() {
+        use std::time::Instant;
+
+        let _guard = SYMBOLIC_INNER_LOOP_TEST_LOCK
+            .lock()
+            .expect("symbolic inner-loop test lock poisoned");
+        TEST_EQUIVALENCE_CHECKS.store(0, Ordering::SeqCst);
+        TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK.store(0, Ordering::SeqCst);
+        TEST_SEQUENCE_COST_DELAY_MS.store(0, Ordering::SeqCst);
+
+        let mut search: SymbolicSearch<TestIsa> = SymbolicSearch::new();
+        let config = SearchConfig::default().with_timeout(Duration::from_millis(1));
+        let all_instructions: Vec<_> = (0..8).map(TestInstruction).collect();
+        let target = [
+            TestInstruction(100),
+            TestInstruction(101),
+            TestInstruction(102),
+            TestInstruction(103),
+        ];
+        let mut best_cost = u64::MAX;
+
+        let result = search.search_at_length(
+            &target,
+            &(),
+            &config,
+            &all_instructions,
+            3,
+            &mut best_cost,
+            Instant::now(),
+        );
+
+        let checks = TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst);
+        assert_eq!(result, None);
+        assert!(
+            checks < 8,
+            "length-3 search should poll timeout inside the instr2/instr3 loops; ran {checks} checks",
+        );
+        assert!(
+            search.statistics().candidates_evaluated < 8,
+            "length-3 search should stop counting candidates promptly after timeout; evaluated {}",
+            search.statistics().candidates_evaluated,
+        );
+    }
+
+    #[test]
+    fn symbolic_timeout_returns_best_at_length() {
+        use std::time::Instant;
+
+        let _guard = SYMBOLIC_INNER_LOOP_TEST_LOCK
+            .lock()
+            .expect("symbolic inner-loop test lock poisoned");
+        TEST_EQUIVALENCE_CHECKS.store(0, Ordering::SeqCst);
+        TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK.store(1, Ordering::SeqCst);
+        TEST_SEQUENCE_COST_DELAY_MS.store(0, Ordering::SeqCst);
+
+        let mut search: SymbolicSearch<TestIsa> = SymbolicSearch::new();
+        let config = SearchConfig::default().with_timeout(Duration::from_millis(1));
+        let all_instructions: Vec<_> = (0..64).map(TestInstruction).collect();
+        let target = [
+            TestInstruction(100),
+            TestInstruction(101),
+            TestInstruction(102),
+        ];
+        let mut best_cost = u64::MAX;
+
+        let result = search.search_at_length(
+            &target,
+            &(),
+            &config,
+            &all_instructions,
+            2,
+            &mut best_cost,
+            Instant::now(),
+        );
+
+        TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK.store(0, Ordering::SeqCst);
+
+        assert_eq!(
+            result,
+            Some(vec![TestInstruction(0), TestInstruction(0)]),
+            "timeout should return the best equivalent candidate found at this length",
+        );
+        assert!(
+            TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst) < 8,
+            "timeout should stop promptly after preserving the best candidate",
         );
     }
 

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -441,6 +441,14 @@ mod tests {
         TestStopFlagGuard
     }
 
+    fn reset_symbolic_inner_loop_test_state() {
+        TEST_EQUIVALENCE_CHECKS.store(0, Ordering::SeqCst);
+        TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK.store(0, Ordering::SeqCst);
+        TEST_SEQUENCE_COST_DELAY_MS.store(0, Ordering::SeqCst);
+        let mut slot = TEST_STOP_FLAG.lock().expect("test stop flag lock poisoned");
+        *slot = None;
+    }
+
     #[derive(Clone)]
     struct TestIsa;
 
@@ -856,9 +864,7 @@ mod tests {
         let _guard = SYMBOLIC_INNER_LOOP_TEST_LOCK
             .lock()
             .expect("symbolic inner-loop test lock poisoned");
-        TEST_EQUIVALENCE_CHECKS.store(0, Ordering::SeqCst);
-        TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK.store(0, Ordering::SeqCst);
-        TEST_SEQUENCE_COST_DELAY_MS.store(0, Ordering::SeqCst);
+        reset_symbolic_inner_loop_test_state();
 
         let flag = Arc::new(AtomicBool::new(false));
         let _stop_guard = install_test_stop_flag(Arc::clone(&flag));
@@ -887,9 +893,14 @@ mod tests {
 
         let checks = TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst);
         assert_eq!(result, None);
-        assert!(
-            checks < 8,
-            "length-2 search should poll cancellation inside the instr2 loop; ran {checks} checks",
+        assert_eq!(
+            checks, 1,
+            "length-2 search should poll cancellation before continuing the instr2 loop",
+        );
+        assert_eq!(
+            search.statistics().candidates_evaluated,
+            1,
+            "length-2 search should stop counting after the first cancelled candidate",
         );
     }
 
@@ -900,52 +911,7 @@ mod tests {
         let _guard = SYMBOLIC_INNER_LOOP_TEST_LOCK
             .lock()
             .expect("symbolic inner-loop test lock poisoned");
-        TEST_EQUIVALENCE_CHECKS.store(0, Ordering::SeqCst);
-        TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK.store(0, Ordering::SeqCst);
-        TEST_SEQUENCE_COST_DELAY_MS.store(0, Ordering::SeqCst);
-
-        let mut search: SymbolicSearch<TestIsa> = SymbolicSearch::new();
-        let config = SearchConfig::default().with_timeout(Duration::from_millis(1));
-        let all_instructions: Vec<_> = (0..64).map(TestInstruction).collect();
-        let target = [
-            TestInstruction(100),
-            TestInstruction(101),
-            TestInstruction(102),
-        ];
-        let mut best_cost = u64::MAX;
-
-        let result = search.search_at_length(
-            &target,
-            &(),
-            &config,
-            &all_instructions,
-            2,
-            &mut best_cost,
-            Instant::now(),
-        );
-
-        let checks = TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst);
-        assert_eq!(result, None);
-        assert!(
-            checks < 8,
-            "length-2 search should poll timeout inside the instr2 loop; ran {checks} checks",
-        );
-        assert!(
-            search.statistics().candidates_evaluated < 8,
-            "length-2 search should stop counting candidates promptly after timeout; evaluated {}",
-            search.statistics().candidates_evaluated,
-        );
-    }
-
-    #[test]
-    fn symbolic_length_two_timeout_is_checked_before_verification() {
-        use std::time::Instant;
-
-        let _guard = SYMBOLIC_INNER_LOOP_TEST_LOCK
-            .lock()
-            .expect("symbolic inner-loop test lock poisoned");
-        TEST_EQUIVALENCE_CHECKS.store(0, Ordering::SeqCst);
-        TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK.store(0, Ordering::SeqCst);
+        reset_symbolic_inner_loop_test_state();
         TEST_SEQUENCE_COST_DELAY_MS.store(2, Ordering::SeqCst);
 
         let mut search: SymbolicSearch<TestIsa> = SymbolicSearch::new();
@@ -974,12 +940,12 @@ mod tests {
         assert_eq!(
             TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst),
             0,
-            "timeout expired during candidate costing, so no SMT verification should run",
+            "length-2 search should poll timeout before verifying a timed-out candidate",
         );
         assert_eq!(
             search.statistics().candidates_evaluated,
             0,
-            "timed-out candidates must not be counted as evaluated",
+            "length-2 search should not count candidates after the timeout expires",
         );
     }
 
@@ -990,9 +956,7 @@ mod tests {
         let _guard = SYMBOLIC_INNER_LOOP_TEST_LOCK
             .lock()
             .expect("symbolic inner-loop test lock poisoned");
-        TEST_EQUIVALENCE_CHECKS.store(0, Ordering::SeqCst);
-        TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK.store(0, Ordering::SeqCst);
-        TEST_SEQUENCE_COST_DELAY_MS.store(0, Ordering::SeqCst);
+        reset_symbolic_inner_loop_test_state();
 
         let flag = Arc::new(AtomicBool::new(false));
         let _stop_guard = install_test_stop_flag(Arc::clone(&flag));
@@ -1022,9 +986,14 @@ mod tests {
 
         let checks = TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst);
         assert_eq!(result, None);
-        assert!(
-            checks < 8,
-            "length-3 search should poll cancellation inside the instr2/instr3 loops; ran {checks} checks",
+        assert_eq!(
+            checks, 1,
+            "length-3 search should poll cancellation before continuing the nested loops",
+        );
+        assert_eq!(
+            search.statistics().candidates_evaluated,
+            1,
+            "length-3 search should stop counting after the first cancelled candidate",
         );
     }
 
@@ -1035,9 +1004,8 @@ mod tests {
         let _guard = SYMBOLIC_INNER_LOOP_TEST_LOCK
             .lock()
             .expect("symbolic inner-loop test lock poisoned");
-        TEST_EQUIVALENCE_CHECKS.store(0, Ordering::SeqCst);
-        TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK.store(0, Ordering::SeqCst);
-        TEST_SEQUENCE_COST_DELAY_MS.store(0, Ordering::SeqCst);
+        reset_symbolic_inner_loop_test_state();
+        TEST_SEQUENCE_COST_DELAY_MS.store(2, Ordering::SeqCst);
 
         let mut search: SymbolicSearch<TestIsa> = SymbolicSearch::new();
         let config = SearchConfig::default().with_timeout(Duration::from_millis(1));
@@ -1060,16 +1028,18 @@ mod tests {
             Instant::now(),
         );
 
-        let checks = TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst);
+        TEST_SEQUENCE_COST_DELAY_MS.store(0, Ordering::SeqCst);
+
         assert_eq!(result, None);
-        assert!(
-            checks < 8,
-            "length-3 search should poll timeout inside the instr2/instr3 loops; ran {checks} checks",
+        assert_eq!(
+            TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst),
+            0,
+            "length-3 search should poll timeout before verifying a timed-out candidate",
         );
-        assert!(
-            search.statistics().candidates_evaluated < 8,
-            "length-3 search should stop counting candidates promptly after timeout; evaluated {}",
+        assert_eq!(
             search.statistics().candidates_evaluated,
+            0,
+            "length-3 search should not count candidates after the timeout expires",
         );
     }
 
@@ -1080,9 +1050,8 @@ mod tests {
         let _guard = SYMBOLIC_INNER_LOOP_TEST_LOCK
             .lock()
             .expect("symbolic inner-loop test lock poisoned");
-        TEST_EQUIVALENCE_CHECKS.store(0, Ordering::SeqCst);
+        reset_symbolic_inner_loop_test_state();
         TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK.store(1, Ordering::SeqCst);
-        TEST_SEQUENCE_COST_DELAY_MS.store(0, Ordering::SeqCst);
 
         // The fake check_equivalence trips the installed stop flag on the first
         // check, so candidate (0, 0) is recorded as best_at_length and the very
@@ -1114,16 +1083,20 @@ mod tests {
             Instant::now(),
         );
 
-        TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK.store(0, Ordering::SeqCst);
-
         assert_eq!(
             result,
             Some(vec![TestInstruction(0), TestInstruction(0)]),
             "an early stop should return the best equivalent candidate found at this length",
         );
-        assert!(
-            TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst) < 8,
-            "search should stop promptly after preserving the best candidate",
+        assert_eq!(
+            TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst),
+            1,
+            "should_stop should stop promptly after preserving the best candidate",
+        );
+        assert_eq!(
+            search.statistics().candidates_evaluated,
+            1,
+            "should_stop should stop counting after preserving the best candidate",
         );
     }
 


### PR DESCRIPTION
Summary:
- add symbolic timeout regression tests for length-2 and length-3 candidate loops
- re-check overall timeout after candidate costing and before evaluation/SMT verification
- preserve the best candidate found at the current length when timeout fires

Closes #221

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**