### PR TITLE
fix(search): enumerate longer candidate products

### DIFF
--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -68,7 +68,7 @@ impl<I: ISA> SharedState<I> {
         // sequentially (worse first, better second) and then have the worse
         // thread acquire the mutex last and clobber the better candidate.
         //
-        // Ordering: the cost-prune fast path in `run_length_one`/`_two` loads
+        // Ordering: the cost-prune fast path in the length runners loads
         // `best_cost` with `Ordering::Acquire`. The store below is `Release`
         // (not `Relaxed`) so those loads observe the new value — the mutex
         // unlock would publish the mutex-protected `best`, but the atomic is
@@ -424,6 +424,49 @@ fn candidate_solver_timeout(config: &SearchConfig, start: Instant) -> Option<Dur
     candidate_solver_timeout_for_elapsed(config, start.elapsed())
 }
 
+fn evaluate_candidate<I>(
+    target: &[I::Instruction],
+    live_out: &<I as EnumerativeBackend<I>>::LiveOut,
+    config: &SearchConfig,
+    mut candidate: Vec<I::Instruction>,
+    terminator: Option<I::Instruction>,
+    shared: &SharedState<I>,
+    start: Instant,
+) where
+    I: ISA + EnumerativeBackend<I>,
+{
+    if let Some(t) = terminator {
+        candidate.push(t);
+    }
+    let candidate_cost = <I as EnumerativeBackend<I>>::sequence_cost(&candidate, config);
+    if candidate_cost >= shared.best_cost.load(Ordering::Acquire) {
+        return;
+    }
+    shared.candidates_evaluated.fetch_add(1, Ordering::Relaxed);
+    if verify_candidate::<I>(target, &candidate, live_out, config, shared, start) {
+        shared.record_improvement(candidate, candidate_cost);
+    }
+}
+
+fn minimum_generated_instruction_cost<I>(
+    config: &SearchConfig,
+    all_instructions: &[I::Instruction],
+) -> Option<u64>
+where
+    I: ISA + EnumerativeBackend<I>,
+{
+    all_instructions
+        .iter()
+        .map(|instr| <I as EnumerativeBackend<I>>::sequence_cost(&[*instr], config))
+        .min()
+}
+
+fn length_cost_lower_bound(length: usize, min_instruction_cost: u64, terminator_cost: u64) -> u64 {
+    min_instruction_cost
+        .saturating_mul(length as u64)
+        .saturating_add(terminator_cost)
+}
+
 fn run_length_one<I>(
     target: &[I::Instruction],
     live_out: &<I as EnumerativeBackend<I>>::LiveOut,
@@ -443,18 +486,15 @@ fn run_length_one<I>(
             shared.stop.store(true, Ordering::Relaxed);
             return;
         }
-        let mut candidate = vec![*instr];
-        if let Some(t) = terminator {
-            candidate.push(t);
-        }
-        let candidate_cost = <I as EnumerativeBackend<I>>::sequence_cost(&candidate, config);
-        if candidate_cost >= shared.best_cost.load(Ordering::Acquire) {
-            return;
-        }
-        shared.candidates_evaluated.fetch_add(1, Ordering::Relaxed);
-        if verify_candidate::<I>(target, &candidate, live_out, config, shared, start) {
-            shared.record_improvement(candidate, candidate_cost);
-        }
+        evaluate_candidate::<I>(
+            target,
+            live_out,
+            config,
+            vec![*instr],
+            terminator,
+            shared,
+            start,
+        );
     });
 }
 
@@ -489,19 +529,97 @@ fn run_length_two<I>(
                 shared.stop.store(true, Ordering::Relaxed);
                 return;
             }
