### PR TITLE
fix(ir): display xzr extended operands as wzr

### DIFF
--- a/src/ir/types.rs
+++ b/src/ir/types.rs
@@ -667,6 +667,19 @@ mod tests {
     }
 
     #[test]
+    fn test_extended_register_display_x_form_xzr() {
+        assert_eq!(
+            Operand::ExtendedRegister {
+                reg: Register::XZR,
+                kind: ExtendKind::Uxtx,
+                shift: 0,
+            }
+            .to_string(),
+            "xzr, uxtx #0"
+        );
+    }
+
+    #[test]
     fn test_condition_invert_pairs() {
         let pairs = [
             (Condition::EQ, Condition::NE),

--- a/src/ir/types.rs
+++ b/src/ir/types.rs
@@ -313,11 +313,14 @@ impl fmt::Display for Operand {
                 let inner = if kind.is_x_form() {
                     format!("{}", reg)
                 } else {
-                    match reg.index() {
-                        Some(idx) => format!("w{}", idx),
-                        // SP has no W-form; fall back to its canonical name
-                        // (encodability gates SP out before any caller sees it).
-                        None => format!("{}", reg),
+                    match reg {
+                        Register::XZR => "wzr".to_string(),
+                        reg => match reg.index() {
+                            Some(idx) => format!("w{}", idx),
+                            // SP has no W-form; fall back to its canonical name
+                            // (encodability gates SP out before any caller sees it).
+                            None => format!("{}", reg),
+                        },
                     }
                 };
                 write!(f, "{}, {} #{}", inner, kind, shift)
@@ -647,6 +650,19 @@ mod tests {
                 }
             ),
             "x1, uxtx #4"
+        );
+    }
+
+    #[test]
+    fn test_extended_register_display_w_form_xzr() {
+        assert_eq!(
+            Operand::ExtendedRegister {
+                reg: Register::XZR,
+                kind: ExtendKind::Uxtb,
+                shift: 0,
+            }
+            .to_string(),
+            "wzr, uxtb #0"
         );
     }
 


### PR DESCRIPTION
Summary:
- Print non-X-form extended-register XZR operands as canonical wzr instead of invalid w31.
- Add a focused regression test for Operand::ExtendedRegister display.

Validation:
- cargo fmt --all
- cargo clippy --all -- -D warnings
- ./build_tests.sh
- cargo test --all (initially failed before fixtures were built; passed after ./build_tests.sh)
- ./ci_check.sh
- scripts/full_test.sh was requested by the run contract but is not present in this s11 repository.

Closes #227

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**