### PR TITLE
fix(parser): reject W-form signed-load destinations

### DIFF
--- a/docs/capability.md
+++ b/docs/capability.md
@@ -61,8 +61,12 @@ Rewritable straight-line mnemonics accepted by the parser and Capstone bridge:
   byte-addressed Z3-array memory model with sound full aliasing, whole-memory
   live-out auto-derived): `ldr`, `ldrb`, `ldrh`, `ldrsb`, `ldrsh`, `ldrsw`,
   `str`, `strb`, `strh`, `ldp`, `stp`, `ldpsw` — accepted in immediate-offset,
-  pre-index, post-index, register-offset, and register-extend addressing
-  forms, in both `W` and `X` widths
+  pre-index, post-index, register-offset, and register-extend addressing forms.
+  Unsized `ldr` / `str` infer `W` vs `X` width from the data register spelling.
+  Zero-extending `ldrb` / `ldrh` loads and `strb` / `strh` stores use scoped
+  `W`/`X` register slots.
+  `ldrsb` / `ldrsh` / `ldrsw` signed loads currently accept only X-form
+  destinations because the current `Ldrs` IR models X-form sign-extension.
 
 Fixed control-flow terminators:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2845,6 +2845,23 @@ mod cli_helper_tests {
         }
     }
 
+    #[test]
+    fn convert_capstone_op_rejects_w_form_signed_load_destinations() {
+        for (mnem, ops) in [
+            ("ldrsb", "w0, [x1]"),
+            ("ldrsh", "w0, [x1]"),
+            ("ldrsw", "w0, [x1]"),
+        ] {
+            match convert_capstone_op(mnem, ops) {
+                ConvertOutcome::Unsupported(line) => {
+                    assert!(line.contains(mnem));
+                    assert!(line.contains("X-form"));
+                }
+                other => panic!("expected Unsupported for `{mnem} {ops}`, got {other:?}"),
+            }
+        }
+    }
+
     fn assemble_aarch64_test_bytes(instructions: &[Instruction]) -> Vec<u8> {
         AArch64Assembler::new()
             .assemble_instructions(instructions, 0x1000)

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1046,6 +1046,26 @@ fn parse_single_reg_mem(
     Ok(builder(rt, addr, width))
 }
 
+fn parse_signed_load_mem(
+    mnem: &str,
+    operands: &[&str],
+    width: crate::ir::types::AccessWidth,
+) -> Result<Instruction, String> {
+    if operands.len() >= 2 {
+        let (_, dst_width) = parse_sized_register(operands[0])
+            .map_err(|e| format!("{}: invalid Xt: {}", mnem, e))?;
+        if dst_width != RegisterWidth::X64 {
+            return Err(format!("{} signed-load destination must be X-form", mnem));
+        }
+    }
+
+    parse_single_reg_mem(mnem, operands, width, |rt, addr, w| Instruction::Ldrs {
+        rt,
+        addr,
+        width: w,
+    })
+}
+
 /// Parse a pair memory instruction (LDP/STP/LDPSW). The destination
 /// pair is the first two operands; the remaining tokens form the
 /// address operand. `signed=true` only for LDPSW.
@@ -1906,27 +1926,12 @@ pub fn parse_line(line: &str) -> Result<LineResult, ParseLineError> {
             |rt, addr, w| Instruction::Ldr { rt, addr, width: w },
         )
         .map_err(ParseLineError::Other)?,
-        "ldrsb" => parse_single_reg_mem(
-            "ldrsb",
-            &operands,
-            crate::ir::types::AccessWidth::Byte,
-            |rt, addr, w| Instruction::Ldrs { rt, addr, width: w },
-        )
-        .map_err(ParseLineError::Other)?,
-        "ldrsh" => parse_single_reg_mem(
-            "ldrsh",
-            &operands,
-            crate::ir::types::AccessWidth::Half,
-            |rt, addr, w| Instruction::Ldrs { rt, addr, width: w },
-        )
-        .map_err(ParseLineError::Other)?,
-        "ldrsw" => parse_single_reg_mem(
-            "ldrsw",
-            &operands,
-            crate::ir::types::AccessWidth::Word,
-            |rt, addr, w| Instruction::Ldrs { rt, addr, width: w },
-        )
-        .map_err(ParseLineError::Other)?,
+        "ldrsb" => parse_signed_load_mem("ldrsb", &operands, crate::ir::types::AccessWidth::Byte)
+            .map_err(ParseLineError::Other)?,
+        "ldrsh" => parse_signed_load_mem("ldrsh", &operands, crate::ir::types::AccessWidth::Half)
+            .map_err(ParseLineError::Other)?,
+        "ldrsw" => parse_signed_load_mem("ldrsw", &operands, crate::ir::types::AccessWidth::Word)
+            .map_err(ParseLineError::Other)?,
         "str" => parse_single_reg_mem("str", &operands, ldr_width(&operands), |rt, addr, w| {
             Instruction::Str { rt, addr, width: w }
         })
@@ -3501,6 +3506,34 @@ mod tests {
     fn assert_mem_round_trip(text: &str) {
         let instr = parse_one(text);
         assert_eq!(format!("{}", instr), text, "round-trip mismatch");
+    }
+
+    #[test]
+    fn parse_line_rejects_w_form_signed_load_destinations() {
+        for (line, mnemonic) in [
+            ("ldrsb w0, [x1]", "ldrsb"),
+            ("ldrsh w0, [x1]", "ldrsh"),
+            ("ldrsw w0, [x1]", "ldrsw"),
+            ("ldrsb w0, [x1, #1]!", "ldrsb"),
+            ("ldrsh w0, [x1], #2", "ldrsh"),
+            ("ldrsb w0, [x1, x2]", "ldrsb"),
+            ("ldrsb w0, [x1, w2, sxtw]", "ldrsb"),
+        ] {
+            match parse_line(line) {
+                Err(ParseLineError::Other(msg)) => {
+                    assert!(msg.contains(mnemonic), "{line} error should name mnemonic");
+                    assert!(msg.contains("X-form"), "{line} error should name X-form");
+                }
+                other => panic!("expected W-form signed-load rejection for {line}, got {other:?}"),
+            }
+        }
+
+        for line in ["ldrsb x0, [x1]", "ldrsh x0, [x1]", "ldrsw x0, [x1]"] {
+            assert!(
+                matches!(parse_line(line), Ok(LineResult::Instruction(_))),
+                "X-form signed load should remain accepted: {line}"
+            );
+        }
     }
 
     #[test]

--- a/tests/integration/docs_capability.rs
+++ b/tests/integration/docs_capability.rs
@@ -158,6 +158,12 @@ fn memory_operations_are_consistently_documented_with_known_gaps() {
         matrix.contains("`ldur`, `stur`, and `ldr (literal)` are out of scope"),
         "docs/capability.md must document unsupported memory-operation gaps"
     );
+    assert!(
+        matrix.contains(
+            "`ldrsb` / `ldrsh` / `ldrsw` signed loads currently accept only x-form destinations"
+        ),
+        "docs/capability.md must document the current signed-load destination-width limit"
+    );
 
     let tutorial = normalized_doc("TUTORIAL.md");
     assert!(


### PR DESCRIPTION
Summary:
- Reject W-form destinations for AArch64 signed-load mnemonics before the parser erases W/X spelling into the shared register IR.
- Keep X-form `ldrsb` / `ldrsh` / `ldrsw` accepted across text and Capstone paths.
- Document the current X-form-only signed-load limitation in the capability matrix.

Tests:
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`
- `./ci_check.sh`

Closes #306

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**