### PR TITLE
Add 32-bit W-register forms of AArch64 bit-field instructions (#145)

### DIFF
--- a/docs/capability.md
+++ b/docs/capability.md
@@ -56,7 +56,9 @@ Rewritable straight-line mnemonics accepted by the parser and Capstone bridge:
 - Single-source bit manipulation: `clz`, `cls`, `rbit`, `rev`, `rev32`,
   `rev16`
 - Standalone extend aliases: `uxtb`, `uxth`, `sxtb`, `sxth`, `sxtw`
-- Bit-field aliases: `ubfx`, `sbfx`, `bfi`, `bfxil`, `ubfiz`, `sbfiz`
+- Bit-field aliases: `ubfx`, `sbfx`, `bfi`, `bfxil`, `ubfiz`, `sbfiz` — each
+  supports both 64-bit `X` and 32-bit `W` register forms (the W form zeroes the
+  destination's upper 32 bits per the ARM ARM).
 - Memory loads and stores (issue #68, [ADR-0007](adr/0007-memory-model.md);
   byte-addressed Z3-array memory model with sound full aliasing, whole-memory
   live-out auto-derived): `ldr`, `ldrb`, `ldrh`, `ldrsb`, `ldrsh`, `ldrsw`,

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -1835,52 +1835,130 @@ impl AArch64Assembler {
                 }
             }
             // Bit-field manipulation aliases (UBFX/SBFX/BFI/BFXIL/UBFIZ/SBFIZ).
-            Instruction::Ubfx { rd, rn, lsb, width } => {
+            Instruction::Ubfx {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            } => {
                 let rd_reg = register_to_dynasm(*rd)?;
                 let rn_reg = register_to_dynasm(*rn)?;
                 let lsb_imm = *lsb as u32;
                 let width_imm = *width as u32;
-                dynasm!(ops ; .arch aarch64 ; ubfx X(rd_reg), X(rn_reg), lsb_imm, width_imm);
+                match reg_width {
+                    crate::ir::RegisterWidth::W32 => {
+                        dynasm!(ops ; .arch aarch64 ; ubfx W(rd_reg), W(rn_reg), lsb_imm, width_imm)
+                    }
+                    crate::ir::RegisterWidth::X64 => {
+                        dynasm!(ops ; .arch aarch64 ; ubfx X(rd_reg), X(rn_reg), lsb_imm, width_imm)
+                    }
+                }
                 Ok(())
             }
-            Instruction::Sbfx { rd, rn, lsb, width } => {
+            Instruction::Sbfx {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            } => {
                 let rd_reg = register_to_dynasm(*rd)?;
                 let rn_reg = register_to_dynasm(*rn)?;
                 let lsb_imm = *lsb as u32;
                 let width_imm = *width as u32;
-                dynasm!(ops ; .arch aarch64 ; sbfx X(rd_reg), X(rn_reg), lsb_imm, width_imm);
+                match reg_width {
+                    crate::ir::RegisterWidth::W32 => {
+                        dynasm!(ops ; .arch aarch64 ; sbfx W(rd_reg), W(rn_reg), lsb_imm, width_imm)
+                    }
+                    crate::ir::RegisterWidth::X64 => {
+                        dynasm!(ops ; .arch aarch64 ; sbfx X(rd_reg), X(rn_reg), lsb_imm, width_imm)
+                    }
+                }
                 Ok(())
             }
-            Instruction::Bfi { rd, rn, lsb, width } => {
+            Instruction::Bfi {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            } => {
                 let rd_reg = register_to_dynasm(*rd)?;
                 let rn_reg = register_to_dynasm(*rn)?;
                 let lsb_imm = *lsb as u32;
                 let width_imm = *width as u32;
-                dynasm!(ops ; .arch aarch64 ; bfi X(rd_reg), X(rn_reg), lsb_imm, width_imm);
+                match reg_width {
+                    crate::ir::RegisterWidth::W32 => {
+                        dynasm!(ops ; .arch aarch64 ; bfi W(rd_reg), W(rn_reg), lsb_imm, width_imm)
+                    }
+                    crate::ir::RegisterWidth::X64 => {
+                        dynasm!(ops ; .arch aarch64 ; bfi X(rd_reg), X(rn_reg), lsb_imm, width_imm)
+                    }
+                }
                 Ok(())
             }
-            Instruction::Bfxil { rd, rn, lsb, width } => {
+            Instruction::Bfxil {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            } => {
                 let rd_reg = register_to_dynasm(*rd)?;
                 let rn_reg = register_to_dynasm(*rn)?;
                 let lsb_imm = *lsb as u32;
                 let width_imm = *width as u32;
-                dynasm!(ops ; .arch aarch64 ; bfxil X(rd_reg), X(rn_reg), lsb_imm, width_imm);
+                match reg_width {
+                    crate::ir::RegisterWidth::W32 => {
+                        dynasm!(ops ; .arch aarch64 ; bfxil W(rd_reg), W(rn_reg), lsb_imm, width_imm)
+                    }
+                    crate::ir::RegisterWidth::X64 => {
+                        dynasm!(ops ; .arch aarch64 ; bfxil X(rd_reg), X(rn_reg), lsb_imm, width_imm)
+                    }
+                }
                 Ok(())
             }
-            Instruction::Ubfiz { rd, rn, lsb, width } => {
+            Instruction::Ubfiz {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            } => {
                 let rd_reg = register_to_dynasm(*rd)?;
                 let rn_reg = register_to_dynasm(*rn)?;
                 let lsb_imm = *lsb as u32;
                 let width_imm = *width as u32;
-                dynasm!(ops ; .arch aarch64 ; ubfiz X(rd_reg), X(rn_reg), lsb_imm, width_imm);
+                match reg_width {
+                    crate::ir::RegisterWidth::W32 => {
+                        dynasm!(ops ; .arch aarch64 ; ubfiz W(rd_reg), W(rn_reg), lsb_imm, width_imm)
+                    }
+                    crate::ir::RegisterWidth::X64 => {
+                        dynasm!(ops ; .arch aarch64 ; ubfiz X(rd_reg), X(rn_reg), lsb_imm, width_imm)
+                    }
+                }
                 Ok(())
             }
-            Instruction::Sbfiz { rd, rn, lsb, width } => {
+            Instruction::Sbfiz {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            } => {
                 let rd_reg = register_to_dynasm(*rd)?;
                 let rn_reg = register_to_dynasm(*rn)?;
                 let lsb_imm = *lsb as u32;
                 let width_imm = *width as u32;
-                dynasm!(ops ; .arch aarch64 ; sbfiz X(rd_reg), X(rn_reg), lsb_imm, width_imm);
+                match reg_width {
+                    crate::ir::RegisterWidth::W32 => {
+                        dynasm!(ops ; .arch aarch64 ; sbfiz W(rd_reg), W(rn_reg), lsb_imm, width_imm)
+                    }
+                    crate::ir::RegisterWidth::X64 => {
+                        dynasm!(ops ; .arch aarch64 ; sbfiz X(rd_reg), X(rn_reg), lsb_imm, width_imm)
+                    }
+                }
                 Ok(())
             }
 
@@ -3088,6 +3166,7 @@ mod tests {
             rn: Register::X1,
             lsb: 8,
             width: 16,
+            reg_width: crate::ir::RegisterWidth::X64,
         }];
         let bytes = assembler
             .assemble_instructions(&instructions, 0)
@@ -3105,6 +3184,7 @@ mod tests {
             rn: Register::X1,
             lsb: 0,
             width: 64,
+            reg_width: crate::ir::RegisterWidth::X64,
         }];
         let bytes = assembler
             .assemble_instructions(&instructions, 0)
@@ -3118,6 +3198,83 @@ mod tests {
     }
 
     #[test]
+    fn test_bitfield_w_form_assembles_to_w_registers() {
+        // Acceptance (#145): each W-form bit-field op emits W operands and
+        // round-trips through Capstone with the same mnemonic. lsb=8/width=8
+        // keeps lsb+width=16 < 32 so we avoid the LSR/MOV alias boundary.
+        use crate::ir::RegisterWidth::W32;
+        let cases: [(&str, Instruction); 6] = [
+            (
+                "ubfx",
+                Instruction::Ubfx {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    lsb: 8,
+                    width: 8,
+                    reg_width: W32,
+                },
+            ),
+            (
+                "sbfx",
+                Instruction::Sbfx {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    lsb: 8,
+                    width: 8,
+                    reg_width: W32,
+                },
+            ),
+            (
+                "bfi",
+                Instruction::Bfi {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    lsb: 8,
+                    width: 8,
+                    reg_width: W32,
+                },
+            ),
+            (
+                "bfxil",
+                Instruction::Bfxil {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    lsb: 8,
+                    width: 8,
+                    reg_width: W32,
+                },
+            ),
+            (
+                "ubfiz",
+                Instruction::Ubfiz {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    lsb: 8,
+                    width: 8,
+                    reg_width: W32,
+                },
+            ),
+            (
+                "sbfiz",
+                Instruction::Sbfiz {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    lsb: 8,
+                    width: 8,
+                    reg_width: W32,
+                },
+            ),
+        ];
+        for (mnem, instr) in cases {
+            let mut assembler = AArch64Assembler::new();
+            let bytes = assembler
+                .assemble_instructions(&[instr], 0)
+                .unwrap_or_else(|e| panic!("{mnem} W encoding should succeed: {e}"));
+            disassemble_and_verify(&bytes, mnem, &["w0", "w1"]);
+        }
+    }
+
+    #[test]
     fn test_sbfiz_correctness() {
         let mut assembler = AArch64Assembler::new();
         let instructions = vec![Instruction::Sbfiz {
@@ -3125,6 +3282,7 @@ mod tests {
             rn: Register::X1,
             lsb: 4,
             width: 8,
+            reg_width: crate::ir::RegisterWidth::X64,
         }];
         let bytes = assembler
             .assemble_instructions(&instructions, 0)
@@ -3140,6 +3298,7 @@ mod tests {
             rn: Register::X1,
             lsb: 4,
             width: 8,
+            reg_width: crate::ir::RegisterWidth::X64,
         }];
         let bytes = assembler
             .assemble_instructions(&instructions, 0)
@@ -3155,6 +3314,7 @@ mod tests {
             rn: Register::X1,
             lsb: 8,
             width: 8,
+            reg_width: crate::ir::RegisterWidth::X64,
         }];
         let bytes = assembler
             .assemble_instructions(&instructions, 0)
@@ -3170,6 +3330,7 @@ mod tests {
             rn: Register::X1,
             lsb: 4,
             width: 8,
+            reg_width: crate::ir::RegisterWidth::X64,
         }];
         let bytes = assembler
             .assemble_instructions(&instructions, 0)
@@ -3185,6 +3346,7 @@ mod tests {
             rn: Register::X1,
             lsb: 8,
             width: 16,
+            reg_width: crate::ir::RegisterWidth::X64,
         }];
         let bytes = assembler
             .assemble_instructions(&instructions, 0)
@@ -3204,6 +3366,7 @@ mod tests {
             rn: Register::X3,
             lsb: 32,
             width: 8,
+            reg_width: crate::ir::RegisterWidth::X64,
         }];
         let bytes = assembler
             .assemble_instructions(&instructions, 0)

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -414,45 +414,53 @@ pub enum Instruction {
         rd: Register,
         rn: Register,
     },
-    // Bit-field manipulation (64-bit, aliases of UBFM/SBFM/BFM per ARM ARM C6.2).
+    // Bit-field manipulation (aliases of UBFM/SBFM/BFM per ARM ARM C6.2).
     // `lsb` is the bit position of the least-significant bit of the field in the
-    // source; `width` is the field width. Constraint: lsb ∈ [0..=63],
-    // width ∈ [1..=64-lsb]. Enforced in `is_encodable_aarch64`.
+    // source; `width` is the field width. `reg_width` selects the X (64-bit) or
+    // W (32-bit) form. Constraints (enforced in `is_encodable_aarch64`):
+    //   X64: lsb ∈ [0..=63], width ∈ [1..=64-lsb]
+    //   W32: lsb ∈ [0..=31], width ∈ [1..=32-lsb]; the result zeroes bits [63:32].
     Ubfx {
         rd: Register,
         rn: Register,
         lsb: u8,
         width: u8,
+        reg_width: RegisterWidth,
     },
     Sbfx {
         rd: Register,
         rn: Register,
         lsb: u8,
         width: u8,
+        reg_width: RegisterWidth,
     },
     Bfi {
         rd: Register,
         rn: Register,
         lsb: u8,
         width: u8,
+        reg_width: RegisterWidth,
     },
     Bfxil {
         rd: Register,
         rn: Register,
         lsb: u8,
         width: u8,
+        reg_width: RegisterWidth,
     },
     Ubfiz {
         rd: Register,
         rn: Register,
         lsb: u8,
         width: u8,
+        reg_width: RegisterWidth,
     },
     Sbfiz {
         rd: Register,
         rn: Register,
         lsb: u8,
         width: u8,
+        reg_width: RegisterWidth,
     },
 
     // Branches / control flow (terminators only — never appear in the
@@ -1010,19 +1018,58 @@ impl Instruction {
             | Instruction::Sxtw { rd, rn }
             | Instruction::Uxtb { rd, rn }
             | Instruction::Uxth { rd, rn } => *rd != Register::SP && *rn != Register::SP,
-            // Bit-field aliases of UBFM/SBFM/BFM. Constraint: lsb ∈ [0..=63],
-            // width ∈ [1..=64-lsb]. SP rejected in rd and rn.
-            Instruction::Ubfx { rd, rn, lsb, width }
-            | Instruction::Sbfx { rd, rn, lsb, width }
-            | Instruction::Bfi { rd, rn, lsb, width }
-            | Instruction::Bfxil { rd, rn, lsb, width }
-            | Instruction::Ubfiz { rd, rn, lsb, width }
-            | Instruction::Sbfiz { rd, rn, lsb, width } => {
+            // Bit-field aliases of UBFM/SBFM/BFM. SP rejected in rd and rn.
+            // Constraint depends on the register width:
+            //   X64: lsb ∈ [0..=63], width ∈ [1..=64-lsb]
+            //   W32: lsb ∈ [0..=31], width ∈ [1..=32-lsb]
+            Instruction::Ubfx {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            }
+            | Instruction::Sbfx {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            }
+            | Instruction::Bfi {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            }
+            | Instruction::Bfxil {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            }
+            | Instruction::Ubfiz {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            }
+            | Instruction::Sbfiz {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            } => {
+                let bound = reg_width.bit_width() as u16;
                 *rd != Register::SP
                     && *rn != Register::SP
-                    && *lsb <= 63
+                    && (*lsb as u16) < bound
                     && *width >= 1
-                    && (*lsb as u16 + *width as u16) <= 64
+                    && (*lsb as u16 + *width as u16) <= bound
             }
 
             // Branches: encodability is checked against PC-relative range at
@@ -1533,24 +1580,90 @@ impl fmt::Display for Instruction {
                 RegisterWidth::W32.register_name(*rd),
                 RegisterWidth::W32.register_name(*rn)
             ),
-            Instruction::Ubfx { rd, rn, lsb, width } => {
-                write!(f, "ubfx {}, {}, #{}, #{}", rd, rn, lsb, width)
-            }
-            Instruction::Sbfx { rd, rn, lsb, width } => {
-                write!(f, "sbfx {}, {}, #{}, #{}", rd, rn, lsb, width)
-            }
-            Instruction::Bfi { rd, rn, lsb, width } => {
-                write!(f, "bfi {}, {}, #{}, #{}", rd, rn, lsb, width)
-            }
-            Instruction::Bfxil { rd, rn, lsb, width } => {
-                write!(f, "bfxil {}, {}, #{}, #{}", rd, rn, lsb, width)
-            }
-            Instruction::Ubfiz { rd, rn, lsb, width } => {
-                write!(f, "ubfiz {}, {}, #{}, #{}", rd, rn, lsb, width)
-            }
-            Instruction::Sbfiz { rd, rn, lsb, width } => {
-                write!(f, "sbfiz {}, {}, #{}, #{}", rd, rn, lsb, width)
-            }
+            Instruction::Ubfx {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            } => write!(
+                f,
+                "ubfx {}, {}, #{}, #{}",
+                reg_width.register_name(*rd),
+                reg_width.register_name(*rn),
+                lsb,
+                width
+            ),
+            Instruction::Sbfx {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            } => write!(
+                f,
+                "sbfx {}, {}, #{}, #{}",
+                reg_width.register_name(*rd),
+                reg_width.register_name(*rn),
+                lsb,
+                width
+            ),
+            Instruction::Bfi {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            } => write!(
+                f,
+                "bfi {}, {}, #{}, #{}",
+                reg_width.register_name(*rd),
+                reg_width.register_name(*rn),
+                lsb,
+                width
+            ),
+            Instruction::Bfxil {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            } => write!(
+                f,
+                "bfxil {}, {}, #{}, #{}",
+                reg_width.register_name(*rd),
+                reg_width.register_name(*rn),
+                lsb,
+                width
+            ),
+            Instruction::Ubfiz {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            } => write!(
+                f,
+                "ubfiz {}, {}, #{}, #{}",
+                reg_width.register_name(*rd),
+                reg_width.register_name(*rn),
+                lsb,
+                width
+            ),
+            Instruction::Sbfiz {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            } => write!(
+                f,
+                "sbfiz {}, {}, #{}, #{}",
+                reg_width.register_name(*rd),
+                reg_width.register_name(*rn),
+                lsb,
+                width
+            ),
 
             Instruction::B { target } => write!(f, "b {}", target),
             Instruction::BCond { target, cond } => write!(f, "b.{} {}", cond, target),
@@ -1684,6 +1797,7 @@ mod tests {
             rn: Register::X1,
             lsb: 5,
             width: 10,
+            reg_width: crate::ir::RegisterWidth::X64,
         };
         assert_eq!(format!("{}", ubfx), "ubfx x0, x1, #5, #10");
     }
@@ -3074,6 +3188,7 @@ mod tests {
                 rn: Register::X1,
                 lsb,
                 width,
+                reg_width: crate::ir::RegisterWidth::X64,
             };
             assert!(
                 instr.is_encodable_aarch64(),
@@ -3090,6 +3205,7 @@ mod tests {
                 rn: Register::X1,
                 lsb: 0,
                 width: 8,
+                reg_width: crate::ir::RegisterWidth::X64
             }
             .is_encodable_aarch64()
         );
@@ -3101,6 +3217,7 @@ mod tests {
                 rn: Register::SP,
                 lsb: 0,
                 width: 8,
+                reg_width: crate::ir::RegisterWidth::X64
             }
             .is_encodable_aarch64()
         );
@@ -3112,6 +3229,7 @@ mod tests {
                 rn: Register::X1,
                 lsb: 0,
                 width: 8,
+                reg_width: crate::ir::RegisterWidth::X64
             }
             .is_encodable_aarch64()
         );
@@ -3123,6 +3241,7 @@ mod tests {
                 rn: Register::X1,
                 lsb: 0,
                 width: 0,
+                reg_width: crate::ir::RegisterWidth::X64
             }
             .is_encodable_aarch64()
         );
