### PR TITLE
fix(wtm): preserve directory for keep-dir removal

### DIFF
--- a/scripts/test_wtm.py
+++ b/scripts/test_wtm.py
@@ -1,0 +1,258 @@
+"""Tests for scripts/wtm.py.
+
+Run with: python3 -m unittest discover -s scripts -p 'test_wtm.py'
+"""
+
+import contextlib
+import io
+import pathlib
+import subprocess
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import wtm
+
+
+def run_git(repo, *args):
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+class TestRemoveWorktreeKeepDir(unittest.TestCase):
+    def test_keep_dir_does_not_call_git_worktree_remove(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            worktree_path = root / "repo_feature"
+            worktree_path.mkdir()
+            common_dir = root / "repo" / ".git"
+            admin_dir = common_dir / "worktrees" / "repo_feature"
+            admin_dir.mkdir(parents=True)
+            (worktree_path / ".git").write_text(f"gitdir: {admin_dir}\n")
+            calls = []
+
+            def fake_run_command(cmd, **kwargs):
+                calls.append(cmd)
+                if cmd == ["git", "worktree", "list"]:
+                    return SimpleNamespace(stdout=f"{worktree_path} abc123 [feature]\n")
+                if cmd == [
+                    "git",
+                    "-C",
+                    str(worktree_path),
+                    "rev-parse",
+                    "--git-common-dir",
+                ]:
+                    return SimpleNamespace(stdout=f"{common_dir}\n", returncode=0)
+                if cmd == [
+                    "git",
+                    "--git-dir",
+                    str(common_dir),
+                    "worktree",
+                    "prune",
+                    "--expire",
+                    "now",
+                ]:
+                    admin_dir.rmdir()
+                return SimpleNamespace(stdout="", returncode=0)
+
+            with (
+                mock.patch("builtins.input", return_value="yes"),
+                mock.patch.object(wtm, "run_command", side_effect=fake_run_command),
+                contextlib.redirect_stdout(io.StringIO()),
+            ):
+                self.assertTrue(wtm.remove_worktree(str(worktree_path), keep_dir=True))
+
+            self.assertTrue(worktree_path.exists())
+            self.assertFalse(
+                any(call[:3] == ["git", "worktree", "remove"] for call in calls),
+                "keep_dir=True must not invoke destructive git worktree remove",
+            )
+
+    def test_preserve_helper_removes_only_git_pointer_and_prunes_metadata(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            worktree_path = root / "repo_feature"
+            worktree_path.mkdir()
+            common_dir = root / "repo" / ".git"
+            admin_dir = common_dir / "worktrees" / "repo_feature"
+            admin_dir.mkdir(parents=True)
+            (worktree_path / ".git").write_text(f"gitdir: {admin_dir}\n")
+            untracked_file = worktree_path / "notes.txt"
+            untracked_file.write_text("do not delete me\n")
+            calls = []
+
+            def fake_run_command(cmd, **kwargs):
+                calls.append(cmd)
+                if cmd == [
+                    "git",
+                    "-C",
+                    str(worktree_path),
+                    "rev-parse",
+                    "--git-common-dir",
+                ]:
+                    return SimpleNamespace(stdout=f"{common_dir}\n", returncode=0)
+                if cmd == [
+                    "git",
+                    "--git-dir",
+                    str(common_dir),
+                    "worktree",
+                    "prune",
+                    "--expire",
+                    "now",
+                ]:
+                    admin_dir.rmdir()
+                return SimpleNamespace(stdout="", returncode=0)
+
+            with (
+                mock.patch.object(wtm, "run_command", side_effect=fake_run_command),
+                contextlib.redirect_stdout(io.StringIO()),
+            ):
+                self.assertTrue(wtm.unregister_worktree_preserving_dir(worktree_path))
+
+            self.assertFalse((worktree_path / ".git").exists())
+            self.assertEqual(untracked_file.read_text(), "do not delete me\n")
+            self.assertIn(
+                ["git", "--git-dir", str(common_dir), "worktree", "prune", "--expire", "now"],
+                calls,
+            )
+
+    def test_preserve_helper_restores_git_pointer_when_metadata_remains(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            worktree_path = root / "repo_feature"
+            worktree_path.mkdir()
+            common_dir = root / "repo" / ".git"
+            admin_dir = common_dir / "worktrees" / "repo_feature"
+            admin_dir.mkdir(parents=True)
+            git_file = worktree_path / ".git"
+            git_file_contents = f"gitdir: {admin_dir}\n"
+            git_file.write_text(git_file_contents)
+
+            def fake_run_command(cmd, **kwargs):
+                if cmd == [
+                    "git",
+                    "-C",
+                    str(worktree_path),
+                    "rev-parse",
+                    "--git-common-dir",
+                ]:
+                    return SimpleNamespace(stdout=f"{common_dir}\n", returncode=0)
+                return SimpleNamespace(stdout="", returncode=0)
+
+            with (
+                mock.patch.object(wtm, "run_command", side_effect=fake_run_command),
+                contextlib.redirect_stdout(io.StringIO()),
+            ):
+                self.assertFalse(wtm.unregister_worktree_preserving_dir(worktree_path))
+
+            self.assertEqual(git_file.read_text(), git_file_contents)
+            self.assertTrue(admin_dir.exists())
+
+    def test_preserve_helper_dry_run_does_not_remove_git_pointer(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            worktree_path = root / "repo_feature"
+            worktree_path.mkdir()
+            common_dir = root / "repo" / ".git"
+            admin_dir = common_dir / "worktrees" / "repo_feature"
+            admin_dir.mkdir(parents=True)
+            git_file = worktree_path / ".git"
+            git_file.write_text(f"gitdir: {admin_dir}\n")
+            calls = []
+
+            def fake_run_command(cmd, **kwargs):
+                calls.append(cmd)
+                if cmd == [
+                    "git",
+                    "-C",
+                    str(worktree_path),
+                    "rev-parse",
+                    "--git-common-dir",
+                ]:
+                    return SimpleNamespace(stdout=f"{common_dir}\n", returncode=0)
+                return SimpleNamespace(stdout="", returncode=0)
+
+            with (
+                mock.patch.object(wtm, "DRY_RUN", True),
+                mock.patch.object(wtm, "run_command", side_effect=fake_run_command),
+                contextlib.redirect_stdout(io.StringIO()),
+            ):
+                self.assertTrue(wtm.unregister_worktree_preserving_dir(worktree_path))
+
+            self.assertTrue(git_file.exists())
+            self.assertNotIn(
+                ["git", "--git-dir", str(common_dir), "worktree", "prune", "--expire", "now"],
+                calls,
+            )
+
+    def test_keep_dir_preserves_modified_and_untracked_files_in_real_repo(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            repo = root / "repo"
+            worktree_path = root / "repo_feature"
+            repo.mkdir()
+
+            run_git(repo, "init")
+            (repo / "tracked.txt").write_text("base\n")
+            run_git(repo, "add", "tracked.txt")
+            run_git(
+                repo,
+                "-c",
+                "user.name=wtm test",
+                "-c",
+                "user.email=wtm@example.com",
+                "commit",
+                "-m",
+                "initial",
+            )
+            run_git(repo, "worktree", "add", "-b", "feature", str(worktree_path))
+
+            (worktree_path / "tracked.txt").write_text("modified\n")
+            untracked_file = worktree_path / "untracked.txt"
+            untracked_file.write_text("draft\n")
+
+            with (
+                contextlib.chdir(repo),
+                mock.patch("builtins.input", return_value="yes"),
+                contextlib.redirect_stdout(io.StringIO()),
+            ):
+                self.assertTrue(wtm.remove_worktree(str(worktree_path), keep_dir=True))
+
+            self.assertTrue(worktree_path.exists())
+            self.assertEqual((worktree_path / "tracked.txt").read_text(), "modified\n")
+            self.assertEqual(untracked_file.read_text(), "draft\n")
+            worktree_list = run_git(repo, "worktree", "list", "--porcelain").stdout
+            self.assertNotIn(str(worktree_path), worktree_list)
+
+    def test_remove_without_keep_dir_uses_git_remove_and_rmtree_fallback(self):
+        with tempfile.TemporaryDirectory() as d:
+            worktree_path = pathlib.Path(d) / "repo_feature"
+            worktree_path.mkdir()
+            calls = []
+
+            def fake_run_command(cmd, **kwargs):
+                calls.append(cmd)
+                if cmd == ["git", "worktree", "list"]:
+                    return SimpleNamespace(stdout=f"{worktree_path} abc123 [feature]\n")
+                return SimpleNamespace(stdout="", returncode=0)
+
+            with (
+                mock.patch("builtins.input", return_value="yes"),
+                mock.patch.object(wtm, "run_command", side_effect=fake_run_command),
+                mock.patch.object(wtm.shutil, "rmtree") as rmtree,
+                contextlib.redirect_stdout(io.StringIO()),
+            ):
+                self.assertTrue(wtm.remove_worktree(str(worktree_path), keep_dir=False))
+
+            self.assertIn(["git", "worktree", "remove", str(worktree_path)], calls)
+            rmtree.assert_called_once_with(worktree_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_wtm.py
+++ b/scripts/test_wtm.py
@@ -154,6 +154,45 @@ class TestRemoveWorktreeKeepDir(unittest.TestCase):
             self.assertEqual(git_file.read_text(), git_file_contents)
             self.assertTrue(admin_dir.exists())
 
+    def test_preserve_helper_reports_lost_pointer_when_rollback_write_fails(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            worktree_path = root / "repo_feature"
+            worktree_path.mkdir()
+            common_dir = root / "repo" / ".git"
+            admin_dir = common_dir / "worktrees" / "repo_feature"
+            admin_dir.mkdir(parents=True)
+            git_file = worktree_path / ".git"
+            git_file_contents = f"gitdir: {admin_dir}\n"
+            git_file.write_text(git_file_contents)
+
+            def fake_run_command(cmd, **kwargs):
+                if cmd == [
+                    "git",
+                    "-C",
+                    str(worktree_path),
+                    "rev-parse",
+                    "--git-common-dir",
+                ]:
+                    return SimpleNamespace(stdout=f"{common_dir}\n", returncode=0)
+                # prune leaves admin_dir in place, forcing the rollback path
+                return SimpleNamespace(stdout="", returncode=0)
+
+            output = io.StringIO()
+            with (
+                mock.patch.object(wtm, "run_command", side_effect=fake_run_command),
+                mock.patch.object(
+                    pathlib.Path, "write_text", side_effect=OSError("disk full")
+                ),
+                contextlib.redirect_stdout(output),
+            ):
+                self.assertFalse(wtm.unregister_worktree_preserving_dir(worktree_path))
+
+            # The rollback could not recreate the pointer; the user must be told distinctly.
+            self.assertFalse(git_file.exists())
+            self.assertIn("Rollback also failed", output.getvalue())
+            self.assertIn(".git pointer lost", output.getvalue())
+
     def test_preserve_helper_dry_run_does_not_remove_git_pointer(self):
         with tempfile.TemporaryDirectory() as d:
             root = pathlib.Path(d)

--- a/scripts/wtm.py
+++ b/scripts/wtm.py
@@ -286,6 +286,81 @@ def find_worktree_by_branch(branch_name):
         return None
 
 
+def resolve_gitfile_path(path_text, worktree_path):
+    """Resolve a path from a linked-worktree .git file."""
+    path = Path(path_text)
+    if not path.is_absolute():
+        path = worktree_path / path
+    return path.resolve()
+
+
+def unregister_worktree_preserving_dir(worktree_path):
+    """Unregister a linked worktree without deleting its directory contents."""
+    git_file = worktree_path / ".git"
+    if not git_file.exists():
+        print(f"❌ Cannot preserve '{worktree_path}': missing .git pointer")
+        return False
+    if git_file.is_dir():
+        print(
+            f"❌ Cannot preserve '{worktree_path}': "
+            ".git is a directory, not a worktree pointer"
+        )
+        return False
+
+    try:
+        common_dir_result = run_command(
+            ["git", "-C", str(worktree_path), "rev-parse", "--git-common-dir"],
+            capture_output=True,
+        )
+        common_dir_text = common_dir_result.stdout.strip()
+        if not common_dir_text:
+            print(f"❌ Cannot preserve '{worktree_path}': git common dir is empty")
+            return False
+        common_dir = resolve_gitfile_path(common_dir_text, worktree_path)
+
+        git_file_contents = git_file.read_text()
+        git_file_lines = git_file_contents.splitlines()
+        first_line = git_file_lines[0] if git_file_lines else ""
+        if not first_line.startswith("gitdir:"):
+            print(f"❌ Cannot preserve '{worktree_path}': malformed .git pointer")
+            return False
+
+        admin_gitdir = resolve_gitfile_path(first_line[len("gitdir:") :].strip(), worktree_path)
+        worktrees_dir = (common_dir / "worktrees").resolve()
+        if not admin_gitdir.is_relative_to(worktrees_dir):
+            print(
+                f"❌ Cannot preserve '{worktree_path}': worktree metadata is outside {worktrees_dir}"
+            )
+            return False
+        if not admin_gitdir.exists():
+            print(f"❌ Cannot preserve '{worktree_path}': worktree metadata is missing")
+            return False
+
+        if DRY_RUN:
+            print("   [DRY RUN] Would remove .git pointer and prune worktree metadata")
+            return True
+
+        git_file.unlink()
+        try:
+            run_command(
+                ["git", "--git-dir", str(common_dir), "worktree", "prune", "--expire", "now"]
+            )
+            if admin_gitdir.exists():
+                raise RuntimeError(f"worktree metadata still exists: {admin_gitdir}")
+            if not worktree_path.exists():
+                raise RuntimeError(f"preserved directory disappeared: {worktree_path}")
+        except Exception as e:
+            if not git_file.exists():
+                git_file.write_text(git_file_contents)
+            print(f"❌ Failed to unregister worktree while preserving directory: {e}")
+            return False
+
+        return True
+    except (OSError, subprocess.CalledProcessError) as e:
+        print(f"❌ Failed to unregister worktree while preserving directory: {e}")
+        return False
+
+
 def remove_worktree(branch_or_path, keep_dir=False):
     """Remove a worktree and optionally its directory."""
     worktree_path = None
@@ -344,7 +419,8 @@ def remove_worktree(branch_or_path, keep_dir=False):
     try:
         print("🗑️  Removing worktree registration...")
         if keep_dir:
-            run_command(["git", "worktree", "remove", "--force", str(worktree_path)])
+            if not unregister_worktree_preserving_dir(worktree_path):
+                return False
         else:
             # Remove worktree and let git handle directory removal
             run_command(["git", "worktree", "remove", str(worktree_path)])

--- a/scripts/wtm.py
+++ b/scripts/wtm.py
@@ -351,7 +351,13 @@ def unregister_worktree_preserving_dir(worktree_path):
                 raise RuntimeError(f"preserved directory disappeared: {worktree_path}")
         except Exception as e:
             if not git_file.exists():
-                git_file.write_text(git_file_contents)
+                try:
+                    git_file.write_text(git_file_contents)
+                except OSError as rollback_error:
+                    print(
+                        f"❌ Rollback also failed — .git pointer lost for "
+                        f"'{worktree_path}': {rollback_error}"
+                    )
             print(f"❌ Failed to unregister worktree while preserving directory: {e}")
             return False
 


### PR DESCRIPTION
Summary:
- avoid git worktree remove in the --keep-dir path so Git cannot delete the preserved directory
- unregister linked worktrees by removing only the .git pointer, pruning metadata from the common Git dir, and rolling back if cleanup is incomplete
- add mocked and real-temp-repo regression tests for modified/untracked file preservation, dry-run behavior, rollback, and the default destructive path

Choice recorded: implemented the non-destructive unregister flow rather than rejecting --keep-dir, because the existing CLI help promises registration-only removal. The preserved directory is intentionally no longer a Git worktree after success.

Tests:
- python3 -m unittest discover -s scripts -p 'test_*.py'
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test --all
- ./test_all.sh
- ./ci_check.sh

Note: scripts/full_test.sh is not present in this repo; ./test_all.sh is the local equivalent and is also invoked by ./ci_check.sh.

Closes #202

**Merge with `gh pr merge --merge` (merge commit, not squash).**