### PR TITLE
Carry-aware arithmetic (ADC/ADCS/SBC/SBCS) + NZCV-in-LiveOut reconciliation

### DIFF
--- a/docs/adr/0008-nzcv-live-out-contract.md
+++ b/docs/adr/0008-nzcv-live-out-contract.md
@@ -1,0 +1,91 @@
+# ADR-0008 — NZCV live-out/live-in contract for carry-aware arithmetic
+
+Status: Accepted
+Date: 2026-06-18
+
+## Context
+
+Issue #205 adds the carry-threading opcodes `ADC` / `ADCS` / `SBC` / `SBCS`
+(`src/ir/instructions.rs`, register-only, X-only). Unlike every prior
+arithmetic opcode, `ADC`/`SBC` *read* the carry flag: NZCV becomes a genuine
+**live-in** to a rewrite window, not only a live-out.
+
+Two earlier ADRs frame the NZCV contract:
+
+- **ADR-0002** restricted the LLM-assisted flow to refuse targets whose flags
+  are live-out, on the grounds that the LLM is the only generator that might
+  *legitimately* drop a final flag-setter. Its 2026-05-19 amendment recorded
+  that the equivalence pipeline already models NZCV-as-live-out
+  (`LiveOut.flags_live`, consumed by both the fast path and the SMT path in
+  `src/semantics/equivalence.rs`), leaving only the LLM-specific static refusal
+  in `src/search/llm/mod.rs` as the authoritative remnant of ADR-0002.
+- **ADR-0006** added the `--live-out '<regs>;nzcv'` CLI grammar and reserved
+  the per-flag tokens `n`/`z`/`c`/`v` after `;` for a future per-flag rev.
+
+What neither ADR settled is (a) how NZCV-as-live-*in* is handled now that an
+opcode reads carry, and (b) whether the LLM static refusal should remain once
+carry-aware arithmetic exists. This ADR closes both.
+
+## Decision
+
+1. **Carry-in is a live-in, surfaced through `reads_flags()`.**
+   `ADC`/`ADCS`/`SBC`/`SBCS` are listed in `Instruction::reads_flags()`
+   (`src/ir/instructions.rs`). This is load-bearing, not cosmetic:
+   `validation::live_out::reads_flags_before_writing()` keys off it, which in
+   turn (a) drives the fast path to enumerate all 16 NZCV input combinations
+   (`fast_path_initial_nzcv_variants` in `src/semantics/equivalence.rs`) and
+   (b) makes live-in analysis treat NZCV as an input. There is **no new CLI
+   knob** — carry-in liveness is derived from the opcode, mirroring how
+   memory liveness is auto-derived in ADR-0007.
+
+2. **The SMT layer treats the initial carry as a free symbolic input.**
+   `MachineState::new_symbolic` already binds the NZCV bits to independent
+   symbolic constants, so a candidate that depends on carry-in cannot be
+   certified equivalent for the carry-in = 0 case alone. The regression tests
+   `test_adc_not_equivalent_to_add_because_carry_in_is_live` and
+   `test_sbc_not_equivalent_to_sub_because_borrow_in_is_live`
+   (`src/semantics/equivalence.rs`) pin this soundness floor.
+
+3. **The four search algorithms keep pinning `flags_live = true`.** Enumerative,
+   stochastic, symbolic, and (now) LLM treat NZCV as a conservative live-out.
+   This is unchanged for the first three and is the basis for decision 4.
+
+4. **The LLM static refusal of flag-live-out targets is removed.** The ADR-0002
+   refusal in `src/search/llm/mod.rs` is dropped; the LLM flow now relies on the
+   same equivalence check as every other generator — the verifier pins
+   `with_flags(true)` (`src/search/llm/outcome.rs`), so a candidate that drops a
+   needed flag-setter is *rejected by equivalence* rather than pre-refused. This
+   supersedes the part of ADR-0002 that its 2026-05-19 amendment had left
+   standing.
+
+5. **`flags_live` stays a single bit on `EquivalenceConfig` / `LiveOut`.** No
+   per-flag (n/z/c/v) liveness split in this rev; the tokens ADR-0006 reserved
+   remain unconsumed. Carry-aware arithmetic does not need finer granularity:
+   treating all of NZCV as live is sound, and ADR-0004 §5 already commits to
+   moving `flags_live` onto the generic mask later.
+
+## Consequences
+
+**Positive:**
+
+- Carry chains (IP-checksum folds, multi-word adders) can be lifted from
+  binaries and verified for the first time, with carry-in soundly modeled on
+  both the fast path (16-way NZCV enumeration) and the SMT path (free symbolic
+  carry).
+- The LLM flow no longer refuses an entire class of targets; it now optimizes
+  flag-live-out windows under the same sound equivalence contract as the other
+  algorithms. ADR-0002's special-case is retired.
+
+**Negative / deferred:**
+
+- Pinning `with_flags(true)` makes the LLM (and the other algorithms) treat
+  NZCV as live-out even when it is provably dead in the surrounding context, so
+  some valid optimizations are still skipped. Plumbing the *actual* post-window
+  live-out (via `flags_read_before_overwrite_after_window`) into the LLM flow is
+  a future enhancement, not part of #205.
+- `ADC`/`SBC` are intentionally absent from the random-generation pool
+  (`opcode_id` 69–72 fall above `opcode_count`), so stochastic/enumerative
+  search will not *synthesize* carry arithmetic yet — they lift, mutate, and
+  verify it, but do not generate it from scratch. Generation is deferred until
+  there is a concrete need, because a carry opcode is only meaningful when a
+  prior instruction has established the carry.

--- a/docs/capability.md
+++ b/docs/capability.md
@@ -39,6 +39,7 @@ Rewritable straight-line mnemonics accepted by the parser and Capstone bridge:
   `movk`
   - Register `mov` supports both 64-bit `X` and 32-bit `W` forms.
 - Arithmetic and flag-setting arithmetic: `add`, `sub`, `adds`, `subs`
+- Add/subtract with carry (X-only, register form): `adc`, `adcs`
   - Non-flag-setting `add` and `sub` support both 64-bit `X` and 32-bit `W`
     register/immediate/shifted-register forms. W extended-register arithmetic
     remains out of scope for now.

--- a/docs/capability.md
+++ b/docs/capability.md
@@ -39,7 +39,7 @@ Rewritable straight-line mnemonics accepted by the parser and Capstone bridge:
   `movk`
   - Register `mov` supports both 64-bit `X` and 32-bit `W` forms.
 - Arithmetic and flag-setting arithmetic: `add`, `sub`, `adds`, `subs`
-- Add/subtract with carry (X-only, register form): `adc`, `adcs`
+- Add/subtract with carry (X-only, register form): `adc`, `adcs`, `sbc`, `sbcs`
   - Non-flag-setting `add` and `sub` support both 64-bit `X` and 32-bit `W`
     register/immediate/shifted-register forms. W extended-register arithmetic
     remains out of scope for now.

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -1728,6 +1728,21 @@ impl AArch64Assembler {
                     }
                 }
             }
