### PR TITLE
fix(llm): bound Codex calls by search timeout

### DIFF
--- a/src/search/llm/codex.rs
+++ b/src/search/llm/codex.rs
@@ -225,40 +225,14 @@ fn create_file(path: &Path) -> Result<File, String> {
 mod tests {
     use super::*;
     #[cfg(unix)]
-    use crate::search::llm::test_support::{FakeCodex, envelope_answer_writer_script};
+    use crate::search::llm::test_support::{
+        FakeCodex, envelope_answer_writer_script, shell_single_quote, wait_until_process_gone,
+    };
     use std::error::Error;
 
     #[cfg(unix)]
     fn generous_timeout() -> Duration {
         Duration::from_secs(5)
-    }
-
-    #[cfg(unix)]
-    fn shell_single_quote(value: &str) -> String {
-        format!("'{}'", value.replace('\'', "'\"'\"'"))
-    }
-
-    #[cfg(unix)]
-    fn process_exists(pid: u32) -> bool {
-        std::process::Command::new("kill")
-            .arg("-0")
-            .arg(pid.to_string())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .map(|status| status.success())
-            .unwrap_or(false)
-    }
-
-    #[cfg(unix)]
-    fn wait_until_process_gone(pid: u32) {
-        for _ in 0..100 {
-            if !process_exists(pid) {
-                return;
-            }
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        panic!("fake codex child {pid} was still alive after invoke_codex returned");
     }
 
     #[test]
@@ -427,7 +401,7 @@ mod tests {
 
         let started = Instant::now();
         let err =
-            invoke_codex(&config, "try a candidate", "{}", Duration::from_millis(50)).unwrap_err();
+            invoke_codex(&config, "try a candidate", "{}", Duration::from_millis(300)).unwrap_err();
         let elapsed = started.elapsed();
 
         assert!(

--- a/src/search/llm/codex.rs
+++ b/src/search/llm/codex.rs
@@ -1,10 +1,12 @@
 //! Codex CLI invocation and response parsing.
 
 use serde::Deserialize;
+use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Child, Command, ExitStatus, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
 
 use crate::search::config::LlmConfig;
 
@@ -34,6 +36,7 @@ impl std::error::Error for EnvelopeError {}
 #[derive(Debug)]
 pub enum CodexError {
     Io(String),
+    TimedOut { timeout: Duration },
     NonZeroExit { status: i32, stderr: String },
     Envelope(EnvelopeError),
 }
@@ -42,6 +45,9 @@ impl std::fmt::Display for CodexError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             CodexError::Io(e) => write!(f, "codex io error: {}", e),
+            CodexError::TimedOut { timeout } => {
+                write!(f, "codex timed out after {:.3}s", timeout.as_secs_f64())
+            }
             CodexError::NonZeroExit { status, stderr } => {
                 write!(f, "codex exited with status {}: {}", status, stderr)
             }
@@ -104,16 +110,23 @@ impl TempPath {
 /// Schema and answer files are written under the system temp dir with PID +
 /// monotonic-counter naming and removed via RAII guards before this function
 /// returns (success, error, or panic).
-pub fn invoke_codex(config: &LlmConfig, prompt: &str, schema: &str) -> Result<String, CodexError> {
+pub fn invoke_codex(
+    config: &LlmConfig,
+    prompt: &str,
+    schema: &str,
+    timeout: Duration,
+) -> Result<String, CodexError> {
     let id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     let pid = std::process::id();
     let tmp = std::env::temp_dir();
     let schema_path = TempPath(tmp.join(format!("s11-codex-schema-{}-{}.json", pid, id)));
     let answer_path = TempPath(tmp.join(format!("s11-codex-answer-{}-{}.json", pid, id)));
+    let stderr_path = TempPath(tmp.join(format!("s11-codex-stderr-{}-{}.txt", pid, id)));
 
     write_file(schema_path.as_path(), schema).map_err(CodexError::Io)?;
+    let stderr_file = create_file(stderr_path.as_path()).map_err(CodexError::Io)?;
 
-    let output = Command::new(&config.codex_bin)
+    let mut child = Command::new(&config.codex_bin)
         .arg("exec")
         .arg("-m")
         .arg(&config.model)
@@ -126,13 +139,18 @@ pub fn invoke_codex(config: &LlmConfig, prompt: &str, schema: &str) -> Result<St
         .arg("-o")
         .arg(answer_path.as_path())
         .arg(prompt)
-        .output()
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(stderr_file))
+        .spawn()
         .map_err(|e| CodexError::Io(e.to_string()))?;
+    let status = wait_for_child(&mut child, timeout)?;
 
-    if !output.status.success() {
+    if !status.success() {
+        let stderr = std::fs::read_to_string(stderr_path.as_path())
+            .unwrap_or_else(|e| format!("<failed to read codex stderr: {}>", e));
         return Err(CodexError::NonZeroExit {
-            status: output.status.code().unwrap_or(-1),
-            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            status: status.code().unwrap_or(-1),
+            stderr,
         });
     }
 
@@ -142,6 +160,42 @@ pub fn invoke_codex(config: &LlmConfig, prompt: &str, schema: &str) -> Result<St
     parse_codex_envelope(&json).map_err(CodexError::Envelope)
 }
 
+fn wait_for_child(child: &mut Child, timeout: Duration) -> Result<ExitStatus, CodexError> {
+    let started = Instant::now();
+    loop {
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|e| CodexError::Io(format!("waiting for codex: {}", e)))?
+        {
+            return Ok(status);
+        }
+
+        let elapsed = started.elapsed();
+        if elapsed >= timeout {
+            if let Err(kill_error) = child.kill() {
+                if child
+                    .try_wait()
+                    .map_err(|e| CodexError::Io(format!("checking timed-out codex: {}", e)))?
+                    .is_none()
+                {
+                    return Err(CodexError::Io(format!(
+                        "killing timed-out codex: {}",
+                        kill_error
+                    )));
+                }
+            } else {
+                child
+                    .wait()
+                    .map_err(|e| CodexError::Io(format!("reaping timed-out codex: {}", e)))?;
+            }
+            return Err(CodexError::TimedOut { timeout });
+        }
+
+        let remaining = timeout.saturating_sub(elapsed);
+        std::thread::sleep(std::cmp::min(remaining, Duration::from_millis(10)));
+    }
+}
+
 /// Create a new file with owner-only (`0o600`) permissions on Unix; falls
 /// back to default permissions on non-Unix platforms (the LLM flow is only
 /// tested on Linux). The schema file is dull but the answer file briefly
@@ -149,8 +203,12 @@ pub fn invoke_codex(config: &LlmConfig, prompt: &str, schema: &str) -> Result<St
 /// on a multi-user host during the (small) window before the RAII guard
 /// removes the file.
 fn write_file(path: &Path, content: &str) -> Result<(), String> {
-    use std::fs::OpenOptions;
+    let mut f = create_file(path)?;
+    f.write_all(content.as_bytes()).map_err(|e| e.to_string())
+}
 
+fn create_file(path: &Path) -> Result<File, String> {
+    use std::fs::OpenOptions;
     let mut opts = OpenOptions::new();
     opts.write(true).create(true).truncate(true);
 
@@ -160,8 +218,7 @@ fn write_file(path: &Path, content: &str) -> Result<(), String> {
         opts.mode(0o600);
     }
 
-    let mut f = opts.open(path).map_err(|e| e.to_string())?;
-    f.write_all(content.as_bytes()).map_err(|e| e.to_string())
+    opts.open(path).map_err(|e| e.to_string())
 }
 
 #[cfg(test)]
@@ -170,6 +227,39 @@ mod tests {
     #[cfg(unix)]
     use crate::search::llm::test_support::{FakeCodex, envelope_answer_writer_script};
     use std::error::Error;
+
+    #[cfg(unix)]
+    fn generous_timeout() -> Duration {
+        Duration::from_secs(5)
+    }
+
+    #[cfg(unix)]
+    fn shell_single_quote(value: &str) -> String {
+        format!("'{}'", value.replace('\'', "'\"'\"'"))
+    }
+
+    #[cfg(unix)]
+    fn process_exists(pid: u32) -> bool {
+        std::process::Command::new("kill")
+            .arg("-0")
+            .arg(pid.to_string())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
+    }
+
+    #[cfg(unix)]
+    fn wait_until_process_gone(pid: u32) {
+        for _ in 0..100 {
+            if !process_exists(pid) {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("fake codex child {pid} was still alive after invoke_codex returned");
+    }
 
     #[test]
     fn parses_basic_envelope() {
@@ -234,6 +324,12 @@ mod tests {
         assert_eq!(io.to_string(), "codex io error: spawn failed");
         assert!(io.source().is_none());
 
+        let timed_out = CodexError::TimedOut {
+            timeout: Duration::from_millis(25),
+        };
+        assert_eq!(timed_out.to_string(), "codex timed out after 0.025s");
+        assert!(timed_out.source().is_none());
+
         let nonzero = CodexError::NonZeroExit {
             status: 7,
             stderr: "bad prompt".to_string(),
@@ -262,8 +358,13 @@ mod tests {
             .with_model("fake-model")
             .with_codex_bin(fake.path_string());
 
-        let asm = invoke_codex(&config, "try a candidate", r#"{"type":"object"}"#)
-            .expect("fake codex should produce an answer");
+        let asm = invoke_codex(
+            &config,
+            "try a candidate",
+            r#"{"type":"object"}"#,
+            generous_timeout(),
+        )
+        .expect("fake codex should produce an answer");
 
         assert_eq!(asm, "mov x0, x1");
     }
@@ -274,7 +375,7 @@ mod tests {
         let fake = FakeCodex::new("echo fake failure >&2\nexit 7\n");
         let config = LlmConfig::default().with_codex_bin(fake.path_string());
 
-        let err = invoke_codex(&config, "try a candidate", "{}").unwrap_err();
+        let err = invoke_codex(&config, "try a candidate", "{}", generous_timeout()).unwrap_err();
 
         match err {
             CodexError::NonZeroExit { status, stderr } => {
@@ -291,7 +392,7 @@ mod tests {
         let fake = FakeCodex::new("exit 0\n");
         let config = LlmConfig::default().with_codex_bin(fake.path_string());
 
-        let err = invoke_codex(&config, "try a candidate", "{}").unwrap_err();
+        let err = invoke_codex(&config, "try a candidate", "{}", generous_timeout()).unwrap_err();
 
         match err {
             CodexError::Io(message) => assert!(message.contains("reading answer file")),
@@ -305,11 +406,41 @@ mod tests {
         let fake = FakeCodex::new(&envelope_answer_writer_script(r#"{"assembly":"   "}"#));
         let config = LlmConfig::default().with_codex_bin(fake.path_string());
 
-        let err = invoke_codex(&config, "try a candidate", "{}").unwrap_err();
+        let err = invoke_codex(&config, "try a candidate", "{}", generous_timeout()).unwrap_err();
 
         assert!(matches!(
             err,
             CodexError::Envelope(EnvelopeError::EmptyAssembly)
         ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn invoke_codex_times_out_and_reaps_slow_child() {
+        let pid_file = tempfile::NamedTempFile::new().expect("create pid file");
+        let pid_path = pid_file.path().to_path_buf();
+        let fake = FakeCodex::new(&format!(
+            "printf '%s\\n' \"$$\" > {}\nsleep 2\n",
+            shell_single_quote(&pid_path.to_string_lossy())
+        ));
+        let config = LlmConfig::default().with_codex_bin(fake.path_string());
+
+        let started = Instant::now();
+        let err =
+            invoke_codex(&config, "try a candidate", "{}", Duration::from_millis(50)).unwrap_err();
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < Duration::from_millis(900),
+            "invoke_codex should return near its timeout; elapsed {elapsed:?}"
+        );
+        assert!(matches!(err, CodexError::TimedOut { .. }));
+
+        let pid = std::fs::read_to_string(&pid_path)
+            .expect("fake codex should record its pid")
+            .trim()
+            .parse::<u32>()
+            .expect("fake codex pid should be numeric");
+        wait_until_process_gone(pid);
     }
 }

--- a/src/search/llm/codex.rs
+++ b/src/search/llm/codex.rs
@@ -139,6 +139,7 @@ pub fn invoke_codex(
         .arg("-o")
         .arg(answer_path.as_path())
         .arg(prompt)
+        .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::from(stderr_file))
         .spawn()

--- a/src/search/llm/mod.rs
+++ b/src/search/llm/mod.rs
@@ -332,7 +332,9 @@ mod tests {
     use crate::ir::{Operand, Register};
     use crate::search::config::LlmConfig;
     #[cfg(unix)]
-    use crate::search::llm::test_support::{FakeCodex, assembly_answer_writer_script};
+    use crate::search::llm::test_support::{
+        FakeCodex, assembly_answer_writer_script, shell_single_quote, wait_until_process_gone,
+    };
 
     #[cfg(unix)]
     fn cfg_with_fake_codex(fake: &FakeCodex, max_calls: u32) -> SearchConfig {
@@ -345,34 +347,6 @@ mod tests {
                     .with_model("fake-model")
                     .with_codex_bin(fake.path_string()),
             )
-    }
-
-    #[cfg(unix)]
-    fn shell_single_quote(value: &str) -> String {
-        format!("'{}'", value.replace('\'', "'\"'\"'"))
-    }
-
-    #[cfg(unix)]
-    fn process_exists(pid: u32) -> bool {
-        std::process::Command::new("kill")
-            .arg("-0")
-            .arg(pid.to_string())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .map(|status| status.success())
-            .unwrap_or(false)
-    }
-
-    #[cfg(unix)]
-    fn wait_until_process_gone(pid: u32) {
-        for _ in 0..100 {
-            if !process_exists(pid) {
-                return;
-            }
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        panic!("fake codex child {pid} was still alive after search returned");
     }
 
     fn reducible_target() -> Vec<Instruction> {
@@ -635,7 +609,7 @@ mod tests {
             assembly_answer_writer_script("add x0, x1, #1")
         );
         let fake = FakeCodex::new(&script);
-        let config = cfg_with_fake_codex(&fake, 3).with_timeout(Duration::from_millis(50));
+        let config = cfg_with_fake_codex(&fake, 3).with_timeout(Duration::from_millis(300));
         let mut search = LlmSearch::new();
 
         let started = Instant::now();

--- a/src/search/llm/mod.rs
+++ b/src/search/llm/mod.rs
@@ -24,6 +24,8 @@ use self::ledger::UnsupportedMnemonicLedger;
 use self::outcome::{IterationOutcome, classify};
 use self::prompt::{OUTPUT_SCHEMA, build_prompt};
 
+const MIN_SMT_TIMEOUT: Duration = Duration::from_millis(1);
+
 /// LLM-assisted search using the Codex CLI.
 ///
 /// Each call to `search` invokes `codex exec` up to `LlmConfig.max_codex_calls`
@@ -132,17 +134,18 @@ impl SearchAlgorithm<crate::isa::AArch64> for LlmSearch {
         let live_in = compute_live_in_registers(target);
         let prompt = build_prompt(target, &live_in, live_out);
         let timeout = config.timeout.unwrap_or(Duration::from_secs(60));
+        let deadline = started.checked_add(timeout);
         let max_calls = config.llm.max_codex_calls;
 
         let mut found: Option<Vec<Instruction>> = None;
 
         for call_idx in 0..max_calls {
-            if started.elapsed() >= timeout {
+            let Some(remaining) = remaining_until(started, timeout, deadline) else {
                 if config.verbose {
                     eprintln!("llm-search: timeout after {} calls", call_idx);
                 }
                 break;
-            }
+            };
 
             if config.verbose {
                 eprintln!(
@@ -153,7 +156,7 @@ impl SearchAlgorithm<crate::isa::AArch64> for LlmSearch {
                 );
             }
             let call_start = Instant::now();
-            let codex_result = invoke_codex(&config.llm, &prompt, OUTPUT_SCHEMA);
+            let codex_result = invoke_codex(&config.llm, &prompt, OUTPUT_SCHEMA, remaining);
             let codex_elapsed = call_start.elapsed();
             timings.codex_calls += 1;
             timings.codex_time += codex_elapsed;
@@ -186,8 +189,19 @@ impl SearchAlgorithm<crate::isa::AArch64> for LlmSearch {
                 }
             };
 
+            let Some(verify_remaining) =
+                remaining_until(started, timeout, deadline).filter(|d| *d >= MIN_SMT_TIMEOUT)
+            else {
+                if config.verbose {
+                    eprintln!(
+                        "llm-search: timeout before verifying candidate on call {}",
+                        call_idx
+                    );
+                }
+                break;
+            };
             let verify_start = Instant::now();
-            let (outcome, metrics) = classify(target, &raw, live_out);
+            let (outcome, metrics) = classify(target, &raw, live_out, verify_remaining);
             let verify_elapsed = verify_start.elapsed();
             // Only count as a "verification" when the verifier actually ran.
             // Parse-fail and not-shorter short-circuit before the verifier.
@@ -294,6 +308,18 @@ impl SearchAlgorithm<crate::isa::AArch64> for LlmSearch {
     }
 }
 
+fn remaining_until(
+    started: Instant,
+    timeout: Duration,
+    deadline: Option<Instant>,
+) -> Option<Duration> {
+    let remaining = match deadline {
+        Some(deadline) => deadline.saturating_duration_since(Instant::now()),
+        None => timeout.saturating_sub(started.elapsed()),
+    };
+    (!remaining.is_zero()).then_some(remaining)
+}
+
 #[cfg(test)]
 mod tests {
     //! No-Codex unit tests of `LlmSearch::search` flow gates.
@@ -319,6 +345,34 @@ mod tests {
                     .with_model("fake-model")
                     .with_codex_bin(fake.path_string()),
             )
+    }
+
+    #[cfg(unix)]
+    fn shell_single_quote(value: &str) -> String {
+        format!("'{}'", value.replace('\'', "'\"'\"'"))
+    }
+
+    #[cfg(unix)]
+    fn process_exists(pid: u32) -> bool {
+        std::process::Command::new("kill")
+            .arg("-0")
+            .arg(pid.to_string())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
+    }
+
+    #[cfg(unix)]
+    fn wait_until_process_gone(pid: u32) {
+        for _ in 0..100 {
+            if !process_exists(pid) {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("fake codex child {pid} was still alive after search returned");
     }
 
     fn reducible_target() -> Vec<Instruction> {
@@ -568,5 +622,40 @@ mod tests {
         assert!(!result.found_optimization);
         assert_eq!(search.timings().codex_calls, 0);
         assert_eq!(search.statistics().candidates_evaluated, 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn search_timeout_kills_slow_codex_child() {
+        let pid_file = tempfile::NamedTempFile::new().expect("create pid file");
+        let pid_path = pid_file.path().to_path_buf();
+        let script = format!(
+            "printf '%s\\n' \"$$\" > {}\nsleep 2\n{}",
+            shell_single_quote(&pid_path.to_string_lossy()),
+            assembly_answer_writer_script("add x0, x1, #1")
+        );
+        let fake = FakeCodex::new(&script);
+        let config = cfg_with_fake_codex(&fake, 3).with_timeout(Duration::from_millis(50));
+        let mut search = LlmSearch::new();
+
+        let started = Instant::now();
+        let result = search.search(&reducible_target(), &live_out_x0(), &config);
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < Duration::from_millis(900),
+            "search should return near its timeout instead of waiting for fake codex sleep; elapsed {elapsed:?}"
+        );
+        assert!(!result.found_optimization);
+        assert_eq!(search.timings().codex_calls, 1);
+        assert_eq!(search.timings().verifications, 0);
+        assert_eq!(search.statistics().candidates_evaluated, 0);
+
+        let pid = std::fs::read_to_string(&pid_path)
+            .expect("fake codex should record its pid")
+            .trim()
+            .parse::<u32>()
+            .expect("fake codex pid should be numeric");
+        wait_until_process_gone(pid);
     }
 }

--- a/src/search/llm/outcome.rs
+++ b/src/search/llm/outcome.rs
@@ -3,6 +3,8 @@
 //! Given the raw assembly text returned by Codex, classify it as one of:
 //! Success, ParseFail, NotShorter, EquivFail, EquivUnknown.
 
+use std::time::Duration;
+
 use crate::ir::Instruction;
 use crate::parser::{ParseLineError, parse_assembly_string, parse_line};
 use crate::semantics::equivalence::{
@@ -36,6 +38,7 @@ pub fn classify(
     target: &[Instruction],
     raw_asm: &str,
     live_out: &LiveOut,
+    smt_timeout: Duration,
 ) -> (IterationOutcome, Option<EquivalenceMetrics>) {
     let candidate = match parse_assembly_string(raw_asm, "<llm-output>".to_string()) {
         Ok(v) => v,
@@ -64,9 +67,7 @@ pub fn classify(
     // comparison; without `with_flags(true)` here a future relaxation of any
     // upstream flag-liveness early-exit could silently accept flag-divergent
     // rewrites.
-    let cfg = EquivalenceConfig::default()
-        .live_out(live_out.clone())
-        .with_flags(true);
+    let cfg = verification_config(live_out, smt_timeout);
     let (result, metrics) = check_equivalence_with_config_metrics(target, &candidate, &cfg);
     let outcome = match result {
         EquivalenceResult::Equivalent => IterationOutcome::Success(candidate),
@@ -76,6 +77,13 @@ pub fn classify(
         EquivalenceResult::Unknown(_) => IterationOutcome::EquivUnknown,
     };
     (outcome, Some(metrics))
+}
+
+fn verification_config(live_out: &LiveOut, smt_timeout: Duration) -> EquivalenceConfig {
+    EquivalenceConfig::default()
+        .timeout(smt_timeout)
+        .live_out(live_out.clone())
+        .with_flags(true)
 }
 
 /// Walk every line of the raw response and collect mnemonics the parser
@@ -114,6 +122,26 @@ mod tests {
         LiveOut::from_registers(vec![Register::X0])
     }
 
+    fn classify_with_test_timeout(
+        target: &[Instruction],
+        raw_asm: &str,
+        live_out: &LiveOut,
+    ) -> (IterationOutcome, Option<EquivalenceMetrics>) {
+        classify(target, raw_asm, live_out, Duration::from_secs(5))
+    }
+
+    #[test]
+    fn verification_config_uses_supplied_timeout_and_forces_flags_live() {
+        let cfg = verification_config(&live_out_x0(), Duration::from_millis(17));
+
+        assert_eq!(cfg.smt_timeout, Some(Duration::from_millis(17)));
+        assert!(cfg.live_out.contains(Register::X0));
+        assert!(
+            cfg.live_out.flags_live(),
+            "LLM verification must keep NZCV live"
+        );
+    }
+
     #[test]
     fn parse_fail_extracts_unsupported_mnemonic() {
         let target = vec![Instruction::MovImm {
@@ -123,7 +151,8 @@ mod tests {
         // NEON FADD is unsupported by the parser today; use it as the
         // canonical unsupported mnemonic so the test does not fight the
         // memory-ops support added in issue #68.
-        let (outcome, metrics) = classify(&target, "fadd v0.4s, v1.4s, v2.4s", &live_out_x0());
+        let (outcome, metrics) =
+            classify_with_test_timeout(&target, "fadd v0.4s, v1.4s, v2.4s", &live_out_x0());
         assert_eq!(
             outcome,
             IterationOutcome::ParseFail {
@@ -144,7 +173,7 @@ mod tests {
         }];
         let raw =
             "fadd v0.4s, v1.4s, v2.4s\nmov x0, x1\nfmla v3.4s, v4.4s, v5.4s\nld1 {v6.16b}, [x7]\n";
-        let (outcome, metrics) = classify(&target, raw, &live_out_x0());
+        let (outcome, metrics) = classify_with_test_timeout(&target, raw, &live_out_x0());
         let mnemonics = match outcome {
             IterationOutcome::ParseFail {
                 unsupported_mnemonics,
@@ -183,7 +212,8 @@ mod tests {
                 rm: Operand::Immediate(1),
             },
         ];
-        let (outcome, metrics) = classify(&target, "add x0, x1, #1", &live_out_x0());
+        let (outcome, metrics) =
+            classify_with_test_timeout(&target, "add x0, x1, #1", &live_out_x0());
         match outcome {
             IterationOutcome::Success(seq) => {
                 assert_eq!(seq.len(), 1);
@@ -213,7 +243,7 @@ mod tests {
             rd: Register::X0,
             imm: 0,
         }];
-        let (outcome, metrics) = classify(&target, "mov x0, #0", &live_out_x0());
+        let (outcome, metrics) = classify_with_test_timeout(&target, "mov x0, #0", &live_out_x0());
         assert_eq!(outcome, IterationOutcome::NotShorter { candidate_len: 1 });
         assert!(metrics.is_none(), "not-shorter must short-circuit verifier");
     }
@@ -232,7 +262,7 @@ mod tests {
                 rm: Operand::Immediate(1),
             },
         ];
-        let (outcome, metrics) = classify(&target, "mov x0, #5", &live_out_x0());
+        let (outcome, metrics) = classify_with_test_timeout(&target, "mov x0, #5", &live_out_x0());
         assert_eq!(outcome, IterationOutcome::EquivFail);
         let metrics = metrics.expect("equiv-fail still passes through verifier");
         // Fast-path random testing should have refuted this without reaching SMT.

--- a/src/search/llm/test_support.rs
+++ b/src/search/llm/test_support.rs
@@ -113,6 +113,27 @@ printf '%s' {} > "$answer"
     )
 }
 
-fn shell_single_quote(value: &str) -> String {
+pub(crate) fn shell_single_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+fn process_exists(pid: u32) -> bool {
+    std::process::Command::new("kill")
+        .arg("-0")
+        .arg(pid.to_string())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+pub(crate) fn wait_until_process_gone(pid: u32) {
+    for _ in 0..100 {
+        if !process_exists(pid) {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    panic!("fake codex child {pid} was still alive after the call returned");
 }


### PR DESCRIPTION
Summary:
- carry the LLM search deadline into Codex process execution and candidate verification
- replace blocking Codex output collection with a killable child wait and stderr temp-file capture
- add slow fake-Codex regressions for search-level and wrapper-level timeout behavior

Tests:
- cargo fmt --all -- --check
- cargo clippy --all -- -D warnings
- ./build_tests.sh
- cargo test --all
- ./ci_check.sh

Closes #211

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**