@@ -3134,6 +3253,7 @@ mod tests {
                 rn: Register::X1,
                 lsb: 60,
                 width: 10,
+                reg_width: crate::ir::RegisterWidth::X64
             }
             .is_encodable_aarch64()
         );
@@ -3145,6 +3265,74 @@ mod tests {
                 rn: Register::X1,
                 lsb: 63,
                 width: 1,
+                reg_width: crate::ir::RegisterWidth::X64
+            }
+            .is_encodable_aarch64()
+        );
+    }
+
+    #[test]
+    fn test_is_encodable_bitfield_w_form() {
+        use crate::ir::RegisterWidth::W32;
+        // Valid W combinations: lsb ∈ [0..=31], width ∈ [1..=32-lsb].
+        for (lsb, width) in [(0u8, 1u8), (0, 32), (5, 10), (16, 16), (31, 1)] {
+            let instr = Instruction::Ubfx {
+                rd: Register::X0,
+                rn: Register::X1,
+                lsb,
+                width,
+                reg_width: W32,
+            };
+            assert!(
+                instr.is_encodable_aarch64(),
+                "valid W (lsb={lsb}, width={width}) must be encodable"
+            );
+        }
+
+        // lsb=32 is out of range for the W form (valid only for X).
+        assert!(
+            !Instruction::Ubfx {
+                rd: Register::X0,
+                rn: Register::X1,
+                lsb: 32,
+                width: 1,
+                reg_width: W32,
+            }
+            .is_encodable_aarch64()
+        );
+
+        // lsb+width > 32 rejected for the W form.
+        assert!(
+            !Instruction::Sbfx {
+                rd: Register::X0,
+                rn: Register::X1,
+                lsb: 16,
+                width: 17,
+                reg_width: W32,
+            }
+            .is_encodable_aarch64()
+        );
+
+        // width=0 still rejected for W.
+        assert!(
+            !Instruction::Bfi {
+                rd: Register::X0,
+                rn: Register::X1,
+                lsb: 0,
+                width: 0,
+                reg_width: W32,
+            }
+            .is_encodable_aarch64()
+        );
+
+        // width=32 only valid at lsb=0 for the W form.
+        assert!(
+            !Instruction::Ubfiz {
+                rd: Register::X0,
+                rn: Register::X1,
+                lsb: 1,
+                width: 32,
+                reg_width: W32,
             }
             .is_encodable_aarch64()
         );

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -667,11 +667,12 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
             }
         }
 
