### PR TITLE
fix(search): count SMT-reaching candidates as fast passes

### DIFF
--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -271,7 +271,11 @@ where
         .fetch_add(solver_nanos, Ordering::Relaxed);
     // Count only candidates that actually reached `solver.check()`. The same
     // metric also marks candidates that passed fast concrete validation,
-    // including ones later disproved by SMT.
+    // including ones later disproved by SMT. `smt_called` is the right guard
+    // because every early return that never reaches the solver leaves it
+    // false: the pre-SMT guard (`flag_writers_diverge && flags_live`) returns
+    // `NotEquivalent` and the fast-path returns `NotEquivalentFast`, neither of
+    // which should count as a fast pass (PR #269 review).
     if metrics.smt_called {
         shared.smt_queries.fetch_add(1, Ordering::Relaxed);
         shared
@@ -1354,6 +1358,39 @@ mod tests {
         assert_eq!(shared.smt_queries.load(Ordering::Relaxed), 1);
         assert_eq!(shared.candidates_passed_fast.load(Ordering::Relaxed), 1);
         assert_eq!(shared.smt_equivalent.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn verify_candidate_counts_smt_equivalence() {
+        // Commutativity: `add x0, x1, x2` == `add x0, x2, x1`. The candidate
+        // passes fast concrete validation and Z3 then proves equivalence, so
+        // the success path must record one SMT query, one fast pass, and one
+        // equivalence.
+        let target = vec![Instruction::Add {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        }];
+        let candidate = vec![Instruction::Add {
+            rd: Register::X0,
+            rn: Register::X2,
+            rm: Operand::Register(Register::X1),
+        }];
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
+        let config = SearchConfig::default().with_timeout_option(None);
+        let shared = SharedState::<AArch64>::new(u64::MAX);
+
+        assert!(verify_candidate::<AArch64>(
+            &target,
+            &candidate,
+            &live_out,
+            &config,
+            &shared,
+            std::time::Instant::now(),
+        ));
+        assert_eq!(shared.smt_queries.load(Ordering::Relaxed), 1);
+        assert_eq!(shared.candidates_passed_fast.load(Ordering::Relaxed), 1);
+        assert_eq!(shared.smt_equivalent.load(Ordering::Relaxed), 1);
     }
 
     #[test]

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -269,21 +269,18 @@ where
     shared
         .smt_elapsed_nanos
         .fetch_add(solver_nanos, Ordering::Relaxed);
-    // Count only candidates that actually reached `solver.check()`. The
-    // pre-SMT guard (`flag_writers_diverge && flags_live`) returns
-    // `NotEquivalent` with `metrics.smt_called == false`, and the
-    // fast-path returns `NotEquivalentFast` the same way — using the
-    // metric is both correct and future-proof against new early-return
-    // paths (PR #269 review).
+    // Count only candidates that actually reached `solver.check()`. The same
+    // metric also marks candidates that passed fast concrete validation,
+    // including ones later disproved by SMT.
     if metrics.smt_called {
         shared.smt_queries.fetch_add(1, Ordering::Relaxed);
+        shared
+            .candidates_passed_fast
+            .fetch_add(1, Ordering::Relaxed);
     }
     match verdict {
         EquivalenceResult::Equivalent => {
             shared.smt_equivalent.fetch_add(1, Ordering::Relaxed);
-            shared
-                .candidates_passed_fast
-                .fetch_add(1, Ordering::Relaxed);
             true
         }
         _ => false,
@@ -1302,6 +1299,61 @@ mod tests {
         assert!(shared.stop.load(Ordering::Relaxed));
         assert_eq!(shared.smt_queries.load(Ordering::Relaxed), 0);
         assert_eq!(shared.smt_elapsed_nanos.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn verify_candidate_does_not_count_pre_smt_guard_as_smt() {
+        let target = vec![Instruction::Cmp {
+            rn: Register::X0,
+            rm: Operand::Immediate(0),
+        }];
+        let candidate = vec![Instruction::MovImm {
+            rd: Register::X1,
+            imm: 7,
+        }];
+        let live_out = LiveOut::from_registers(vec![]).with_flags(true);
+        let config = SearchConfig::default().with_timeout_option(None);
+        let shared = SharedState::<AArch64>::new(u64::MAX);
+
+        assert!(!verify_candidate::<AArch64>(
+            &target,
+            &candidate,
+            &live_out,
+            &config,
+            &shared,
+            std::time::Instant::now(),
+        ));
+        assert_eq!(shared.smt_queries.load(Ordering::Relaxed), 0);
+        assert_eq!(shared.candidates_passed_fast.load(Ordering::Relaxed), 0);
+        assert_eq!(shared.smt_elapsed_nanos.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn verify_candidate_counts_smt_refutation_as_fast_pass() {
+        let target = vec![Instruction::Add {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Immediate(1),
+        }];
+        let candidate = vec![Instruction::MovImm {
+            rd: Register::X0,
+            imm: 1,
+        }];
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
+        let config = SearchConfig::default().with_timeout_option(None);
+        let shared = SharedState::<AArch64>::new(u64::MAX);
+
+        assert!(!verify_candidate::<AArch64>(
+            &target,
+            &candidate,
+            &live_out,
+            &config,
+            &shared,
+            std::time::Instant::now(),
+        ));
+        assert_eq!(shared.smt_queries.load(Ordering::Relaxed), 1);
+        assert_eq!(shared.candidates_passed_fast.load(Ordering::Relaxed), 1);
+        assert_eq!(shared.smt_equivalent.load(Ordering::Relaxed), 0);
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- Count enumerative `candidates_passed_fast` from `metrics.smt_called` so SMT refutations are included without counting pre-SMT rejections.
- Add regressions for pre-SMT flag-writer rejection and fast-pass-then-SMT-fail statistics.

Verification:
- cargo fmt --all
- cargo clippy --all -- -D warnings
- ./build_tests.sh
- cargo test --all (after building test binaries; the first run failed only because binaries/ fixtures were missing)
- ./ci_check.sh
- `scripts/full_test.sh` was requested by the generic run contract but does not exist in this s11 repository. The repo-specific `./ci_check.sh` ran `./test_all.sh`.

Closes #238

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**