### PR TITLE
feat(semantics): surface flag guard metric

### DIFF
--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -298,6 +298,9 @@ pub fn check_equivalence(seq1: &[Instruction], seq2: &[Instruction]) -> Equivale
 /// Optional per-call metrics from the equivalence pipeline.
 #[derive(Debug, Default, Clone)]
 pub struct EquivalenceMetrics {
+    /// Whether a pre-SMT flag-writer guard rejected the candidate before
+    /// concrete or symbolic equivalence checking.
+    pub flag_guard_rejected: bool,
     /// Whether the SMT solver was actually invoked. False when fast-path
     /// refuted the candidate, when fast_only is set, or when the candidate
     /// was rejected before reaching SMT for any other reason.
@@ -769,7 +772,13 @@ where
     I::adjust_config_for_sequences(&mut effective_config, prefix1, prefix2, terminator1);
 
     if let Some(early) = I::pre_smt_guard_for(prefix1, prefix2, &effective_config) {
-        return (early, metrics);
+        return (
+            early,
+            EquivalenceMetrics {
+                flag_guard_rejected: true,
+                ..metrics
+            },
+        );
     }
 
     if let Some(fast) = I::run_fast_path_for(prefix1, prefix2, &effective_config) {
@@ -792,6 +801,7 @@ where
             smt_called: true,
             smt_formula_bytes,
             smt_elapsed,
+            ..EquivalenceMetrics::default()
         },
     )
 }
@@ -2502,6 +2512,17 @@ mod tests {
             EquivalenceResult::NotEquivalent,
             "Dropping a flag-writer must not be certified as equivalent when flags are live"
         );
+        let (metrics_result, metrics) =
+            check_equivalence_with_config_metrics(&adds, &add, &cfg_flags_live);
+        assert_eq!(metrics_result, EquivalenceResult::NotEquivalent);
+        assert!(
+            metrics.flag_guard_rejected,
+            "Metrics should identify pre-SMT flag-guard rejections"
+        );
+        assert!(!metrics.smt_called);
+        assert!(metrics.smt_formula_bytes.is_none());
+        assert_eq!(metrics.smt_elapsed, Duration::ZERO);
+
         // The unmasked path always treats NZCV as part of full state, so it
         // also rejects.
         assert_eq!(
@@ -2629,12 +2650,16 @@ mod tests {
         );
         // Mirror the assertion for the metrics-returning entry point, which
         // shares the same pre_smt_guard plumbing.
-        let (metrics_result, _metrics) =
+        let (metrics_result, metrics) =
             check_equivalence_with_config_metrics(&target, &candidate, &cfg_flags_dead);
         assert_eq!(
             metrics_result,
             EquivalenceResult::Equivalent,
             "Metrics entry point also accepts flag-only divergence when flags are dead"
+        );
+        assert!(
+            !metrics.flag_guard_rejected,
+            "Flag guard metric should remain false when flags are dead"
         );
     }
 

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- add EquivalenceMetrics::flag_guard_rejected for pre-SMT flag-writer guard exits
- assert the metric is true for flag-live rejections and false when flags are dead
- clean up current clippy needless-borrow warnings in SMT bit-vector helpers

Tests:
- cargo test test_adds_to_add_rewrite_rejected_when_flags_live
- cargo test test_dropping_flag_writer_allowed_when_flags_dead
- cargo test semantics::equivalence
- cargo fmt --all
- cargo clippy --all -- -D warnings
- ./build_tests.sh
- cargo test --all
- ./ci_check.sh

Closes #94

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**