### PR TITLE
fix(stochastic): reject SMT-refuted MCMC proposals

### DIFF
--- a/src/search/stochastic/backend.rs
+++ b/src/search/stochastic/backend.rs
@@ -42,6 +42,18 @@ pub trait StochasticBackend<I: ISA>: Sized {
     /// immediates, mutation weights, mode-where-applicable).
     fn make_mutator(config: &SearchConfig) -> I::Mutator;
 
+    /// Registers to randomize during stochastic fast validation.
+    ///
+    /// Defaults to the configured mutation pool. Backends may extend this
+    /// when a target can read registers outside that pool.
+    fn validation_registers(
+        configured: &[I::Register],
+        _target: &[I::Instruction],
+        _live_out: &Self::LiveOut,
+    ) -> Vec<I::Register> {
+        configured.to_vec()
+    }
+
     /// Random test inputs covering `regs`. The width parameter sizes
     /// x86 register-write masking; AArch64 ignores it.
     fn make_test_inputs(regs: &[I::Register], width: u32, count: usize) -> Vec<Self::State>;
@@ -52,19 +64,9 @@ pub trait StochasticBackend<I: ISA>: Sized {
     fn apply_sequence(state: Self::State, seq: &[I::Instruction]) -> Self::State;
     /// Compare two states over the live-out contract.
     ///
-    /// **Invariant:** any `flags_live` bit on the mask is honoured by the
-    /// equivalence-checking layer (`semantics::equivalence`), not here.
-    /// Implementations of this trait method **must** treat the comparison as
-    /// register-only — the pre-SMT flag-writer guard upstream rejects
-    /// flag-divergent candidates before stochastic comparison runs. If the
-    /// call path is ever rearranged so stochastic compares states without
-    /// passing through the upstream guard, this invariant has to be revisited.
-    ///
-    /// This is the only known caller in the codebase that intentionally
-    /// passes `flags_live=false` to `concrete::states_equal_for_live_out`
-    /// regardless of the mask's `flags_live()` value; the cleanup tracked in
-    /// issue #282 must preserve this exception (e.g. by routing every other
-    /// caller through `live_out.flags_live()` and leaving this one explicit).
+    /// Implementations should honor the observable state carried by their
+    /// live-out mask. Stochastic validation is a prefilter; the full
+    /// equivalence checker remains authoritative.
     fn states_equal(s1: &Self::State, s2: &Self::State, live_out: &Self::LiveOut) -> bool;
 
     /// Sum the cost of every instruction in the sequence.
@@ -129,6 +131,30 @@ impl StochasticBackend<crate::isa::AArch64> for crate::isa::AArch64 {
         )
     }
 
+    fn validation_registers(
+        configured: &[crate::ir::Register],
+        target: &[crate::ir::Instruction],
+        live_out: &Self::LiveOut,
+    ) -> Vec<crate::ir::Register> {
+        let mut regs = std::collections::HashSet::new();
+
+        for reg in configured {
+            regs.insert(*reg);
+        }
+        for reg in live_out.iter() {
+            regs.insert(*reg);
+        }
+        for instr in target {
+            for reg in instr.source_registers() {
+                regs.insert(reg);
+            }
+        }
+
+        let mut regs: Vec<_> = regs.into_iter().collect();
+        regs.sort_by_key(|reg| reg.index().unwrap_or(u8::MAX));
+        regs
+    }
+
     fn make_test_inputs(
         regs: &[crate::ir::Register],
         _width: u32,
@@ -152,14 +178,16 @@ impl StochasticBackend<crate::isa::AArch64> for crate::isa::AArch64 {
     }
 
     fn states_equal(s1: &Self::State, s2: &Self::State, live_out: &Self::LiveOut) -> bool {
-        // Pass `flags_live = false` deliberately: the over-approximate
-        // flag-writer guard in equivalence.rs pre-SMT already handles flag
-        // divergence before stochastic comparison is reached. The mask may
-        // carry `flags_live = true`, but it is honoured upstream, not here.
-        // `memory_live = false` here for the same reason — equivalence.rs
-        // force-enables it via `touches_memory()` before calling this path.
-        // Mirrors mcmc.rs's existing call site.
-        crate::semantics::concrete::states_equal_for_live_out(s1, s2, live_out, false, false)
+        // `memory_live = false`: stochastic validation is still a register /
+        // flag prefilter. The full equivalence path force-enables memory
+        // comparison when either sequence touches memory.
+        crate::semantics::concrete::states_equal_for_live_out(
+            s1,
+            s2,
+            live_out,
+            live_out.flags_live(),
+            false,
+        )
     }
 
     fn sequence_cost(seq: &[crate::ir::Instruction], metric: &CostMetric, _width: u32) -> u64 {
@@ -462,6 +490,7 @@ mod tests {
     use crate::isa::x86::{X86Instruction, X86Register};
     use crate::semantics::live_out::LiveOut;
     use crate::semantics::live_out::X86LiveOut;
+    use crate::semantics::state::{ConcreteMachineState, ConditionFlags};
 
     #[test]
     fn aarch64_backend_honors_flags_dead_live_out_mask() {
@@ -500,6 +529,52 @@ mod tests {
         );
 
         assert_ne!(flags_live_result.0, EquivalenceResult::Equivalent);
+    }
+
+    #[test]
+    fn aarch64_validation_registers_include_target_sources() {
+        let target = vec![
+            Instruction::MovReg {
+                rd: Register::X0,
+                rn: Register::X1,
+            },
+            Instruction::Add {
+                rd: Register::X0,
+                rn: Register::X0,
+                rm: Operand::Immediate(1),
+            },
+        ];
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
+
+        let regs = <AArch64 as StochasticBackend<AArch64>>::validation_registers(
+            &[Register::X0],
+            &target,
+            &live_out,
+        );
+
+        assert_eq!(regs, vec![Register::X0, Register::X1]);
+    }
+
+    #[test]
+    fn aarch64_fast_state_comparison_honors_flags_live() {
+        let state1 = ConcreteMachineState::new_zeroed();
+        let mut state2 = ConcreteMachineState::new_zeroed();
+        state2.set_flags(ConditionFlags {
+            n: true,
+            z: false,
+            c: false,
+            v: false,
+        });
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
+
+        assert!(<AArch64 as StochasticBackend<AArch64>>::states_equal(
+            &state1, &state2, &live_out,
+        ));
+        assert!(!<AArch64 as StochasticBackend<AArch64>>::states_equal(
+            &state1,
+            &state2,
+            &live_out.with_flags(true),
+        ));
     }
 
     #[test]

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -273,6 +273,9 @@ where
                     EquivalenceResult::NotEquivalent | EquivalenceResult::NotEquivalentFast(_) => {
                         smt_refuted = true;
                     }
+                    // SMT timeout / inconclusive: we cannot prove the proposal
+                    // incorrect, so leave the Metropolis decision below intact
+                    // rather than vetoing exploration.
                     EquivalenceResult::Unknown(_) => {}
                 }
             }

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -544,7 +544,7 @@ mod tests {
         static RECORDED_SMT_TIMEOUT_MS: std::cell::Cell<Option<u64>> =
             const { std::cell::Cell::new(None) };
         static PROBE_EQUIVALENCE_RESULT: std::cell::RefCell<EquivalenceResult> =
-            std::cell::RefCell::new(EquivalenceResult::Equivalent);
+            const { std::cell::RefCell::new(EquivalenceResult::Equivalent) };
     }
 
     impl StochasticBackend<TimeoutProbeIsa> for TimeoutProbeIsa {

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -102,14 +102,16 @@ where
         // Pull register / immediate pools out of the config via the backend.
         let regs = <I as StochasticBackend<I>>::registers_from_config(config);
         let imms = <I as StochasticBackend<I>>::immediates_from_config(config);
+        let validation_regs =
+            <I as StochasticBackend<I>>::validation_registers(&regs, target, live_out);
 
         // Generate test cases: random + edge.
         let test_inputs = <I as StochasticBackend<I>>::make_test_inputs(
-            &regs,
+            &validation_regs,
             width,
             config.stochastic.test_count,
         );
-        let edge_inputs = <I as StochasticBackend<I>>::make_edge_inputs(&regs, width);
+        let edge_inputs = <I as StochasticBackend<I>>::make_edge_inputs(&validation_regs, width);
 
         // Precompute target outputs.
         let target_outputs: Vec<_> = test_inputs
@@ -240,6 +242,7 @@ where
 
             self.statistics.candidates_passed_fast += 1;
 
+            let mut smt_refuted = false;
             if proposal_cost < best_cost {
                 self.statistics.smt_queries += 1;
 
@@ -251,21 +254,31 @@ where
                     smt_timeout,
                 );
                 self.statistics.smt_elapsed += metrics.smt_elapsed;
-                if let EquivalenceResult::Equivalent = verdict {
-                    self.statistics.smt_equivalent += 1;
-                    self.statistics.improvements_found += 1;
+                match verdict {
+                    EquivalenceResult::Equivalent => {
+                        self.statistics.smt_equivalent += 1;
+                        self.statistics.improvements_found += 1;
 
-                    best_equivalent = Some(proposal.clone());
-                    best_cost = proposal_cost;
-                    self.statistics.best_cost_found = best_cost;
+                        best_equivalent = Some(proposal.clone());
+                        best_cost = proposal_cost;
+                        self.statistics.best_cost_found = best_cost;
 
-                    if config.verbose {
-                        println!(
-                            "Found improvement at iteration {}: cost {} -> {}",
-                            iteration, original_cost, best_cost
-                        );
+                        if config.verbose {
+                            println!(
+                                "Found improvement at iteration {}: cost {} -> {}",
+                                iteration, original_cost, best_cost
+                            );
+                        }
                     }
+                    EquivalenceResult::NotEquivalent | EquivalenceResult::NotEquivalentFast(_) => {
+                        smt_refuted = true;
+                    }
+                    EquivalenceResult::Unknown(_) => {}
                 }
+            }
+
+            if smt_refuted {
+                continue;
             }
 
             if acceptance.accept(&mut rng, current_cost, proposal_cost) {
@@ -316,7 +329,13 @@ pub fn evaluate_with_tests(
 
     for (input, target_output) in test_inputs.iter().zip(target_outputs.iter()) {
         let proposal_output = apply_sequence_concrete(input.clone(), proposal);
-        if !states_equal_for_live_out(&proposal_output, target_output, live_out, false, false) {
+        if !states_equal_for_live_out(
+            &proposal_output,
+            target_output,
+            live_out,
+            live_out.flags_live(),
+            false,
+        ) {
             passes_all = false;
             break;
         }
@@ -524,6 +543,8 @@ mod tests {
     std::thread_local! {
         static RECORDED_SMT_TIMEOUT_MS: std::cell::Cell<Option<u64>> =
             const { std::cell::Cell::new(None) };
+        static PROBE_EQUIVALENCE_RESULT: std::cell::RefCell<EquivalenceResult> =
+            std::cell::RefCell::new(EquivalenceResult::Equivalent);
     }
 
     impl StochasticBackend<TimeoutProbeIsa> for TimeoutProbeIsa {
@@ -582,10 +603,8 @@ mod tests {
             timeout: Duration,
         ) -> (EquivalenceResult, crate::semantics::EquivalenceMetrics) {
             RECORDED_SMT_TIMEOUT_MS.with(|recorded| recorded.set(Some(timeout.as_millis() as u64)));
-            (
-                EquivalenceResult::Equivalent,
-                crate::semantics::EquivalenceMetrics::default(),
-            )
+            let verdict = PROBE_EQUIVALENCE_RESULT.with(|result| result.borrow().clone());
+            (verdict, crate::semantics::EquivalenceMetrics::default())
         }
 
         fn random_sequence<R: rand::RngExt>(
@@ -605,6 +624,8 @@ mod tests {
 
     fn run_timeout_probe_search(symbolic_config: SymbolicConfig) -> Option<u64> {
         RECORDED_SMT_TIMEOUT_MS.with(|recorded| recorded.set(None));
+        PROBE_EQUIVALENCE_RESULT
+            .with(|result| *result.borrow_mut() = EquivalenceResult::Equivalent);
 
         let mut search: StochasticSearch<TimeoutProbeIsa> = StochasticSearch::new();
         let config = SearchConfig::default()
@@ -620,6 +641,30 @@ mod tests {
         assert_eq!(result.statistics.smt_queries, 1);
 
         RECORDED_SMT_TIMEOUT_MS.with(|recorded| recorded.get())
+    }
+
+    #[test]
+    fn stochastic_search_does_not_accept_smt_refuted_cheaper_proposal() {
+        RECORDED_SMT_TIMEOUT_MS.with(|recorded| recorded.set(None));
+        PROBE_EQUIVALENCE_RESULT
+            .with(|result| *result.borrow_mut() = EquivalenceResult::NotEquivalent);
+
+        let mut search: StochasticSearch<TimeoutProbeIsa> = StochasticSearch::new();
+        let config = SearchConfig::default().with_stochastic(
+            StochasticConfig::default()
+                .with_iterations(1)
+                .with_test_count(0)
+                .with_seed(1),
+        );
+        let target = [TimeoutProbeInstruction(1), TimeoutProbeInstruction(2)];
+
+        let result = search.search(&target, &(), &config);
+
+        assert_eq!(result.statistics.smt_queries, 1);
+        assert_eq!(result.statistics.smt_equivalent, 0);
+        assert_eq!(result.statistics.improvements_found, 0);
+        assert!(!result.found_optimization);
+        assert_eq!(result.statistics.accepted_proposals, 0);
     }
 
     #[test]

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -784,9 +784,8 @@ pub fn apply_sequence_concrete(
 /// must be structurally equal (prune-on-write guarantees structural ==
 /// semantic equality).
 ///
-/// TODO(#282): The explicit `flags_live` parameter is now redundant with
-/// `live_out.flags_live()` for every caller except the stochastic backend
-/// (which deliberately passes `false`). Tracked for cleanup in issue #282.
+/// TODO(#282): Production callers now pass `live_out.flags_live()` here; the
+/// explicit parameter is retained for direct tests and future cleanup.
 pub fn states_equal_for_live_out(
     state1: &ConcreteMachineState,
     state2: &ConcreteMachineState,
@@ -812,8 +811,8 @@ pub fn states_equal_for_live_out(
 /// Flag divergence (when `flags_live` is set) is reported via the `XZR`
 /// sentinel since the function signature is register-typed.
 ///
-/// TODO(#282): see `states_equal_for_live_out` — the same `flags_live`
-/// redundancy applies here. Tracked for follow-up cleanup.
+/// TODO(#282): see `states_equal_for_live_out` — the same explicit
+/// `flags_live` parameter remains for follow-up cleanup.
 pub fn find_first_difference(
     state1: &ConcreteMachineState,
     state2: &ConcreteMachineState,

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -1234,9 +1234,8 @@ pub fn states_not_equal(state1: &MachineState, state2: &MachineState) -> z3::ast
 /// registers, optionally including the NZCV flag bits and the whole memory
 /// image (see ADR-0007).
 ///
-/// TODO(#282): The explicit `flags_live` parameter duplicates
-/// `live_out.flags_live()` for every non-stochastic caller. Tracked for
-/// cleanup in issue #282.
+/// TODO(#282): Production equivalence callers pass `live_out.flags_live()`
+/// here; the explicit parameter remains for direct tests and future cleanup.
 pub fn states_not_equal_for_live_out(
     state1: &MachineState,
     state2: &MachineState,


### PR DESCRIPTION
Summary
- Skip Metropolis acceptance after SMT or fast equivalence refutes a cheaper stochastic proposal.
- Broaden AArch64 stochastic validation inputs to include live-out and target source registers.
- Honor live-out flag liveness in AArch64 stochastic concrete comparisons.

Tests
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test search::stochastic::mcmc
- cargo test search::stochastic::backend
- cargo test semantics::equivalence
- ./build_tests.sh
- cargo test --all
- ./ci_check.sh

Closes #232

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**