### PR TITLE
fix(symbolic): enforce configured cost and window bounds

### DIFF
--- a/src/search/config.rs
+++ b/src/search/config.rs
@@ -214,9 +214,16 @@ impl std::str::FromStr for SearchMode {
 /// Configuration for symbolic (SMT) search
 #[derive(Debug, Clone)]
 pub struct SymbolicConfig {
-    /// Maximum window size for synthesis
+    /// Maximum number of synthesized non-terminator instructions to consider.
+    ///
+    /// A value of 0 disables candidate search. If the target ends in a fixed
+    /// terminator, that terminator is appended after synthesis and does not
+    /// count against this window.
     pub window_size: usize,
-    /// Initial cost bound (None = use target cost)
+    /// Exclusive initial cost bound.
+    ///
+    /// Candidate sequences must be strictly cheaper than this bound and the
+    /// original target cost. `None` uses the original target cost.
     pub cost_bound: Option<u64>,
     /// Search mode (linear or binary)
     pub search_mode: SearchMode,

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -2,8 +2,8 @@
 //!
 //! This module implements symbolic search using Z3 for equivalence verification.
 //! The approach uses linear cost search: try sequences of length 1, 2, ... up to
-//! the target length - 1, and for each length, enumerate candidates and verify
-//! equivalence with SMT.
+//! the configured synthesis window and target length - 1, and for each length,
+//! enumerate candidates and verify equivalence with SMT.
 //!
 //! Note: Full symbolic synthesis with symbolic opcodes/operands is very complex.
 //! This implementation uses a hybrid approach: enumerate concrete candidates
@@ -60,7 +60,8 @@ impl<I> SymbolicSearch<I>
 where
     I: ISA + SymbolicBackend<I>,
 {
-    /// Linear cost search: try each length from 1 to target length - 1
+    /// Linear cost search: try each length from 1 to the configured window,
+    /// capped at target length - 1.
     fn linear_search(
         &mut self,
         target: &[I::Instruction],
@@ -76,10 +77,17 @@ where
         let original_cost =
             <I as SymbolicBackend<I>>::sequence_cost(target, &config.cost_metric, width);
         let mut best_solution: Option<Vec<I::Instruction>> = None;
-        let mut best_cost = original_cost;
+        let mut best_cost = config
+            .symbolic
+            .cost_bound
+            .map_or(original_cost, |bound| bound.min(original_cost));
 
         // Try sequences of increasing length
-        for length in 1..target.len() {
+        let max_len = target
+            .len()
+            .saturating_sub(1)
+            .min(config.symbolic.window_size);
+        for length in 1..=max_len {
             if config.verbose {
                 println!("Searching for equivalent sequences of length {}...", length);
             }
@@ -717,6 +725,78 @@ mod tests {
             // The instruction should write to X0
             assert_eq!(optimized[0].destination(), Some(Register::X0));
         }
+    }
+
+    #[test]
+    fn symbolic_cost_bound_zero_prevents_known_mov_add_rewrite() {
+        let mut search: SymbolicSearch<AArch64> = SymbolicSearch::new();
+
+        let config = SearchConfig::default()
+            .with_symbolic(
+                SymbolicConfig::default()
+                    .with_cost_bound(0)
+                    .with_timeout(Duration::from_secs(10)),
+            )
+            .with_registers(vec![Register::X0, Register::X1, Register::X2])
+            .with_immediates(vec![-1, 0, 1, 2]);
+
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
+        let target = mov_add_sequence();
+
+        let result = search.search(&target, &live_out, &config);
+
+        assert!(!result.found_optimization);
+        assert!(result.optimized_sequence.is_none());
+        assert_eq!(result.statistics.best_cost_found, 2);
+        assert_eq!(result.statistics.candidates_evaluated, 0);
+        assert_eq!(result.statistics.smt_queries, 0);
+    }
+
+    #[test]
+    fn symbolic_cost_bound_is_exclusive() {
+        let _guard = SYMBOLIC_INNER_LOOP_TEST_LOCK
+            .lock()
+            .expect("symbolic inner-loop test lock poisoned");
+        reset_symbolic_inner_loop_test_state();
+        TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK.store(1, Ordering::SeqCst);
+
+        let mut search: SymbolicSearch<TestIsa> = SymbolicSearch::new();
+        let config =
+            SearchConfig::default().with_symbolic(SymbolicConfig::default().with_cost_bound(1));
+        let target = [TestInstruction(100), TestInstruction(101)];
+
+        let result = search.search(&target, &(), &config);
+
+        assert!(!result.found_optimization);
+        assert!(result.optimized_sequence.is_none());
+        assert_eq!(result.statistics.best_cost_found, 2);
+        assert_eq!(TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst), 0);
+        assert_eq!(result.statistics.candidates_evaluated, 0);
+    }
+
+    #[test]
+    fn symbolic_window_size_caps_candidate_lengths() {
+        let _guard = SYMBOLIC_INNER_LOOP_TEST_LOCK
+            .lock()
+            .expect("symbolic inner-loop test lock poisoned");
+        reset_symbolic_inner_loop_test_state();
+
+        let mut search: SymbolicSearch<TestIsa> = SymbolicSearch::new();
+        let config =
+            SearchConfig::default().with_symbolic(SymbolicConfig::default().with_window_size(1));
+        let target = [
+            TestInstruction(100),
+            TestInstruction(101),
+            TestInstruction(102),
+            TestInstruction(103),
+        ];
+
+        let result = search.search(&target, &(), &config);
+
+        assert!(!result.found_optimization);
+        assert!(result.optimized_sequence.is_none());
+        assert_eq!(TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst), 1);
+        assert_eq!(result.statistics.candidates_evaluated, 1);
     }
 
     #[test]

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -745,6 +745,10 @@ mod tests {
 
         let result = search.search(&target, &live_out, &config);
 
+        // cost_bound = 0 caps best_cost at min(0, original) = 0. Every AArch64
+        // instruction has cost >= 1, so no candidate sequence can be strictly
+        // cheaper than 0; the length loop prunes every candidate before any SMT
+        // query runs (candidates_evaluated == 0, smt_queries == 0).
         assert!(!result.found_optimization);
         assert!(result.optimized_sequence.is_none());
         assert_eq!(result.statistics.best_cost_found, 2);


### PR DESCRIPTION
Summary:
- enforce SymbolicConfig::cost_bound as an exclusive pruning threshold capped by original target cost
- cap symbolic linear search lengths by SymbolicConfig::window_size
- document the config semantics and add regressions for cost/window enforcement

Tests:
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test --all
- ./ci_check.sh
- scripts/full_test.sh: not present in this s11 workspace

Closes #222

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**