### PR TITLE
fix(parser): reject pair register-index addressing

### DIFF
--- a/docs/adr/0007-memory-model.md
+++ b/docs/adr/0007-memory-model.md
@@ -5,7 +5,7 @@ Date: 2026-05-18
 
 ## Context
 
-Before this ADR, the AArch64 IR (`src/ir/instructions.rs:22-402`) and machine-state types (`src/semantics/state.rs:257-261`, `src/semantics/smt.rs:128-138`) carried no memory. The pipeline reasoned only about general-purpose registers and the four NZCV flag bits. Issue #68 closes that gap by adding the LDR / LDRB / LDRH / LDRSB / LDRSH / LDRSW / STR / STRB / STRH / LDP / STP / LDPSW family across all five addressing modes (immediate-offset, pre-index, post-index, register-offset, register-extend) and both W/X widths.
+Before this ADR, the AArch64 IR (`src/ir/instructions.rs:22-402`) and machine-state types (`src/semantics/state.rs:257-261`, `src/semantics/smt.rs:128-138`) carried no memory. The pipeline reasoned only about general-purpose registers and the four NZCV flag bits. Issue #68 closes that gap by adding the LDR / LDRB / LDRH / LDRSB / LDRSH / LDRSW / STR / STRB / STRH single-register family across all five addressing modes (immediate-offset, pre-index, post-index, register-offset, register-extend), plus the LDP / STP / LDPSW pair family across the architecturally valid immediate-offset, pre-index, and post-index forms.
 
 The user-facing scope decision for this work was the most ambitious option on every axis: the *full* instruction family, *full* search wiring (enumerative + stochastic + symbolic + LLM), *whole-memory* live-out, and *sound full aliasing*. This ADR records the resulting model choices so a future reviewer of `src/semantics/concrete.rs` or `src/semantics/smt.rs` can reconstruct *why* the layers look the way they do — and so a future widening (multi-region live-out, typed-array model, etc.) has a single document to revise.
 

--- a/docs/capability.md
+++ b/docs/capability.md
@@ -60,9 +60,12 @@ Rewritable straight-line mnemonics accepted by the parser and Capstone bridge:
 - Memory loads and stores (issue #68, [ADR-0007](adr/0007-memory-model.md);
   byte-addressed Z3-array memory model with sound full aliasing, whole-memory
   live-out auto-derived): `ldr`, `ldrb`, `ldrh`, `ldrsb`, `ldrsh`, `ldrsw`,
-  `str`, `strb`, `strh`, `ldp`, `stp`, `ldpsw` — accepted in immediate-offset,
-  pre-index, post-index, register-offset, and register-extend addressing
-  forms, in both `W` and `X` widths
+  `str`, `strb`, `strh`, `ldp`, `stp`, `ldpsw`. Single-register memory
+  instructions accept immediate-offset, pre-index, post-index, register-offset,
+  and register-extend addressing in supported `W`/`X`-sized forms. Pair memory
+  instructions accept immediate-offset, pre-index, and post-index addressing
+  only; `ldp`/`stp` cover `W` and `X` pairs, and `ldpsw` loads sign-extended
+  word pairs.
 
 Fixed control-flow terminators:
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1076,6 +1076,23 @@ fn parse_pair_mem(
             2 + consumed
         ));
     }
+    match &addr {
+        crate::ir::types::AddressOperand::Reg { .. } => {
+            return Err(format!(
+                "{}: pair instructions do not support register-offset addressing; \
+                 use immediate-offset, pre-index, or post-index addressing",
+                mnem
+            ));
+        }
+        crate::ir::types::AddressOperand::Ext { .. } => {
+            return Err(format!(
+                "{}: pair instructions do not support register-extend addressing; \
+                 use immediate-offset, pre-index, or post-index addressing",
+                mnem
+            ));
+        }
+        crate::ir::types::AddressOperand::Imm { .. } => {}
+    }
     if is_load {
         Ok(Instruction::Ldp {
             rt1,
@@ -3637,6 +3654,49 @@ mod tests {
                     shift: expected_shift,
                 },
                 "{text}"
+            );
+        }
+    }
+
+    #[test]
+    fn pair_mem_rejects_register_offset_addressing() {
+        for text in [
+            "ldp x0, x1, [x2, x3]",
+            "ldp x0, x1, [x2, x3, lsl #3]",
+            "stp x0, x1, [x2, x3]",
+            "ldpsw x0, x1, [x2, x3, lsl #2]",
+        ] {
+            let err = parse_line(text).expect_err("pair register-offset should be rejected");
+            let msg = err.to_string();
+            let mnemonic = text.split_whitespace().next().unwrap();
+            assert!(
+                msg.contains(mnemonic),
+                "{text}: error should name mnemonic `{mnemonic}`, got {msg}"
+            );
+            assert!(
+                msg.contains("register-offset"),
+                "{text}: error should name register-offset addressing, got {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn pair_mem_rejects_register_extend_addressing() {
+        for text in [
+            "ldp x0, x1, [x2, w3, uxtw #3]",
+            "stp x0, x1, [x2, w3, sxtw]",
+            "ldpsw x0, x1, [x2, w3, sxtw #2]",
+        ] {
+            let err = parse_line(text).expect_err("pair register-extend should be rejected");
+            let msg = err.to_string();
+            let mnemonic = text.split_whitespace().next().unwrap();
+            assert!(
+                msg.contains(mnemonic),
+                "{text}: error should name mnemonic `{mnemonic}`, got {msg}"
+            );
+            assert!(
+                msg.contains("register-extend"),
+                "{text}: error should name register-extend addressing, got {msg}"
             );
         }
     }

--- a/tests/integration/docs_capability.rs
+++ b/tests/integration/docs_capability.rs
@@ -209,6 +209,36 @@ fn memory_operations_are_consistently_documented_with_known_gaps() {
 }
 
 #[test]
+fn docs_capability_documents_pair_memory_addressing_restriction() {
+    let matrix = normalized_doc("docs/capability.md");
+    assert!(
+        matrix.contains(
+            "single-register memory instructions accept immediate-offset, pre-index, post-index, register-offset, and register-extend addressing"
+        ),
+        "docs/capability.md must keep single-register memory addressing support visible"
+    );
+    assert!(
+        matrix.contains(
+            "pair memory instructions accept immediate-offset, pre-index, and post-index addressing only"
+        ),
+        "docs/capability.md must document pair memory addressing restrictions"
+    );
+
+    for (text, expected) in [
+        ("ldp x0, x1, [x2, x3]", "register-offset"),
+        ("stp x0, x1, [x2, w3, sxtw]", "register-extend"),
+    ] {
+        let err = s11::parser::parse_line(text)
+            .expect_err("pair register-index addressing should be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains(expected),
+            "{text}: error should mention {expected}, got {msg}"
+        );
+    }
+}
+
+#[test]
 fn stale_aarch64_count_and_branch_unsupported_claims_are_removed() {
     let mut docs = vec![
         "README.md".to_string(),


### PR DESCRIPTION
Summary:
- Reject LDP/STP/LDPSW register-offset and register-extend pair operands in parse_pair_mem with pair-specific diagnostics.
- Document single-register vs pair memory addressing support in capability docs/ADR and pin it with docs integration coverage.

Tests:
- cargo fmt --all -- --check
- cargo clippy --all -- -D warnings
- ./build_tests.sh
- cargo test --all
- ./ci_check.sh

Note: scripts/full_test.sh from the autonomous template is not present in this s11 workspace; ./ci_check.sh invokes the repo test_all.sh.

Closes #340

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**