-            let mut candidate = vec![*instr1, *instr2];
-            if let Some(t) = terminator {
-                candidate.push(t);
-            }
-            let candidate_cost = <I as EnumerativeBackend<I>>::sequence_cost(&candidate, config);
-            if candidate_cost >= shared.best_cost.load(Ordering::Acquire) {
-                continue;
-            }
-            shared.candidates_evaluated.fetch_add(1, Ordering::Relaxed);
-            if verify_candidate::<I>(target, &candidate, live_out, config, shared, start) {
-                shared.record_improvement(candidate, candidate_cost);
-            }
+            evaluate_candidate::<I>(
+                target,
+                live_out,
+                config,
+                vec![*instr1, *instr2],
+                terminator,
+                shared,
+                start,
+            );
         }
+    });
+}
+
+struct ProductContext<'a, I>
+where
+    I: ISA + EnumerativeBackend<I>,
+{
+    length: usize,
+    target: &'a [I::Instruction],
+    live_out: &'a <I as EnumerativeBackend<I>>::LiveOut,
+    config: &'a SearchConfig,
+    all_instructions: &'a [I::Instruction],
+    terminator: Option<I::Instruction>,
+    shared: &'a SharedState<I>,
+    start: Instant,
+}
+
+impl<I> ProductContext<'_, I>
+where
+    I: ISA + EnumerativeBackend<I>,
+{
+    fn stop_if_timed_out(&self) -> bool {
+        if self.shared.stop.load(Ordering::Relaxed) {
+            return true;
+        }
+        if EnumerativeSearch::<I>::timed_out(self.start, self.config.timeout) {
+            self.shared.stop.store(true, Ordering::Relaxed);
+            return true;
+        }
+        false
+    }
+
+    fn enumerate_suffix(&self, candidate: &mut Vec<I::Instruction>) {
+        if self.stop_if_timed_out() {
+            return;
+        }
+
+        if candidate.len() == self.length {
+            if self.stop_if_timed_out() {
+                return;
+            }
+            evaluate_candidate::<I>(
+                self.target,
+                self.live_out,
+                self.config,
+                candidate.clone(),
+                self.terminator,
+                self.shared,
+                self.start,
+            );
+            return;
+        }
+
+        for instr in self.all_instructions {
+            if self.stop_if_timed_out() {
+                return;
+            }
+            candidate.push(*instr);
+            self.enumerate_suffix(candidate);
+            candidate.pop();
+        }
+    }
+}
+
+fn run_length_product<I>(context: ProductContext<'_, I>)
+where
+    I: ISA + EnumerativeBackend<I>,
+{
+    if context.length == 0 {
+        return;
+    }
+
+    context.all_instructions.par_iter().for_each(|instr| {
+        if context.stop_if_timed_out() {
+            return;
+        }
+
+        let mut candidate =
+            Vec::with_capacity(context.length + usize::from(context.terminator.is_some()));
+        candidate.push(*instr);
+        context.enumerate_suffix(&mut candidate);
     });
 }
 
@@ -543,15 +661,28 @@ where
         let all_instructions: &[I::Instruction] = &all_instructions_owned;
         let terminator = <I as EnumerativeBackend<I>>::target_terminator(target);
         let shared = SharedState::new(original_cost);
+        let min_instruction_cost =
+            minimum_generated_instruction_cost::<I>(config, all_instructions);
+        let terminator_cost = terminator
+            .map(|t| <I as EnumerativeBackend<I>>::sequence_cost(&[t], config))
+            .unwrap_or(0);
 
         let run_lengths = |s: &SharedState<I>| {
             // Search increasing lengths up to target.len()-1 so we never
-            // propose a candidate as long as the target. We keep going after a
-            // hit because length-1 may exist alongside length-2; cost-pruning
-            // enforces strict improvement.
+            // propose a candidate as long as the target. We keep going after
+            // a hit only while this length can still beat the current best;
+            // the lower-bound check avoids cost-pruned product sweeps.
             for length in 1..target.len() {
                 if Self::timed_out(start, config.timeout) || s.stop.load(Ordering::Relaxed) {
                     break;
+                }
+                let Some(min_instruction_cost) = min_instruction_cost else {
+                    break;
+                };
+                let lower_bound =
+                    length_cost_lower_bound(length, min_instruction_cost, terminator_cost);
+                if lower_bound >= s.best_cost.load(Ordering::Acquire) {
+                    continue;
                 }
                 match length {
                     1 => run_length_one::<I>(
@@ -572,7 +703,16 @@ where
                         s,
                         start,
                     ),
-                    _ => {} // length >= 3 lands in a follow-up TDD cycle.
+                    _ => run_length_product::<I>(ProductContext {
+                        length,
+                        target,
+                        live_out,
+                        config,
+                        all_instructions,
+                        terminator,
+                        shared: s,
+                        start,
+                    }),
                 }
             }
         };
@@ -1132,7 +1272,16 @@ mod tests {
         }
     }
 
