### PR TITLE
fix(equiv): warn when memory disables fast-only

### DIFF
--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -378,9 +378,16 @@ impl EquivalenceBackend for AArch64 {
             || crate::validation::live_out::touches_memory(seq2);
         if memory_touched {
             if config.fast_only {
-                eprintln!(
-                    "[s11] warning: --fast-only disabled for memory-bearing window (see ADR-0007)"
-                );
+                // This carve-out fires once per equivalence check, and a search
+                // pass invokes the check per candidate/window. Emit the warning
+                // at most once per process so multi-window `opt --fast-only` runs
+                // don't flood stderr with identical lines (ADR-0007).
+                static FAST_ONLY_WARNED: std::sync::Once = std::sync::Once::new();
+                FAST_ONLY_WARNED.call_once(|| {
+                    eprintln!(
+                        "[s11] warning: --fast-only disabled for memory-bearing window (see ADR-0007)"
+                    );
+                });
             }
             config.memory_live = true;
             config.fast_only = false;

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -377,6 +377,11 @@ impl EquivalenceBackend for AArch64 {
         let memory_touched = crate::validation::live_out::touches_memory(seq1)
             || crate::validation::live_out::touches_memory(seq2);
         if memory_touched {
+            if config.fast_only {
+                eprintln!(
+                    "[s11] warning: --fast-only disabled for memory-bearing window (see ADR-0007)"
+                );
+            }
             config.memory_live = true;
             config.fast_only = false;
         }

--- a/tests/integration/equiv_test.rs
+++ b/tests/integration/equiv_test.rs
@@ -1,0 +1,79 @@
+use std::process::{Command, Output};
+
+const FAST_ONLY_MEMORY_WARNING: &str =
+    "[s11] warning: --fast-only disabled for memory-bearing window (see ADR-0007)";
+
+fn get_binary_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_s11"))
+}
+
+fn run_equiv_fast_only(seq1_text: &str, seq2_text: &str) -> Output {
+    let dir = tempfile::tempdir().expect("create temp dir for equiv fixtures");
+    let seq1 = dir.path().join("seq1.s");
+    let seq2 = dir.path().join("seq2.s");
+    std::fs::write(&seq1, seq1_text).expect("write first sequence");
+    std::fs::write(&seq2, seq2_text).expect("write second sequence");
+
+    Command::new(get_binary_path())
+        .arg("equiv")
+        .arg(&seq1)
+        .arg(&seq2)
+        .arg("--fast-only")
+        .arg("--live-out")
+        .arg("x0")
+        .arg("--timeout")
+        .arg("5")
+        .output()
+        .expect("execute s11 equiv")
+}
+
+#[test]
+fn equiv_fast_only_memory_window_warns_when_overridden() {
+    let output = run_equiv_fast_only("ldr x0, [x1]\n", "ldr x0, [x1]\n");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "s11 equiv should succeed, status: {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        stdout,
+        stderr
+    );
+    assert!(
+        stdout.contains("EQUIVALENT"),
+        "stdout should report equivalence, stdout:\n{}",
+        stdout
+    );
+    assert_eq!(
+        stderr.matches(FAST_ONLY_MEMORY_WARNING).count(),
+        1,
+        "stderr should contain the ADR-0007 fast-only override warning exactly once, stderr:\n{}",
+        stderr
+    );
+}
+
+#[test]
+fn equiv_fast_only_register_window_does_not_warn() {
+    let output = run_equiv_fast_only("mov x0, x1\n", "mov x0, x1\n");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "s11 equiv should succeed, status: {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        stdout,
+        stderr
+    );
+    assert!(
+        stdout.contains("EQUIVALENT"),
+        "stdout should report equivalence, stdout:\n{}",
+        stdout
+    );
+    assert!(
+        !stderr.contains(FAST_ONLY_MEMORY_WARNING),
+        "stderr should not contain the memory fast-only override warning, stderr:\n{}",
+        stderr
+    );
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,3 +1,4 @@
 mod disasm_test;
 mod docs_capability;
+mod equiv_test;
 mod opt_test;


### PR DESCRIPTION
Summary:
- Emit the ADR-0007 warning when AArch64 memory-bearing equivalence checks force --fast-only off.
- Add CLI integration coverage for the memory warning and a register-only no-warning guard.

Closes #303

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**