-        // Bit-field aliases (issue #61: UBFX/SBFX/BFI/BFXIL/UBFIZ/SBFIZ).
-        // Sparse (lsb, width) sampling to keep the enumerative budget bounded.
-        // Filter SP from both rd and rn (matches is_encodable_aarch64). 2D
-        // constraint lsb + width <= 64 enforced via the if-guard. Mirrors the
-        // sampling tables in `src/search/candidate.rs::generate_all_instructions`.
+        // Bit-field aliases (issue #61: UBFX/SBFX/BFI/BFXIL/UBFIZ/SBFIZ) in both
+        // X (64-bit) and W (32-bit) forms (issue #145). Sparse (lsb, width)
+        // sampling to keep the enumerative budget bounded; SP filtered from rd
+        // and rn (matches is_encodable_aarch64). The shared sample tables are
+        // filtered per width against the bound (lsb < bound, lsb+width <= bound).
+        // Mirrors `src/search/candidate.rs::generate_all_instructions`.
         const BITFIELD_LSB_SAMPLES: [u8; 5] = [0, 1, 16, 32, 63];
         const BITFIELD_WIDTH_SAMPLES: [u8; 6] = [1, 4, 8, 16, 32, 64];
         for &rd in registers {
@@ -682,17 +683,59 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                 if rn == Register::SP {
                     continue;
                 }
-                for &lsb in &BITFIELD_LSB_SAMPLES {
-                    for &width in &BITFIELD_WIDTH_SAMPLES {
-                        if (lsb as u16 + width as u16) > 64 {
+                for reg_width in [RegisterWidth::X64, RegisterWidth::W32] {
+                    let bound = reg_width.bit_width() as u16;
+                    for &lsb in &BITFIELD_LSB_SAMPLES {
+                        if lsb as u16 >= bound {
                             continue;
                         }
-                        instructions.push(Instruction::Ubfx { rd, rn, lsb, width });
-                        instructions.push(Instruction::Sbfx { rd, rn, lsb, width });
-                        instructions.push(Instruction::Bfi { rd, rn, lsb, width });
-                        instructions.push(Instruction::Bfxil { rd, rn, lsb, width });
-                        instructions.push(Instruction::Ubfiz { rd, rn, lsb, width });
-                        instructions.push(Instruction::Sbfiz { rd, rn, lsb, width });
+                        for &width in &BITFIELD_WIDTH_SAMPLES {
+                            if width as u16 > bound || (lsb as u16 + width as u16) > bound {
+                                continue;
+                            }
+                            instructions.push(Instruction::Ubfx {
+                                rd,
+                                rn,
+                                lsb,
+                                width,
+                                reg_width,
+                            });
+                            instructions.push(Instruction::Sbfx {
+                                rd,
+                                rn,
+                                lsb,
+                                width,
+                                reg_width,
+                            });
+                            instructions.push(Instruction::Bfi {
+                                rd,
+                                rn,
+                                lsb,
+                                width,
+                                reg_width,
+                            });
+                            instructions.push(Instruction::Bfxil {
+                                rd,
+                                rn,
+                                lsb,
+                                width,
+                                reg_width,
+                            });
+                            instructions.push(Instruction::Ubfiz {
+                                rd,
+                                rn,
+                                lsb,
+                                width,
+                                reg_width,
+                            });
+                            instructions.push(Instruction::Sbfiz {
+                                rd,
+                                rn,
+                                lsb,
+                                width,
+                                reg_width,
+                            });
+                        }
                     }
                 }
             }
@@ -977,8 +1020,14 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                 let pick_non_sp = |rng: &mut R| non_sp[rng.random_range(0..non_sp.len())];
                 let bf_rd = pick_non_sp(rng);
                 let bf_rn = pick_non_sp(rng);
-                let lsb = (rng.random::<u32>() & 0x3F) as u8;
-                let max_w = 64 - lsb as u32;
+                let reg_width = if rng.random_bool(0.5) {
+                    RegisterWidth::W32
+                } else {
+                    RegisterWidth::X64
+                };
+                let bound = reg_width.bit_width() as u32;
+                let lsb = (rng.random::<u32>() % bound) as u8;
+                let max_w = bound - lsb as u32;
                 let width = ((rng.random::<u32>() % max_w) + 1) as u8;
                 match rng.random_range(0..6) {
                     0 => Instruction::Ubfx {
@@ -986,36 +1035,42 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                         rn: bf_rn,
                         lsb,
                         width,
+                        reg_width,
                     },
                     1 => Instruction::Sbfx {
                         rd: bf_rd,
                         rn: bf_rn,
                         lsb,
                         width,
+                        reg_width,
                     },
                     2 => Instruction::Bfi {
                         rd: bf_rd,
                         rn: bf_rn,
                         lsb,
                         width,
+                        reg_width,
                     },
                     3 => Instruction::Bfxil {
                         rd: bf_rd,
                         rn: bf_rn,
                         lsb,
                         width,
+                        reg_width,
                     },
                     4 => Instruction::Ubfiz {
                         rd: bf_rd,
                         rn: bf_rn,
                         lsb,
                         width,
+                        reg_width,
                     },
                     _ => Instruction::Sbfiz {
                         rd: bf_rd,
                         rn: bf_rn,
                         lsb,
                         width,
+                        reg_width,
                     },
                 }
             }
@@ -1196,41 +1251,83 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                     Instruction::Sxtw { rn, .. } => Instruction::Sxtw { rd: new_rd, rn },
                     Instruction::Uxtb { rn, .. } => Instruction::Uxtb { rd: new_rd, rn },
                     Instruction::Uxth { rn, .. } => Instruction::Uxth { rd: new_rd, rn },
-                    Instruction::Ubfx { rn, lsb, width, .. } => Instruction::Ubfx {
+                    Instruction::Ubfx {
+                        rn,
+                        lsb,
+                        width,
+                        reg_width,
+                        ..
+                    } => Instruction::Ubfx {
                         rd: new_rd,
                         rn,
                         lsb,
                         width,
+                        reg_width,
                     },
-                    Instruction::Sbfx { rn, lsb, width, .. } => Instruction::Sbfx {
+                    Instruction::Sbfx {
+                        rn,
+                        lsb,
+                        width,
+                        reg_width,
+                        ..
+                    } => Instruction::Sbfx {
                         rd: new_rd,
                         rn,
                         lsb,
                         width,
+                        reg_width,
                     },
-                    Instruction::Bfi { rn, lsb, width, .. } => Instruction::Bfi {
+                    Instruction::Bfi {
+                        rn,
+                        lsb,
+                        width,
+                        reg_width,
+                        ..
+                    } => Instruction::Bfi {
                         rd: new_rd,
                         rn,
                         lsb,
                         width,
+                        reg_width,
                     },
-                    Instruction::Bfxil { rn, lsb, width, .. } => Instruction::Bfxil {
+                    Instruction::Bfxil {
+                        rn,
+                        lsb,
+                        width,
+                        reg_width,
+                        ..
+                    } => Instruction::Bfxil {
                         rd: new_rd,
                         rn,
                         lsb,
                         width,
+                        reg_width,
                     },
-                    Instruction::Ubfiz { rn, lsb, width, .. } => Instruction::Ubfiz {
+                    Instruction::Ubfiz {
+                        rn,
+                        lsb,
+                        width,
+                        reg_width,
+                        ..
+                    } => Instruction::Ubfiz {
                         rd: new_rd,
                         rn,
                         lsb,
                         width,
+                        reg_width,
                     },
-                    Instruction::Sbfiz { rn, lsb, width, .. } => Instruction::Sbfiz {
+                    Instruction::Sbfiz {
+                        rn,
+                        lsb,
+                        width,
+                        reg_width,
+                        ..
+                    } => Instruction::Sbfiz {
                         rd: new_rd,
                         rn,
                         lsb,
                         width,
+                        reg_width,
                     },
                     // Branches have no rd; identity-mutate.
                     Instruction::B { target } => Instruction::B { target },
@@ -1649,41 +1746,83 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                         rd,
                         rn: registers[rng.random_range(0..registers.len())],
                     },
-                    Instruction::Ubfx { rd, lsb, width, .. } => Instruction::Ubfx {
+                    Instruction::Ubfx {
+                        rd,
+                        lsb,
+                        width,
+                        reg_width,
+                        ..
+                    } => Instruction::Ubfx {
                         rd,
                         rn: registers[rng.random_range(0..registers.len())],
                         lsb,
                         width,
+                        reg_width,
                     },
-                    Instruction::Sbfx { rd, lsb, width, .. } => Instruction::Sbfx {
+                    Instruction::Sbfx {
+                        rd,
+                        lsb,
+                        width,
+                        reg_width,
+                        ..
+                    } => Instruction::Sbfx {
                         rd,
                         rn: registers[rng.random_range(0..registers.len())],
                         lsb,
                         width,
+                        reg_width,
                     },
-                    Instruction::Bfi { rd, lsb, width, .. } => Instruction::Bfi {
+                    Instruction::Bfi {
+                        rd,
+                        lsb,
+                        width,
+                        reg_width,
+                        ..
+                    } => Instruction::Bfi {
                         rd,
                         rn: registers[rng.random_range(0..registers.len())],
                         lsb,
                         width,
+                        reg_width,
                     },
-                    Instruction::Bfxil { rd, lsb, width, .. } => Instruction::Bfxil {
+                    Instruction::Bfxil {
+                        rd,
+                        lsb,
+                        width,
+                        reg_width,
+                        ..
+                    } => Instruction::Bfxil {
                         rd,
                         rn: registers[rng.random_range(0..registers.len())],
                         lsb,
                         width,
+                        reg_width,
                     },
-                    Instruction::Ubfiz { rd, lsb, width, .. } => Instruction::Ubfiz {
+                    Instruction::Ubfiz {
+                        rd,
+                        lsb,
+                        width,
+                        reg_width,
+                        ..
+                    } => Instruction::Ubfiz {
                         rd,
                         rn: registers[rng.random_range(0..registers.len())],
                         lsb,
                         width,
+                        reg_width,
                     },
-                    Instruction::Sbfiz { rd, lsb, width, .. } => Instruction::Sbfiz {
+                    Instruction::Sbfiz {
+                        rd,
+                        lsb,
+                        width,
+                        reg_width,
+                        ..
+                    } => Instruction::Sbfiz {
                         rd,
                         rn: registers[rng.random_range(0..registers.len())],
                         lsb,
                         width,
+                        reg_width,
                     },
                     // Branches: no source operand mutation; identity.
                     Instruction::B { target } => Instruction::B { target },
@@ -2044,36 +2183,42 @@ mod tests {
                 rn: Register::X1,
                 lsb: 8,
                 width: 16,
+                reg_width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Sbfx {
                 rd: Register::X0,
                 rn: Register::X1,
                 lsb: 8,
                 width: 16,
+                reg_width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Bfi {
                 rd: Register::X0,
                 rn: Register::X1,
                 lsb: 4,
                 width: 8,
+                reg_width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Bfxil {
                 rd: Register::X0,
                 rn: Register::X1,
                 lsb: 4,
                 width: 8,
+                reg_width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Ubfiz {
                 rd: Register::X0,
                 rn: Register::X1,
                 lsb: 4,
                 width: 8,
+                reg_width: crate::ir::RegisterWidth::X64,
             },
             Instruction::Sbfiz {
                 rd: Register::X0,
                 rn: Register::X1,
                 lsb: 4,
                 width: 8,
+                reg_width: crate::ir::RegisterWidth::X64,
             },
         ]
     }
@@ -2353,6 +2498,51 @@ mod tests {
             })
             .collect();
         assert_eq!(seen.len(), generator.opcode_count() as usize);
+    }
+
+    #[test]
+    fn generate_all_emits_encodable_w_bitfield() {
+        let generator = AArch64InstructionGenerator;
+        let regs = vec![Register::X0, Register::X1];
+        let imms = vec![0, 1];
+        let all = generator.generate_all(&regs, &imms);
+        let w_bitfields: Vec<&Instruction> = all
+            .iter()
+            .filter(|i| {
+                matches!(
+                    i,
+                    Instruction::Ubfx {
+                        reg_width: RegisterWidth::W32,
+                        ..
+                    } | Instruction::Sbfx {
+                        reg_width: RegisterWidth::W32,
+                        ..
+                    } | Instruction::Bfi {
+                        reg_width: RegisterWidth::W32,
+                        ..
+                    } | Instruction::Bfxil {
+                        reg_width: RegisterWidth::W32,
+                        ..
+                    } | Instruction::Ubfiz {
+                        reg_width: RegisterWidth::W32,
+                        ..
+                    } | Instruction::Sbfiz {
+                        reg_width: RegisterWidth::W32,
+                        ..
+                    }
+                )
+            })
+            .collect();
+        assert!(
+            !w_bitfields.is_empty(),
+            "trait generator must emit W-form bit-field instructions"
+        );
+        for instr in w_bitfields {
+            assert!(
+                instr.is_encodable_aarch64(),
+                "trait generator produced un-encodable W bit-field: {instr}"
+            );
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2545,6 +2545,15 @@ mod cli_helper_tests {
             ("bfxil", "x0, x1, #8, #8"),
             ("ubfiz", "x0, x1, #4, #8"),
             ("sbfiz", "x0, x1, #4, #8"),
+            // Issue #145: 32-bit W-register forms. Capstone emits `wN` operands
+            // for these encodings; lsb+width stays < 32 to avoid the LSR/MOV
+            // alias boundary.
+            ("ubfx", "w0, w1, #8, #16"),
+            ("sbfx", "w0, w1, #8, #16"),
+            ("bfi", "w0, w1, #4, #8"),
+            ("bfxil", "w0, w1, #8, #8"),
+            ("ubfiz", "w0, w1, #4, #8"),
+            ("sbfiz", "w0, w1, #4, #8"),
             // Issue #69: branch / control-flow mnemonics. Capstone emits
             // branch targets as `#0x...` (immediate-with-hash) and renders
             // TBZ/TBNZ as `wN` when bit<32, `xN` otherwise.
@@ -2635,7 +2644,7 @@ mod cli_helper_tests {
         // Tripwire: bump in lockstep when adding/removing rows. Catches
         // accidental row deletion and forces a re-read when adding a parser
         // mnemonic without a matching test row.
-        assert_eq!(cases.len(), 144);
+        assert_eq!(cases.len(), 150);
 
         fn docs_mnemonic(mnemonic: &'static str) -> &'static str {
             if mnemonic.starts_with("b.") {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1480,7 +1480,10 @@ fn parse_ccmn(operands: &[&str]) -> Result<Instruction, String> {
 
 /// Parse a bit-field-manipulation instruction operand list:
 /// `rd, rn, #lsb, #width`. Used by UBFX/SBFX/BFI/BFXIL/UBFIZ/SBFIZ.
-fn parse_bfm_like(operands: &[&str], mnem: &str) -> Result<(Register, Register, u8, u8), String> {
+fn parse_bfm_like(
+    operands: &[&str],
+    mnem: &str,
+) -> Result<(Register, Register, u8, u8, RegisterWidth), String> {
     if operands.len() != 4 {
         return Err(format!(
             "{} requires 4 operands, got {}",
@@ -1488,25 +1491,35 @@ fn parse_bfm_like(operands: &[&str], mnem: &str) -> Result<(Register, Register, 
             operands.len()
         ));
     }
-    let rd = parse_register(operands[0])?;
-    let rn = parse_register(operands[1])?;
+    // rd and rn must use matching widths; the width selects X (64) vs W (32)
+    // and bounds the lsb/width immediates accordingly.
+    let (rd, rn, reg_width) = parse_same_width_registers(mnem, operands)?;
+    let bound = reg_width.bit_width() as i64;
     let lsb_raw = parse_immediate(operands[2])?;
-    if !(0..=63).contains(&lsb_raw) {
-        return Err(format!("{} lsb {} out of range (0..=63)", mnem, lsb_raw));
+    if !(0..bound).contains(&lsb_raw) {
+        return Err(format!(
+            "{} lsb {} out of range (0..={})",
+            mnem,
+            lsb_raw,
+            bound - 1
+        ));
     }
     let width_raw = parse_immediate(operands[3])?;
-    if !(1..=64).contains(&width_raw) {
+    if !(1..=bound).contains(&width_raw) {
         return Err(format!(
-            "{} width {} out of range (1..=64)",
-            mnem, width_raw
+            "{} width {} out of range (1..={})",
+            mnem, width_raw, bound
         ));
     }
     let lsb = lsb_raw as u8;
     let width = width_raw as u8;
-    if (lsb as u16 + width as u16) > 64 {
-        return Err(format!("{} lsb {} + width {} exceeds 64", mnem, lsb, width));
+    if (lsb as u16 + width as u16) > bound as u16 {
+        return Err(format!(
+            "{} lsb {} + width {} exceeds {}",
+            mnem, lsb, width, bound
+        ));
     }
-    Ok((rd, rn, lsb, width))
+    Ok((rd, rn, lsb, width, reg_width))
 }
 
 fn parse_ccmp_like(
@@ -1800,22 +1813,58 @@ pub fn parse_line(line: &str) -> Result<LineResult, ParseLineError> {
         "ccmp" => parse_ccmp(&operands).map_err(ParseLineError::Other)?,
         "ccmn" => parse_ccmn(&operands).map_err(ParseLineError::Other)?,
         "ubfx" => parse_bfm_like(&operands, "ubfx")
-            .map(|(rd, rn, lsb, width)| Instruction::Ubfx { rd, rn, lsb, width })
+            .map(|(rd, rn, lsb, width, reg_width)| Instruction::Ubfx {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            })
             .map_err(ParseLineError::Other)?,
         "sbfx" => parse_bfm_like(&operands, "sbfx")
-            .map(|(rd, rn, lsb, width)| Instruction::Sbfx { rd, rn, lsb, width })
+            .map(|(rd, rn, lsb, width, reg_width)| Instruction::Sbfx {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            })
             .map_err(ParseLineError::Other)?,
         "bfi" => parse_bfm_like(&operands, "bfi")
-            .map(|(rd, rn, lsb, width)| Instruction::Bfi { rd, rn, lsb, width })
+            .map(|(rd, rn, lsb, width, reg_width)| Instruction::Bfi {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            })
             .map_err(ParseLineError::Other)?,
         "bfxil" => parse_bfm_like(&operands, "bfxil")
-            .map(|(rd, rn, lsb, width)| Instruction::Bfxil { rd, rn, lsb, width })
+            .map(|(rd, rn, lsb, width, reg_width)| Instruction::Bfxil {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            })
             .map_err(ParseLineError::Other)?,
         "ubfiz" => parse_bfm_like(&operands, "ubfiz")
-            .map(|(rd, rn, lsb, width)| Instruction::Ubfiz { rd, rn, lsb, width })
+            .map(|(rd, rn, lsb, width, reg_width)| Instruction::Ubfiz {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            })
             .map_err(ParseLineError::Other)?,
         "sbfiz" => parse_bfm_like(&operands, "sbfiz")
-            .map(|(rd, rn, lsb, width)| Instruction::Sbfiz { rd, rn, lsb, width })
+            .map(|(rd, rn, lsb, width, reg_width)| Instruction::Sbfiz {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            })
             .map_err(ParseLineError::Other)?,
         "csel" => parse_csel(&operands).map_err(ParseLineError::Other)?,
         "csinc" => parse_csinc(&operands).map_err(ParseLineError::Other)?,
@@ -2688,9 +2737,63 @@ mod tests {
                 rn: Register::X1,
                 lsb: 5,
                 width: 10,
+                reg_width: crate::ir::RegisterWidth::X64
             }
         );
         assert_eq!(format!("{}", parsed), "ubfx x0, x1, #5, #10");
+    }
+
+    #[test]
+    fn parse_bitfield_w_roundtrip() {
+        // Each W-form mnemonic round-trips: parse `w` operands, build a W32
+        // variant, and Display back to `w` operands.
+        for mnem in ["ubfx", "sbfx", "bfi", "bfxil", "ubfiz", "sbfiz"] {
+            let text = format!("{mnem} w0, w1, #5, #10");
+            let parsed = match parse_line(&text).unwrap() {
+                LineResult::Instruction(instr) => instr,
+                LineResult::Skip => panic!("unexpected skip"),
+            };
+            assert_eq!(
+                parsed.destination(),
+                Some(Register::X0),
+                "{mnem} W destination"
+            );
+            assert_eq!(format!("{parsed}"), text, "{mnem} W round-trip Display");
+        }
+    }
+
+    #[test]
+    fn parse_bitfield_w_builds_w32_variant() {
+        let parsed = match parse_line("ubfx w0, w1, #5, #10").unwrap() {
+            LineResult::Instruction(instr) => instr,
+            LineResult::Skip => panic!("unexpected skip"),
+        };
+        assert_eq!(
+            parsed,
+            Instruction::Ubfx {
+                rd: Register::X0,
+                rn: Register::X1,
+                lsb: 5,
+                width: 10,
+                reg_width: crate::ir::RegisterWidth::W32,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_bitfield_rejects_mixed_widths() {
+        assert!(parse_line("ubfx w0, x1, #5, #10").is_err());
+        assert!(parse_line("ubfx x0, w1, #5, #10").is_err());
+    }
+
+    #[test]
+    fn parse_bitfield_w_rejects_out_of_range() {
+        // lsb=32 is valid for X but not W.
+        assert!(parse_line("ubfx w0, w1, #32, #1").is_err());
+        // lsb+width > 32 rejected for W.
+        assert!(parse_line("sbfx w0, w1, #16, #17").is_err());
+        // width=33 rejected for W.
+        assert!(parse_line("bfi w0, w1, #0, #33").is_err());
     }
 
     #[test]
@@ -2706,6 +2809,7 @@ mod tests {
                 rn: Register::X1,
                 lsb: 5,
                 width: 10,
+                reg_width: crate::ir::RegisterWidth::X64
             }
         );
         assert_eq!(format!("{}", parsed), "sbfx x0, x1, #5, #10");
@@ -2724,6 +2828,7 @@ mod tests {
                 rn: Register::X1,
                 lsb: 5,
                 width: 10,
+                reg_width: crate::ir::RegisterWidth::X64
             }
         );
         assert_eq!(format!("{}", parsed), "bfi x0, x1, #5, #10");
@@ -2742,6 +2847,7 @@ mod tests {
                 rn: Register::X1,
                 lsb: 5,
                 width: 10,
+                reg_width: crate::ir::RegisterWidth::X64
             }
         );
         assert_eq!(format!("{}", parsed), "bfxil x0, x1, #5, #10");
@@ -2760,6 +2866,7 @@ mod tests {
                 rn: Register::X1,
                 lsb: 5,
                 width: 10,
+                reg_width: crate::ir::RegisterWidth::X64
             }
         );
         assert_eq!(format!("{}", parsed), "ubfiz x0, x1, #5, #10");
@@ -2778,6 +2885,7 @@ mod tests {
                 rn: Register::X1,
                 lsb: 5,
                 width: 10,
+                reg_width: crate::ir::RegisterWidth::X64
             }
         );
         assert_eq!(format!("{}", parsed), "sbfiz x0, x1, #5, #10");

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -587,9 +587,11 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
     }
 
     // Bit-field manipulation (UBFX/SBFX/BFI/BFXIL/UBFIZ/SBFIZ): sparse
-    // (lsb, width) samples to keep the enumerative budget bounded. With
-    // 31 non-SP registers × 31 rn × ~24 valid (lsb,width) pairs × 6 variants
-    // ≈ 138k additional candidates, comparable to the CCMP/CCMN budget.
+    // (lsb, width) samples to keep the enumerative budget bounded, emitted for
+    // both the X (64-bit) and W (32-bit) register forms. The shared sample
+    // tables are filtered per width against the encodability bound
+    // (lsb < bound, lsb+width <= bound), so the W form naturally drops lsb=32/63
+    // and width=64. This roughly doubles the bit-field slice of the pool.
     const BITFIELD_LSB_SAMPLES: [u8; 5] = [0, 1, 16, 32, 63];
     const BITFIELD_WIDTH_SAMPLES: [u8; 6] = [1, 4, 8, 16, 32, 64];
     for &rd in registers {
@@ -600,17 +602,59 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
             if rn == Register::SP {
                 continue;
             }
-            for &lsb in &BITFIELD_LSB_SAMPLES {
-                for &width in &BITFIELD_WIDTH_SAMPLES {
-                    if (lsb as u16 + width as u16) > 64 {
+            for reg_width in [RegisterWidth::X64, RegisterWidth::W32] {
+                let bound = reg_width.bit_width() as u16;
+                for &lsb in &BITFIELD_LSB_SAMPLES {
+                    if lsb as u16 >= bound {
                         continue;
                     }
-                    instrs.push(Instruction::Ubfx { rd, rn, lsb, width });
-                    instrs.push(Instruction::Sbfx { rd, rn, lsb, width });
-                    instrs.push(Instruction::Bfi { rd, rn, lsb, width });
-                    instrs.push(Instruction::Bfxil { rd, rn, lsb, width });
-                    instrs.push(Instruction::Ubfiz { rd, rn, lsb, width });
-                    instrs.push(Instruction::Sbfiz { rd, rn, lsb, width });
+                    for &width in &BITFIELD_WIDTH_SAMPLES {
+                        if width as u16 > bound || (lsb as u16 + width as u16) > bound {
+                            continue;
+                        }
+                        instrs.push(Instruction::Ubfx {
+                            rd,
+                            rn,
+                            lsb,
+                            width,
+                            reg_width,
+                        });
+                        instrs.push(Instruction::Sbfx {
+                            rd,
+                            rn,
+                            lsb,
+                            width,
+                            reg_width,
+                        });
+                        instrs.push(Instruction::Bfi {
+                            rd,
+                            rn,
+                            lsb,
+                            width,
+                            reg_width,
+                        });
+                        instrs.push(Instruction::Bfxil {
+                            rd,
+                            rn,
+                            lsb,
+                            width,
+                            reg_width,
+                        });
+                        instrs.push(Instruction::Ubfiz {
+                            rd,
+                            rn,
+                            lsb,
+                            width,
+                            reg_width,
+                        });
+                        instrs.push(Instruction::Sbfiz {
+                            rd,
+                            rn,
+                            lsb,
+                            width,
+                            reg_width,
+                        });
+                    }
                 }
             }
         }
@@ -875,8 +919,9 @@ pub fn generate_random_instruction<R: rand::RngExt>(
         }
         // Bit-field manipulation (UBFX/SBFX/BFI/BFXIL/UBFIZ/SBFIZ).
         // SP rejected in rd and rn (matches `generate_all_instructions` and
-        // `is_encodable_aarch64`); 2D constraint on (lsb, width) enforced by
-        // sampling width AFTER lsb so width is bounded by `64-lsb`.
+        // `is_encodable_aarch64`). The register width is picked first; the 2D
+        // constraint on (lsb, width) is enforced relative to that width's bound
+        // (32 for W, 64 for X) by sampling width AFTER lsb.
         33 => {
             let non_sp: Vec<Register> = registers
                 .iter()
@@ -893,8 +938,14 @@ pub fn generate_random_instruction<R: rand::RngExt>(
             let pick_non_sp = |rng: &mut R| non_sp[rng.random_range(0..non_sp.len())];
             let rd_local = pick_non_sp(rng);
             let rn = pick_non_sp(rng);
-            let lsb = (rng.random::<u32>() & 0x3F) as u8;
-            let max_w = 64 - lsb as u32;
+            let reg_width = if rng.random_bool(0.5) {
+                RegisterWidth::W32
+            } else {
+                RegisterWidth::X64
+            };
+            let bound = reg_width.bit_width() as u32;
+            let lsb = (rng.random::<u32>() % bound) as u8;
+            let max_w = bound - lsb as u32;
             let width = ((rng.random::<u32>() % max_w) + 1) as u8;
             match rng.random_range(0..6) {
                 0 => Instruction::Ubfx {
@@ -902,36 +953,42 @@ pub fn generate_random_instruction<R: rand::RngExt>(
                     rn,
                     lsb,
                     width,
+                    reg_width,
                 },
                 1 => Instruction::Sbfx {
                     rd: rd_local,
                     rn,
                     lsb,
                     width,
+                    reg_width,
                 },
                 2 => Instruction::Bfi {
                     rd: rd_local,
                     rn,
                     lsb,
                     width,
+                    reg_width,
                 },
                 3 => Instruction::Bfxil {
                     rd: rd_local,
                     rn,
                     lsb,
                     width,
+                    reg_width,
                 },
                 4 => Instruction::Ubfiz {
                     rd: rd_local,
                     rn,
                     lsb,
                     width,
+                    reg_width,
                 },
                 _ => Instruction::Sbfiz {
                     rd: rd_local,
                     rn,
                     lsb,
                     width,
+                    reg_width,
                 },
             }
         }
@@ -2043,6 +2100,48 @@ mod tests {
         let ids: Vec<_> = instrs.iter().map(InstructionType::opcode_id).collect();
         let unique: std::collections::HashSet<_> = ids.iter().collect();
         assert_eq!(ids.len(), unique.len());
+    }
+
+    #[test]
+    fn test_generate_all_instructions_includes_w_bitfield() {
+        let registers = vec![Register::X0, Register::X1];
+        let all = generate_all_instructions(&registers, &[0]);
+        let is_w = |i: &Instruction| {
+            matches!(
+                i,
+                Instruction::Ubfx {
+                    reg_width: RegisterWidth::W32,
+                    ..
+                } | Instruction::Sbfx {
+                    reg_width: RegisterWidth::W32,
+                    ..
+                } | Instruction::Bfi {
+                    reg_width: RegisterWidth::W32,
+                    ..
+                } | Instruction::Bfxil {
+                    reg_width: RegisterWidth::W32,
+                    ..
+                } | Instruction::Ubfiz {
+                    reg_width: RegisterWidth::W32,
+                    ..
+                } | Instruction::Sbfiz {
+                    reg_width: RegisterWidth::W32,
+                    ..
+                }
+            )
+        };
+        assert!(
+            all.iter().any(is_w),
+            "enumerative output must contain W-form bit-field instructions"
+        );
+        // Every W-form bit-field instruction must satisfy is_encodable_aarch64
+        // (lsb<=31, lsb+width<=32).
+        for instr in all.iter().filter(|i| is_w(i)) {
+            assert!(
+                instr.is_encodable_aarch64(),
+                "enumerative produced un-encodable W bit-field: {instr}"
+            );
+        }
     }
 
     #[test]

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -394,28 +394,67 @@ impl Mutator {
                 }
             }
             // Bit-field manipulation: 4-way operand mutation (rd, rn, lsb, width)
-            // with 2D clamping so the (lsb + width <= 64) constraint is always
-            // preserved. When mutating lsb, clamp width if necessary.
-            Instruction::Ubfx { rd, rn, lsb, width }
-            | Instruction::Sbfx { rd, rn, lsb, width }
-            | Instruction::Bfi { rd, rn, lsb, width }
-            | Instruction::Bfxil { rd, rn, lsb, width }
-            | Instruction::Ubfiz { rd, rn, lsb, width }
-            | Instruction::Sbfiz { rd, rn, lsb, width } => {
+            // with 2D clamping so the (lsb + width <= bound) constraint is always
+            // preserved, where `bound` is 32 for the W form and 64 for X. The
+            // register width form itself is never changed here (that would be a
+            // cross-width opcode bridge, which we deliberately avoid).
+            Instruction::Ubfx {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            }
+            | Instruction::Sbfx {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            }
+            | Instruction::Bfi {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            }
+            | Instruction::Bfxil {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            }
+            | Instruction::Ubfiz {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            }
+            | Instruction::Sbfiz {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            } => {
+                let bound = reg_width.bit_width() as u32;
                 match rng.random_range(0..4) {
                     0 => *rd = self.random_register(rng),
                     1 => *rn = self.random_register(rng),
                     2 => {
                         // Mutate width: bound by current lsb so the pair stays valid.
-                        let max_w = (64 - *lsb).max(1);
-                        *width = ((rng.random::<u32>() % max_w as u32) + 1) as u8;
+                        let max_w = (bound - *lsb as u32).max(1);
+                        *width = ((rng.random::<u32>() % max_w) + 1) as u8;
                     }
                     _ => {
                         // Mutate lsb; clamp width down if the new lsb would
-                        // overflow the (lsb + width <= 64) constraint.
-                        *lsb = (rng.random::<u32>() & 0x3F) as u8;
-                        if (*lsb as u16 + *width as u16) > 64 {
-                            *width = 64 - *lsb;
+                        // overflow the (lsb + width <= bound) constraint.
+                        *lsb = (rng.random::<u32>() % bound) as u8;
+                        if (*lsb as u16 + *width as u16) > bound as u16 {
+                            *width = bound as u8 - *lsb;
                         }
                     }
                 }
@@ -970,53 +1009,305 @@ impl Mutator {
             // and insert (BFI/BFXIL/UBFIZ/SBFIZ) variants changes whether rd
             // is read; MCMC tolerates this because invalid proposals fail
             // equivalence checking and are rejected by the acceptance step.
-            Instruction::Ubfx { rd, rn, lsb, width } => match rng.random_range(0..6) {
-                0 => Instruction::Sbfx { rd, rn, lsb, width },
-                1 => Instruction::Bfi { rd, rn, lsb, width },
-                2 => Instruction::Bfxil { rd, rn, lsb, width },
-                3 => Instruction::Ubfiz { rd, rn, lsb, width },
-                4 => Instruction::Sbfiz { rd, rn, lsb, width },
-                _ => Instruction::Ubfx { rd, rn, lsb, width },
+            Instruction::Ubfx {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            } => match rng.random_range(0..6) {
+                0 => Instruction::Sbfx {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                1 => Instruction::Bfi {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                2 => Instruction::Bfxil {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                3 => Instruction::Ubfiz {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                4 => Instruction::Sbfiz {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                _ => Instruction::Ubfx {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
             },
-            Instruction::Sbfx { rd, rn, lsb, width } => match rng.random_range(0..6) {
-                0 => Instruction::Ubfx { rd, rn, lsb, width },
-                1 => Instruction::Bfi { rd, rn, lsb, width },
-                2 => Instruction::Bfxil { rd, rn, lsb, width },
-                3 => Instruction::Ubfiz { rd, rn, lsb, width },
-                4 => Instruction::Sbfiz { rd, rn, lsb, width },
-                _ => Instruction::Sbfx { rd, rn, lsb, width },
+            Instruction::Sbfx {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            } => match rng.random_range(0..6) {
+                0 => Instruction::Ubfx {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                1 => Instruction::Bfi {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                2 => Instruction::Bfxil {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                3 => Instruction::Ubfiz {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                4 => Instruction::Sbfiz {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                _ => Instruction::Sbfx {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
             },
-            Instruction::Bfi { rd, rn, lsb, width } => match rng.random_range(0..6) {
-                0 => Instruction::Ubfx { rd, rn, lsb, width },
-                1 => Instruction::Sbfx { rd, rn, lsb, width },
-                2 => Instruction::Bfxil { rd, rn, lsb, width },
-                3 => Instruction::Ubfiz { rd, rn, lsb, width },
-                4 => Instruction::Sbfiz { rd, rn, lsb, width },
-                _ => Instruction::Bfi { rd, rn, lsb, width },
+            Instruction::Bfi {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            } => match rng.random_range(0..6) {
+                0 => Instruction::Ubfx {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                1 => Instruction::Sbfx {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                2 => Instruction::Bfxil {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                3 => Instruction::Ubfiz {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                4 => Instruction::Sbfiz {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                _ => Instruction::Bfi {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
             },
-            Instruction::Bfxil { rd, rn, lsb, width } => match rng.random_range(0..6) {
-                0 => Instruction::Ubfx { rd, rn, lsb, width },
-                1 => Instruction::Sbfx { rd, rn, lsb, width },
-                2 => Instruction::Bfi { rd, rn, lsb, width },
-                3 => Instruction::Ubfiz { rd, rn, lsb, width },
-                4 => Instruction::Sbfiz { rd, rn, lsb, width },
-                _ => Instruction::Bfxil { rd, rn, lsb, width },
+            Instruction::Bfxil {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            } => match rng.random_range(0..6) {
+                0 => Instruction::Ubfx {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                1 => Instruction::Sbfx {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                2 => Instruction::Bfi {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                3 => Instruction::Ubfiz {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                4 => Instruction::Sbfiz {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                _ => Instruction::Bfxil {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
             },
-            Instruction::Ubfiz { rd, rn, lsb, width } => match rng.random_range(0..6) {
-                0 => Instruction::Ubfx { rd, rn, lsb, width },
-                1 => Instruction::Sbfx { rd, rn, lsb, width },
-                2 => Instruction::Bfi { rd, rn, lsb, width },
-                3 => Instruction::Bfxil { rd, rn, lsb, width },
-                4 => Instruction::Sbfiz { rd, rn, lsb, width },
-                _ => Instruction::Ubfiz { rd, rn, lsb, width },
+            Instruction::Ubfiz {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            } => match rng.random_range(0..6) {
+                0 => Instruction::Ubfx {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                1 => Instruction::Sbfx {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                2 => Instruction::Bfi {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                3 => Instruction::Bfxil {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                4 => Instruction::Sbfiz {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                _ => Instruction::Ubfiz {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
             },
-            Instruction::Sbfiz { rd, rn, lsb, width } => match rng.random_range(0..6) {
-                0 => Instruction::Ubfx { rd, rn, lsb, width },
-                1 => Instruction::Sbfx { rd, rn, lsb, width },
-                2 => Instruction::Bfi { rd, rn, lsb, width },
-                3 => Instruction::Bfxil { rd, rn, lsb, width },
-                4 => Instruction::Ubfiz { rd, rn, lsb, width },
-                _ => Instruction::Sbfiz { rd, rn, lsb, width },
+            Instruction::Sbfiz {
+                rd,
+                rn,
+                lsb,
+                width,
+                reg_width,
+            } => match rng.random_range(0..6) {
+                0 => Instruction::Ubfx {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                1 => Instruction::Sbfx {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                2 => Instruction::Bfi {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                3 => Instruction::Bfxil {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                4 => Instruction::Ubfiz {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
+                _ => Instruction::Sbfiz {
+                    rd,
+                    rn,
+                    lsb,
+                    width,
+                    reg_width,
+                },
             },
             // Branches / terminators: never opcode-mutated. rewritable_len()
             // excludes the terminator slot before this fires; identity is
@@ -2822,6 +3113,75 @@ mod tests {
     }
 
     #[test]
+    fn w_bitfield_operand_mutation_stays_encodable_and_keeps_width() {
+        let mutator = default_mutator();
+        let mut rng = rand::rng();
+
+        let original = Instruction::Sbfx {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 4,
+            width: 8,
+            reg_width: crate::ir::RegisterWidth::W32,
+        };
+        for _ in 0..400 {
+            let mut seq = vec![original];
+            mutator.mutate_operand(&mut rng, &mut seq);
+            assert!(
+                seq[0].is_encodable_aarch64(),
+                "W operand mutation must stay encodable (lsb<=31, lsb+width<=32): {}",
+                seq[0]
+            );
+            // Operand mutation must not change the register width form.
+            assert!(
+                matches!(
+                    seq[0],
+                    Instruction::Sbfx {
+                        reg_width: crate::ir::RegisterWidth::W32,
+                        ..
+                    }
+                ),
+                "operand mutation changed the W form: {}",
+                seq[0]
+            );
+        }
+    }
+
+    #[test]
+    fn w_bitfield_opcode_mutation_preserves_width() {
+        let mutator = default_mutator();
+        let mut rng = rand::rng();
+
+        let original = Instruction::Ubfx {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 4,
+            width: 8,
+            reg_width: crate::ir::RegisterWidth::W32,
+        };
+        for _ in 0..200 {
+            let mut seq = vec![original];
+            mutator.mutate_opcode(&mut rng, &mut seq);
+            let reg_width = match seq[0] {
+                Instruction::Ubfx { reg_width, .. }
+                | Instruction::Sbfx { reg_width, .. }
+                | Instruction::Bfi { reg_width, .. }
+                | Instruction::Bfxil { reg_width, .. }
+                | Instruction::Ubfiz { reg_width, .. }
+                | Instruction::Sbfiz { reg_width, .. } => Some(reg_width),
+                _ => None,
+            };
+            assert_eq!(
+                reg_width,
+                Some(crate::ir::RegisterWidth::W32),
+                "opcode mutation must keep the W width (no X<->W bridging): {}",
+                seq[0]
+            );
+            assert!(seq[0].is_encodable_aarch64());
+        }
+    }
+
+    #[test]
     fn test_bitfield_operand_mutation_changes_fields_and_stays_encodable() {
         let mutator = default_mutator();
         let mut rng = rand::rng();
@@ -2831,6 +3191,7 @@ mod tests {
             rn: Register::X1,
             lsb: 8,
             width: 16,
+            reg_width: crate::ir::RegisterWidth::X64,
         };
         let mut changed = false;
         for _ in 0..200 {
@@ -2861,6 +3222,7 @@ mod tests {
             rn: Register::X1,
             lsb: 8,
             width: 16,
+            reg_width: crate::ir::RegisterWidth::X64,
         };
         let mut swapped_to_peer = false;
         for _ in 0..200 {

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -49,6 +49,21 @@ fn set_w_register(state: &mut ConcreteMachineState, reg: Register, value: u64) {
     state.set_register(reg, ConcreteValue::new(value & u32::MAX as u64));
 }
 
+// Store a bit-field op's 64-bit result into `rd`, honouring the register width.
+// For the W form, the upper 32 bits of the destination are zeroed (ARM ARM:
+// writing a W register clears bits [63:32]); the X form stores all 64 bits.
+fn store_bitfield_result(
+    state: &mut ConcreteMachineState,
+    rd: Register,
+    result: u64,
+    reg_width: crate::ir::RegisterWidth,
+) {
+    match reg_width {
+        crate::ir::RegisterWidth::W32 => set_w_register(state, rd, result),
+        crate::ir::RegisterWidth::X64 => state.set_register(rd, ConcreteValue::new(result)),
+    }
+}
+
 fn eval_w_operand(state: &ConcreteMachineState, operand: &Operand) -> u64 {
     match operand {
         Operand::Register(reg) => state.get_register(*reg).as_u64() & u32::MAX as u64,
@@ -490,7 +505,13 @@ pub fn apply_instruction_concrete(
         // UBFX rd, rn, #lsb, #width: extract bits [lsb+width-1:lsb] of rn,
         // zero-extend the result into rd. width=64 must use u64::MAX as the
         // low-bits mask to avoid the `1u64 << 64` UB.
-        Instruction::Ubfx { rd, rn, lsb, width } => {
+        Instruction::Ubfx {
+            rd,
+            rn,
+            lsb,
+            width,
+            reg_width,
+        } => {
             let value = state.get_register(*rn).as_u64();
             let low_mask = if *width == 64 {
                 u64::MAX
@@ -498,11 +519,17 @@ pub fn apply_instruction_concrete(
                 (1u64 << *width) - 1
             };
             let extracted = (value >> *lsb) & low_mask;
-            state.set_register(*rd, ConcreteValue::new(extracted));
+            store_bitfield_result(&mut state, *rd, extracted, *reg_width);
         }
         // SBFX rd, rn, #lsb, #width: extract bits [lsb+width-1:lsb] of rn,
         // sign-extend the result into rd. width=64 is the no-op identity.
-        Instruction::Sbfx { rd, rn, lsb, width } => {
+        Instruction::Sbfx {
+            rd,
+            rn,
+            lsb,
+            width,
+            reg_width,
+        } => {
             let value = state.get_register(*rn).as_u64();
             // Shift left then arithmetic-right by the same amount, computed on
             // i64, to sign-extend the field MSB across the upper bits.
@@ -512,12 +539,20 @@ pub fn apply_instruction_concrete(
             let shift_left = 64 - ((*lsb as u32) + (*width as u32));
             let intermediate = (value << shift_left) as i64;
             // Right shift by (64 - width) sign-extends from bit (width-1).
+            // For the W form the low 32 bits hold the 32-bit sign-extended value;
+            // store_bitfield_result then zeroes bits [63:32].
             let result = (intermediate >> (64 - *width as u32)) as u64;
-            state.set_register(*rd, ConcreteValue::new(result));
+            store_bitfield_result(&mut state, *rd, result, *reg_width);
         }
         // BFI rd, rn, #lsb, #width: insert low `width` bits of rn at position
         // lsb of rd, preserving the other bits of rd.
-        Instruction::Bfi { rd, rn, lsb, width } => {
+        Instruction::Bfi {
+            rd,
+            rn,
+            lsb,
+            width,
+            reg_width,
+        } => {
             let dest = state.get_register(*rd).as_u64();
             let src = state.get_register(*rn).as_u64();
             let low_mask = if *width == 64 {
@@ -528,11 +563,17 @@ pub fn apply_instruction_concrete(
             let shifted_mask = low_mask << *lsb;
             let inserted = (src & low_mask) << *lsb;
             let result = (dest & !shifted_mask) | inserted;
-            state.set_register(*rd, ConcreteValue::new(result));
+            store_bitfield_result(&mut state, *rd, result, *reg_width);
         }
         // BFXIL rd, rn, #lsb, #width: extract bits [lsb+width-1:lsb] of rn,
         // place at [width-1:0] of rd, preserve rd[63:width].
-        Instruction::Bfxil { rd, rn, lsb, width } => {
+        Instruction::Bfxil {
+            rd,
+            rn,
+            lsb,
+            width,
+            reg_width,
+        } => {
             let dest = state.get_register(*rd).as_u64();
             let src = state.get_register(*rn).as_u64();
             let low_mask = if *width == 64 {
@@ -542,11 +583,17 @@ pub fn apply_instruction_concrete(
             };
             let extracted = (src >> *lsb) & low_mask;
             let result = (dest & !low_mask) | extracted;
-            state.set_register(*rd, ConcreteValue::new(result));
+            store_bitfield_result(&mut state, *rd, result, *reg_width);
         }
         // UBFIZ rd, rn, #lsb, #width: take low `width` bits of rn, zero-extend
         // to 64, shift left by lsb → rd (other bits zero).
-        Instruction::Ubfiz { rd, rn, lsb, width } => {
+        Instruction::Ubfiz {
+            rd,
+            rn,
+            lsb,
+            width,
+            reg_width,
+        } => {
             let value = state.get_register(*rn).as_u64();
             let low_mask = if *width == 64 {
                 u64::MAX
@@ -554,18 +601,24 @@ pub fn apply_instruction_concrete(
                 (1u64 << *width) - 1
             };
             let inserted = (value & low_mask) << *lsb;
-            state.set_register(*rd, ConcreteValue::new(inserted));
+            store_bitfield_result(&mut state, *rd, inserted, *reg_width);
         }
         // SBFIZ rd, rn, #lsb, #width: low `width` bits of rn, sign-extended
         // across bits [63:width], then shifted left by lsb → rd.
-        Instruction::Sbfiz { rd, rn, lsb, width } => {
+        Instruction::Sbfiz {
+            rd,
+            rn,
+            lsb,
+            width,
+            reg_width,
+        } => {
             let value = state.get_register(*rn).as_u64();
             // Sign-extend the low `width` bits to 64.
             let shift_left = 64 - *width as u32;
             let sign_extended = ((value << shift_left) as i64 >> shift_left) as u64;
             // Then shift left by lsb.
             let result = sign_extended << *lsb;
-            state.set_register(*rd, ConcreteValue::new(result));
+            store_bitfield_result(&mut state, *rd, result, *reg_width);
         }
         // Branches / terminators: callers must strip terminators before
         // apply_sequence_concrete. The equivalence layer handles them via
@@ -2479,6 +2532,7 @@ mod tests {
             rn: Register::X1,
             lsb: 8,
             width: 16,
+            reg_width: crate::ir::RegisterWidth::X64,
         };
         let after = apply_instruction_concrete(state, &instr);
         // bits [23:8] of 0xDEAD_BEEF_CAFE_0123 = 0xFE01
@@ -2495,6 +2549,7 @@ mod tests {
             rn: Register::X1,
             lsb: 0,
             width: 64,
+            reg_width: crate::ir::RegisterWidth::X64,
         };
         let after = apply_instruction_concrete(state, &instr);
         assert_eq!(
@@ -2514,6 +2569,7 @@ mod tests {
             rn: Register::X1,
             lsb: 4,
             width: 8,
+            reg_width: crate::ir::RegisterWidth::X64,
         };
         let after = apply_instruction_concrete(state, &instr);
         // 0xF0 sign-extended from 8 bits = 0xFFFF_FFFF_FFFF_FFF0
@@ -2532,9 +2588,122 @@ mod tests {
             rn: Register::X1,
             lsb: 8,
             width: 8,
+            reg_width: crate::ir::RegisterWidth::X64,
         };
         let after = apply_instruction_concrete(state, &instr);
         assert_eq!(after.get_register(Register::X0).as_u64(), 0x7F);
+    }
+
+    #[test]
+    fn test_sbfx_w_form_zeroes_upper_32_bits() {
+        // SBFX W0, W1, #4, #8: extract bits [11:4] = 0xF0 of W1, sign-extend
+        // within 32 bits, then zero bits [63:32] of the destination X register
+        // (ARM ARM: writing a W register zeroes the upper half). The X form would
+        // instead fill [63:32] with the sign bit.
+        let state = state_with(vec![(Register::X1, 0xF00)]);
+        let instr = Instruction::Sbfx {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 4,
+            width: 8,
+            reg_width: crate::ir::RegisterWidth::W32,
+        };
+        let after = apply_instruction_concrete(state, &instr);
+        // 0xF0 sign-extended from 8 bits within 32 = 0xFFFF_FFF0; upper 32 zeroed.
+        assert_eq!(
+            after.get_register(Register::X0).as_u64(),
+            0x0000_0000_FFFF_FFF0
+        );
+    }
+
+    #[test]
+    fn test_bfi_w_form_zeroes_upper_32_bits() {
+        // BFI W0, W1, #4, #8: insert low 8 bits of W1 (0x00) at position 4 of W0,
+        // preserving the other low-32 bits of W0, and zero bits [63:32].
+        let state = state_with(vec![(Register::X0, u64::MAX), (Register::X1, 0x00)]);
+        let instr = Instruction::Bfi {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 4,
+            width: 8,
+            reg_width: crate::ir::RegisterWidth::W32,
+        };
+        let after = apply_instruction_concrete(state, &instr);
+        // low 32 of rd = 0xFFFF_FFFF, clear [11:4], insert 0 -> 0xFFFF_F00F; upper 32 zeroed.
+        assert_eq!(
+            after.get_register(Register::X0).as_u64(),
+            0x0000_0000_FFFF_F00F
+        );
+    }
+
+    #[test]
+    fn test_bfxil_w_form_zeroes_upper_32_bits() {
+        // BFXIL W0, W1, #4, #8: extract bits [11:4] of W1 (=0) into [7:0] of W0,
+        // preserve W0[31:8], and zero bits [63:32].
+        let state = state_with(vec![(Register::X0, u64::MAX), (Register::X1, 0x00)]);
+        let instr = Instruction::Bfxil {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 4,
+            width: 8,
+            reg_width: crate::ir::RegisterWidth::W32,
+        };
+        let after = apply_instruction_concrete(state, &instr);
+        // low 32 of rd keeps [31:8]=1, [7:0]=0 -> 0xFFFF_FF00; upper 32 zeroed.
+        assert_eq!(
+            after.get_register(Register::X0).as_u64(),
+            0x0000_0000_FFFF_FF00
+        );
+    }
+
+    #[test]
+    fn test_sbfiz_w_form_zeroes_upper_32_bits() {
+        // SBFIZ W0, W1, #4, #8: low 8 bits of W1 (0xAB, MSB set), sign-extend
+        // within 32 bits, shift left by 4, and zero bits [63:32].
+        let state = state_with(vec![(Register::X1, 0xAB)]);
+        let instr = Instruction::Sbfiz {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 4,
+            width: 8,
+            reg_width: crate::ir::RegisterWidth::W32,
+        };
+        let after = apply_instruction_concrete(state, &instr);
+        // 0xAB sign-extended within 32 = 0xFFFF_FFAB, <<4 = 0xFFFF_FAB0; upper 32 zeroed.
+        assert_eq!(
+            after.get_register(Register::X0).as_u64(),
+            0x0000_0000_FFFF_FAB0
+        );
+    }
+
+    #[test]
+    fn test_ubfx_w_form_matches_x_form_for_valid_field() {
+        // UBFX zero-extends, so for a W field (width<=32) the result already has
+        // zero upper bits: W and X agree. Guards against accidental divergence.
+        let state = state_with(vec![(Register::X1, 0xF00)]);
+        let instr = Instruction::Ubfx {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 4,
+            width: 8,
+            reg_width: crate::ir::RegisterWidth::W32,
+        };
+        let after = apply_instruction_concrete(state, &instr);
+        assert_eq!(after.get_register(Register::X0).as_u64(), 0xF0);
+    }
+
+    #[test]
+    fn test_ubfiz_w_form_matches_x_form_for_valid_field() {
+        let state = state_with(vec![(Register::X1, 0xAB)]);
+        let instr = Instruction::Ubfiz {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 4,
+            width: 8,
+            reg_width: crate::ir::RegisterWidth::W32,
+        };
+        let after = apply_instruction_concrete(state, &instr);
+        assert_eq!(after.get_register(Register::X0).as_u64(), 0xAB0);
     }
 
     #[test]
@@ -2547,6 +2716,7 @@ mod tests {
             rn: Register::X1,
             lsb: 4,
             width: 8,
+            reg_width: crate::ir::RegisterWidth::X64,
         };
         let after = apply_instruction_concrete(state, &instr);
         // 0xAB sign-extended from 8 bits → 0xFFFF_FFFF_FFFF_FFAB
@@ -2566,6 +2736,7 @@ mod tests {
             rn: Register::X1,
             lsb: 4,
             width: 8,
+            reg_width: crate::ir::RegisterWidth::X64,
         };
         let after = apply_instruction_concrete(state, &instr);
         // 0x7F << 4 = 0x7F0; no sign extension.
@@ -2585,6 +2756,7 @@ mod tests {
             rn: Register::X1,
             lsb: 4,
             width: 8,
+            reg_width: crate::ir::RegisterWidth::X64,
         };
         let after = apply_instruction_concrete(state, &instr);
         // 0xAB << 4 = 0xAB0; everything else zero.
@@ -2604,6 +2776,7 @@ mod tests {
             rn: Register::X1,
             lsb: 8,
             width: 8,
+            reg_width: crate::ir::RegisterWidth::X64,
         };
         let after = apply_instruction_concrete(state, &instr);
         // X0 upper 56 bits preserved (all ones), low 8 bits = 0xAB
@@ -2626,6 +2799,7 @@ mod tests {
             rn: Register::X1,
             lsb: 4,
             width: 8,
+            reg_width: crate::ir::RegisterWidth::X64,
         };
         let after = apply_instruction_concrete(state, &instr);
         // Bits [11:4] become 0xAA (from rn low 8 bits); other bits of X0 preserved.
@@ -2648,6 +2822,7 @@ mod tests {
             rn: Register::X1,
             lsb: 63,
             width: 1,
+            reg_width: crate::ir::RegisterWidth::X64,
         };
         let after = apply_instruction_concrete(state, &instr);
         assert_eq!(after.get_register(Register::X0).as_u64(), 1);

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -2755,6 +2755,7 @@ mod tests {
             rn: Register::X1,
             lsb,
             width,
+            reg_width: crate::ir::RegisterWidth::X64,
         }];
 
         let expanded = vec![
@@ -2807,6 +2808,7 @@ mod tests {
             rn: Register::X1,
             lsb: lsb as u8,
             width,
+            reg_width: crate::ir::RegisterWidth::X64,
         }];
 
         let lsr_lsl_asr = vec![
@@ -2847,6 +2849,7 @@ mod tests {
             rn: Register::X1,
             lsb: lsb as u8,
             width,
+            reg_width: crate::ir::RegisterWidth::X64,
         }];
 
         let lsr_and = vec![
@@ -2870,6 +2873,127 @@ mod tests {
         );
     }
 
+    /// Acceptance (#145): the SMT lowering of a W-form bit-field op zeroes bits
+    /// [63:32]. SBFX is the discriminating case (the X form fills the upper half
+    /// with the sign). `SBFX W0,W1,#0,#8` must equal `SBFX X2,X1,#0,#8; MOV W0,W2`
+    /// (the W MOV zeroes the upper half). This only holds when the W SMT lowering
+    /// narrows the result to 32 bits before storing.
+    #[test]
+    fn test_sbfx_w_form_zeroes_upper_half_smt() {
+        let lhs = vec![Instruction::Sbfx {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: 0,
+            width: 8,
+            reg_width: crate::ir::RegisterWidth::W32,
+        }];
+        let rhs = vec![
+            Instruction::Sbfx {
+                rd: Register::X2,
+                rn: Register::X1,
+                lsb: 0,
+                width: 8,
+                reg_width: crate::ir::RegisterWidth::X64,
+            },
+            Instruction::MovRegW {
+                rd: Register::X0,
+                rn: Register::X2,
+            },
+        ];
+        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
+        assert_eq!(
+            check_equivalence_with_config(&lhs, &rhs, &config),
+            EquivalenceResult::Equivalent
+        );
+    }
+
+    /// Acceptance (#145): a W-form UBFX equals an LSR/AND mask sequence whose
+    /// final AND is a W op (so the result is a 32-bit value zero-extended to 64).
+    #[test]
+    fn test_ubfx_w_form_equivalent_to_lsr_w_and_mask() {
+        let lsb = 4i64;
+        let width = 8u8;
+        let mask = (1i64 << width) - 1;
+
+        let ubfx_w = vec![Instruction::Ubfx {
+            rd: Register::X0,
+            rn: Register::X1,
+            lsb: lsb as u8,
+            width,
+            reg_width: crate::ir::RegisterWidth::W32,
+        }];
+
+        let lsr_and = vec![
+            Instruction::Lsr {
+                rd: Register::X2,
+                rn: Register::X1,
+                shift: Operand::Immediate(lsb),
+            },
+            Instruction::And {
+                rd: Register::X0,
+                rn: Register::X2,
+                rm: Operand::Immediate(mask),
+                width: crate::ir::RegisterWidth::W32,
+            },
+        ];
+
+        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
+        assert_eq!(
+            check_equivalence_with_config(&ubfx_w, &lsr_and, &config),
+            EquivalenceResult::Equivalent
+        );
+    }
+
+    /// Acceptance (#145): a sequence mixing X-form and W-form bit-field ops is
+    /// handled by the equivalence checker. The mixed sequence (X-form UBFX then
+    /// W-form SBFX) equals the all-X expansion where the W result is reproduced
+    /// by an X-form SBFX followed by a W MOV that zeroes bits [63:32].
+    #[test]
+    fn cross_width_mixed_bitfield_sequence_survives_equivalence() {
+        use crate::ir::RegisterWidth::{W32, X64};
+        let mixed = vec![
+            Instruction::Ubfx {
+                rd: Register::X2,
+                rn: Register::X1,
+                lsb: 8,
+                width: 16,
+                reg_width: X64,
+            },
+            Instruction::Sbfx {
+                rd: Register::X0,
+                rn: Register::X2,
+                lsb: 0,
+                width: 8,
+                reg_width: W32,
+            },
+        ];
+        let expanded = vec![
+            Instruction::Ubfx {
+                rd: Register::X2,
+                rn: Register::X1,
+                lsb: 8,
+                width: 16,
+                reg_width: X64,
+            },
+            Instruction::Sbfx {
+                rd: Register::X0,
+                rn: Register::X2,
+                lsb: 0,
+                width: 8,
+                reg_width: X64,
+            },
+            Instruction::MovRegW {
+                rd: Register::X0,
+                rn: Register::X0,
+            },
+        ];
+        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
+        assert_eq!(
+            check_equivalence_with_config(&mixed, &expanded, &config),
+            EquivalenceResult::Equivalent
+        );
+    }
+
     /// SMT proves `BFXIL rd,rn,#lsb,#width` ≡ {
     ///   LSR tmp,rn,#lsb; AND tmp,tmp,#low_mask;
     ///   AND clear,rd,#!low_mask; ORR rd,clear,tmp
@@ -2886,6 +3010,7 @@ mod tests {
             rn: Register::X1,
             lsb: lsb as u8,
             width,
+            reg_width: crate::ir::RegisterWidth::X64,
         }];
 
         let expanded = vec![
@@ -2934,6 +3059,7 @@ mod tests {
             rn: Register::X1,
             lsb: lsb as u8,
             width,
+            reg_width: crate::ir::RegisterWidth::X64,
         }];
 
         let and_lsl = vec![
@@ -2970,6 +3096,7 @@ mod tests {
             rn: Register::X1,
             lsb: lsb as u8,
             width,
+            reg_width: crate::ir::RegisterWidth::X64,
         }];
 
         let lsl_asr_lsl = vec![

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -107,6 +107,22 @@ fn zero_extend_to_state_width(value: BV, value_width: u32, state_width: u32) -> 
     }
 }
 
+// Store a bit-field op's 64-bit result BV into `rd`, honouring the register
+// width. For the W form, the low 32 bits hold the architectural result and bits
+// [63:32] are zeroed (ARM ARM: writing a W register clears the upper half).
+fn store_bitfield_result(
+    state: &mut MachineState,
+    rd: Register,
+    result: BV,
+    reg_width: RegisterWidth,
+) {
+    let stored = match reg_width {
+        RegisterWidth::W32 => zero_extend_to_state_width(result.extract(31, 0), 32, state.width()),
+        RegisterWidth::X64 => result,
+    };
+    state.set_register(rd, stored);
+}
+
 /// Count leading zeros of a `width`-bit BV with a binary-search decomposition.
 ///
 /// The result remains `width` bits wide, while the selected chunk halves on
@@ -976,7 +992,13 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
         }
         // UBFX rd, rn, #lsb, #width: extract bits [lsb+width-1:lsb] of rn,
         // zero-extend the result into rd.
-        Instruction::Ubfx { rd, rn, lsb, width } => {
+        Instruction::Ubfx {
+            rd,
+            rn,
+            lsb,
+            width,
+            reg_width,
+        } => {
             let value = state.get_register(*rn).clone();
             let hi = (*lsb as u32) + (*width as u32) - 1;
             let lo = *lsb as u32;
@@ -987,11 +1009,17 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             } else {
                 extracted.zero_ext(64 - *width as u32)
             };
-            state.set_register(*rd, result);
+            store_bitfield_result(&mut state, *rd, result, *reg_width);
         }
         // SBFX rd, rn, #lsb, #width: extract bits [lsb+width-1:lsb] of rn,
         // sign-extend into rd.
-        Instruction::Sbfx { rd, rn, lsb, width } => {
+        Instruction::Sbfx {
+            rd,
+            rn,
+            lsb,
+            width,
+            reg_width,
+        } => {
             let value = state.get_register(*rn).clone();
             let hi = (*lsb as u32) + (*width as u32) - 1;
             let lo = *lsb as u32;
@@ -1001,11 +1029,17 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             } else {
                 extracted.sign_ext(64 - *width as u32)
             };
-            state.set_register(*rd, result);
+            store_bitfield_result(&mut state, *rd, result, *reg_width);
         }
         // BFI rd, rn, #lsb, #width: insert low `width` bits of rn at position
         // lsb of rd, preserving the other bits of rd.
-        Instruction::Bfi { rd, rn, lsb, width } => {
+        Instruction::Bfi {
+            rd,
+            rn,
+            lsb,
+            width,
+            reg_width,
+        } => {
             let dest = state.get_register(*rd).clone();
             let src = state.get_register(*rn).clone();
             let low_mask_const = if *width == 64 {
@@ -1019,11 +1053,17 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let shift = BV::from_u64(*lsb as u64, 64);
             let inserted = src.bvand(&low_mask).bvshl(&shift);
             let cleared = dest.bvand(&clear_mask);
-            state.set_register(*rd, cleared.bvor(&inserted));
+            store_bitfield_result(&mut state, *rd, cleared.bvor(&inserted), *reg_width);
         }
         // BFXIL rd, rn, #lsb, #width: extract bits [lsb+width-1:lsb] of rn,
         // place at [width-1:0] of rd preserving rd[63:width].
-        Instruction::Bfxil { rd, rn, lsb, width } => {
+        Instruction::Bfxil {
+            rd,
+            rn,
+            lsb,
+            width,
+            reg_width,
+        } => {
             let dest = state.get_register(*rd).clone();
             let src = state.get_register(*rn).clone();
             let low_mask_const = if *width == 64 {
@@ -1037,11 +1077,17 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             // (rn >> lsb) & low_mask
             let extracted = src.bvlshr(&shift).bvand(&low_mask);
             let cleared = dest.bvand(&clear_mask);
-            state.set_register(*rd, cleared.bvor(&extracted));
+            store_bitfield_result(&mut state, *rd, cleared.bvor(&extracted), *reg_width);
         }
         // UBFIZ rd, rn, #lsb, #width: low `width` bits of rn, zero-extend,
         // shift left by lsb → rd (other bits zero).
-        Instruction::Ubfiz { rd, rn, lsb, width } => {
+        Instruction::Ubfiz {
+            rd,
+            rn,
+            lsb,
+            width,
+            reg_width,
+        } => {
             let value = state.get_register(*rn).clone();
             let field = value.extract(*width as u32 - 1, 0);
             let widened = if *width == 64 {
@@ -1050,11 +1096,17 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
                 field.zero_ext(64 - *width as u32)
             };
             let shift = BV::from_u64(*lsb as u64, 64);
-            state.set_register(*rd, widened.bvshl(&shift));
+            store_bitfield_result(&mut state, *rd, widened.bvshl(&shift), *reg_width);
         }
         // SBFIZ rd, rn, #lsb, #width: low `width` bits of rn, sign-extended
         // to 64, then shifted left by lsb → rd.
-        Instruction::Sbfiz { rd, rn, lsb, width } => {
+        Instruction::Sbfiz {
+            rd,
+            rn,
+            lsb,
+            width,
+            reg_width,
+        } => {
             let value = state.get_register(*rn).clone();
             let field = value.extract(*width as u32 - 1, 0);
             let widened = if *width == 64 {
@@ -1063,7 +1115,7 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
                 field.sign_ext(64 - *width as u32)
             };
             let shift = BV::from_u64(*lsb as u64, 64);
-            state.set_register(*rd, widened.bvshl(&shift));
+            store_bitfield_result(&mut state, *rd, widened.bvshl(&shift), *reg_width);
         }
         // Branches / terminators: callers must strip terminators before
         // apply_sequence. The equivalence layer handles them via


### PR DESCRIPTION
Closes #145.

## Summary
Adds the 32-bit **W-register** forms of the six AArch64 bit-field instructions
(`UBFX`/`SBFX`/`BFI`/`BFXIL`/`UBFIZ`/`SBFIZ`) alongside the existing 64-bit X forms.

Register width is modeled by a new `reg_width: RegisterWidth` field on the six
existing IR variants — the same pattern `And`/`Orr`/`Eor` already use — so the
`Register` enum is **not** changed and the variant/`opcode_id` set stays stable.

## What changed
- **IR** (`ir/instructions.rs`): `reg_width` field; width-aware `is_encodable_aarch64`
  (W: `lsb ≤ 31`, `lsb+width ≤ 32`) and width-aware `Display`.
- **Semantics**: W forms zero bits `[63:32]` of the destination per the ARM ARM, via a
  uniform "compute the 64-bit result, then narrow to 32 + zero-extend" path in both the
  concrete interpreter (`set_w_register`) and the SMT lowering
  (`zero_extend_to_state_width(result.extract(31,0), 32, …)`).
- **Parser**: `parse_bfm_like` now parses matching-width operands and bounds the
  immediates per width; mixed-width operands (`ubfx w0, x1, …`) are rejected.
- **Assembler**: emits `W(..)` vs `X(..)` dynasm operands by width.
- **Search**: enumerative + random generation and MCMC mutation are width-aware;
  `mutate_opcode` preserves the width form (no 32↔64 bridging). Mirrored into the
  (test-only) trait generator for parity.
- **Capstone** W-name pass-through (no alias-bridge change needed) and
  `docs/capability.md` updated.

## Acceptance criteria
- ✅ SMT proves a W-form equivalence that only holds when the upper half is zeroed
  (`SBFX W0,W1,#0,#8` ≡ `SBFX X2,X1,#0,#8; MOV W0,W2`).
- ✅ All six W forms round-trip through Capstone (`disassemble_and_verify`), choosing
  non-alias vectors to avoid the `lsb+width==32`→`lsr` / `lsb=0,width=32`→`mov` boundary.
- ✅ Cross-width mixed sequences parse, encode, and survive equivalence checking.

## Testing
Built with TDD (red→green per behavior). New tests cover concrete upper-half zeroing
for all six ops, encodability bounds, parser/Display round-trips, the SMT/equivalence
acceptance cases, W assembler emission, and width-aware generation/mutation. Full
`./ci_check.sh` passes (fmt, build, unit + integration tests, test-binary builds).

## Notes
- Generation is deliberately **not** alias-filtered (a boundary W-form UBFX may
  Capstone-decode as `lsr`/`mov`) — identical to the existing 64-bit behavior and
  semantically equivalent within the optimizer; only `disassemble_and_verify` test
  vectors avoid the boundary.
- 32-bit forms of other instructions (LSL/LSR/ASR/MOV) remain out of scope per the issue.