+    static INNER_TIMEOUT_TEST_LOCK: TestMutex<()> = TestMutex::new(());
     static INNER_TIMEOUT_COST_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    fn reset_inner_timeout_counter() -> MutexGuard<'static, ()> {
+        let guard = INNER_TIMEOUT_TEST_LOCK
+            .lock()
+            .expect("inner timeout test lock poisoned");
+        INNER_TIMEOUT_COST_CALLS.store(0, Ordering::Relaxed);
+        guard
+    }
 
     impl EnumerativeBackend<InnerTimeoutIsa> for InnerTimeoutIsa {
         type LiveOut = ();
@@ -1167,7 +1316,7 @@ mod tests {
 
     #[test]
     fn run_length_two_sets_stop_when_inner_deadline_expires() {
-        INNER_TIMEOUT_COST_CALLS.store(0, Ordering::Relaxed);
+        let _guard = reset_inner_timeout_counter();
 
         let config = SearchConfig::default().with_timeout(std::time::Duration::from_millis(25));
         let target = vec![InnerTimeoutInstruction(9), InnerTimeoutInstruction(8)];
@@ -1201,6 +1350,51 @@ mod tests {
             INNER_TIMEOUT_COST_CALLS.load(Ordering::Relaxed),
             1,
             "timeout should be checked before evaluating the second inner candidate"
+        );
+    }
+
+    #[test]
+    fn run_length_product_sets_stop_when_nested_deadline_expires() {
+        let _guard = reset_inner_timeout_counter();
+
+        let config = SearchConfig::default().with_timeout(std::time::Duration::from_millis(25));
+        let target = vec![
+            InnerTimeoutInstruction(9),
+            InnerTimeoutInstruction(8),
+            InnerTimeoutInstruction(7),
+            InnerTimeoutInstruction(6),
+        ];
+        let all_instructions =
+            <InnerTimeoutIsa as EnumerativeBackend<InnerTimeoutIsa>>::enumerate_all(&[], &[]);
+        // Positive candidate costs prune before equivalence, isolating timeout behavior.
+        let shared = SharedState::<InnerTimeoutIsa>::new(0);
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .expect("private rayon pool should build");
+
+        pool.install(|| {
+            let start = Instant::now();
+            run_length_product::<InnerTimeoutIsa>(ProductContext {
+                length: 3,
+                target: &target,
+                live_out: &(),
+                config: &config,
+                all_instructions: &all_instructions,
+                terminator: None,
+                shared: &shared,
+                start,
+            });
+        });
+
+        let cost_calls = INNER_TIMEOUT_COST_CALLS.load(Ordering::Relaxed);
+        assert!(
+            shared.stop.load(Ordering::Relaxed),
+            "nested product loop should set stop after the timeout expires"
+        );
+        assert!(
+            cost_calls < 8,
+            "timeout should stop before the full length-three product sweep; saw {cost_calls} cost calls"
         );
     }
 
@@ -1672,14 +1866,11 @@ mod tests {
     }
 
     #[test]
-    fn length_four_target_iterates_past_length_three_dispatch() {
-        // Pins the `_ => {}` arm of the per-length dispatch: a length-4
-        // target makes the outer loop iterate over lengths 1, 2, and 3, so
-        // length 3 must hit the not-yet-implemented arm without panicking.
-        // The target intentionally has a length-1 equivalent (`add x0, x1,
-        // #1`) so cost-pruning collapses the length-2 enumeration after the
-        // first hit and the test completes in well under a second; the
-        // assertion still proves we *reached and survived* length 3.
+    fn length_four_target_with_length_one_rewrite_returns_promptly() {
+        // This target intentionally has a length-1 equivalent (`add x0, x1,
+        // #1`). Once that best cost is found, longer lengths cannot strictly
+        // improve under the configured cost model, so the length-level lower
+        // bound should skip the expensive length-3 product sweep.
         let target = vec![
             Instruction::MovReg {
                 rd: Register::X0,
@@ -1706,12 +1897,157 @@ mod tests {
         let mut search = EnumerativeSearch::<crate::isa::AArch64>::new();
         let result = search.search(&target, &live_out, &small_config());
 
-        // The important assertion is that the search returned — i.e. the
-        // length-3 `_ => {}` arm did not panic, the loop iterated past it,
-        // and the result was assembled cleanly.
         assert!(result.statistics.elapsed_time > std::time::Duration::ZERO);
         assert!(result.found_optimization, "length-1 collapse should fire");
         assert_eq!(result.optimized_sequence.as_ref().map(Vec::len), Some(1));
+    }
+
+    #[derive(Clone)]
+    struct LengthThreeProbeIsa;
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+    struct LengthThreeProbeInstruction(u8);
+
+    impl std::fmt::Display for LengthThreeProbeInstruction {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "probe{}", self.0)
+        }
+    }
+
+    impl InstructionType for LengthThreeProbeInstruction {
+        type Register = Register;
+        type Operand = Operand;
+
+        fn destination(&self) -> Option<Self::Register> {
+            None
+        }
+
+        fn source_registers(&self) -> Vec<Self::Register> {
+            Vec::new()
+        }
+
+        fn opcode_id(&self) -> u8 {
+            self.0
+        }
+
+        fn mnemonic(&self) -> &'static str {
+            "probe"
+        }
+    }
+
+    struct LengthThreeProbeMutator;
+
+    impl ISAMutator<LengthThreeProbeInstruction> for LengthThreeProbeMutator {
+        fn mutate<R: rand::RngExt>(
+            &self,
+            _rng: &mut R,
+            sequence: &[LengthThreeProbeInstruction],
+        ) -> Vec<LengthThreeProbeInstruction> {
+            sequence.to_vec()
+        }
+    }
+
+    impl ISA for LengthThreeProbeIsa {
+        type Register = Register;
+        type Operand = Operand;
+        type Instruction = LengthThreeProbeInstruction;
+        type Width = U64;
+        type Flags = ();
+        type Mutator = LengthThreeProbeMutator;
+
+        fn name(&self) -> &'static str {
+            "LengthThreeProbe"
+        }
+
+        fn register_count(&self) -> usize {
+            1
+        }
+
+        fn instruction_size(&self) -> Option<usize> {
+            Some(1)
+        }
+
+        fn general_registers(&self) -> Vec<Self::Register> {
+            vec![Register::X0]
+        }
+
+        fn zero_register(&self) -> Option<Self::Register> {
+            Some(Register::XZR)
+        }
+    }
+
+    impl EnumerativeBackend<LengthThreeProbeIsa> for LengthThreeProbeIsa {
+        type LiveOut = ();
+
+        fn registers_from_config(_config: &SearchConfig) -> Vec<Register> {
+            vec![Register::X0]
+        }
+
+        fn immediates_from_config(_config: &SearchConfig) -> Vec<i64> {
+            vec![0]
+        }
+
+        fn enumerate_all(_regs: &[Register], _imms: &[i64]) -> Vec<LengthThreeProbeInstruction> {
+            vec![
+                LengthThreeProbeInstruction(1),
+                LengthThreeProbeInstruction(2),
+                LengthThreeProbeInstruction(3),
+            ]
+        }
+
+        fn sequence_cost(seq: &[LengthThreeProbeInstruction], _config: &SearchConfig) -> u64 {
+            seq.len() as u64
+        }
+
+        fn check_equivalence(
+            _target: &[LengthThreeProbeInstruction],
+            candidate: &[LengthThreeProbeInstruction],
+            _live_out: &Self::LiveOut,
+            _smt_timeout: Duration,
+        ) -> (EquivalenceResult, EquivalenceMetrics) {
+            let expected = [
+                LengthThreeProbeInstruction(1),
+                LengthThreeProbeInstruction(2),
+                LengthThreeProbeInstruction(3),
+            ];
+            let verdict = if candidate == expected {
+                EquivalenceResult::Equivalent
+            } else {
+                EquivalenceResult::NotEquivalent
+            };
+
+            (verdict, EquivalenceMetrics::default())
+        }
+    }
+
+    #[test]
+    fn length_four_target_finds_length_three_only_rewrite() {
+        let target = vec![
+            LengthThreeProbeInstruction(9),
+            LengthThreeProbeInstruction(8),
+            LengthThreeProbeInstruction(7),
+            LengthThreeProbeInstruction(6),
+        ];
+        let config = SearchConfig::default()
+            .with_timeout_option(None)
+            .with_cores(Some(1));
+
+        let mut search = EnumerativeSearch::<LengthThreeProbeIsa>::new();
+        let result = search.search(&target, &(), &config);
+
+        assert!(
+            result.found_optimization,
+            "length-three candidate should be searched for a length-four target"
+        );
+        assert_eq!(
+            result.optimized_sequence,
+            Some(vec![
+                LengthThreeProbeInstruction(1),
+                LengthThreeProbeInstruction(2),
+                LengthThreeProbeInstruction(3),
+            ])
+        );
+        assert_eq!(result.optimized_sequence.as_ref().map(Vec::len), Some(3));
     }
 
     #[test]

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -577,9 +577,6 @@ where
         }
 
         if candidate.len() == self.length {
-            if self.stop_if_timed_out() {
-                return;
-            }
             evaluate_candidate::<I>(
                 self.target,
                 self.live_out,
@@ -669,9 +666,10 @@ where
 
         let run_lengths = |s: &SharedState<I>| {
             // Search increasing lengths up to target.len()-1 so we never
-            // propose a candidate as long as the target. We keep going after
-            // a hit only while this length can still beat the current best;
-            // the lower-bound check avoids cost-pruned product sweeps.
+            // propose a candidate as long as the target. The per-length cost
+            // lower bound is non-decreasing in length and `best_cost` only
+            // falls, so once a length cannot beat the current best no longer
+            // length can either — break out instead of scanning the rest.
             for length in 1..target.len() {
                 if Self::timed_out(start, config.timeout) || s.stop.load(Ordering::Relaxed) {
                     break;
@@ -682,7 +680,7 @@ where
                 let lower_bound =
                     length_cost_lower_bound(length, min_instruction_cost, terminator_cost);
                 if lower_bound >= s.best_cost.load(Ordering::Acquire) {
-                    continue;
+                    break;
                 }
                 match length {
                     1 => run_length_one::<I>(


### PR DESCRIPTION
Summary:
- Add generic product enumeration for candidate lengths 3..target.len()-1.
- Share candidate finalization so terminator handling, cost pruning, stats, and equivalence checks stay consistent across lengths.
- Add a length lower-bound skip to avoid exhaustive product sweeps once the current best cannot be beaten.
- Add regressions for a length-4 target whose only rewrite is length 3 and for nested product timeout handling.

Tests:
- cargo fmt --all -- --check
- cargo clippy --all -- -D warnings
- cargo test search::enumerative
- cargo test --all (after ./build_tests.sh; first run failed only because fixture binaries were absent)
- ./ci_check.sh

Note: scripts/full_test.sh was requested by the autonomous contract but does not exist in this repo.

Closes #239

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**