+            // Add with carry: register-only form. Slot 31 = XZR.
+            Instruction::Adc { rd, rn, rm } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                let rm_reg = register_to_dynasm(*rm)?;
+                dynasm!(ops ; .arch aarch64 ; adc X(rd_reg), X(rn_reg), X(rm_reg));
+                Ok(())
+            }
+            Instruction::Adcs { rd, rn, rm } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                let rm_reg = register_to_dynasm(*rm)?;
+                dynasm!(ops ; .arch aarch64 ; adcs X(rd_reg), X(rn_reg), X(rm_reg));
+                Ok(())
+            }
             Instruction::Ands { rd, rn, rm, width } => {
                 let rd_reg = register_to_dynasm(*rd)?;
                 let rn_reg = register_to_dynasm(*rn)?;
@@ -3492,6 +3507,34 @@ mod tests {
     /// Capstone round-trip for ADDS with SP as `rn` — guards against silent
     /// off-by-one in the encoded slot. Capstone must disassemble back to
     /// `adds` with `sp` in the rn position.
+    #[test]
+    fn test_adc_adcs_register_roundtrip() {
+        let mut assembler = AArch64Assembler::new();
+        let bytes = assembler
+            .assemble_instructions(
+                &[Instruction::Adc {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Register::X2,
+                }],
+                0,
+            )
+            .expect("ADC register form should encode");
+        disassemble_and_verify(&bytes, "adc", &["x0", "x1", "x2"]);
+
+        let bytes = assembler
+            .assemble_instructions(
+                &[Instruction::Adcs {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Register::X2,
+                }],
+                0,
+            )
+            .expect("ADCS register form should encode");
+        disassemble_and_verify(&bytes, "adcs", &["x0", "x1", "x2"]);
+    }
+
     #[test]
     fn test_adds_imm_sp_rn_roundtrip() {
         let mut assembler = AArch64Assembler::new();

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -1743,6 +1743,21 @@ impl AArch64Assembler {
                 dynasm!(ops ; .arch aarch64 ; adcs X(rd_reg), X(rn_reg), X(rm_reg));
                 Ok(())
             }
+            // Subtract with carry: register-only form.
+            Instruction::Sbc { rd, rn, rm } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                let rm_reg = register_to_dynasm(*rm)?;
+                dynasm!(ops ; .arch aarch64 ; sbc X(rd_reg), X(rn_reg), X(rm_reg));
+                Ok(())
+            }
+            Instruction::Sbcs { rd, rn, rm } => {
+                let rd_reg = register_to_dynasm(*rd)?;
+                let rn_reg = register_to_dynasm(*rn)?;
+                let rm_reg = register_to_dynasm(*rm)?;
+                dynasm!(ops ; .arch aarch64 ; sbcs X(rd_reg), X(rn_reg), X(rm_reg));
+                Ok(())
+            }
             Instruction::Ands { rd, rn, rm, width } => {
                 let rd_reg = register_to_dynasm(*rd)?;
                 let rn_reg = register_to_dynasm(*rn)?;
@@ -3533,6 +3548,34 @@ mod tests {
             )
             .expect("ADCS register form should encode");
         disassemble_and_verify(&bytes, "adcs", &["x0", "x1", "x2"]);
+    }
+
+    #[test]
+    fn test_sbc_sbcs_register_roundtrip() {
+        let mut assembler = AArch64Assembler::new();
+        let bytes = assembler
+            .assemble_instructions(
+                &[Instruction::Sbc {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Register::X2,
+                }],
+                0,
+            )
+            .expect("SBC register form should encode");
+        disassemble_and_verify(&bytes, "sbc", &["x0", "x1", "x2"]);
+
+        let bytes = assembler
+            .assemble_instructions(
+                &[Instruction::Sbcs {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Register::X2,
+                }],
+                0,
+            )
+            .expect("SBCS register form should encode");
+        disassemble_and_verify(&bytes, "sbcs", &["x0", "x1", "x2"]);
     }
 
     #[test]

--- a/src/docs_support.rs
+++ b/src/docs_support.rs
@@ -5,12 +5,13 @@
 //! Capstone conversion tripwire.
 
 pub const AARCH64_REWRITABLE_MNEMONICS: &[&str] = &[
-    "mov", "mvn", "neg", "negs", "movn", "movz", "movk", "add", "sub", "adds", "subs", "and",
-    "ands", "orr", "eor", "bic", "bics", "orn", "eon", "lsl", "lsr", "asr", "ror", "mul", "madd",
-    "msub", "mneg", "smulh", "umulh", "sdiv", "udiv", "cmp", "cmn", "tst", "ccmp", "ccmn", "csel",
-    "csinc", "csinv", "csneg", "cset", "csetm", "clz", "cls", "rbit", "rev", "rev32", "rev16",
-    "uxtb", "uxth", "sxtb", "sxth", "sxtw", "ubfx", "sbfx", "bfi", "bfxil", "ubfiz", "sbfiz",
-    "ldr", "ldrb", "ldrh", "ldrsb", "ldrsh", "ldrsw", "str", "strb", "strh", "ldp", "stp", "ldpsw",
+    "mov", "mvn", "neg", "negs", "movn", "movz", "movk", "add", "sub", "adds", "subs", "adc",
+    "adcs", "and", "ands", "orr", "eor", "bic", "bics", "orn", "eon", "lsl", "lsr", "asr", "ror",
+    "mul", "madd", "msub", "mneg", "smulh", "umulh", "sdiv", "udiv", "cmp", "cmn", "tst", "ccmp",
+    "ccmn", "csel", "csinc", "csinv", "csneg", "cset", "csetm", "clz", "cls", "rbit", "rev",
+    "rev32", "rev16", "uxtb", "uxth", "sxtb", "sxth", "sxtw", "ubfx", "sbfx", "bfi", "bfxil",
+    "ubfiz", "sbfiz", "ldr", "ldrb", "ldrh", "ldrsb", "ldrsh", "ldrsw", "str", "strb", "strh",
+    "ldp", "stp", "ldpsw",
 ];
 
 pub const AARCH64_FIXED_TERMINATORS: &[&str] = &[

--- a/src/docs_support.rs
+++ b/src/docs_support.rs
@@ -6,12 +6,12 @@
 
 pub const AARCH64_REWRITABLE_MNEMONICS: &[&str] = &[
     "mov", "mvn", "neg", "negs", "movn", "movz", "movk", "add", "sub", "adds", "subs", "adc",
-    "adcs", "and", "ands", "orr", "eor", "bic", "bics", "orn", "eon", "lsl", "lsr", "asr", "ror",
-    "mul", "madd", "msub", "mneg", "smulh", "umulh", "sdiv", "udiv", "cmp", "cmn", "tst", "ccmp",
-    "ccmn", "csel", "csinc", "csinv", "csneg", "cset", "csetm", "clz", "cls", "rbit", "rev",
-    "rev32", "rev16", "uxtb", "uxth", "sxtb", "sxth", "sxtw", "ubfx", "sbfx", "bfi", "bfxil",
-    "ubfiz", "sbfiz", "ldr", "ldrb", "ldrh", "ldrsb", "ldrsh", "ldrsw", "str", "strb", "strh",
-    "ldp", "stp", "ldpsw",
+    "adcs", "sbc", "sbcs", "and", "ands", "orr", "eor", "bic", "bics", "orn", "eon", "lsl", "lsr",
+    "asr", "ror", "mul", "madd", "msub", "mneg", "smulh", "umulh", "sdiv", "udiv", "cmp", "cmn",
+    "tst", "ccmp", "ccmn", "csel", "csinc", "csinv", "csneg", "cset", "csetm", "clz", "cls",
+    "rbit", "rev", "rev32", "rev16", "uxtb", "uxth", "sxtb", "sxth", "sxtw", "ubfx", "sbfx", "bfi",
+    "bfxil", "ubfiz", "sbfiz", "ldr", "ldrb", "ldrh", "ldrsb", "ldrsh", "ldrsw", "str", "strb",
+    "strh", "ldp", "stp", "ldpsw",
 ];
 
 pub const AARCH64_FIXED_TERMINATORS: &[&str] = &[

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -352,6 +352,16 @@ pub enum Instruction {
         rn: Register,
         rm: Register,
     },
+    Sbc {
+        rd: Register,
+        rn: Register,
+        rm: Register,
+    },
+    Sbcs {
+        rd: Register,
+        rn: Register,
+        rm: Register,
+    },
     Ands {
         rd: Register,
         rn: Register,
@@ -613,6 +623,8 @@ impl Instruction {
             | Instruction::Subs { rd, .. }
             | Instruction::Adc { rd, .. }
             | Instruction::Adcs { rd, .. }
+            | Instruction::Sbc { rd, .. }
+            | Instruction::Sbcs { rd, .. }
             | Instruction::Ands { rd, .. }
             | Instruction::Cset { rd, .. }
             | Instruction::Csetm { rd, .. }
@@ -726,6 +738,7 @@ impl Instruction {
                 | Instruction::Adds { .. }
                 | Instruction::Subs { .. }
                 | Instruction::Adcs { .. }
+                | Instruction::Sbcs { .. }
                 | Instruction::Ands { .. }
                 | Instruction::Ccmp { .. }
                 | Instruction::Ccmn { .. }
@@ -749,6 +762,8 @@ impl Instruction {
                 // ADC/SBC family reads the carry flag as a live-in.
                 | Instruction::Adc { .. }
                 | Instruction::Adcs { .. }
+                | Instruction::Sbc { .. }
+                | Instruction::Sbcs { .. }
         )
     }
 
@@ -956,8 +971,11 @@ impl Instruction {
                 Operand::ShiftedRegister { .. } => false,
                 Operand::ExtendedRegister { .. } => false,
             },
-            // ADC/ADCS: register-only form, always encodable.
-            Instruction::Adc { .. } | Instruction::Adcs { .. } => true,
+            // ADC/ADCS/SBC/SBCS: register-only form, always encodable.
+            Instruction::Adc { .. }
+            | Instruction::Adcs { .. }
+            | Instruction::Sbc { .. }
+            | Instruction::Sbcs { .. } => true,
             // ANDS: register or encodable bitmask immediate (issue #65).
             // ShiftedRegister out of scope (#59). The immediate form uses the
             // plain X slot for both rd and rn (rejects SP); XZR is fine for rd
@@ -1184,8 +1202,11 @@ impl Instruction {
                 }
                 regs
             }
-            // ADC/ADCS read rn and rm (both plain registers).
-            Instruction::Adc { rn, rm, .. } | Instruction::Adcs { rn, rm, .. } => {
+            // ADC/ADCS/SBC/SBCS read rn and rm (both plain registers).
+            Instruction::Adc { rn, rm, .. }
+            | Instruction::Adcs { rn, rm, .. }
+            | Instruction::Sbc { rn, rm, .. }
+            | Instruction::Sbcs { rn, rm, .. } => {
                 vec![*rn, *rm]
             }
             // CSET / CSETM have no source registers (read flags, not regs).
@@ -1533,6 +1554,8 @@ impl fmt::Display for Instruction {
             Instruction::Subs { rd, rn, rm } => write!(f, "subs {}, {}, {}", rd, rn, rm),
             Instruction::Adc { rd, rn, rm } => write!(f, "adc {}, {}, {}", rd, rn, rm),
             Instruction::Adcs { rd, rn, rm } => write!(f, "adcs {}, {}, {}", rd, rn, rm),
+            Instruction::Sbc { rd, rn, rm } => write!(f, "sbc {}, {}, {}", rd, rn, rm),
+            Instruction::Sbcs { rd, rn, rm } => write!(f, "sbcs {}, {}, {}", rd, rn, rm),
             Instruction::Ands { rd, rn, rm, width } => write!(
                 f,
                 "ands {}, {}, {}",

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -339,6 +339,19 @@ pub enum Instruction {
         rn: Register,
         rm: Operand,
     },
+    // Add/subtract with carry. AArch64 has only the register form (no
+    // immediate, no shifted-register), so `rm` is a plain `Register`.
+    // Adc/Sbc read the carry flag; Adcs/Sbcs additionally write NZCV.
+    Adc {
+        rd: Register,
+        rn: Register,
+        rm: Register,
+    },
+    Adcs {
+        rd: Register,
+        rn: Register,
+        rm: Register,
+    },
     Ands {
         rd: Register,
         rn: Register,
@@ -598,6 +611,8 @@ impl Instruction {
             | Instruction::Eon { rd, .. }
             | Instruction::Adds { rd, .. }
             | Instruction::Subs { rd, .. }
+            | Instruction::Adc { rd, .. }
+            | Instruction::Adcs { rd, .. }
             | Instruction::Ands { rd, .. }
             | Instruction::Cset { rd, .. }
             | Instruction::Csetm { rd, .. }
@@ -710,6 +725,7 @@ impl Instruction {
                 | Instruction::Bics { .. }
                 | Instruction::Adds { .. }
                 | Instruction::Subs { .. }
+                | Instruction::Adcs { .. }
                 | Instruction::Ands { .. }
                 | Instruction::Ccmp { .. }
                 | Instruction::Ccmn { .. }
@@ -730,6 +746,9 @@ impl Instruction {
                 | Instruction::Ccmp { .. }
                 | Instruction::Ccmn { .. }
                 | Instruction::BCond { .. }
+                // ADC/SBC family reads the carry flag as a live-in.
+                | Instruction::Adc { .. }
+                | Instruction::Adcs { .. }
         )
     }
 
@@ -937,6 +956,8 @@ impl Instruction {
                 Operand::ShiftedRegister { .. } => false,
                 Operand::ExtendedRegister { .. } => false,
             },
+            // ADC/ADCS: register-only form, always encodable.
+            Instruction::Adc { .. } | Instruction::Adcs { .. } => true,
             // ANDS: register or encodable bitmask immediate (issue #65).
             // ShiftedRegister out of scope (#59). The immediate form uses the
             // plain X slot for both rd and rn (rejects SP); XZR is fine for rd
@@ -1162,6 +1183,10 @@ impl Instruction {
                     regs.push(*r);
                 }
                 regs
+            }
+            // ADC/ADCS read rn and rm (both plain registers).
+            Instruction::Adc { rn, rm, .. } | Instruction::Adcs { rn, rm, .. } => {
+                vec![*rn, *rm]
             }
             // CSET / CSETM have no source registers (read flags, not regs).
             Instruction::Cset { .. } | Instruction::Csetm { .. } => vec![],
@@ -1506,6 +1531,8 @@ impl fmt::Display for Instruction {
             Instruction::Eon { rd, rn, rm } => write!(f, "eon {}, {}, {}", rd, rn, rm),
             Instruction::Adds { rd, rn, rm } => write!(f, "adds {}, {}, {}", rd, rn, rm),
             Instruction::Subs { rd, rn, rm } => write!(f, "subs {}, {}, {}", rd, rn, rm),
+            Instruction::Adc { rd, rn, rm } => write!(f, "adc {}, {}, {}", rd, rn, rm),
+            Instruction::Adcs { rd, rn, rm } => write!(f, "adcs {}, {}, {}", rd, rn, rm),
             Instruction::Ands { rd, rn, rm, width } => write!(
                 f,
                 "ands {}, {}, {}",

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -280,6 +280,8 @@ impl InstructionType for Instruction {
             // (same as branches/memory).
             Instruction::Adc { .. } => 69,
             Instruction::Adcs { .. } => 70,
+            Instruction::Sbc { .. } => 71,
+            Instruction::Sbcs { .. } => 72,
         }
     }
 
@@ -318,6 +320,8 @@ impl InstructionType for Instruction {
             Instruction::Subs { .. } => "subs",
             Instruction::Adc { .. } => "adc",
             Instruction::Adcs { .. } => "adcs",
+            Instruction::Sbc { .. } => "sbc",
+            Instruction::Sbcs { .. } => "sbcs",
             Instruction::Ands { .. } => "ands",
             Instruction::Cset { .. } => "cset",
             Instruction::Csetm { .. } => "csetm",
@@ -1181,6 +1185,8 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     Instruction::Subs { rn, rm, .. } => Instruction::Subs { rd: new_rd, rn, rm },
                     Instruction::Adc { rn, rm, .. } => Instruction::Adc { rd: new_rd, rn, rm },
                     Instruction::Adcs { rn, rm, .. } => Instruction::Adcs { rd: new_rd, rn, rm },
+                    Instruction::Sbc { rn, rm, .. } => Instruction::Sbc { rd: new_rd, rn, rm },
+                    Instruction::Sbcs { rn, rm, .. } => Instruction::Sbcs { rd: new_rd, rn, rm },
                     Instruction::Ands { rn, rm, width, .. } => Instruction::Ands {
                         rd: new_rd,
                         rn,
@@ -1588,6 +1594,14 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     Instruction::Adcs { rd, rn, .. } => {
                         let new_rm = registers[rng.random_range(0..registers.len())];
                         Instruction::Adcs { rd, rn, rm: new_rm }
+                    }
+                    Instruction::Sbc { rd, rn, .. } => {
+                        let new_rm = registers[rng.random_range(0..registers.len())];
+                        Instruction::Sbc { rd, rn, rm: new_rm }
+                    }
+                    Instruction::Sbcs { rd, rn, .. } => {
+                        let new_rm = registers[rng.random_range(0..registers.len())];
+                        Instruction::Sbcs { rd, rn, rm: new_rm }
                     }
                     Instruction::Ands {
                         rd,

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -275,6 +275,11 @@ impl InstructionType for Instruction {
             Instruction::Ldp { .. } => 67,
             // Pair store (STP).
             Instruction::Stp { .. } => 68,
+            // Add/subtract with carry (issue #205). Not in the random-
+            // generation pool, so these ids fall above `opcode_count`
+            // (same as branches/memory).
+            Instruction::Adc { .. } => 69,
+            Instruction::Adcs { .. } => 70,
         }
     }
 
@@ -311,6 +316,8 @@ impl InstructionType for Instruction {
             Instruction::Eon { .. } => "eon",
             Instruction::Adds { .. } => "adds",
             Instruction::Subs { .. } => "subs",
+            Instruction::Adc { .. } => "adc",
+            Instruction::Adcs { .. } => "adcs",
             Instruction::Ands { .. } => "ands",
             Instruction::Cset { .. } => "cset",
             Instruction::Csetm { .. } => "csetm",
@@ -1172,6 +1179,8 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     Instruction::Eon { rn, rm, .. } => Instruction::Eon { rd: new_rd, rn, rm },
                     Instruction::Adds { rn, rm, .. } => Instruction::Adds { rd: new_rd, rn, rm },
                     Instruction::Subs { rn, rm, .. } => Instruction::Subs { rd: new_rd, rn, rm },
+                    Instruction::Adc { rn, rm, .. } => Instruction::Adc { rd: new_rd, rn, rm },
+                    Instruction::Adcs { rn, rm, .. } => Instruction::Adcs { rd: new_rd, rn, rm },
                     Instruction::Ands { rn, rm, width, .. } => Instruction::Ands {
                         rd: new_rd,
                         rn,
@@ -1571,6 +1580,14 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     Instruction::Subs { rd, rn, rm } => {
                         let new_rm = mutate_operand(rng, rm, registers, immediates, 0xFFF);
                         Instruction::Subs { rd, rn, rm: new_rm }
+                    }
+                    Instruction::Adc { rd, rn, .. } => {
+                        let new_rm = registers[rng.random_range(0..registers.len())];
+                        Instruction::Adc { rd, rn, rm: new_rm }
+                    }
+                    Instruction::Adcs { rd, rn, .. } => {
+                        let new_rm = registers[rng.random_range(0..registers.len())];
+                        Instruction::Adcs { rd, rn, rm: new_rm }
                     }
                     Instruction::Ands {
                         rd,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2485,6 +2485,8 @@ mod cli_helper_tests {
             ("subs", "x0, x1, x2"),
             ("adc", "x0, x1, x2"),
             ("adcs", "x0, x1, x2"),
+            ("sbc", "x0, x1, x2"),
+            ("sbcs", "x0, x1, x2"),
             ("and", "x0, x1, x2"),
             ("and", "w0, w1, #0xff"),
             ("ands", "x0, x1, x2"),
@@ -2637,7 +2639,7 @@ mod cli_helper_tests {
         // Tripwire: bump in lockstep when adding/removing rows. Catches
         // accidental row deletion and forces a re-read when adding a parser
         // mnemonic without a matching test row.
-        assert_eq!(cases.len(), 146);
+        assert_eq!(cases.len(), 148);
 
         fn docs_mnemonic(mnemonic: &'static str) -> &'static str {
             if mnemonic.starts_with("b.") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2483,6 +2483,8 @@ mod cli_helper_tests {
             ("sub", "w0, w1, #3"),
             ("adds", "x0, x1, #1"),
             ("subs", "x0, x1, x2"),
+            ("adc", "x0, x1, x2"),
+            ("adcs", "x0, x1, x2"),
             ("and", "x0, x1, x2"),
             ("and", "w0, w1, #0xff"),
             ("ands", "x0, x1, x2"),
@@ -2635,7 +2637,7 @@ mod cli_helper_tests {
         // Tripwire: bump in lockstep when adding/removing rows. Catches
         // accidental row deletion and forces a re-read when adding a parser
         // mnemonic without a matching test row.
-        assert_eq!(cases.len(), 144);
+        assert_eq!(cases.len(), 146);
 
         fn docs_mnemonic(mnemonic: &'static str) -> &'static str {
             if mnemonic.starts_with("b.") {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -568,6 +568,28 @@ fn parse_adcs(operands: &[&str]) -> Result<Instruction, String> {
     Ok(Instruction::Adcs { rd, rn, rm })
 }
 
+/// Parse SBC instruction (register-only; no immediate or shifted form)
+fn parse_sbc(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() != 3 {
+        return Err(format!("sbc requires 3 operands, got {}", operands.len()));
+    }
+    let rd = parse_register(operands[0])?;
+    let rn = parse_register(operands[1])?;
+    let rm = parse_register(operands[2])?;
+    Ok(Instruction::Sbc { rd, rn, rm })
+}
+
+/// Parse SBCS instruction (register-only; no immediate or shifted form)
+fn parse_sbcs(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() != 3 {
+        return Err(format!("sbcs requires 3 operands, got {}", operands.len()));
+    }
+    let rd = parse_register(operands[0])?;
+    let rn = parse_register(operands[1])?;
+    let rm = parse_register(operands[2])?;
+    Ok(Instruction::Sbcs { rd, rn, rm })
+}
+
 /// Parse ANDS instruction (register-only rm)
 fn parse_ands(operands: &[&str]) -> Result<Instruction, String> {
     if operands.len() == 3 {
@@ -1865,6 +1887,8 @@ pub fn parse_line(line: &str) -> Result<LineResult, ParseLineError> {
         "subs" => parse_subs(&operands).map_err(ParseLineError::Other)?,
         "adc" => parse_adc(&operands).map_err(ParseLineError::Other)?,
         "adcs" => parse_adcs(&operands).map_err(ParseLineError::Other)?,
+        "sbc" => parse_sbc(&operands).map_err(ParseLineError::Other)?,
+        "sbcs" => parse_sbcs(&operands).map_err(ParseLineError::Other)?,
         "ands" => parse_ands(&operands).map_err(ParseLineError::Other)?,
         "cset" => parse_cset(&operands).map_err(ParseLineError::Other)?,
         "csetm" => parse_csetm(&operands).map_err(ParseLineError::Other)?,
@@ -2307,6 +2331,24 @@ mod tests {
         // ADC/ADCS have no immediate form — an immediate operand must be rejected.
         assert!(parse_line("adc x0, x1, #1").is_err());
         assert!(parse_line("adcs x0, x1, #1").is_err());
+    }
+
+    #[test]
+    fn test_parse_line_sbc_register_only() {
+        match parse_line("sbc x0, x1, x2").unwrap() {
+            LineResult::Instruction(Instruction::Sbc { rd, rn, rm }) => {
+                assert_eq!((rd, rn, rm), (Register::X0, Register::X1, Register::X2));
+            }
+            _ => panic!("expected Sbc"),
+        }
+        match parse_line("sbcs x0, x1, x2").unwrap() {
+            LineResult::Instruction(Instruction::Sbcs { rd, rn, rm }) => {
+                assert_eq!((rd, rn, rm), (Register::X0, Register::X1, Register::X2));
+            }
+            _ => panic!("expected Sbcs"),
+        }
+        assert!(parse_line("sbc x0, x1, #1").is_err());
+        assert!(parse_line("sbcs x0, x1, #1").is_err());
     }
 
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -546,6 +546,28 @@ fn parse_subs(operands: &[&str]) -> Result<Instruction, String> {
     Ok(Instruction::Subs { rd, rn, rm })
 }
 
+/// Parse ADC instruction (register-only; no immediate or shifted form)
+fn parse_adc(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() != 3 {
+        return Err(format!("adc requires 3 operands, got {}", operands.len()));
+    }
+    let rd = parse_register(operands[0])?;
+    let rn = parse_register(operands[1])?;
+    let rm = parse_register(operands[2])?;
+    Ok(Instruction::Adc { rd, rn, rm })
+}
+
+/// Parse ADCS instruction (register-only; no immediate or shifted form)
+fn parse_adcs(operands: &[&str]) -> Result<Instruction, String> {
+    if operands.len() != 3 {
+        return Err(format!("adcs requires 3 operands, got {}", operands.len()));
+    }
+    let rd = parse_register(operands[0])?;
+    let rn = parse_register(operands[1])?;
+    let rm = parse_register(operands[2])?;
+    Ok(Instruction::Adcs { rd, rn, rm })
+}
+
 /// Parse ANDS instruction (register-only rm)
 fn parse_ands(operands: &[&str]) -> Result<Instruction, String> {
     if operands.len() == 3 {
@@ -1841,6 +1863,8 @@ pub fn parse_line(line: &str) -> Result<LineResult, ParseLineError> {
         "eon" => parse_eon(&operands).map_err(ParseLineError::Other)?,
         "adds" => parse_adds(&operands).map_err(ParseLineError::Other)?,
         "subs" => parse_subs(&operands).map_err(ParseLineError::Other)?,
+        "adc" => parse_adc(&operands).map_err(ParseLineError::Other)?,
+        "adcs" => parse_adcs(&operands).map_err(ParseLineError::Other)?,
         "ands" => parse_ands(&operands).map_err(ParseLineError::Other)?,
         "cset" => parse_cset(&operands).map_err(ParseLineError::Other)?,
         "csetm" => parse_csetm(&operands).map_err(ParseLineError::Other)?,
@@ -2264,6 +2288,25 @@ mod tests {
             }
             _ => panic!("expected Add"),
         }
+    }
+
+    #[test]
+    fn test_parse_line_adc_register_only() {
+        match parse_line("adc x0, x1, x2").unwrap() {
+            LineResult::Instruction(Instruction::Adc { rd, rn, rm }) => {
+                assert_eq!((rd, rn, rm), (Register::X0, Register::X1, Register::X2));
+            }
+            _ => panic!("expected Adc"),
+        }
+        match parse_line("adcs x0, x1, x2").unwrap() {
+            LineResult::Instruction(Instruction::Adcs { rd, rn, rm }) => {
+                assert_eq!((rd, rn, rm), (Register::X0, Register::X1, Register::X2));
+            }
+            _ => panic!("expected Adcs"),
+        }
+        // ADC/ADCS have no immediate form — an immediate operand must be rejected.
+        assert!(parse_line("adc x0, x1, #1").is_err());
+        assert!(parse_line("adcs x0, x1, #1").is_err());
     }
 
     #[test]

--- a/src/search/llm/mod.rs
+++ b/src/search/llm/mod.rs
@@ -17,7 +17,7 @@ use crate::search::SearchAlgorithm;
 use crate::search::config::SearchConfig;
 use crate::search::result::{SearchResult, SearchStatistics};
 use crate::semantics::live_out::LiveOut;
-use crate::validation::live_out::{compute_live_in_registers, flags_live_out};
+use crate::validation::live_out::compute_live_in_registers;
 
 use self::codex::invoke_codex;
 use self::ledger::UnsupportedMnemonicLedger;
@@ -114,23 +114,11 @@ impl SearchAlgorithm<crate::isa::AArch64> for LlmSearch {
         let mut timings = LlmTimings::default();
         let started = Instant::now();
 
-        // Per ADR-0002 (as amended by ADR-0006): the equivalence pipeline
-        // now models NZCV, but the LLM flow still refuses flag-live-out
-        // targets as a conservative pre-Codex gate. Removing this is a
-        // deliberate policy decision, not a bug.
-        if flags_live_out(target) {
-            eprintln!(
-                "llm-search: target has flags live-out — the LLM flow does \
-                 not process flag-live-out targets (conservative policy per \
-                 ADR-0002 as amended by ADR-0006). Refusing."
-            );
-            stats.elapsed_time = started.elapsed();
-            self.last_stats = stats.clone();
-            self.last_ledger = ledger;
-            self.last_timings = timings;
-            return SearchResult::no_optimization(target.to_vec(), stats);
-        }
-
+        // Per ADR-0008: the LLM flow no longer statically refuses flag-live-out
+        // targets. It relies on the same equivalence check as every other
+        // generator — the verifier pins `with_flags(true)` (see `outcome.rs`),
+        // so a candidate that drops a needed flag-setter is rejected by
+        // equivalence rather than pre-refused. This supersedes ADR-0002.
         let live_in = compute_live_in_registers(target);
         let prompt = build_prompt(target, &live_in, live_out);
         let timeout = config.timeout.unwrap_or(Duration::from_secs(60));
@@ -385,9 +373,16 @@ mod tests {
         SearchConfig::default().with_llm(LlmConfig::default().with_max_codex_calls(0))
     }
 
+    #[cfg(unix)]
     #[test]
-    fn flags_live_out_target_is_refused_without_calling_codex() {
-        // Target ends in a flag-writer; per ADR-0002 the LLM flow refuses.
+    fn flags_live_out_target_is_no_longer_refused_and_reaches_codex() {
+        // Per ADR-0008 the static refusal is gone: a flag-live-out target (one
+        // ending in CMP) must now be processed like any other. The fake codex
+        // proposes `mov x0, x1`, which drops the flag-setter; because the LLM
+        // verifier pins `with_flags(true)`, equivalence rejects it — so no
+        // optimization is reported, but codex WAS invoked (the key signal that
+        // the pre-refusal is gone).
+        let fake = FakeCodex::new(&assembly_answer_writer_script("mov x0, x1"));
         let target = vec![
             Instruction::Add {
                 rd: Register::X0,
@@ -401,25 +396,17 @@ mod tests {
         ];
 
         let mut search = LlmSearch::new();
-        let result = search.search(&target, &live_out_x0(), &cfg_no_calls());
+        let result = search.search(&target, &live_out_x0(), &cfg_with_fake_codex(&fake, 1));
 
         assert!(
             !result.found_optimization,
-            "flags-live-out target must be refused, not optimized"
+            "a flag-dropping candidate must be rejected by equivalence"
         );
-        assert!(
-            result.optimized_sequence.is_none(),
-            "no optimized sequence expected on refusal"
-        );
-
-        let timings = search.timings();
         assert_eq!(
-            timings.codex_calls, 0,
-            "refusal must short-circuit before any codex invocation"
+            search.timings().codex_calls,
+            1,
+            "flag-live-out target must reach codex, not be statically refused"
         );
-        assert_eq!(timings.smt_calls, 0);
-        assert_eq!(timings.verifications, 0);
-        assert!(search.ledger().is_empty());
     }
 
     #[test]

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -395,6 +395,14 @@ impl Mutator {
                     _ => *rm = Self::clamp_imm12(self.random_operand(rng)),
                 }
             }
+            // ADC/ADCS are register-only (rd, rn, rm all registers).
+            Instruction::Adc { rd, rn, rm } | Instruction::Adcs { rd, rn, rm } => {
+                match rng.random_range(0..3) {
+                    0 => *rd = self.random_register(rng),
+                    1 => *rn = self.random_register(rng),
+                    _ => *rm = self.random_register(rng),
+                }
+            }
             Instruction::Ands { rd, rn, rm, width } => {
                 let choice = rng.random_range(0..3);
                 match choice {
@@ -927,6 +935,15 @@ impl Mutator {
                     width: RegisterWidth::X64,
                 },
                 _ => Instruction::Subs { rd, rn, rm },
+            },
+            // ADC/ADCS toggle within the carry family (register-only).
+            Instruction::Adc { rd, rn, rm } => match rng.random_range(0..2) {
+                0 => Instruction::Adcs { rd, rn, rm },
+                _ => Instruction::Adc { rd, rn, rm },
+            },
+            Instruction::Adcs { rd, rn, rm } => match rng.random_range(0..2) {
+                0 => Instruction::Adc { rd, rn, rm },
+                _ => Instruction::Adcs { rd, rn, rm },
             },
             Instruction::Ands { rd, rn, rm, width } => match rng.random_range(0..4) {
                 0 => Instruction::And { rd, rn, rm, width },

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -395,14 +395,15 @@ impl Mutator {
                     _ => *rm = Self::clamp_imm12(self.random_operand(rng)),
                 }
             }
-            // ADC/ADCS are register-only (rd, rn, rm all registers).
-            Instruction::Adc { rd, rn, rm } | Instruction::Adcs { rd, rn, rm } => {
-                match rng.random_range(0..3) {
-                    0 => *rd = self.random_register(rng),
-                    1 => *rn = self.random_register(rng),
-                    _ => *rm = self.random_register(rng),
-                }
-            }
+            // ADC/ADCS/SBC/SBCS are register-only (rd, rn, rm all registers).
+            Instruction::Adc { rd, rn, rm }
+            | Instruction::Adcs { rd, rn, rm }
+            | Instruction::Sbc { rd, rn, rm }
+            | Instruction::Sbcs { rd, rn, rm } => match rng.random_range(0..3) {
+                0 => *rd = self.random_register(rng),
+                1 => *rn = self.random_register(rng),
+                _ => *rm = self.random_register(rng),
+            },
             Instruction::Ands { rd, rn, rm, width } => {
                 let choice = rng.random_range(0..3);
                 match choice {
@@ -936,7 +937,7 @@ impl Mutator {
                 },
                 _ => Instruction::Subs { rd, rn, rm },
             },
-            // ADC/ADCS toggle within the carry family (register-only).
+            // ADC/ADCS/SBC/SBCS toggle within the carry family (register-only).
             Instruction::Adc { rd, rn, rm } => match rng.random_range(0..2) {
                 0 => Instruction::Adcs { rd, rn, rm },
                 _ => Instruction::Adc { rd, rn, rm },
@@ -944,6 +945,14 @@ impl Mutator {
             Instruction::Adcs { rd, rn, rm } => match rng.random_range(0..2) {
                 0 => Instruction::Adc { rd, rn, rm },
                 _ => Instruction::Adcs { rd, rn, rm },
+            },
+            Instruction::Sbc { rd, rn, rm } => match rng.random_range(0..2) {
+                0 => Instruction::Sbcs { rd, rn, rm },
+                _ => Instruction::Sbc { rd, rn, rm },
+            },
+            Instruction::Sbcs { rd, rn, rm } => match rng.random_range(0..2) {
+                0 => Instruction::Sbc { rd, rn, rm },
+                _ => Instruction::Sbcs { rd, rn, rm },
             },
             Instruction::Ands { rd, rn, rm, width } => match rng.random_range(0..4) {
                 0 => Instruction::And { rd, rn, rm, width },

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -385,6 +385,23 @@ pub fn apply_instruction_concrete(
             state.set_register(*rd, ConcreteValue::new(result));
             state.set_flags(ConditionFlags::from_sub(lhs, rhs, result));
         }
+        // Add with carry: rd = rn + rm + C. Adc leaves flags untouched;
+        // Adcs writes NZCV.
+        Instruction::Adc { rd, rn, rm } => {
+            let lhs = state.get_register(*rn).as_u64();
+            let rhs = state.get_register(*rm).as_u64();
+            let carry = state.get_flags().c as u64;
+            let result = lhs.wrapping_add(rhs).wrapping_add(carry);
+            state.set_register(*rd, ConcreteValue::new(result));
+        }
+        Instruction::Adcs { rd, rn, rm } => {
+            let lhs = state.get_register(*rn).as_u64();
+            let rhs = state.get_register(*rm).as_u64();
+            let carry = state.get_flags().c as u64;
+            let result = lhs.wrapping_add(rhs).wrapping_add(carry);
+            state.set_register(*rd, ConcreteValue::new(result));
+            state.set_flags(ConditionFlags::from_adc(lhs, rhs, carry));
+        }
         Instruction::Ands { rd, rn, rm, width } => {
             let lhs = state.get_register(*rn).as_u64() & mask_for_register_width(*width);
             let rhs = eval_logical_operand(&state, rm, *width);
@@ -1745,6 +1762,51 @@ mod tests {
         let new_state = apply_instruction_concrete(state, &instr);
         let f = new_state.get_flags();
         assert!(!f.c, "SUBS(3, 5): C=0 (borrow)");
+    }
+
+    #[test]
+    fn test_adc_threads_carry_in() {
+        // ADC: rd = rn + rm + C. With C=1: 5 + 7 + 1 = 13.
+        let mut state = state_with(vec![(Register::X1, 5), (Register::X2, 7)]);
+        state.set_flags(ConditionFlags {
+            n: false,
+            z: false,
+            c: true,
+            v: false,
+        });
+        let instr = Instruction::Adc {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+        };
+        let new_state = apply_instruction_concrete(state, &instr);
+        assert_eq!(new_state.get_register(Register::X0).as_u64(), 13);
+        // ADC must NOT modify flags.
+        assert!(new_state.get_flags().c, "ADC leaves C untouched");
+
+        // With C=0: 5 + 7 + 0 = 12.
+        let state = state_with(vec![(Register::X1, 5), (Register::X2, 7)]);
+        let new_state = apply_instruction_concrete(state, &instr);
+        assert_eq!(new_state.get_register(Register::X0).as_u64(), 12);
+    }
+
+    #[test]
+    fn test_adcs_sets_carry_out_flag() {
+        // ADCS(u64::MAX, 0) with C=1 → wraps to 0, carry-out C=1, Z=1.
+        let mut state = state_with(vec![(Register::X1, u64::MAX), (Register::X2, 0)]);
+        state.set_flags(ConditionFlags {
+            c: true,
+            ..Default::default()
+        });
+        let instr = Instruction::Adcs {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+        };
+        let new_state = apply_instruction_concrete(state, &instr);
+        assert_eq!(new_state.get_register(Register::X0).as_u64(), 0);
+        let f = new_state.get_flags();
+        assert_eq!((f.n, f.z, f.c, f.v), (false, true, true, false));
     }
 
     #[test]

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -402,6 +402,23 @@ pub fn apply_instruction_concrete(
             state.set_register(*rd, ConcreteValue::new(result));
             state.set_flags(ConditionFlags::from_adc(lhs, rhs, carry));
         }
+        // Subtract with carry: rd = rn + NOT(rm) + C = rn - rm - (1 - C).
+        // Sbc leaves flags untouched; Sbcs writes NZCV.
+        Instruction::Sbc { rd, rn, rm } => {
+            let lhs = state.get_register(*rn).as_u64();
+            let rhs = state.get_register(*rm).as_u64();
+            let carry = state.get_flags().c as u64;
+            let result = lhs.wrapping_add(!rhs).wrapping_add(carry);
+            state.set_register(*rd, ConcreteValue::new(result));
+        }
+        Instruction::Sbcs { rd, rn, rm } => {
+            let lhs = state.get_register(*rn).as_u64();
+            let rhs = state.get_register(*rm).as_u64();
+            let carry = state.get_flags().c as u64;
+            let result = lhs.wrapping_add(!rhs).wrapping_add(carry);
+            state.set_register(*rd, ConcreteValue::new(result));
+            state.set_flags(ConditionFlags::from_sbc(lhs, rhs, carry));
+        }
         Instruction::Ands { rd, rn, rm, width } => {
             let lhs = state.get_register(*rn).as_u64() & mask_for_register_width(*width);
             let rhs = eval_logical_operand(&state, rm, *width);
@@ -1807,6 +1824,68 @@ mod tests {
         assert_eq!(new_state.get_register(Register::X0).as_u64(), 0);
         let f = new_state.get_flags();
         assert_eq!((f.n, f.z, f.c, f.v), (false, true, true, false));
+    }
+
+    #[test]
+    fn test_sbc_threads_borrow() {
+        // SBC = rn - rm - (1 - C). With C=1 (no borrow): 10 - 3 = 7.
+        let mut state = state_with(vec![(Register::X1, 10), (Register::X2, 3)]);
+        state.set_flags(ConditionFlags {
+            c: true,
+            ..Default::default()
+        });
+        let instr = Instruction::Sbc {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+        };
+        let new_state = apply_instruction_concrete(state, &instr);
+        assert_eq!(new_state.get_register(Register::X0).as_u64(), 7);
+
+        // With C=0 (borrow asserted): 10 - 3 - 1 = 6.
+        let state = state_with(vec![(Register::X1, 10), (Register::X2, 3)]);
+        let new_state = apply_instruction_concrete(state, &instr);
+        assert_eq!(new_state.get_register(Register::X0).as_u64(), 6);
+    }
+
+    #[test]
+    fn test_sbcs_carry_is_no_borrow() {
+        // SBCS(10, 3) with C=1 → 7, C=1 (no borrow).
+        let mut state = state_with(vec![(Register::X1, 10), (Register::X2, 3)]);
+        state.set_flags(ConditionFlags {
+            c: true,
+            ..Default::default()
+        });
+        let s = apply_instruction_concrete(
+            state,
+            &Instruction::Sbcs {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Register::X2,
+            },
+        );
+        assert_eq!(s.get_register(Register::X0).as_u64(), 7);
+        let f = s.get_flags();
+        assert!(f.c, "SBCS(10,3): no borrow → C=1");
+        assert!(!f.z && !f.n);
+
+        // SBCS(3, 10) with C=1 → -7, C=0 (borrow), N=1.
+        let mut state = state_with(vec![(Register::X1, 3), (Register::X2, 10)]);
+        state.set_flags(ConditionFlags {
+            c: true,
+            ..Default::default()
+        });
+        let s = apply_instruction_concrete(
+            state,
+            &Instruction::Sbcs {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Register::X2,
+            },
+        );
+        let f = s.get_flags();
+        assert!(!f.c, "SBCS(3,10): borrow → C=0");
+        assert!(f.n, "negative result → N=1");
     }
 
     #[test]

--- a/src/semantics/cost.rs
+++ b/src/semantics/cost.rs
@@ -67,7 +67,10 @@ fn instruction_latency(instr: &Instruction) -> u64 {
         // Flag-setting arith / logical
         Instruction::Adds { .. } | Instruction::Subs { .. } | Instruction::Ands { .. } => 1,
         // Add/subtract with carry
-        Instruction::Adc { .. } | Instruction::Adcs { .. } => 1,
+        Instruction::Adc { .. }
+        | Instruction::Adcs { .. }
+        | Instruction::Sbc { .. }
+        | Instruction::Sbcs { .. } => 1,
         // Conditional set aliases
         Instruction::Cset { .. } | Instruction::Csetm { .. } => 1,
         // Rotate right

--- a/src/semantics/cost.rs
+++ b/src/semantics/cost.rs
@@ -66,6 +66,8 @@ fn instruction_latency(instr: &Instruction) -> u64 {
         | Instruction::Eon { .. } => 1,
         // Flag-setting arith / logical
         Instruction::Adds { .. } | Instruction::Subs { .. } | Instruction::Ands { .. } => 1,
+        // Add/subtract with carry
+        Instruction::Adc { .. } | Instruction::Adcs { .. } => 1,
         // Conditional set aliases
         Instruction::Cset { .. } | Instruction::Csetm { .. } => 1,
         // Rotate right

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -2529,6 +2529,32 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_sbc_not_equivalent_to_sub_because_borrow_in_is_live() {
+        // SBC = rn - rm - (1 - carry); it reads the carry/borrow flag, unlike
+        // SUB. They must not be certified equivalent.
+        let sbc = vec![Instruction::Sbc {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+        }];
+        let sub = vec![Instruction::Sub {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        }];
+        assert_eq!(
+            check_equivalence(&sbc, &sub),
+            EquivalenceResult::NotEquivalent,
+            "SBC must not be equal to SUB: it depends on borrow-in"
+        );
+        assert_eq!(
+            check_equivalence(&sbc, &sbc),
+            EquivalenceResult::Equivalent,
+            "SBC must be equivalent to itself"
+        );
+    }
+
     /// Soundness regression: `BICS x0, x1, x2` → `BIC x0, x1, x2` drops the
     /// NZCV side-effect. Rejected when flags are observable.
     #[test]

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -2499,6 +2499,36 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_adc_not_equivalent_to_add_because_carry_in_is_live() {
+        // ADC reads the carry flag as a live-in; ADD ignores it. They must
+        // NOT be certified equivalent, because for carry-in = 1 the results
+        // differ. This is the soundness guard that the SMT layer treats the
+        // initial carry as a free symbolic input (the fast path only probes
+        // carry-in = 0).
+        let adc = vec![Instruction::Adc {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Register::X2,
+        }];
+        let add = vec![Instruction::Add {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        }];
+        assert_eq!(
+            check_equivalence(&adc, &add),
+            EquivalenceResult::NotEquivalent,
+            "ADC must not be equal to ADD: it depends on carry-in"
+        );
+        // ADC is equivalent to itself.
+        assert_eq!(
+            check_equivalence(&adc, &adc),
+            EquivalenceResult::Equivalent,
+            "ADC must be equivalent to itself"
+        );
+    }
+
     /// Soundness regression: `BICS x0, x1, x2` → `BIC x0, x1, x2` drops the
     /// NZCV side-effect. Rejected when flags are observable.
     #[test]

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -475,6 +475,31 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
     (n, z, c, v)
 }
 
+/// Compute symbolic NZCV for add-with-carry `lhs + rhs + carry` at `width`.
+/// `carry` is a 1-bit BV. Mirrors `ConditionFlags::from_adc` in `state.rs`.
+/// The three addends are widened to `width + 1` bits; because `bvadd` is
+/// modular same-width, the sum is `width + 1` bits and bit `width` is the
+/// carry-out.
+pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
+    let sum = lhs
+        .zero_ext(1)
+        .bvadd(&rhs.zero_ext(1))
+        .bvadd(&carry.zero_ext(width));
+    let result = sum.extract(width - 1, 0);
+    let zero = BV::from_u64(0, width);
+    let msb = width - 1;
+    let n = result.extract(msb, msb);
+    let z = result.eq(&zero).ite(&bv_one(), &bv_zero());
+    let c = sum.extract(width, width); // carry-out
+    let lhs_sign = lhs.extract(msb, msb);
+    let rhs_sign = rhs.extract(msb, msb);
+    let res_sign = result.extract(msb, msb);
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_flip = lhs_sign.bvxor(&res_sign);
+    let v = signs_match.bvand(&signs_flip);
+    (n, z, c, v)
+}
+
 /// Convert a 4-bit NZCV literal to four 1-bit BV constants.
 /// Layout per ARM ARM: bit3 = N, bit2 = Z, bit1 = C, bit0 = V.
 pub fn nzcv_to_bvs(byte: u8) -> Nzcv {
@@ -849,6 +874,21 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let rhs = state.eval_operand(rm);
             let (n, z, c, v) = compute_flags_sub(&lhs, &rhs, width);
             state.set_register(*rd, lhs.bvsub(&rhs));
+            state.set_flags(n, z, c, v);
+        }
+        // Add with carry: rd = rn + rm + C (1-bit carry widened to `width`).
+        Instruction::Adc { rd, rn, rm } => {
+            let lhs = state.get_register(*rn).clone();
+            let rhs = state.get_register(*rm).clone();
+            let carry = state.get_flags().2.clone();
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+        }
+        Instruction::Adcs { rd, rn, rm } => {
+            let lhs = state.get_register(*rn).clone();
+            let rhs = state.get_register(*rm).clone();
+            let carry = state.get_flags().2.clone();
+            let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -500,6 +500,12 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     (n, z, c, v)
 }
 
+/// Compute symbolic NZCV for subtract-with-carry `lhs - rhs - (1 - carry)`,
+/// which equals `lhs + NOT(rhs) + carry`. Mirrors `ConditionFlags::from_sbc`.
+pub fn compute_flags_sbc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
+    compute_flags_adc(lhs, &rhs.bvnot(), carry, width)
+}
+
 /// Convert a 4-bit NZCV literal to four 1-bit BV constants.
 /// Layout per ARM ARM: bit3 = N, bit2 = Z, bit1 = C, bit0 = V.
 pub fn nzcv_to_bvs(byte: u8) -> Nzcv {
@@ -889,6 +895,27 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
             state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_flags(n, z, c, v);
+        }
+        // Subtract with carry: rd = rn + NOT(rm) + C.
+        Instruction::Sbc { rd, rn, rm } => {
+            let lhs = state.get_register(*rn).clone();
+            let rhs = state.get_register(*rm).clone();
+            let carry = state.get_flags().2.clone();
+            state.set_register(
+                *rd,
+                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
+            );
+        }
+        Instruction::Sbcs { rd, rn, rm } => {
+            let lhs = state.get_register(*rn).clone();
+            let rhs = state.get_register(*rm).clone();
+            let carry = state.get_flags().2.clone();
+            let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
+            state.set_register(
+                *rd,
+                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
+            );
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {

--- a/src/semantics/state.rs
+++ b/src/semantics/state.rs
@@ -53,6 +53,22 @@ impl ConditionFlags {
         Self { n, z, c, v }
     }
 
+    /// Compute flags from an add-with-carry result: `lhs + rhs + carry_in`.
+    /// `carry_in` is 0 or 1. Uses 128-bit widening for exact carry-out (C)
+    /// and signed overflow (V).
+    pub fn from_adc(lhs: u64, rhs: u64, carry_in: u64) -> Self {
+        let wide = lhs as u128 + rhs as u128 + carry_in as u128;
+        let result = wide as u64;
+        let v =
+            (lhs as i64 as i128 + rhs as i64 as i128 + carry_in as i128) != result as i64 as i128;
+        Self {
+            n: (result as i64) < 0,
+            z: result == 0,
+            c: wide > u64::MAX as u128,
+            v,
+        }
+    }
+
     /// Compute flags from a logical operation result (AND, ORR, EOR, TST)
     pub fn from_logical(result: u64) -> Self {
         Self {

--- a/src/semantics/state.rs
+++ b/src/semantics/state.rs
@@ -69,6 +69,14 @@ impl ConditionFlags {
         }
     }
 
+    /// Compute flags from a subtract-with-carry result. AArch64 SBC computes
+    /// `rn - rm - (1 - carry_in)`, which equals `rn + NOT(rm) + carry_in`.
+    /// `carry_in` is 0 or 1. Reusing the add-with-carry rule on the bitwise
+    /// complement of `rm` gives the correct NZCV (C = "no borrow").
+    pub fn from_sbc(lhs: u64, rhs: u64, carry_in: u64) -> Self {
+        Self::from_adc(lhs, !rhs, carry_in)
+    }
+
     /// Compute flags from a logical operation result (AND, ORR, EOR, TST)
     pub fn from_logical(result: u64) -> Self {
         Self {

--- a/tests/integration/carry_chain.rs
+++ b/tests/integration/carry_chain.rs
@@ -1,0 +1,69 @@
+//! End-to-end coverage for carry-aware arithmetic (issue #205): parse
+//! ADC/ADCS-bearing assembly through the public parser, then exercise it via
+//! the concrete interpreter and the equivalence checker. Deterministic — no
+//! timed search.
+
+use s11::ir::{Instruction, Register};
+use s11::parser::{LineResult, parse_line};
+use s11::semantics::concrete::apply_instruction_concrete;
+use s11::semantics::equivalence::{EquivalenceResult, check_equivalence};
+use s11::semantics::state::ConcreteMachineState;
+use std::collections::HashMap;
+
+fn parse_seq(lines: &[&str]) -> Vec<Instruction> {
+    lines
+        .iter()
+        .map(|line| match parse_line(line).expect("parse") {
+            LineResult::Instruction(instr) => instr,
+            other => panic!("expected an instruction for {line:?}, got {other:?}"),
+        })
+        .collect()
+}
+
+/// A two-word (128-bit) add `(x3:x2) += (x5:x4)` expressed as the canonical
+/// `adds`/`adc` pair must thread the carry across the word boundary.
+#[test]
+fn adds_adc_compute_128bit_add_across_carry() {
+    let seq = parse_seq(&["adds x2, x2, x4", "adc x3, x3, x5"]);
+
+    // A = 2^64 - 1 (low = u64::MAX, high = 0), B = 1 (low = 1, high = 0).
+    // The low add overflows, so the carry must propagate into the high word.
+    let mut values = HashMap::new();
+    values.insert(Register::X2, u64::MAX);
+    values.insert(Register::X3, 0);
+    values.insert(Register::X4, 1);
+    values.insert(Register::X5, 0);
+
+    let mut state = ConcreteMachineState::from_values(values);
+    for instr in &seq {
+        state = apply_instruction_concrete(state, instr);
+    }
+
+    // A + B = 2^64  ->  (x3:x2) = (1, 0).
+    assert_eq!(state.get_register(Register::X2).as_u64(), 0);
+    assert_eq!(state.get_register(Register::X3).as_u64(), 1);
+}
+
+/// Replacing the carry-absorbing `adc` tail with a plain `add` drops the
+/// carry-out of the first `adds`, changing the high word. The equivalence
+/// checker must reject the rewrite, while the chain is equivalent to itself.
+#[test]
+fn dropping_the_adc_carry_tail_is_not_equivalent() {
+    let full = parse_seq(&["adds x2, x2, x4", "adc x3, x3, x5"]);
+    let dropped = parse_seq(&["adds x2, x2, x4", "add x3, x3, x5"]);
+
+    let result = check_equivalence(&full, &dropped);
+    assert!(
+        matches!(
+            result,
+            EquivalenceResult::NotEquivalent | EquivalenceResult::NotEquivalentFast(_)
+        ),
+        "ignoring the carry tail changes the high word; got {result:?}"
+    );
+
+    assert_eq!(
+        check_equivalence(&full, &full),
+        EquivalenceResult::Equivalent,
+        "the carry chain is equivalent to itself"
+    );
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,3 +1,4 @@
+mod carry_chain;
 mod disasm_test;
 mod docs_capability;
 mod opt_test;


### PR DESCRIPTION
Closes #205.

Implements the carry-threading opcodes plus the residual Track B work, as five self-contained commits.

## Track A — opcodes (X-only, register form)
- **ADC/ADCS** and **SBC/SBCS** end to end: IR variants, concrete + SMT semantics, dynasm encoding, parser, cost model, Capstone regression coverage, capability matrix, and `isa`/mutation plumbing.
- AArch64 has no immediate or shifted form for these, so `rm` is a plain `Register` (illegal operands rejected by construction).
- SBC uses the `Rn + NOT(Rm) + C` formulation, so concrete/SMT flag rules reuse the add-with-carry helpers on the complement of `rm`.

## Track B — NZCV contract
- **ADR-0008** documents the contract: carry-in is a live-in surfaced via `reads_flags()` (driving fast-path NZCV enumeration and free symbolic carry in SMT); the search algorithms keep pinning `flags_live=true`.
- **LLM static refusal dropped**: the flag-live-out pre-refusal from ADR-0002 is removed; the LLM flow now relies on the same equivalence check (`with_flags(true)`) as every other generator.

## Soundness
ADC/SBC read carry as a live-in. The key guard is that the four opcodes are wired into `reads_flags()`, and SMT treats the initial carry as a free symbolic input. Regression tests pin that `ADC ≠ ADD` and `SBC ≠ SUB`, and an end-to-end test shows a 128-bit `adds`/`adc` add and that dropping the carry tail is not equivalent.

## Notes
- `#121` (W-form) has already landed, but `Adds`/`Subs` remain X-only; these opcodes match that, with W-forms left as a follow-up for all flag-setters together.
- ADC/SBC are intentionally **not** in the random-generation pool yet (lifted/verified, not synthesized) — see ADR-0008.

All five commits pass `./ci_check.sh` independently.