### PR TITLE
fix(aarch64): bound single-reg memory immediates

### DIFF
--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -1253,7 +1253,10 @@ fn address_source_registers(addr: &AddressOperand) -> Vec<Register> {
 /// level; (d) signed loads only support B/H/W access widths (LDRSX does
 /// not exist — LDR handles 64-bit zero-extension); (e) for `Reg` / `Ext`
 /// address modes the index register cannot be SP — the Rm field encodes
-/// X0..X30 / XZR, not SP (`register_to_dynasm(SP)` returns None).
+/// X0..X30 / XZR, not SP (`register_to_dynasm(SP)` returns None);
+/// (f) offset-mode immediates must fit either the unsigned scaled LDR/STR
+/// range or the signed 9-bit LDUR/STUR fallback, while pre/post-index
+/// immediates must fit the signed 9-bit writeback field.
 fn is_encodable_ldr_like(rt: Register, addr: &AddressOperand, width: AccessWidth) -> bool {
     if rt == Register::SP {
         return false;
@@ -1270,7 +1273,20 @@ fn is_encodable_ldr_like(rt: Register, addr: &AddressOperand, width: AccessWidth
                 return false;
             }
         }
-        AddressOperand::Imm { .. } => {}
+        AddressOperand::Imm {
+            offset,
+            mode: IndexMode::Offset,
+            ..
+        } => {
+            if !single_reg_offset_mode_imm_encodable(*offset, width) {
+                return false;
+            }
+        }
+        AddressOperand::Imm { offset, .. } => {
+            if !single_reg_signed_9_offset_encodable(*offset) {
+                return false;
+            }
+        }
     }
     if width == AccessWidth::Extended {
         // The caller decides whether Extended is valid (LDR allows it, but
@@ -1280,6 +1296,23 @@ fn is_encodable_ldr_like(rt: Register, addr: &AddressOperand, width: AccessWidth
         // layers on the narrower rule.
     }
     true
+}
+
+fn single_reg_offset_mode_imm_encodable(offset: i64, width: AccessWidth) -> bool {
+    single_reg_scaled_offset_encodable(offset, width)
+        || single_reg_signed_9_offset_encodable(offset)
+}
+
+fn single_reg_scaled_offset_encodable(offset: i64, width: AccessWidth) -> bool {
+    if offset < 0 {
+        return false;
+    }
+    let scale = i64::from(width.bytes());
+    offset % scale == 0 && offset <= 4095 * scale
+}
+
+fn single_reg_signed_9_offset_encodable(offset: i64) -> bool {
+    (-256..=255).contains(&offset)
 }
 
 /// Encodability gate for the LDP / STP family. See `is_encodable_ldr_like`
@@ -2179,6 +2212,67 @@ mod tests {
 
     // ---- is_encodable_aarch64 rules for memory ops ----
 
+    fn single_reg_imm_addr(offset: i64, mode: IndexMode) -> AddressOperand {
+        AddressOperand::Imm {
+            base: Register::X1,
+            offset,
+            mode,
+        }
+    }
+
+    fn single_reg_imm_instructions(
+        width: AccessWidth,
+        offset: i64,
+        mode: IndexMode,
+    ) -> Vec<Instruction> {
+        single_reg_instructions(width, single_reg_imm_addr(offset, mode))
+    }
+
+    fn single_reg_instructions(width: AccessWidth, addr: AddressOperand) -> Vec<Instruction> {
+        let mut instructions = vec![
+            Instruction::Ldr {
+                rt: Register::X0,
+                addr,
+                width,
+            },
+            Instruction::Str {
+                rt: Register::X0,
+                addr,
+                width,
+            },
+        ];
+        if width != AccessWidth::Extended {
+            instructions.push(Instruction::Ldrs {
+                rt: Register::X0,
+                addr,
+                width,
+            });
+        }
+        instructions
+    }
+
+    fn assert_single_reg_encodable(width: AccessWidth, addr: AddressOperand) {
+        for instruction in single_reg_instructions(width, addr) {
+            assert!(
+                instruction.is_encodable_aarch64(),
+                "{instruction:?} should be encodable"
+            );
+        }
+    }
+
+    fn assert_single_reg_imm_encodable(width: AccessWidth, offset: i64, mode: IndexMode) {
+        assert_single_reg_encodable(width, single_reg_imm_addr(offset, mode));
+    }
+
+    fn assert_single_reg_imm_not_encodable(width: AccessWidth, offset: i64, mode: IndexMode) {
+        for instruction in single_reg_imm_instructions(width, offset, mode) {
+            assert!(
+                !instruction.is_encodable_aarch64(),
+                "{instruction:?} should be rejected"
+            );
+        }
+    }
+
     #[test]
     fn ldr_rejects_xzr_base() {
         let ldr = Instruction::Ldr {
@@ -2245,6 +2339,78 @@ mod tests {
             width: AccessWidth::Extended,
         };
         assert!(ldr.is_encodable_aarch64());
+    }
+
+    #[test]
+    fn single_reg_memory_offset_mode_checks_scaled_and_unscaled_immediates() {
+        for (width, max_scaled) in [
+            (AccessWidth::Byte, 4095),
+            (AccessWidth::Half, 8190),
+            (AccessWidth::Word, 16380),
+            (AccessWidth::Extended, 32760),
+        ] {
+            assert_single_reg_imm_encodable(width, max_scaled, IndexMode::Offset);
+            assert_single_reg_imm_encodable(width, -256, IndexMode::Offset);
+            assert_single_reg_imm_encodable(width, 255, IndexMode::Offset);
+            assert_single_reg_imm_encodable(width, 256, IndexMode::Offset);
+
+            assert_single_reg_imm_not_encodable(
+                width,
+                max_scaled + i64::from(width.bytes()),
+                IndexMode::Offset,
+            );
+            assert_single_reg_imm_not_encodable(width, -257, IndexMode::Offset);
+        }
+
+        assert_single_reg_imm_not_encodable(AccessWidth::Half, 257, IndexMode::Offset);
+        assert_single_reg_imm_not_encodable(AccessWidth::Word, 258, IndexMode::Offset);
+        assert_single_reg_imm_not_encodable(AccessWidth::Extended, 257, IndexMode::Offset);
+    }
+
+    #[test]
+    fn single_reg_memory_writeback_modes_check_signed_9_bit_immediates() {
+        for mode in [IndexMode::PreIndex, IndexMode::PostIndex] {
+            for width in [
+                AccessWidth::Byte,
+                AccessWidth::Half,
+                AccessWidth::Word,
+                AccessWidth::Extended,
+            ] {
+                assert_single_reg_imm_encodable(width, -256, mode);
+                assert_single_reg_imm_encodable(width, 255, mode);
+
+                assert_single_reg_imm_not_encodable(width, -257, mode);
+                assert_single_reg_imm_not_encodable(width, 256, mode);
+            }
+        }
+    }
+
+    #[test]
+    fn single_reg_memory_non_immediate_modes_remain_encodable() {
+        use crate::ir::types::ExtendKind;
+
+        for addr in [
+            AddressOperand::Reg {
+                base: Register::X1,
+                idx: Register::X2,
+                shift: 0,
+            },
+            AddressOperand::Ext {
+                base: Register::X1,
+                idx: Register::X2,
+                kind: ExtendKind::Uxtx,
+                shift: 0,
+            },
+        ] {
+            for width in [
+                AccessWidth::Byte,
+                AccessWidth::Half,
+                AccessWidth::Word,
+                AccessWidth::Extended,
+            ] {
+                assert_single_reg_encodable(width, addr);
+            }
+        }
     }
 
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3539,6 +3539,32 @@ mod tests {
     }
 
     #[test]
+    fn parse_single_reg_memory_rejects_unencodable_immediate_offsets() {
+        for text in [
+            "ldr x0, [x1, #32768]",
+            "str x0, [x1, #256]!",
+            "str x0, [x1], #256",
+            "ldrsw x0, [x1, #-257]",
+        ] {
+            let err = parse_line(text).expect_err("unencodable memory offset should be rejected");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("instruction cannot be encoded in AArch64"),
+                "{text}: error should come from encodability gate, got {msg}"
+            );
+        }
+
+        for text in [
+            "ldr x0, [x1, #32760]",
+            "str x0, [x1, #-256]!",
+            "str x0, [x1], #255",
+            "ldr x0, [x1, #255]",
+        ] {
+            parse_line(text).unwrap_or_else(|err| panic!("{text}: expected parse, got {err}"));
+        }
+    }
+
+    #[test]
     fn parse_ldr_pre_index_yields_pre_index_mode() {
         use crate::ir::types::{AccessWidth, AddressOperand, IndexMode};
         let instr = parse_one("ldr x0, [x1, #8]!");


### PR DESCRIPTION
Summary:
- reject single-register AArch64 LDR/LDRS/STR immediates that cannot be emitted
- mirror the assembler scaled-offset and signed 9-bit writeback/unscaled ranges in the IR encodability gate
- add IR and parser regressions for invalid offsets and legal boundaries

Closes #307

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**