### PR TITLE
fix(parser): restrict memory extend shifts

### DIFF
--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -2,8 +2,8 @@
 
 use crate::ir::aarch64_encoding::logical_imm64_encodable;
 use crate::ir::types::{
-    AccessWidth, AddressOperand, Condition, IndexMode, LabelId, Operand, Register, RegisterWidth,
-    ShiftKind,
+    AccessWidth, AddressOperand, Condition, ExtendKind, IndexMode, LabelId, Operand, Register,
+    RegisterWidth, ShiftKind,
 };
 use std::fmt;
 
@@ -1253,7 +1253,9 @@ fn address_source_registers(addr: &AddressOperand) -> Vec<Register> {
 /// level; (d) signed loads only support B/H/W access widths (LDRSX does
 /// not exist — LDR handles 64-bit zero-extension); (e) for `Reg` / `Ext`
 /// address modes the index register cannot be SP — the Rm field encodes
-/// X0..X30 / XZR, not SP (`register_to_dynasm(SP)` returns None).
+/// X0..X30 / XZR, not SP (`register_to_dynasm(SP)` returns None); (f)
+/// memory `Ext` modes only accept UXTW/SXTW/UXTX/SXTX with shift 0 or the
+/// access-size scale shift.
 fn is_encodable_ldr_like(rt: Register, addr: &AddressOperand, width: AccessWidth) -> bool {
     if rt == Register::SP {
         return false;
@@ -1265,8 +1267,25 @@ fn is_encodable_ldr_like(rt: Register, addr: &AddressOperand, width: AccessWidth
         return false;
     }
     match addr {
-        AddressOperand::Reg { idx, .. } | AddressOperand::Ext { idx, .. } => {
+        AddressOperand::Reg { idx, .. } => {
             if *idx == Register::SP {
+                return false;
+            }
+        }
+        AddressOperand::Ext {
+            idx, kind, shift, ..
+        } => {
+            if *idx == Register::SP {
+                return false;
+            }
+            if !matches!(
+                kind,
+                ExtendKind::Uxtw | ExtendKind::Sxtw | ExtendKind::Uxtx | ExtendKind::Sxtx
+            ) {
+                return false;
+            }
+            let scaled_shift = width.scale_shift();
+            if *shift != 0 && *shift != scaled_shift {
                 return false;
             }
         }
@@ -1983,6 +2002,85 @@ mod tests {
             width: AccessWidth::Extended,
         };
         assert!(!ldr.is_encodable_aarch64());
+    }
+
+    #[test]
+    fn memory_register_extend_shift_encodability_matches_access_width() {
+        use crate::ir::ExtendKind;
+
+        for (width, shift) in [
+            (AccessWidth::Byte, 1),
+            (AccessWidth::Half, 2),
+            (AccessWidth::Word, 3),
+            (AccessWidth::Extended, 4),
+        ] {
+            let ldr = Instruction::Ldr {
+                rt: Register::X0,
+                addr: AddressOperand::Ext {
+                    base: Register::X1,
+                    idx: Register::X2,
+                    kind: ExtendKind::Uxtw,
+                    shift,
+                },
+                width,
+            };
+            assert!(
+                !ldr.is_encodable_aarch64(),
+                "{width:?} access should reject extend shift {shift}"
+            );
+        }
+
+        let bad_str = Instruction::Str {
+            rt: Register::X0,
+            addr: AddressOperand::Ext {
+                base: Register::X1,
+                idx: Register::X2,
+                kind: ExtendKind::Sxtx,
+                shift: 2,
+            },
+            width: AccessWidth::Extended,
+        };
+        assert!(!bad_str.is_encodable_aarch64());
+
+        let bad_kind = Instruction::Ldr {
+            rt: Register::X0,
+            addr: AddressOperand::Ext {
+                base: Register::X1,
+                idx: Register::X2,
+                kind: ExtendKind::Uxtb,
+                shift: 0,
+            },
+            width: AccessWidth::Byte,
+        };
+        assert!(!bad_kind.is_encodable_aarch64());
+    }
+
+    #[test]
+    fn memory_register_extend_shift_encodability_allows_scaled_forms() {
+        use crate::ir::ExtendKind;
+
+        for (width, kind, shift) in [
+            (AccessWidth::Byte, ExtendKind::Uxtw, 0),
+            (AccessWidth::Half, ExtendKind::Sxtw, 1),
+            (AccessWidth::Word, ExtendKind::Uxtw, 2),
+            (AccessWidth::Extended, ExtendKind::Uxtx, 3),
+            (AccessWidth::Extended, ExtendKind::Sxtx, 0),
+        ] {
+            let ldr = Instruction::Ldr {
+                rt: Register::X0,
+                addr: AddressOperand::Ext {
+                    base: Register::X1,
+                    idx: Register::X2,
+                    kind,
+                    shift,
+                },
+                width,
+            };
+            assert!(
+                ldr.is_encodable_aarch64(),
+                "{width:?} access should accept {kind:?} shift {shift}"
+            );
+        }
     }
 
     #[test]

--- a/src/ir/types.rs
+++ b/src/ir/types.rs
@@ -363,6 +363,17 @@ impl AccessWidth {
             AccessWidth::Extended => 8,
         }
     }
+
+    /// Log2 of the access size in bytes, used by scaled memory operands.
+    #[must_use]
+    pub fn scale_shift(&self) -> u8 {
+        match self {
+            AccessWidth::Byte => 0,
+            AccessWidth::Half => 1,
+            AccessWidth::Word => 2,
+            AccessWidth::Extended => 3,
+        }
+    }
 }
 
 /// Writeback / index selector for memory-address operands (`[Xn, #imm]`,
@@ -396,9 +407,9 @@ pub enum AddressOperand {
         shift: u8,
     },
     /// `[base, idx, kind{ #shift}]` where `kind` is one of UXTW/SXTW (idx
-    /// is W-form) or UXTX/SXTX (idx is X-form). UXTB/UXTH/SXTB/SXTH are
-    /// not valid AArch64 memory-extend kinds and are rejected by
-    /// `is_encodable_aarch64`.
+    /// is W-form) or UXTX/SXTX (idx is X-form), and `shift` is 0 or the
+    /// access-size scale shift. UXTB/UXTH/SXTB/SXTH and invalid shifts are
+    /// rejected by `is_encodable_aarch64`.
     Ext {
         base: Register,
         idx: Register,
@@ -848,5 +859,9 @@ mod tests {
         assert_eq!(AccessWidth::Half.bytes(), 2);
         assert_eq!(AccessWidth::Word.bytes(), 4);
         assert_eq!(AccessWidth::Extended.bytes(), 8);
+        assert_eq!(AccessWidth::Byte.scale_shift(), 0);
+        assert_eq!(AccessWidth::Half.scale_shift(), 1);
+        assert_eq!(AccessWidth::Word.scale_shift(), 2);
+        assert_eq!(AccessWidth::Extended.scale_shift(), 3);
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -788,7 +788,8 @@ fn is_extend_keyword(kw: &str) -> bool {
 ///   - `[Xn, Xm]`                      → Reg { shift=0 }
 ///   - `[Xn, Xm, LSL #shift]`          → Reg { shift }, where shift is 0 or
 ///     log2(access bytes)
-///   - `[Xn, {W|X}m, UXTW/SXTW/UXTX/SXTX{ #shift}]`  → Ext
+///   - `[Xn, {W|X}m, UXTW/SXTW/UXTX/SXTX{ #shift}]`  → Ext, where shift is
+///     0 or log2(access bytes)
 ///
 /// Returns the parsed operand and the number of input tokens consumed (1 for
 /// the four bracketed forms, 2 for the trailing-immediate post-index form).
@@ -857,7 +858,7 @@ fn parse_memory_operand(
         } else if is_extend_keyword(kw) {
             let idx = parse_w_or_x_register(inner_parts[1])
                 .map_err(|e| format!("invalid index register in memory operand: {}", e))?;
-            let (kind, shift) = parse_memory_extend_tail(third)?;
+            let (kind, shift) = parse_memory_extend_tail(third, width)?;
             // Memory operands only accept the W/X-extend kinds (no byte/half).
             if !matches!(
                 kind,
@@ -948,12 +949,7 @@ fn parse_lsl_amount(tail: &str) -> Result<u8, String> {
 /// Parse the narrower `LSL #N` tail accepted by memory register-offset forms.
 fn parse_memory_lsl_amount(tail: &str, width: crate::ir::types::AccessWidth) -> Result<u8, String> {
     let shift = parse_lsl_amount(tail)?;
-    let scaled_shift = match width {
-        crate::ir::types::AccessWidth::Byte => 0,
-        crate::ir::types::AccessWidth::Half => 1,
-        crate::ir::types::AccessWidth::Word => 2,
-        crate::ir::types::AccessWidth::Extended => 3,
-    };
+    let scaled_shift = width.scale_shift();
 
     if shift == 0 || shift == scaled_shift {
         return Ok(shift);
@@ -973,7 +969,10 @@ fn parse_memory_lsl_amount(tail: &str, width: crate::ir::types::AccessWidth) -> 
 
 /// Parse a `<extend> #shift` tail used in memory operands. Returns the
 /// extend kind plus the optional shift (defaults to 0 if absent).
-fn parse_memory_extend_tail(tail: &str) -> Result<(crate::ir::types::ExtendKind, u8), String> {
+fn parse_memory_extend_tail(
+    tail: &str,
+    width: crate::ir::types::AccessWidth,
+) -> Result<(crate::ir::types::ExtendKind, u8), String> {
     use crate::ir::types::ExtendKind;
     let mut parts = tail.split_whitespace();
     let kw = parts.next().unwrap_or("").to_lowercase();
@@ -985,16 +984,25 @@ fn parse_memory_extend_tail(tail: &str) -> Result<(crate::ir::types::ExtendKind,
         _ => return Err(format!("unsupported memory extend keyword `{}`", kw)),
     };
     let shift = match parts.next() {
-        None => 0u8,
-        Some(imm_tok) => {
-            let amt = parse_immediate(imm_tok)?;
-            if !(0..=4).contains(&amt) {
-                return Err(format!("extend shift {} out of range (0..=4)", amt));
-            }
-            amt as u8
-        }
+        None => 0,
+        Some(imm_tok) => parse_immediate(imm_tok)?,
     };
-    Ok((kind, shift))
+    let scaled_shift = width.scale_shift();
+
+    if shift == 0 || shift == i64::from(scaled_shift) {
+        return Ok((kind, shift as u8));
+    }
+
+    let access_bytes = 1u8 << scaled_shift;
+    let expected = if scaled_shift == 0 {
+        "0".to_string()
+    } else {
+        format!("0 or {}", scaled_shift)
+    };
+    Err(format!(
+        "memory extend shift {} invalid for {}-byte access (expected {})",
+        shift, access_bytes, expected
+    ))
 }
 
 /// Infer `AccessWidth` for the unsized LDR/STR mnemonics (where the data
@@ -3066,14 +3074,14 @@ mod tests {
         );
 
         assert_eq!(
-            parse_one("ldr x0, [x1, w2, UxTw #2]"),
+            parse_one("ldr x0, [x1, w2, UxTw #3]"),
             Instruction::Ldr {
                 rt: Register::X0,
                 addr: AddressOperand::Ext {
                     base: Register::X1,
                     idx: Register::X2,
                     kind: ExtendKind::Uxtw,
-                    shift: 2,
+                    shift: 3,
                 },
                 width: AccessWidth::Extended,
             }
@@ -3519,7 +3527,7 @@ mod tests {
         assert_mem_round_trip("ldr x0, [x1, x2]");
         assert_mem_round_trip("ldr x0, [x1, x2, lsl #3]");
         // Register-extend.
-        assert_mem_round_trip("ldr x0, [x1, w2, uxtw #2]");
+        assert_mem_round_trip("ldr x0, [x1, w2, uxtw #3]");
         assert_mem_round_trip("ldr x0, [x1, w2, sxtw]");
         // Other mnemonics.
         assert_mem_round_trip("ldrb x0, [x1]");
@@ -3642,9 +3650,59 @@ mod tests {
     }
 
     #[test]
+    fn parse_memory_register_extend_rejects_illegal_shift_for_access_width() {
+        for (text, expected) in [
+            ("ldrb w0, [x1, w2, uxtw #1]", "expected 0"),
+            ("ldrh w0, [x1, w2, sxtw #2]", "expected 0 or 1"),
+            ("ldr w0, [x1, w2, uxtw #3]", "expected 0 or 2"),
+            ("ldr x0, [x1, w2, uxtw #4]", "expected 0 or 3"),
+            ("str x0, [x1, x2, sxtx #2]", "expected 0 or 3"),
+        ] {
+            let err = parse_line(text).expect_err("memory extend shift should be rejected");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("memory extend shift"),
+                "{text}: error should name memory extend shift, got {msg}"
+            );
+            assert!(
+                msg.contains(expected),
+                "{text}: error should mention {expected}, got {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_memory_register_extend_accepts_legal_shift_for_access_width() {
+        use crate::ir::types::{AddressOperand, ExtendKind};
+
+        for (text, expected_kind, expected_shift) in [
+            ("ldrb w0, [x1, w2, uxtw #0]", ExtendKind::Uxtw, 0),
+            ("ldrh w0, [x1, w2, sxtw #1]", ExtendKind::Sxtw, 1),
+            ("ldr w0, [x1, w2, uxtw #2]", ExtendKind::Uxtw, 2),
+            ("ldr x0, [x1, w2, uxtw #3]", ExtendKind::Uxtw, 3),
+            ("str x0, [x1, x2, sxtx #3]", ExtendKind::Sxtx, 3),
+        ] {
+            let instr = parse_one(text);
+            let (Instruction::Ldr { addr, .. } | Instruction::Str { addr, .. }) = instr else {
+                panic!("{text}: expected ldr/str-like instruction, got {instr:?}");
+            };
+            assert_eq!(
+                addr,
+                AddressOperand::Ext {
+                    base: Register::X1,
+                    idx: Register::X2,
+                    kind: expected_kind,
+                    shift: expected_shift,
+                },
+                "{text}"
+            );
+        }
+    }
+
+    #[test]
     fn parse_ldr_register_extend_with_w_index() {
         use crate::ir::types::{AccessWidth, AddressOperand, ExtendKind};
-        let instr = parse_one("ldr x0, [x1, w2, uxtw #2]");
+        let instr = parse_one("ldr x0, [x1, w2, uxtw #3]");
         assert_eq!(
             instr,
             Instruction::Ldr {
@@ -3653,7 +3711,7 @@ mod tests {
                     base: Register::X1,
                     idx: Register::X2,
                     kind: ExtendKind::Uxtw,
-                    shift: 2,
+                    shift: 3,
                 },
                 width: AccessWidth::Extended,
             }


### PR DESCRIPTION
Summary:
- Restrict AArch64 memory extend shifts to 0 or the access-size scale at parse time.
- Mirror the same rule in is_encodable_aarch64 for hand-built IR.

Closes #302

Verification:
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test --all
- ./ci_check.sh
- Note: scripts/full_test.sh is not present in this s11 repo; ./ci_check.sh builds test binaries and runs ./test_all.sh.

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**