### PR TITLE
fix(cli): print arch mismatches with CLI names

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,19 @@ pub enum CliArch {
     X86_32,
 }
 
+impl std::fmt::Display for CliArch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = match self {
+            CliArch::Aarch64 => "aarch64",
+            CliArch::Riscv32 => "riscv32",
+            CliArch::Riscv64 => "riscv64",
+            CliArch::X86_64 => "x86-64",
+            CliArch::X86_32 => "x86-32",
+        };
+        f.write_str(value)
+    }
+}
+
 impl From<DetectedArch> for CliArch {
     fn from(arch: DetectedArch) -> Self {
         // DetectedArch is the closed set of architectures ElfPatcher accepts
@@ -289,7 +302,7 @@ fn analyze_elf_binary(
         && expected_arch != detected_arch
     {
         return Err(format!(
-            "{ARCH_MISMATCH_PREFIX} --arch {expected_arch:?} but ELF reports {detected_arch:?}"
+            "{ARCH_MISMATCH_PREFIX} --arch {expected_arch} but ELF reports {detected_arch}"
         )
         .into());
     }
@@ -2174,9 +2187,7 @@ fn main() {
             let cli_arch = match arch {
                 Some(a) if a == detected_arch => a,
                 Some(a) => {
-                    eprintln!(
-                        "{ARCH_MISMATCH_PREFIX} --arch {a:?} but ELF reports {detected_arch:?}"
-                    );
+                    eprintln!("{ARCH_MISMATCH_PREFIX} --arch {a} but ELF reports {detected_arch}");
                     std::process::exit(1);
                 }
                 None => detected_arch,
@@ -2381,6 +2392,15 @@ mod cli_helper_tests {
     }
 
     #[test]
+    fn cli_arch_display_uses_cli_value_names() {
+        assert_eq!(CliArch::Aarch64.to_string(), "aarch64");
+        assert_eq!(CliArch::Riscv32.to_string(), "riscv32");
+        assert_eq!(CliArch::Riscv64.to_string(), "riscv64");
+        assert_eq!(CliArch::X86_64.to_string(), "x86-64");
+        assert_eq!(CliArch::X86_32.to_string(), "x86-32");
+    }
+
+    #[test]
     fn analyze_elf_binary_rejects_expected_arch_mismatch() {
         let elf_bytes = build_minimal_elf64(&[0xc3], 0x1000, elf::abi::EM_X86_64);
         let input = TempFile::new_bytes("s11-disasm-mismatch", "elf", &elf_bytes);
@@ -2388,9 +2408,14 @@ mod cli_helper_tests {
         let err = analyze_elf_binary(input.path(), true, Some(CliArch::Aarch64))
             .expect_err("mismatched expected architecture should fail");
 
+        let message = err.to_string();
+        assert_eq!(
+            message,
+            "Architecture mismatch: --arch aarch64 but ELF reports x86-64"
+        );
         assert!(
-            err.to_string().starts_with(ARCH_MISMATCH_PREFIX),
-            "diagnostic should report architecture mismatch: {err}"
+            !message.contains("Aarch64") && !message.contains("X86_64"),
+            "diagnostic should use CLI architecture names: {message}"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,14 +120,14 @@ pub enum CliArch {
 
 impl std::fmt::Display for CliArch {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let value = match self {
-            CliArch::Aarch64 => "aarch64",
-            CliArch::Riscv32 => "riscv32",
-            CliArch::Riscv64 => "riscv64",
-            CliArch::X86_64 => "x86-64",
-            CliArch::X86_32 => "x86-32",
-        };
-        f.write_str(value)
+        // Derive the spelling from clap's ValueEnum so Display and the CLI
+        // parser stay in sync by construction (a `#[value(name = ...)]` or a
+        // renamed variant can never drift the error message from what users type).
+        f.write_str(
+            self.to_possible_value()
+                .expect("CliArch has no skipped variants")
+                .get_name(),
+        )
     }
 }
 

--- a/tests/integration/disasm_test.rs
+++ b/tests/integration/disasm_test.rs
@@ -219,8 +219,14 @@ fn test_disasm_arch_mismatch_rejected_before_disassembly() {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.trim_start().starts_with("Architecture mismatch:"),
+        stderr
+            .trim_start()
+            .starts_with("Architecture mismatch: --arch x86-64 but ELF reports aarch64"),
         "Should reject mismatched architecture without starting disassembly, stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("X86_64") && !stderr.contains("Aarch64"),
+        "Should report CLI architecture names, stderr: {stderr}"
     );
 
     let stdout = String::from_utf8_lossy(&output.stdout);

--- a/tests/integration/opt_test.rs
+++ b/tests/integration/opt_test.rs
@@ -79,7 +79,7 @@ fn executable_window(path: &Path, width: u64) -> (u64, u64) {
     panic!("no executable window of {width} bytes found in {path:?}");
 }
 
-fn assert_opt_arch_mismatch_rejected(test_elf: &Path, arch: &str) {
+fn assert_opt_arch_mismatch_rejected(test_elf: &Path, arch: &str, detected_arch: &str) {
     let output = Command::new(get_binary_path())
         .arg("opt")
         .arg(test_elf)
@@ -98,9 +98,16 @@ fn assert_opt_arch_mismatch_rejected(test_elf: &Path, arch: &str) {
     );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
+    let expected_message =
+        format!("Architecture mismatch: --arch {arch} but ELF reports {detected_arch}");
     assert!(
-        stderr.contains("Architecture mismatch"),
-        "Should reject before optimization, stderr: {}",
+        stderr.trim_start().starts_with(&expected_message),
+        "Should reject before optimization with CLI architecture names, stderr: {}",
+        stderr
+    );
+    assert!(
+        !stderr.contains("Aarch64") && !stderr.contains("X86_64") && !stderr.contains("X86_32"),
+        "Should not report Rust architecture variant names, stderr: {}",
         stderr
     );
 
@@ -310,15 +317,15 @@ fn test_opt_rejects_arch_mismatch_before_optimization() {
         .join("simple_debug");
 
     check_test_binary(&aarch64_elf);
-    assert_opt_arch_mismatch_rejected(&aarch64_elf, "x86-64");
-    assert_opt_arch_mismatch_rejected(&aarch64_elf, "x86-32");
+    assert_opt_arch_mismatch_rejected(&aarch64_elf, "x86-64", "aarch64");
+    assert_opt_arch_mismatch_rejected(&aarch64_elf, "x86-32", "aarch64");
 
     let x86_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("binaries")
         .join("x86_64")
         .join("simple_debug");
     if x86_elf.exists() {
-        assert_opt_arch_mismatch_rejected(&x86_elf, "aarch64");
+        assert_opt_arch_mismatch_rejected(&x86_elf, "aarch64", "x86-64");
     } else {
         eprintln!(
             "Skipping x86-64 opt mismatch case: {:?} not present (run build_tests.sh)",


### PR DESCRIPTION
Summary:
- Implement Display for CliArch using the clap value spellings.
- Use Display in disasm and opt architecture mismatch diagnostics.
- Pin mismatch stderr tests against CLI names instead of Rust enum variants.

Tests:
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test --all
- ./ci_check.sh
- scripts/full_test.sh (not present in this repo)

Closes #206

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**