### PR TITLE
feat(search): warn on skipped enumerative lengths

### DIFF
--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -425,6 +425,14 @@ fn candidate_solver_timeout(config: &SearchConfig, start: Instant) -> Option<Dur
     candidate_solver_timeout_for_elapsed(config, start.elapsed())
 }
 
+fn report_skipped_length(length: usize, verbose: bool, mut emit: impl FnMut(&str)) {
+    if verbose {
+        emit(&format!(
+            "warning: enumerative search length {length} is not yet implemented; skipping"
+        ));
+    }
+}
+
 fn run_length_one<I>(
     target: &[I::Instruction],
     live_out: &<I as EnumerativeBackend<I>>::LiveOut,
@@ -573,7 +581,9 @@ where
                         s,
                         start,
                     ),
-                    _ => {} // length >= 3 lands in a follow-up TDD cycle.
+                    _ => report_skipped_length(length, config.verbose, |message| {
+                        eprintln!("{message}")
+                    }),
                 }
             }
         };
@@ -1940,7 +1950,7 @@ mod tests {
 
     #[test]
     fn length_four_target_iterates_past_length_three_dispatch() {
-        // Pins the `_ => {}` arm of the per-length dispatch: a length-4
+        // Pins the skipped-length arm of the per-length dispatch: a length-4
         // target makes the outer loop iterate over lengths 1, 2, and 3, so
         // length 3 must hit the not-yet-implemented arm without panicking.
         // The target intentionally has a length-1 equivalent (`add x0, x1,
@@ -1971,14 +1981,33 @@ mod tests {
         let live_out = LiveOut::from_registers(vec![Register::X0]);
 
         let mut search = EnumerativeSearch::<crate::isa::AArch64>::new();
-        let result = search.search(&target, &live_out, &small_config());
+        let result = search.search(&target, &live_out, &small_config().verbose());
 
         // The important assertion is that the search returned — i.e. the
-        // length-3 `_ => {}` arm did not panic, the loop iterated past it,
-        // and the result was assembled cleanly.
+        // length-3 skipped-length arm did not panic, the loop iterated past
+        // it, and the result was assembled cleanly.
         assert!(result.statistics.elapsed_time > std::time::Duration::ZERO);
         assert!(result.found_optimization, "length-1 collapse should fire");
         assert_eq!(result.optimized_sequence.as_ref().map(Vec::len), Some(1));
+    }
+
+    #[test]
+    fn skipped_length_warning_is_verbose_gated() {
+        let mut quiet_messages = Vec::new();
+        report_skipped_length(3, false, |message| quiet_messages.push(message.to_owned()));
+
+        assert!(
+            quiet_messages.is_empty(),
+            "quiet enumerative search should not report skipped lengths"
+        );
+
+        let mut verbose_messages = Vec::new();
+        report_skipped_length(3, true, |message| verbose_messages.push(message.to_owned()));
+
+        assert_eq!(
+            verbose_messages,
+            vec!["warning: enumerative search length 3 is not yet implemented; skipping"]
+        );
     }
 
     #[test]

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- emit a verbose stderr warning when enumerative search reaches unimplemented length >= 3 buckets
- cover the warning text and verbose gating with a focused unit test
- apply a small Clippy cleanup in SMT bitvector calls required by the local gate

Verification:
- cargo test --lib search::enumerative::search::tests::skipped_length_warning_is_verbose_gated
- cargo test --lib search::enumerative::search::tests::length_four_target_iterates_past_length_three_dispatch
- cargo test --lib search::enumerative
- cargo clippy --all -- -D warnings
- ./build_tests.sh
- cargo test --all
- ./ci_check.sh

Note: scripts/full_test.sh from the generic run template is absent in this s11 workspace; ./ci_check.sh ran ./test_all.sh as the repo-specific full suite.

Closes #158

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**