### PR TITLE
fix(search): align fast-pass counter semantics

### DIFF
--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -1208,6 +1208,16 @@ mod tests {
         assert_eq!(shared.smt_equivalent.load(Ordering::Relaxed), 1);
     }
 
+    #[test]
+    fn enumerative_verify_does_not_count_fast_refutation_as_fast_pass() {
+        let (is_equivalent, shared) = verify_stats_candidate(VERIFY_STATS_NOT_EQUIVALENT, false);
+
+        assert!(!is_equivalent);
+        assert_eq!(shared.smt_queries.load(Ordering::Relaxed), 0);
+        assert_eq!(shared.candidates_passed_fast.load(Ordering::Relaxed), 0);
+        assert_eq!(shared.smt_equivalent.load(Ordering::Relaxed), 0);
+    }
+
     fn small_config() -> SearchConfig {
         // Tight register/immediate pool so unit tests run fast.
         //

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -269,21 +269,17 @@ where
     shared
         .smt_elapsed_nanos
         .fetch_add(solver_nanos, Ordering::Relaxed);
-    // Count only candidates that actually reached `solver.check()`. The
-    // pre-SMT guard (`flag_writers_diverge && flags_live`) returns
-    // `NotEquivalent` with `metrics.smt_called == false`, and the
-    // fast-path returns `NotEquivalentFast` the same way — using the
-    // metric is both correct and future-proof against new early-return
-    // paths (PR #269 review).
+    // `smt_called` means the candidate survived the fast concrete pre-filter
+    // and reached Z3, regardless of the solver verdict.
     if metrics.smt_called {
         shared.smt_queries.fetch_add(1, Ordering::Relaxed);
+        shared
+            .candidates_passed_fast
+            .fetch_add(1, Ordering::Relaxed);
     }
     match verdict {
         EquivalenceResult::Equivalent => {
             shared.smt_equivalent.fetch_add(1, Ordering::Relaxed);
-            shared
-                .candidates_passed_fast
-                .fetch_add(1, Ordering::Relaxed);
             true
         }
         _ => false,
@@ -637,7 +633,7 @@ where
 mod tests {
     use super::*;
     use std::fmt;
-    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering as AtomicOrdering};
     use std::sync::{Mutex as TestMutex, MutexGuard};
 
     use crate::ir::{Instruction, Operand, Register};
@@ -1042,6 +1038,174 @@ mod tests {
             result.statistics.smt_elapsed,
             result.statistics.elapsed_time
         );
+    }
+
+    #[derive(Clone)]
+    struct VerifyStatsIsa;
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+    struct VerifyStatsInstruction(u8);
+
+    impl fmt::Display for VerifyStatsInstruction {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "verify{}", self.0)
+        }
+    }
+
+    impl InstructionType for VerifyStatsInstruction {
+        type Register = Register;
+        type Operand = Operand;
+
+        fn destination(&self) -> Option<Self::Register> {
+            Some(Register::X0)
+        }
+
+        fn source_registers(&self) -> Vec<Self::Register> {
+            Vec::new()
+        }
+
+        fn opcode_id(&self) -> u8 {
+            self.0
+        }
+
+        fn mnemonic(&self) -> &'static str {
+            "verify"
+        }
+    }
+
+    struct VerifyStatsMutator;
+
+    impl ISAMutator<VerifyStatsInstruction> for VerifyStatsMutator {
+        fn mutate<R: rand::RngExt>(
+            &self,
+            _rng: &mut R,
+            sequence: &[VerifyStatsInstruction],
+        ) -> Vec<VerifyStatsInstruction> {
+            sequence.to_vec()
+        }
+    }
+
+    impl ISA for VerifyStatsIsa {
+        type Register = Register;
+        type Operand = Operand;
+        type Instruction = VerifyStatsInstruction;
+        type Width = U64;
+        type Flags = ();
+        type Mutator = VerifyStatsMutator;
+
+        fn name(&self) -> &'static str {
+            "VerifyStats"
+        }
+
+        fn register_count(&self) -> usize {
+            1
+        }
+
+        fn instruction_size(&self) -> Option<usize> {
+            Some(1)
+        }
+
+        fn general_registers(&self) -> Vec<Self::Register> {
+            vec![Register::X0]
+        }
+
+        fn zero_register(&self) -> Option<Self::Register> {
+            Some(Register::XZR)
+        }
+    }
+
+    const VERIFY_STATS_NOT_EQUIVALENT: usize = 0;
+    const VERIFY_STATS_EQUIVALENT: usize = 1;
+
+    static VERIFY_STATS_TEST_LOCK: TestMutex<()> = TestMutex::new(());
+    static VERIFY_STATS_VERDICT: AtomicUsize = AtomicUsize::new(VERIFY_STATS_NOT_EQUIVALENT);
+    static VERIFY_STATS_SMT_CALLED: AtomicBool = AtomicBool::new(false);
+
+    fn set_verify_stats_result(verdict: usize, smt_called: bool) -> MutexGuard<'static, ()> {
+        let guard = VERIFY_STATS_TEST_LOCK
+            .lock()
+            .expect("verify stats test lock poisoned");
+        VERIFY_STATS_VERDICT.store(verdict, AtomicOrdering::SeqCst);
+        VERIFY_STATS_SMT_CALLED.store(smt_called, AtomicOrdering::SeqCst);
+        guard
+    }
+
+    impl EnumerativeBackend<VerifyStatsIsa> for VerifyStatsIsa {
+        type LiveOut = ();
+
+        fn registers_from_config(_config: &SearchConfig) -> Vec<Register> {
+            vec![Register::X0]
+        }
+
+        fn immediates_from_config(_config: &SearchConfig) -> Vec<i64> {
+            vec![0]
+        }
+
+        fn enumerate_all(_regs: &[Register], _imms: &[i64]) -> Vec<VerifyStatsInstruction> {
+            vec![VerifyStatsInstruction(0)]
+        }
+
+        fn sequence_cost(seq: &[VerifyStatsInstruction], _config: &SearchConfig) -> u64 {
+            seq.len() as u64
+        }
+
+        fn check_equivalence(
+            _target: &[VerifyStatsInstruction],
+            _candidate: &[VerifyStatsInstruction],
+            _live_out: &Self::LiveOut,
+            _smt_timeout: Duration,
+        ) -> (EquivalenceResult, EquivalenceMetrics) {
+            let metrics = EquivalenceMetrics {
+                smt_called: VERIFY_STATS_SMT_CALLED.load(AtomicOrdering::SeqCst),
+                ..EquivalenceMetrics::default()
+            };
+            match VERIFY_STATS_VERDICT.load(AtomicOrdering::SeqCst) {
+                VERIFY_STATS_EQUIVALENT => (EquivalenceResult::Equivalent, metrics),
+                _ => (EquivalenceResult::NotEquivalent, metrics),
+            }
+        }
+    }
+
+    fn verify_stats_candidate(
+        verdict: usize,
+        smt_called: bool,
+    ) -> (bool, SharedState<VerifyStatsIsa>) {
+        let _guard = set_verify_stats_result(verdict, smt_called);
+        let target = [VerifyStatsInstruction(1)];
+        let candidate = [VerifyStatsInstruction(2)];
+        let config = SearchConfig::default().with_timeout_option(None);
+        let shared = SharedState::<VerifyStatsIsa>::new(u64::MAX);
+
+        let is_equivalent = verify_candidate::<VerifyStatsIsa>(
+            &target,
+            &candidate,
+            &(),
+            &config,
+            &shared,
+            Instant::now(),
+        );
+
+        (is_equivalent, shared)
+    }
+
+    #[test]
+    fn enumerative_verify_counts_smt_counterexample_as_fast_pass() {
+        let (is_equivalent, shared) = verify_stats_candidate(VERIFY_STATS_NOT_EQUIVALENT, true);
+
+        assert!(!is_equivalent);
+        assert_eq!(shared.smt_queries.load(Ordering::Relaxed), 1);
+        assert_eq!(shared.candidates_passed_fast.load(Ordering::Relaxed), 1);
+        assert_eq!(shared.smt_equivalent.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn enumerative_verify_counts_smt_equivalence_as_fast_pass_and_equivalent() {
+        let (is_equivalent, shared) = verify_stats_candidate(VERIFY_STATS_EQUIVALENT, true);
+
+        assert!(is_equivalent);
+        assert_eq!(shared.smt_queries.load(Ordering::Relaxed), 1);
+        assert_eq!(shared.candidates_passed_fast.load(Ordering::Relaxed), 1);
+        assert_eq!(shared.smt_equivalent.load(Ordering::Relaxed), 1);
     }
 
     fn small_config() -> SearchConfig {

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -309,22 +309,20 @@ where
             .unwrap_or(Duration::from_secs(5));
         let width = <I as SymbolicBackend<I>>::width(config);
 
-        self.statistics.smt_queries += 1;
-
         let (verdict, metrics) = <I as SymbolicBackend<I>>::check_equivalence(
             target, candidate, live_out, width, timeout,
         );
         self.statistics.smt_elapsed += metrics.smt_elapsed;
+        // `smt_called` means the candidate survived the fast concrete
+        // pre-filter and reached Z3, regardless of the solver verdict.
+        if metrics.smt_called {
+            self.statistics.smt_queries += 1;
+            self.statistics.candidates_passed_fast += 1;
+        }
         match verdict {
             EquivalenceResult::Equivalent => {
                 self.statistics.smt_equivalent += 1;
-                self.statistics.candidates_passed_fast += 1;
                 true
-            }
-            EquivalenceResult::NotEquivalentFast(_) => {
-                // Failed fast test, no SMT query needed
-                self.statistics.smt_queries -= 1; // Don't count as SMT query
-                false
             }
             _ => false,
         }
@@ -415,12 +413,15 @@ mod tests {
     use crate::semantics::EquivalenceMetrics;
     use crate::semantics::cost::CostMetric;
     use crate::semantics::live_out::LiveOut;
+    use crate::semantics::state::ConcreteMachineState;
     use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
     static TEST_EQUIVALENCE_CHECKS: AtomicUsize = AtomicUsize::new(0);
     static TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK: AtomicUsize = AtomicUsize::new(0);
+    static TEST_EQUIVALENCE_FAST_FAILURE: AtomicBool = AtomicBool::new(false);
+    static TEST_EQUIVALENCE_SMT_CALLED: AtomicBool = AtomicBool::new(false);
     static TEST_SEQUENCE_COST_DELAY_MS: AtomicU64 = AtomicU64::new(0);
     static TEST_STOP_FLAG: Mutex<Option<Arc<AtomicBool>>> = Mutex::new(None);
     static SYMBOLIC_INNER_LOOP_TEST_LOCK: Mutex<()> = Mutex::new(());
@@ -444,6 +445,8 @@ mod tests {
     fn reset_symbolic_inner_loop_test_state() {
         TEST_EQUIVALENCE_CHECKS.store(0, Ordering::SeqCst);
         TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK.store(0, Ordering::SeqCst);
+        TEST_EQUIVALENCE_FAST_FAILURE.store(false, Ordering::SeqCst);
+        TEST_EQUIVALENCE_SMT_CALLED.store(false, Ordering::SeqCst);
         TEST_SEQUENCE_COST_DELAY_MS.store(0, Ordering::SeqCst);
         let mut slot = TEST_STOP_FLAG.lock().expect("test stop flag lock poisoned");
         *slot = None;
@@ -629,13 +632,20 @@ mod tests {
                 }
             }
             std::thread::sleep(Duration::from_millis(1));
+            let metrics = EquivalenceMetrics {
+                smt_called: TEST_EQUIVALENCE_SMT_CALLED.load(Ordering::SeqCst),
+                ..EquivalenceMetrics::default()
+            };
             if check_number == TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK.load(Ordering::SeqCst) {
-                return (EquivalenceResult::Equivalent, EquivalenceMetrics::default());
+                return (EquivalenceResult::Equivalent, metrics);
             }
-            (
-                EquivalenceResult::NotEquivalent,
-                EquivalenceMetrics::default(),
-            )
+            if TEST_EQUIVALENCE_FAST_FAILURE.load(Ordering::SeqCst) {
+                return (
+                    EquivalenceResult::NotEquivalentFast(ConcreteMachineState::new_zeroed()),
+                    metrics,
+                );
+            }
+            (EquivalenceResult::NotEquivalent, metrics)
         }
 
         fn width(_config: &SearchConfig) -> u32 {
@@ -1138,6 +1148,48 @@ mod tests {
         }];
 
         assert!(!search.verify_equivalence(&target, &candidate, &live_out, &config));
+    }
+
+    #[test]
+    fn symbolic_verify_counts_smt_counterexample_as_fast_pass() {
+        let _guard = SYMBOLIC_INNER_LOOP_TEST_LOCK
+            .lock()
+            .expect("symbolic inner-loop test lock poisoned");
+        reset_symbolic_inner_loop_test_state();
+        TEST_EQUIVALENCE_SMT_CALLED.store(true, Ordering::SeqCst);
+
+        let mut search: SymbolicSearch<TestIsa> = SymbolicSearch::new();
+        let config = SearchConfig::default().with_timeout_option(None);
+        let target = [TestInstruction(1)];
+        let candidate = [TestInstruction(2)];
+
+        assert!(!search.verify_equivalence(&target, &candidate, &(), &config));
+
+        let stats = search.statistics();
+        assert_eq!(stats.smt_queries, 1);
+        assert_eq!(stats.candidates_passed_fast, 1);
+        assert_eq!(stats.smt_equivalent, 0);
+    }
+
+    #[test]
+    fn symbolic_verify_does_not_count_fast_refutation_as_fast_pass() {
+        let _guard = SYMBOLIC_INNER_LOOP_TEST_LOCK
+            .lock()
+            .expect("symbolic inner-loop test lock poisoned");
+        reset_symbolic_inner_loop_test_state();
+        TEST_EQUIVALENCE_FAST_FAILURE.store(true, Ordering::SeqCst);
+
+        let mut search: SymbolicSearch<TestIsa> = SymbolicSearch::new();
+        let config = SearchConfig::default().with_timeout_option(None);
+        let target = [TestInstruction(1)];
+        let candidate = [TestInstruction(2)];
+
+        assert!(!search.verify_equivalence(&target, &candidate, &(), &config));
+
+        let stats = search.statistics();
+        assert_eq!(stats.smt_queries, 0);
+        assert_eq!(stats.candidates_passed_fast, 0);
+        assert_eq!(stats.smt_equivalent, 0);
     }
 
     // ---- x86 symbolic search (issue #73 Phase D step 7) ----


### PR DESCRIPTION
Summary:
- Count candidates_passed_fast from EquivalenceMetrics::smt_called in symbolic and enumerative verification paths.
- Keep smt_equivalent tied only to proven equivalence.
- Add regression coverage for SMT counterexamples and fast refutations/success cases.

Tests:
- cargo clippy --all -- -D warnings
- ./build_tests.sh
- cargo test --all
- ./ci_check.sh

Closes #156

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**