### PR TITLE
fix(x86): derive stochastic symbolic registers from target

### DIFF
--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -744,11 +744,11 @@ impl X86Mutator {
         }
     }
 
-    fn pick_register<R: rand::RngExt>(&self, rng: &mut R) -> X86Register {
+    fn pick_register<R: rand::RngExt>(&self, rng: &mut R) -> Option<X86Register> {
         if self.registers.is_empty() {
-            X86Register::RAX
+            None
         } else {
-            self.registers[rng.random_range(0..self.registers.len())]
+            Some(self.registers[rng.random_range(0..self.registers.len())])
         }
     }
 
@@ -760,14 +760,14 @@ impl X86Mutator {
         }
     }
 
-    fn random_instruction<R: rand::RngExt>(&self, rng: &mut R) -> X86Instruction {
+    fn random_instruction<R: rand::RngExt>(&self, rng: &mut R) -> Option<X86Instruction> {
         // Rewritable variants only: 7 reg-reg + 7 reg-imm + CMOVcc.
         let opcode = rng.random_range(0..u32::from(X86_REWRITABLE_OPCODE_COUNT));
-        let rd = self.pick_register(rng);
-        let rs = self.pick_register(rng);
+        let rd = self.pick_register(rng)?;
+        let rs = self.pick_register(rng)?;
         let imm = self.pick_immediate(rng);
         let cond = X86Condition::ALL[rng.random_range(0..X86Condition::ALL.len())];
-        match opcode {
+        Some(match opcode {
             0 => X86Instruction::MovReg { rd, rs },
             1 => X86Instruction::MovImm { rd, imm },
             2 => X86Instruction::AddReg { rd, rs },
@@ -783,7 +783,7 @@ impl X86Mutator {
             12 => X86Instruction::CmpReg { rn: rd, rs },
             13 => X86Instruction::CmpImm { rn: rd, imm },
             _ => X86Instruction::Cmov { rd, rs, cond },
-        }
+        })
     }
 
     fn mutate_operand<R: rand::RngExt>(&self, rng: &mut R, sequence: &mut [X86Instruction]) {
@@ -791,17 +791,38 @@ impl X86Mutator {
             return;
         }
         let idx = rng.random_range(0..sequence.len());
+        if self.registers.is_empty() {
+            match &mut sequence[idx] {
+                X86Instruction::MovImm { imm, .. }
+                | X86Instruction::AddImm { imm, .. }
+                | X86Instruction::SubImm { imm, .. }
+                | X86Instruction::AndImm { imm, .. }
+                | X86Instruction::OrImm { imm, .. }
+                | X86Instruction::XorImm { imm, .. }
+                | X86Instruction::CmpImm { imm, .. } => *imm = self.pick_immediate(rng),
+                X86Instruction::MovReg { .. }
+                | X86Instruction::AddReg { .. }
+                | X86Instruction::SubReg { .. }
+                | X86Instruction::AndReg { .. }
+                | X86Instruction::OrReg { .. }
+                | X86Instruction::XorReg { .. }
+                | X86Instruction::CmpReg { .. }
+                | X86Instruction::Cmov { .. }
+                | X86Instruction::Jcc { .. } => {}
+            }
+            return;
+        }
         match &mut sequence[idx] {
             X86Instruction::MovReg { rd, rs } => {
                 if rng.random_bool(0.5) {
-                    *rd = self.pick_register(rng);
+                    *rd = self.pick_register(rng).expect("register pool is non-empty");
                 } else {
-                    *rs = self.pick_register(rng);
+                    *rs = self.pick_register(rng).expect("register pool is non-empty");
                 }
             }
             X86Instruction::MovImm { rd, imm } => {
                 if rng.random_bool(0.5) {
-                    *rd = self.pick_register(rng);
+                    *rd = self.pick_register(rng).expect("register pool is non-empty");
                 } else {
                     *imm = self.pick_immediate(rng);
                 }
@@ -812,9 +833,9 @@ impl X86Mutator {
             | X86Instruction::OrReg { rd, rs }
             | X86Instruction::XorReg { rd, rs } => {
                 if rng.random_bool(0.5) {
-                    *rd = self.pick_register(rng);
+                    *rd = self.pick_register(rng).expect("register pool is non-empty");
                 } else {
-                    *rs = self.pick_register(rng);
+                    *rs = self.pick_register(rng).expect("register pool is non-empty");
                 }
             }
             X86Instruction::AddImm { rd, imm }
@@ -823,21 +844,21 @@ impl X86Mutator {
             | X86Instruction::OrImm { rd, imm }
             | X86Instruction::XorImm { rd, imm } => {
                 if rng.random_bool(0.5) {
-                    *rd = self.pick_register(rng);
+                    *rd = self.pick_register(rng).expect("register pool is non-empty");
                 } else {
                     *imm = self.pick_immediate(rng);
                 }
             }
             X86Instruction::CmpReg { rn, rs } => {
                 if rng.random_bool(0.5) {
-                    *rn = self.pick_register(rng);
+                    *rn = self.pick_register(rng).expect("register pool is non-empty");
                 } else {
-                    *rs = self.pick_register(rng);
+                    *rs = self.pick_register(rng).expect("register pool is non-empty");
                 }
             }
             X86Instruction::CmpImm { rn, imm } => {
                 if rng.random_bool(0.5) {
-                    *rn = self.pick_register(rng);
+                    *rn = self.pick_register(rng).expect("register pool is non-empty");
                 } else {
                     *imm = self.pick_immediate(rng);
                 }
@@ -846,9 +867,9 @@ impl X86Mutator {
                 // Cond stays fixed — stochastic mutation only swaps registers
                 // for now; cycle 16+ may add condition-bridging.
                 if rng.random_bool(0.5) {
-                    *rd = self.pick_register(rng);
+                    *rd = self.pick_register(rng).expect("register pool is non-empty");
                 } else {
-                    *rs = self.pick_register(rng);
+                    *rs = self.pick_register(rng).expect("register pool is non-empty");
                 }
             }
             // Jcc is a terminator; mutation never reaches it because the
@@ -905,9 +926,9 @@ impl X86Mutator {
                 rn,
                 imm: self.pick_immediate(rng),
             },
-            X86Instruction::CmpImm { rn, .. } => X86Instruction::CmpReg {
-                rn,
-                rs: self.pick_register(rng),
+            X86Instruction::CmpImm { rn, .. } => match self.pick_register(rng) {
+                Some(rs) => X86Instruction::CmpReg { rn, rs },
+                None => current,
             },
             // Cmov has a unique shape (rd, rs, cond) with no opcode-shape
             // siblings; keep it unchanged in the opcode-bridge mutator.
@@ -934,7 +955,9 @@ impl X86Mutator {
             return;
         }
         let idx = rng.random_range(0..sequence.len());
-        sequence[idx] = self.random_instruction(rng);
+        if let Some(instr) = self.random_instruction(rng) {
+            sequence[idx] = instr;
+        }
     }
 }
 
@@ -1867,6 +1890,33 @@ mod tests {
                 rs: X86Register::RBX,
             }]
         );
+    }
+
+    #[test]
+    fn x86_mutator_empty_register_pool_does_not_invent_writable_registers() {
+        use crate::isa::traits::ISAMutator;
+        use crate::search::config::MutationWeights;
+        use rand::SeedableRng;
+        use rand_chacha::ChaCha8Rng;
+
+        let mutator = X86Mutator::new(
+            Vec::new(),
+            vec![0],
+            MutationWeights {
+                operand: 0.0,
+                opcode: 0.0,
+                swap: 0.0,
+                instruction: 1.0,
+            },
+            crate::assembler::x86::X86Mode::Mode64,
+        );
+        let target = vec![X86Instruction::CmpImm {
+            rn: X86Register::R10,
+            imm: 1,
+        }];
+        let mut rng = ChaCha8Rng::seed_from_u64(7);
+
+        assert_eq!(mutator.mutate(&mut rng, &target), target);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -903,7 +903,11 @@ fn build_hybrid_search_config(
         .with_timeout_option(options.timeout)
 }
 
-fn build_x86_stochastic_search_config(width: u32, options: &OptimizationOptions) -> SearchConfig {
+fn build_x86_stochastic_search_config(
+    target: &[isa::x86::X86Instruction],
+    width: u32,
+    options: &OptimizationOptions,
+) -> SearchConfig {
     let stochastic_config = StochasticConfig::default()
         .with_beta(options.beta)
         .with_iterations(options.iterations)
@@ -917,7 +921,26 @@ fn build_x86_stochastic_search_config(width: u32, options: &OptimizationOptions)
         .with_cost_metric(options.cost_metric)
         .with_timeout_option(options.timeout)
         .with_verbose(options.verbose)
-        .with_x86_registers(isa::x86::default_x86_registers())
+        .with_x86_registers(x86_registers_from_target(target))
+        .with_immediates(isa::x86::default_x86_immediates())
+        .with_x86_width(width)
+}
+
+fn build_x86_symbolic_search_config(
+    target: &[isa::x86::X86Instruction],
+    width: u32,
+    options: &OptimizationOptions,
+) -> SearchConfig {
+    let symbolic_config = SymbolicConfig::default()
+        .with_search_mode(options.search_mode)
+        .with_timeout(options.solver_timeout);
+
+    SearchConfig::default()
+        .with_symbolic(symbolic_config)
+        .with_cost_metric(options.cost_metric)
+        .with_timeout_option(options.timeout)
+        .with_verbose(options.verbose)
+        .with_x86_registers(x86_registers_from_target(target))
         .with_immediates(isa::x86::default_x86_immediates())
         .with_x86_width(width)
 }
@@ -1645,15 +1668,13 @@ fn convert_to_x86_ir(
     Ok(out)
 }
 
-/// Candidate register pool for the x86 enumerative path, drawn from the
-/// target's own registers (destinations + sources). The trait refactor
-/// regressed coverage by defaulting to the fixed `default_x86_registers()`
-/// pool, so a window over R10–R15 had no representable rewrite. Mirrors the
-/// pre-refactor `find_shorter_equivalent_x86` derivation. Falls back to the
-/// default pool only for an empty target (no rewrite is possible there).
-fn x86_enumerative_registers_from_target(
-    target: &[isa::x86::X86Instruction],
-) -> Vec<isa::x86::X86Register> {
+/// Candidate register pool for x86 search, drawn from the target's own
+/// registers (destinations + sources). The trait refactor regressed coverage by
+/// defaulting to the fixed `default_x86_registers()` pool, so a window over
+/// R10–R15 had no representable rewrite. Mirrors the pre-refactor
+/// `find_shorter_equivalent_x86` derivation. Falls back to the default pool only
+/// for an empty target (no rewrite is possible there).
+fn x86_registers_from_target(target: &[isa::x86::X86Instruction]) -> Vec<isa::x86::X86Register> {
     let mut pool: Vec<isa::x86::X86Register> = Vec::new();
     let referenced = target.iter().flat_map(|instr| {
         instr
@@ -1697,17 +1718,16 @@ fn x86_enumerative_immediates_from_target(target: &[isa::x86::X86Instruction]) -
     imms
 }
 
-/// Build the search config for the x86 *enumerative* path. Unlike stochastic
-/// search (which samples a broad fixed pool), enumerative search draws
-/// candidates from the target's own registers/immediates and honours --cores
-/// now that the trait-backed search is rayon-parallel.
+/// Build the search config for the x86 *enumerative* path. Like stochastic and
+/// symbolic search, enumerative search draws candidates from the target's own
+/// registers; it additionally derives immediates from the target and honours
+/// --cores now that the trait-backed search is rayon-parallel.
 fn build_x86_enumerative_search_config(
     target: &[isa::x86::X86Instruction],
     width: u32,
     options: &OptimizationOptions,
 ) -> SearchConfig {
-    build_x86_stochastic_search_config(width, options)
-        .with_x86_registers(x86_enumerative_registers_from_target(target))
+    build_x86_stochastic_search_config(target, width, options)
         .with_immediates(x86_enumerative_immediates_from_target(target))
         .with_cores(options.cores)
 }
@@ -1763,7 +1783,7 @@ fn run_x86_stochastic(
     use search::stochastic::StochasticSearch;
     use validation::live_out::x86_live_out_from_target;
 
-    let config = build_x86_stochastic_search_config(width, options);
+    let config = build_x86_stochastic_search_config(target, width, options);
     let live_out = x86_live_out_from_target(target);
 
     // Extract (optimized, statistics) in each width branch separately:
@@ -1806,17 +1826,7 @@ fn run_x86_symbolic(
     use search::symbolic::SymbolicSearch;
     use validation::live_out::x86_live_out_from_target;
 
-    let symbolic_config = search::config::SymbolicConfig::default()
-        .with_search_mode(options.search_mode)
-        .with_timeout(options.solver_timeout);
-    let config = search::config::SearchConfig::default()
-        .with_symbolic(symbolic_config)
-        .with_cost_metric(options.cost_metric)
-        .with_timeout_option(options.timeout)
-        .with_verbose(options.verbose)
-        .with_x86_registers(isa::x86::default_x86_registers())
-        .with_immediates(isa::x86::default_x86_immediates())
-        .with_x86_width(width);
+    let config = build_x86_symbolic_search_config(target, width, options);
     let live_out = x86_live_out_from_target(target);
 
     let (optimized, statistics) = if width == 32 {
@@ -3116,6 +3126,29 @@ mod cli_helper_tests {
         assert_eq!(optimized[0].destination(), Some(X86Register::R10));
     }
 
+    #[test]
+    fn x86_register_pool_is_first_seen_target_derived_and_empty_falls_back() {
+        let target = vec![
+            X86Instruction::MovImm {
+                rd: X86Register::R11,
+                imm: 5,
+            },
+            X86Instruction::AddReg {
+                rd: X86Register::R11,
+                rs: X86Register::R12,
+            },
+        ];
+
+        assert_eq!(
+            x86_registers_from_target(&target),
+            vec![X86Register::R11, X86Register::R12]
+        );
+        assert_eq!(
+            x86_registers_from_target(&[]),
+            isa::x86::default_x86_registers()
+        );
+    }
+
     /// Regression (PR #384): the enumerative config must be target-derived and
     /// must thread `--cores` (the trait-backed search is rayon-parallel and
     /// honours `config.cores`, but the old builder left it `None`).
@@ -3243,7 +3276,17 @@ mod cli_helper_tests {
         opts.cost_metric = CostMetric::CodeSize;
         opts.verbose = true;
 
-        let config = build_x86_stochastic_search_config(32, &opts);
+        let target = vec![
+            X86Instruction::MovImm {
+                rd: X86Register::R11,
+                imm: -1,
+            },
+            X86Instruction::AddReg {
+                rd: X86Register::R11,
+                rs: X86Register::R12,
+            },
+        ];
+        let config = build_x86_stochastic_search_config(&target, 32, &opts);
 
         assert_eq!(
             config.symbolic.solver_timeout,
@@ -3257,7 +3300,11 @@ mod cli_helper_tests {
         assert!(config.verbose);
         assert_eq!(
             config.x86_available_registers,
-            isa::x86::default_x86_registers()
+            vec![X86Register::R11, X86Register::R12]
+        );
+        assert!(
+            !config.x86_available_registers.contains(&X86Register::RAX),
+            "stochastic register pool must be derived from the target"
         );
         assert_eq!(
             config.available_immediates,
@@ -3265,6 +3312,51 @@ mod cli_helper_tests {
         );
         assert_eq!(config.x86_width, 32);
         assert_eq!(config.x86_mode, assembler::x86::X86Mode::Mode32);
+    }
+
+    #[test]
+    fn build_x86_symbolic_search_config_is_target_derived_and_preserves_symbolic_options() {
+        let mut opts = options_for(Algorithm::Symbolic);
+        opts.timeout = Some(Duration::from_millis(23));
+        opts.solver_timeout = Duration::from_millis(29);
+        opts.search_mode = SearchMode::Binary;
+        opts.cost_metric = CostMetric::Latency;
+        opts.verbose = true;
+
+        let target = vec![
+            X86Instruction::MovImm {
+                rd: X86Register::R11,
+                imm: -1,
+            },
+            X86Instruction::AddReg {
+                rd: X86Register::R11,
+                rs: X86Register::R12,
+            },
+        ];
+        let config = build_x86_symbolic_search_config(&target, 64, &opts);
+
+        assert_eq!(
+            config.x86_available_registers,
+            vec![X86Register::R11, X86Register::R12]
+        );
+        assert!(
+            !config.x86_available_registers.contains(&X86Register::RAX),
+            "symbolic register pool must be derived from the target"
+        );
+        assert_eq!(config.symbolic.search_mode, SearchMode::Binary);
+        assert_eq!(
+            config.symbolic.solver_timeout,
+            Some(Duration::from_millis(29))
+        );
+        assert_eq!(config.cost_metric, CostMetric::Latency);
+        assert_eq!(config.timeout, Some(Duration::from_millis(23)));
+        assert!(config.verbose);
+        assert_eq!(
+            config.available_immediates,
+            isa::x86::default_x86_immediates()
+        );
+        assert_eq!(config.x86_width, 64);
+        assert_eq!(config.x86_mode, assembler::x86::X86Mode::Mode64);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1672,8 +1672,11 @@ fn convert_to_x86_ir(
 /// registers (destinations + sources). The trait refactor regressed coverage by
 /// defaulting to the fixed `default_x86_registers()` pool, so a window over
 /// R10–R15 had no representable rewrite. Mirrors the pre-refactor
-/// `find_shorter_equivalent_x86` derivation. Falls back to the default pool only
-/// for an empty target (no rewrite is possible there).
+/// `find_shorter_equivalent_x86` derivation. `RSP` is deliberately excluded:
+/// the single candidate pool can place registers in writable positions, while
+/// live-out tracking does not make source-only stack-pointer references
+/// observable. Falls back to the default pool when no usable non-`RSP`
+/// registers remain.
 fn x86_registers_from_target(target: &[isa::x86::X86Instruction]) -> Vec<isa::x86::X86Register> {
     let mut pool: Vec<isa::x86::X86Register> = Vec::new();
     let referenced = target.iter().flat_map(|instr| {
@@ -1683,6 +1686,9 @@ fn x86_registers_from_target(target: &[isa::x86::X86Instruction]) -> Vec<isa::x8
             .chain(instr.source_registers())
     });
     for reg in referenced {
+        if reg == isa::x86::X86Register::RSP {
+            continue;
+        }
         if !pool.contains(&reg) {
             pool.push(reg);
         }
@@ -3129,13 +3135,17 @@ mod cli_helper_tests {
     #[test]
     fn x86_register_pool_is_first_seen_target_derived_and_empty_falls_back() {
         let target = vec![
+            X86Instruction::CmpReg {
+                rn: X86Register::RSP,
+                rs: X86Register::R11,
+            },
             X86Instruction::MovImm {
                 rd: X86Register::R11,
                 imm: 5,
             },
             X86Instruction::AddReg {
-                rd: X86Register::R11,
-                rs: X86Register::R12,
+                rd: X86Register::R12,
+                rs: X86Register::RSP,
             },
         ];
 
@@ -3145,6 +3155,13 @@ mod cli_helper_tests {
         );
         assert_eq!(
             x86_registers_from_target(&[]),
+            isa::x86::default_x86_registers()
+        );
+        assert_eq!(
+            x86_registers_from_target(&[X86Instruction::CmpImm {
+                rn: X86Register::RSP,
+                imm: 1,
+            }]),
             isa::x86::default_x86_registers()
         );
     }
@@ -3277,13 +3294,17 @@ mod cli_helper_tests {
         opts.verbose = true;
 
         let target = vec![
+            X86Instruction::CmpReg {
+                rn: X86Register::RSP,
+                rs: X86Register::R11,
+            },
             X86Instruction::MovImm {
                 rd: X86Register::R11,
                 imm: -1,
             },
             X86Instruction::AddReg {
-                rd: X86Register::R11,
-                rs: X86Register::R12,
+                rd: X86Register::R12,
+                rs: X86Register::RSP,
             },
         ];
         let config = build_x86_stochastic_search_config(&target, 32, &opts);
@@ -3301,6 +3322,10 @@ mod cli_helper_tests {
         assert_eq!(
             config.x86_available_registers,
             vec![X86Register::R11, X86Register::R12]
+        );
+        assert!(
+            !config.x86_available_registers.contains(&X86Register::RSP),
+            "stochastic register pool must not make RSP writable"
         );
         assert!(
             !config.x86_available_registers.contains(&X86Register::RAX),
@@ -3324,20 +3349,21 @@ mod cli_helper_tests {
         opts.verbose = true;
 
         let target = vec![
-            X86Instruction::MovImm {
-                rd: X86Register::R11,
-                imm: -1,
+            X86Instruction::CmpImm {
+                rn: X86Register::RSP,
+                imm: 1,
             },
-            X86Instruction::AddReg {
-                rd: X86Register::R11,
-                rs: X86Register::R12,
+            X86Instruction::CmpImm {
+                rn: X86Register::R11,
+                imm: -1,
             },
         ];
         let config = build_x86_symbolic_search_config(&target, 64, &opts);
 
-        assert_eq!(
-            config.x86_available_registers,
-            vec![X86Register::R11, X86Register::R12]
+        assert_eq!(config.x86_available_registers, vec![X86Register::R11]);
+        assert!(
+            !config.x86_available_registers.contains(&X86Register::RSP),
+            "symbolic register pool must not make RSP writable"
         );
         assert!(
             !config.x86_available_registers.contains(&X86Register::RAX),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1672,11 +1672,12 @@ fn convert_to_x86_ir(
 /// registers (destinations + sources). The trait refactor regressed coverage by
 /// defaulting to the fixed `default_x86_registers()` pool, so a window over
 /// R10–R15 had no representable rewrite. Mirrors the pre-refactor
-/// `find_shorter_equivalent_x86` derivation. `RSP` is deliberately excluded:
-/// the single candidate pool can place registers in writable positions, while
-/// live-out tracking does not make source-only stack-pointer references
-/// observable. Falls back to the default pool when no usable non-`RSP`
-/// registers remain.
+/// `find_shorter_equivalent_x86` derivation. `RSP` and `RBP` are deliberately
+/// excluded: the single candidate pool can place registers in writable
+/// positions, while live-out tracking does not make source-only stack/frame
+/// references observable. Falls back to the default pool only for an empty
+/// target; a non-empty target with no usable non-stack/frame registers returns
+/// an empty pool so search does not introduce unrelated writable registers.
 fn x86_registers_from_target(target: &[isa::x86::X86Instruction]) -> Vec<isa::x86::X86Register> {
     let mut pool: Vec<isa::x86::X86Register> = Vec::new();
     let referenced = target.iter().flat_map(|instr| {
@@ -1686,14 +1687,14 @@ fn x86_registers_from_target(target: &[isa::x86::X86Instruction]) -> Vec<isa::x8
             .chain(instr.source_registers())
     });
     for reg in referenced {
-        if reg == isa::x86::X86Register::RSP {
+        if matches!(reg, isa::x86::X86Register::RSP | isa::x86::X86Register::RBP) {
             continue;
         }
         if !pool.contains(&reg) {
             pool.push(reg);
         }
     }
-    if pool.is_empty() {
+    if target.is_empty() {
         return isa::x86::default_x86_registers();
     }
     pool
@@ -1790,6 +1791,9 @@ fn run_x86_stochastic(
     use validation::live_out::x86_live_out_from_target;
 
     let config = build_x86_stochastic_search_config(target, width, options);
+    if config.x86_available_registers.is_empty() {
+        return None;
+    }
     let live_out = x86_live_out_from_target(target);
 
     // Extract (optimized, statistics) in each width branch separately:
@@ -3139,6 +3143,10 @@ mod cli_helper_tests {
                 rn: X86Register::RSP,
                 rs: X86Register::R11,
             },
+            X86Instruction::CmpReg {
+                rn: X86Register::RBP,
+                rs: X86Register::R12,
+            },
             X86Instruction::MovImm {
                 rd: X86Register::R11,
                 imm: 5,
@@ -3158,11 +3166,17 @@ mod cli_helper_tests {
             isa::x86::default_x86_registers()
         );
         assert_eq!(
-            x86_registers_from_target(&[X86Instruction::CmpImm {
-                rn: X86Register::RSP,
-                imm: 1,
-            }]),
-            isa::x86::default_x86_registers()
+            x86_registers_from_target(&[
+                X86Instruction::CmpImm {
+                    rn: X86Register::RSP,
+                    imm: 1,
+                },
+                X86Instruction::CmpReg {
+                    rn: X86Register::RBP,
+                    rs: X86Register::RBP,
+                },
+            ]),
+            Vec::<X86Register>::new()
         );
     }
 
@@ -3298,6 +3312,10 @@ mod cli_helper_tests {
                 rn: X86Register::RSP,
                 rs: X86Register::R11,
             },
+            X86Instruction::CmpReg {
+                rn: X86Register::RBP,
+                rs: X86Register::R12,
+            },
             X86Instruction::MovImm {
                 rd: X86Register::R11,
                 imm: -1,
@@ -3328,8 +3346,31 @@ mod cli_helper_tests {
             "stochastic register pool must not make RSP writable"
         );
         assert!(
+            !config.x86_available_registers.contains(&X86Register::RBP),
+            "stochastic register pool must not make RBP writable"
+        );
+        assert!(
             !config.x86_available_registers.contains(&X86Register::RAX),
             "stochastic register pool must be derived from the target"
+        );
+        assert!(
+            build_x86_stochastic_search_config(
+                &[
+                    X86Instruction::CmpImm {
+                        rn: X86Register::RSP,
+                        imm: 1,
+                    },
+                    X86Instruction::CmpReg {
+                        rn: X86Register::RBP,
+                        rs: X86Register::RBP,
+                    },
+                ],
+                64,
+                &opts,
+            )
+            .x86_available_registers
+            .is_empty(),
+            "all stack/frame targets must not fall back to writable defaults"
         );
         assert_eq!(
             config.available_immediates,
@@ -3353,6 +3394,10 @@ mod cli_helper_tests {
                 rn: X86Register::RSP,
                 imm: 1,
             },
+            X86Instruction::CmpReg {
+                rn: X86Register::RBP,
+                rs: X86Register::RBP,
+            },
             X86Instruction::CmpImm {
                 rn: X86Register::R11,
                 imm: -1,
@@ -3366,8 +3411,31 @@ mod cli_helper_tests {
             "symbolic register pool must not make RSP writable"
         );
         assert!(
+            !config.x86_available_registers.contains(&X86Register::RBP),
+            "symbolic register pool must not make RBP writable"
+        );
+        assert!(
             !config.x86_available_registers.contains(&X86Register::RAX),
             "symbolic register pool must be derived from the target"
+        );
+        assert!(
+            build_x86_symbolic_search_config(
+                &[
+                    X86Instruction::CmpImm {
+                        rn: X86Register::RSP,
+                        imm: 1,
+                    },
+                    X86Instruction::CmpReg {
+                        rn: X86Register::RBP,
+                        rs: X86Register::RBP,
+                    },
+                ],
+                64,
+                &opts,
+            )
+            .x86_available_registers
+            .is_empty(),
+            "all stack/frame targets must not fall back to writable defaults"
         );
         assert_eq!(config.symbolic.search_mode, SearchMode::Binary);
         assert_eq!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1668,24 +1668,19 @@ fn convert_to_x86_ir(
     Ok(out)
 }
 
-/// Candidate register pool for x86 search, drawn from the target's own
-/// registers (destinations + sources). The trait refactor regressed coverage by
-/// defaulting to the fixed `default_x86_registers()` pool, so a window over
-/// R10–R15 had no representable rewrite. Mirrors the pre-refactor
-/// `find_shorter_equivalent_x86` derivation. `RSP` and `RBP` are deliberately
-/// excluded: the single candidate pool can place registers in writable
-/// positions, while live-out tracking does not make source-only stack/frame
-/// references observable. Falls back to the default pool only for an empty
-/// target; a non-empty target with no usable non-stack/frame registers returns
-/// an empty pool so search does not introduce unrelated writable registers.
+/// Candidate register pool for x86 search, drawn from the target's original
+/// destinations. The trait refactor regressed coverage by defaulting to the
+/// fixed `default_x86_registers()` pool, so a window over R10-R15 had no
+/// representable rewrite. Source-only registers are deliberately excluded: the
+/// single candidate pool can place registers in writable positions, while
+/// live-out tracking only makes original destinations plus EFLAGS observable.
+/// `RSP` and `RBP` are also excluded so search never synthesizes stack/frame
+/// writes. Falls back to the default pool only for an empty target; a non-empty
+/// target with no usable destinations returns an empty pool so search does not
+/// introduce unrelated writable registers.
 fn x86_registers_from_target(target: &[isa::x86::X86Instruction]) -> Vec<isa::x86::X86Register> {
     let mut pool: Vec<isa::x86::X86Register> = Vec::new();
-    let referenced = target.iter().flat_map(|instr| {
-        instr
-            .destination()
-            .into_iter()
-            .chain(instr.source_registers())
-    });
+    let referenced = target.iter().filter_map(|instr| instr.destination());
     for reg in referenced {
         if matches!(reg, isa::x86::X86Register::RSP | isa::x86::X86Register::RBP) {
             continue;
@@ -3137,7 +3132,7 @@ mod cli_helper_tests {
     }
 
     #[test]
-    fn x86_register_pool_is_first_seen_target_derived_and_empty_falls_back() {
+    fn x86_register_pool_is_destination_derived_and_empty_falls_back() {
         let target = vec![
             X86Instruction::CmpReg {
                 rn: X86Register::RSP,
@@ -3147,9 +3142,9 @@ mod cli_helper_tests {
                 rn: X86Register::RBP,
                 rs: X86Register::R12,
             },
-            X86Instruction::MovImm {
+            X86Instruction::MovReg {
                 rd: X86Register::R11,
-                imm: 5,
+                rs: X86Register::R10,
             },
             X86Instruction::AddReg {
                 rd: X86Register::R12,
@@ -3164,6 +3159,19 @@ mod cli_helper_tests {
         assert_eq!(
             x86_registers_from_target(&[]),
             isa::x86::default_x86_registers()
+        );
+        assert_eq!(
+            x86_registers_from_target(&[
+                X86Instruction::CmpImm {
+                    rn: X86Register::R10,
+                    imm: 1,
+                },
+                X86Instruction::CmpImm {
+                    rn: X86Register::R10,
+                    imm: 1,
+                },
+            ]),
+            Vec::<X86Register>::new()
         );
         assert_eq!(
             x86_registers_from_target(&[
@@ -3193,8 +3201,12 @@ mod cli_helper_tests {
                 imm: -1,
             },
             X86Instruction::AddReg {
-                rd: X86Register::R11,
-                rs: X86Register::R12,
+                rd: X86Register::R12,
+                rs: X86Register::R11,
+            },
+            X86Instruction::CmpImm {
+                rn: X86Register::R10,
+                imm: 1,
             },
         ];
         let config = build_x86_enumerative_search_config(&target, 64, &opts);
@@ -3203,6 +3215,10 @@ mod cli_helper_tests {
             config.x86_available_registers.contains(&X86Register::R11)
                 && config.x86_available_registers.contains(&X86Register::R12),
             "register pool must be derived from the target"
+        );
+        assert!(
+            !config.x86_available_registers.contains(&X86Register::R10),
+            "source-only registers must not become writable candidates"
         );
         assert!(
             !config.x86_available_registers.contains(&X86Register::RAX),
@@ -3316,6 +3332,10 @@ mod cli_helper_tests {
                 rn: X86Register::RBP,
                 rs: X86Register::R12,
             },
+            X86Instruction::CmpImm {
+                rn: X86Register::R10,
+                imm: 1,
+            },
             X86Instruction::MovImm {
                 rd: X86Register::R11,
                 imm: -1,
@@ -3348,6 +3368,10 @@ mod cli_helper_tests {
         assert!(
             !config.x86_available_registers.contains(&X86Register::RBP),
             "stochastic register pool must not make RBP writable"
+        );
+        assert!(
+            !config.x86_available_registers.contains(&X86Register::R10),
+            "stochastic register pool must not make source-only registers writable"
         );
         assert!(
             !config.x86_available_registers.contains(&X86Register::RAX),
@@ -3399,13 +3423,21 @@ mod cli_helper_tests {
                 rs: X86Register::RBP,
             },
             X86Instruction::CmpImm {
+                rn: X86Register::R10,
+                imm: 1,
+            },
+            X86Instruction::CmpImm {
                 rn: X86Register::R11,
                 imm: -1,
+            },
+            X86Instruction::MovImm {
+                rd: X86Register::R12,
+                imm: 0,
             },
         ];
         let config = build_x86_symbolic_search_config(&target, 64, &opts);
 
-        assert_eq!(config.x86_available_registers, vec![X86Register::R11]);
+        assert_eq!(config.x86_available_registers, vec![X86Register::R12]);
         assert!(
             !config.x86_available_registers.contains(&X86Register::RSP),
             "symbolic register pool must not make RSP writable"
@@ -3413,6 +3445,11 @@ mod cli_helper_tests {
         assert!(
             !config.x86_available_registers.contains(&X86Register::RBP),
             "symbolic register pool must not make RBP writable"
+        );
+        assert!(
+            !config.x86_available_registers.contains(&X86Register::R10)
+                && !config.x86_available_registers.contains(&X86Register::R11),
+            "symbolic register pool must not make source-only registers writable"
         );
         assert!(
             !config.x86_available_registers.contains(&X86Register::RAX),

--- a/src/search/stochastic/backend.rs
+++ b/src/search/stochastic/backend.rs
@@ -251,11 +251,9 @@ fn x86_random_sequence<R: RngExt>(
             mode != crate::assembler::x86::X86Mode::Mode32 || matches!(r.index(), Some(i) if i < 8)
         })
         .collect();
-    let regs = if regs.is_empty() {
-        vec![crate::isa::x86::X86Register::RAX]
-    } else {
-        regs
-    };
+    if regs.is_empty() {
+        return Vec::new();
+    }
     let imms = if imms.is_empty() {
         vec![0]
     } else {
@@ -521,6 +519,25 @@ mod tests {
                 &SearchConfig::default().with_x86_width(32),
             ),
             64
+        );
+    }
+
+    #[test]
+    fn x86_random_sequence_respects_empty_register_pool() {
+        use rand::SeedableRng;
+        use rand_chacha::ChaCha8Rng;
+
+        let mut rng = ChaCha8Rng::seed_from_u64(7);
+
+        assert!(
+            x86_random_sequence(
+                &mut rng,
+                3,
+                &[],
+                &[1],
+                crate::assembler::x86::X86Mode::Mode64,
+            )
+            .is_empty()
         );
     }
 


### PR DESCRIPTION
Summary:
- share the x86 target-derived register pool policy across enumerative, stochastic, and symbolic config builders
- filter RSP and RBP out of target-derived x86 search register pools so candidates cannot make stack/frame registers writable
- keep the default register fallback only for empty targets; non-empty all stack/frame targets now produce an empty pool instead of unrelated writable defaults
- make x86 stochastic search skip when the filtered pool is empty, avoiding backend fallback registers
- keep stochastic/symbolic immediate pools at their existing defaults
- add CLI helper regression tests for first-seen register derivation, stack/frame exclusion, empty-pool behavior, and x86 stochastic/symbolic config preservation

Closes #195

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**