### PR TITLE
refactor(search): promote solver timeout to search config

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ Useful flags on `opt`:
 | `--cores N` | worker threads for `hybrid` |
 | `--timeout SECS` | wall-clock budget for the search |
 | `--beta`, `--iterations`, `--seed` | MCMC tuning for `stochastic` |
-| `--search-mode linear\|binary`, `--solver-timeout SECS` | SMT synthesis tuning |
+| `--search-mode linear\|binary` | SMT synthesis search tuning |
+| `--solver-timeout SECS` | per-query SMT verifier/synthesis timeout |
 | `--no-symbolic` | run hybrid as all-stochastic workers |
 
 Note: enumerative search scales with the generated instruction families in its

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -348,7 +348,8 @@ Uses an SMT solver to synthesize optimal instruction sequences. More principled 
 
 Options:
 - `--search-mode <linear|binary>`: How to search for cost bounds
-- `--solver-timeout <SECS>`: Timeout per SMT query (default: 5)
+- `--solver-timeout <SECS>`: Timeout per SMT verification/synthesis query (default: 5).
+  The same cap applies to SMT verification used by the other search algorithms.
 
 **Best for:** Finding provably optimal solutions when SMT queries succeed.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -875,16 +875,29 @@ fn build_stochastic_search_config(
         .with_iterations(options.iterations)
         .with_seed_option(options.seed);
 
-    let symbolic_config = SymbolicConfig::default().with_timeout(options.solver_timeout);
-
     SearchConfig::default()
         .with_stochastic(stochastic_config)
-        .with_symbolic(symbolic_config)
+        .with_solver_timeout(options.solver_timeout)
         .with_cost_metric(options.cost_metric)
         .with_timeout_option(options.timeout)
         .with_verbose(options.verbose)
         .with_registers(available_registers)
         .with_immediates(available_immediates)
+}
+
+fn build_enumerative_search_config(
+    options: &OptimizationOptions,
+    available_registers: Vec<Register>,
+    available_immediates: Vec<i64>,
+) -> SearchConfig {
+    SearchConfig::default()
+        .with_cost_metric(options.cost_metric)
+        .with_solver_timeout(options.solver_timeout)
+        .with_timeout_option(options.timeout)
+        .with_verbose(options.verbose)
+        .with_registers(available_registers)
+        .with_immediates(available_immediates)
+        .with_cores(options.cores)
 }
 
 /// Build the per-worker `SearchConfig` consumed by the hybrid parallel
@@ -905,13 +918,12 @@ fn build_hybrid_search_config(
         .with_beta(options.beta)
         .with_iterations(options.iterations);
 
-    let symbolic_config = SymbolicConfig::default()
-        .with_search_mode(options.search_mode)
-        .with_timeout(options.solver_timeout);
+    let symbolic_config = SymbolicConfig::default().with_search_mode(options.search_mode);
 
     SearchConfig::default()
         .with_stochastic(stochastic_config)
         .with_symbolic(symbolic_config)
+        .with_solver_timeout(options.solver_timeout)
         .with_cost_metric(options.cost_metric)
         .with_verbose(options.verbose)
         .with_registers(available_registers)
@@ -929,11 +941,9 @@ fn build_x86_stochastic_search_config(
         .with_iterations(options.iterations)
         .with_seed_option(options.seed);
 
-    let symbolic_config = SymbolicConfig::default().with_timeout(options.solver_timeout);
-
     SearchConfig::default()
         .with_stochastic(stochastic_config)
-        .with_symbolic(symbolic_config)
+        .with_solver_timeout(options.solver_timeout)
         .with_cost_metric(options.cost_metric)
         .with_timeout_option(options.timeout)
         .with_verbose(options.verbose)
@@ -947,12 +957,11 @@ fn build_x86_symbolic_search_config(
     width: u32,
     options: &OptimizationOptions,
 ) -> SearchConfig {
-    let symbolic_config = SymbolicConfig::default()
-        .with_search_mode(options.search_mode)
-        .with_timeout(options.solver_timeout);
+    let symbolic_config = SymbolicConfig::default().with_search_mode(options.search_mode);
 
     SearchConfig::default()
         .with_symbolic(symbolic_config)
+        .with_solver_timeout(options.solver_timeout)
         .with_cost_metric(options.cost_metric)
         .with_timeout_option(options.timeout)
         .with_verbose(options.verbose)
@@ -1022,13 +1031,8 @@ fn run_optimization(
                 println!("  Cores: {}", n);
             }
 
-            let config = SearchConfig::default()
-                .with_cost_metric(options.cost_metric)
-                .with_timeout_option(options.timeout)
-                .with_verbose(options.verbose)
-                .with_registers(available_registers)
-                .with_immediates(available_immediates)
-                .with_cores(options.cores);
+            let config =
+                build_enumerative_search_config(options, available_registers, available_immediates);
 
             let mut search = EnumerativeSearch::<isa::AArch64>::new();
             let result = search.search(prefix, &live_out, &config);
@@ -1069,12 +1073,11 @@ fn run_optimization(
             println!("  Search mode: {:?}", options.search_mode);
             println!("  Solver timeout: {:?}", options.solver_timeout);
 
-            let symbolic_config = SymbolicConfig::default()
-                .with_search_mode(options.search_mode)
-                .with_timeout(options.solver_timeout);
+            let symbolic_config = SymbolicConfig::default().with_search_mode(options.search_mode);
 
             let config = SearchConfig::default()
                 .with_symbolic(symbolic_config)
+                .with_solver_timeout(options.solver_timeout)
                 .with_cost_metric(options.cost_metric)
                 .with_timeout_option(options.timeout)
                 .with_verbose(options.verbose)
@@ -1104,6 +1107,7 @@ fn run_optimization(
 
             let config = SearchConfig::default()
                 .with_cost_metric(options.cost_metric)
+                .with_solver_timeout(options.solver_timeout)
                 .with_timeout_option(options.timeout)
                 .with_verbose(options.verbose)
                 .with_registers(available_registers)
@@ -3297,6 +3301,7 @@ mod cli_helper_tests {
     fn build_x86_enumerative_search_config_is_target_derived_and_honors_cores() {
         let mut opts = options_for(Algorithm::Enumerative);
         opts.cores = Some(3);
+        opts.solver_timeout = Duration::from_millis(37);
         let target = vec![
             X86Instruction::MovImm {
                 rd: X86Register::R11,
@@ -3313,6 +3318,7 @@ mod cli_helper_tests {
         ];
         let config = build_x86_enumerative_search_config(&target, 64, &opts);
         assert_eq!(config.cores, Some(3), "--cores must be threaded through");
+        assert_eq!(config.solver_timeout, Some(Duration::from_millis(37)));
         assert!(
             config.x86_available_registers.contains(&X86Register::R11)
                 && config.x86_available_registers.contains(&X86Register::R12),
@@ -3372,17 +3378,41 @@ mod cli_helper_tests {
     fn build_hybrid_search_config_propagates_timeout() {
         let mut opts = options_for(Algorithm::Hybrid);
         opts.timeout = Some(Duration::from_millis(7));
+        opts.solver_timeout = Duration::from_millis(17);
 
         let regs = vec![Register::X0];
         let imms = vec![0, 1];
         let config = build_hybrid_search_config(&opts, regs, imms);
 
         assert_eq!(config.timeout, Some(Duration::from_millis(7)));
+        assert_eq!(config.solver_timeout, Some(Duration::from_millis(17)));
 
         // None should propagate too.
         opts.timeout = None;
         let config = build_hybrid_search_config(&opts, vec![Register::X0], vec![0]);
         assert_eq!(config.timeout, None);
+    }
+
+    #[test]
+    fn build_enumerative_search_config_propagates_solver_timeout() {
+        let mut opts = options_for(Algorithm::Enumerative);
+        opts.timeout = Some(Duration::from_millis(9));
+        opts.solver_timeout = Duration::from_millis(13);
+        opts.cost_metric = CostMetric::Latency;
+        opts.verbose = true;
+        opts.cores = Some(2);
+
+        let regs = vec![Register::X0, Register::X1];
+        let imms = vec![0, 7];
+        let config = build_enumerative_search_config(&opts, regs.clone(), imms.clone());
+
+        assert_eq!(config.solver_timeout, Some(Duration::from_millis(13)));
+        assert_eq!(config.cost_metric, CostMetric::Latency);
+        assert_eq!(config.timeout, Some(Duration::from_millis(9)));
+        assert!(config.verbose);
+        assert_eq!(config.available_registers, regs);
+        assert_eq!(config.available_immediates, imms);
+        assert_eq!(config.cores, Some(2));
     }
 
     #[test]
@@ -3400,10 +3430,7 @@ mod cli_helper_tests {
         let imms = vec![0, 7];
         let config = build_stochastic_search_config(&opts, regs.clone(), imms.clone());
 
-        assert_eq!(
-            config.symbolic.solver_timeout,
-            Some(Duration::from_millis(17))
-        );
+        assert_eq!(config.solver_timeout, Some(Duration::from_millis(17)));
         assert_eq!(config.stochastic.beta, 2.5);
         assert_eq!(config.stochastic.iterations, 123);
         assert_eq!(config.stochastic.seed, Some(99));
@@ -3449,10 +3476,7 @@ mod cli_helper_tests {
         ];
         let config = build_x86_stochastic_search_config(&target, 32, &opts);
 
-        assert_eq!(
-            config.symbolic.solver_timeout,
-            Some(Duration::from_millis(19))
-        );
+        assert_eq!(config.solver_timeout, Some(Duration::from_millis(19)));
         assert_eq!(config.stochastic.beta, 3.5);
         assert_eq!(config.stochastic.iterations, 456);
         assert_eq!(config.stochastic.seed, Some(101));
@@ -3577,10 +3601,7 @@ mod cli_helper_tests {
             "all stack/frame targets must not fall back to writable defaults"
         );
         assert_eq!(config.symbolic.search_mode, SearchMode::Binary);
-        assert_eq!(
-            config.symbolic.solver_timeout,
-            Some(Duration::from_millis(29))
-        );
+        assert_eq!(config.solver_timeout, Some(Duration::from_millis(29)));
         assert_eq!(config.cost_metric, CostMetric::Latency);
         assert_eq!(config.timeout, Some(Duration::from_millis(23)));
         assert!(config.verbose);

--- a/src/search/config.rs
+++ b/src/search/config.rs
@@ -220,8 +220,6 @@ pub struct SymbolicConfig {
     pub cost_bound: Option<u64>,
     /// Search mode (linear or binary)
     pub search_mode: SearchMode,
-    /// Timeout for each SMT query
-    pub solver_timeout: Option<Duration>,
 }
 
 impl Default for SymbolicConfig {
@@ -230,7 +228,6 @@ impl Default for SymbolicConfig {
             window_size: 3,
             cost_bound: None,
             search_mode: SearchMode::Linear,
-            solver_timeout: Some(Duration::from_secs(30)),
         }
     }
 }
@@ -248,11 +245,6 @@ impl SymbolicConfig {
 
     pub fn with_search_mode(mut self, mode: SearchMode) -> Self {
         self.search_mode = mode;
-        self
-    }
-
-    pub fn with_timeout(mut self, timeout: Duration) -> Self {
-        self.solver_timeout = Some(timeout);
         self
     }
 }
@@ -319,6 +311,8 @@ pub struct SearchConfig {
     pub cost_metric: CostMetric,
     /// Overall timeout for the search
     pub timeout: Option<Duration>,
+    /// Timeout for each SMT solver query used by verification/synthesis.
+    pub solver_timeout: Option<Duration>,
     /// Number of worker threads (rayon) for algorithms that parallelise.
     /// `None` lets rayon pick its default (typically logical-core count).
     /// `Some(0)` is coerced to 1 thread (rayon rejects zero-thread pools).
@@ -361,6 +355,7 @@ impl Default for SearchConfig {
             algorithm: Algorithm::default(),
             cost_metric: CostMetric::default(),
             timeout: Some(Duration::from_secs(60)),
+            solver_timeout: Some(Duration::from_secs(30)),
             cores: None,
             available_registers: vec![
                 Register::X0,
@@ -398,6 +393,11 @@ impl SearchConfig {
 
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
         self.timeout = Some(timeout);
+        self
+    }
+
+    pub fn with_solver_timeout(mut self, timeout: Duration) -> Self {
+        self.solver_timeout = Some(timeout);
         self
     }
 
@@ -448,6 +448,11 @@ impl SearchConfig {
 
     pub fn with_timeout_option(mut self, timeout: Option<Duration>) -> Self {
         self.timeout = timeout;
+        self
+    }
+
+    pub fn with_solver_timeout_option(mut self, timeout: Option<Duration>) -> Self {
+        self.solver_timeout = timeout;
         self
     }
 
@@ -586,6 +591,18 @@ mod tests {
     }
 
     #[test]
+    fn search_config_solver_timeout_builder_round_trips() {
+        let default = SearchConfig::default();
+        assert_eq!(default.solver_timeout, Some(Duration::from_secs(30)));
+
+        let explicit = SearchConfig::default().with_solver_timeout(Duration::from_millis(250));
+        assert_eq!(explicit.solver_timeout, Some(Duration::from_millis(250)));
+
+        let unset = SearchConfig::default().with_solver_timeout_option(None);
+        assert_eq!(unset.solver_timeout, None);
+    }
+
+    #[test]
     fn test_stochastic_config_builder() {
         let config = StochasticConfig::default()
             .with_beta(2.0)
@@ -605,13 +622,11 @@ mod tests {
         let config = SymbolicConfig::default()
             .with_window_size(5)
             .with_cost_bound(2)
-            .with_search_mode(SearchMode::Binary)
-            .with_timeout(Duration::from_millis(250));
+            .with_search_mode(SearchMode::Binary);
 
         assert_eq!(config.window_size, 5);
         assert_eq!(config.cost_bound, Some(2));
         assert_eq!(config.search_mode, SearchMode::Binary);
-        assert_eq!(config.solver_timeout, Some(Duration::from_millis(250)));
     }
 
     #[test]

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -402,10 +402,7 @@ where
 }
 
 fn configured_solver_timeout(config: &SearchConfig) -> Duration {
-    config
-        .symbolic
-        .solver_timeout
-        .unwrap_or(Duration::from_secs(5))
+    config.solver_timeout.unwrap_or(Duration::from_secs(5))
 }
 
 fn candidate_solver_timeout_for_elapsed(
@@ -643,7 +640,6 @@ mod tests {
 
     use crate::ir::{Instruction, Operand, Register};
     use crate::isa::{ISA, ISAMutator, InstructionType, OperandType, RegisterType, U64};
-    use crate::search::config::SymbolicConfig;
 
     static LENGTH_TWO_COST_CALLS: AtomicU64 = AtomicU64::new(0);
 
@@ -1404,9 +1400,7 @@ mod tests {
     fn candidate_solver_timeout_is_bounded_by_search_budget() {
         let configured_solver = SearchConfig::default()
             .with_timeout(std::time::Duration::from_secs(10))
-            .with_symbolic(
-                SymbolicConfig::default().with_timeout(std::time::Duration::from_millis(250)),
-            );
+            .with_solver_timeout(std::time::Duration::from_millis(250));
         assert_eq!(
             candidate_solver_timeout_for_elapsed(
                 &configured_solver,
@@ -1417,9 +1411,7 @@ mod tests {
 
         let capped_by_remaining_search = SearchConfig::default()
             .with_timeout(std::time::Duration::from_millis(100))
-            .with_symbolic(
-                SymbolicConfig::default().with_timeout(std::time::Duration::from_secs(1)),
-            );
+            .with_solver_timeout(std::time::Duration::from_secs(1));
         assert_eq!(
             candidate_solver_timeout_for_elapsed(
                 &capped_by_remaining_search,
@@ -1442,13 +1434,9 @@ mod tests {
             None
         );
 
-        let symbolic_without_solver_timeout = SymbolicConfig {
-            solver_timeout: None,
-            ..SymbolicConfig::default()
-        };
         let no_search_timeout = SearchConfig::default()
             .with_timeout_option(None)
-            .with_symbolic(symbolic_without_solver_timeout);
+            .with_solver_timeout_option(None);
         assert_eq!(
             candidate_solver_timeout_for_elapsed(
                 &no_search_timeout,
@@ -2009,9 +1997,7 @@ mod tests {
             .with_immediates(vec![0, 1])
             .with_timeout(std::time::Duration::from_millis(50))
             .with_cores(Some(1))
-            .with_symbolic(
-                SymbolicConfig::default().with_timeout(std::time::Duration::from_millis(200)),
-            );
+            .with_solver_timeout(std::time::Duration::from_millis(200));
 
         let start = std::time::Instant::now();
         let mut search = EnumerativeSearch::<crate::isa::AArch64>::new();

--- a/src/search/llm/mod.rs
+++ b/src/search/llm/mod.rs
@@ -177,8 +177,8 @@ impl SearchAlgorithm<crate::isa::AArch64> for LlmSearch {
                 }
             };
 
-            let Some(verify_remaining) =
-                remaining_until(started, timeout, deadline).filter(|d| *d >= MIN_SMT_TIMEOUT)
+            let Some(verify_remaining) = remaining_until(started, timeout, deadline)
+                .and_then(|remaining| verification_timeout_for_remaining(config, remaining))
             else {
                 if config.verbose {
                     eprintln!(
@@ -306,6 +306,15 @@ fn remaining_until(
     (!remaining.is_zero()).then_some(remaining)
 }
 
+fn verification_timeout_for_remaining(
+    config: &SearchConfig,
+    remaining: Duration,
+) -> Option<Duration> {
+    let solver_timeout = config.solver_timeout.unwrap_or(Duration::from_secs(5));
+    let timeout = remaining.min(solver_timeout);
+    (timeout >= MIN_SMT_TIMEOUT).then_some(timeout)
+}
+
 #[cfg(test)]
 mod tests {
     //! No-Codex unit tests of `LlmSearch::search` flow gates.
@@ -369,6 +378,16 @@ mod tests {
 
     fn cfg_no_calls() -> SearchConfig {
         SearchConfig::default().with_llm(LlmConfig::default().with_max_codex_calls(0))
+    }
+
+    #[test]
+    fn llm_verification_timeout_is_capped_by_solver_timeout() {
+        let config = SearchConfig::default().with_solver_timeout(Duration::from_millis(25));
+
+        assert_eq!(
+            verification_timeout_for_remaining(&config, Duration::from_secs(10)),
+            Some(Duration::from_millis(25))
+        );
     }
 
     #[cfg(unix)]

--- a/src/search/parallel/coordinator.rs
+++ b/src/search/parallel/coordinator.rs
@@ -420,7 +420,7 @@ fn run_stochastic_worker(
 mod tests {
     use super::*;
     use crate::ir::{Operand, Register};
-    use crate::search::config::{SearchConfig, StochasticConfig, SymbolicConfig};
+    use crate::search::config::{SearchConfig, StochasticConfig};
 
     fn mov_add_sequence() -> Vec<Instruction> {
         vec![
@@ -469,13 +469,11 @@ mod tests {
 
         // Keep the symbolic worker's solver budget tight so it terminates
         // quickly under Z3 on this trivial target.
-        let symbolic_cfg = crate::search::config::SymbolicConfig::default()
-            .with_timeout(Duration::from_millis(250));
         let search_config = SearchConfig::default()
             .with_registers(vec![Register::X0, Register::X1])
             .with_immediates(vec![0, 1, 2])
             .with_stochastic(StochasticConfig::default().with_iterations(200))
-            .with_symbolic(symbolic_cfg);
+            .with_solver_timeout(Duration::from_millis(250));
 
         let parallel_config = ParallelConfig::default()
             .with_workers(2)
@@ -733,7 +731,7 @@ mod tests {
         let search_config = SearchConfig::default()
             .with_registers(vec![Register::X0, Register::X1, Register::X2])
             .with_immediates(vec![-1, 0, 1, 2])
-            .with_symbolic(SymbolicConfig::default().with_timeout(Duration::from_secs(10)))
+            .with_solver_timeout(Duration::from_secs(10))
             .with_stochastic(StochasticConfig::default().with_iterations(200));
 
         let parallel_config = ParallelConfig::default()

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -159,10 +159,7 @@ where
         // tail, so length-change proposals only vary the prefix length.
         let min_length = 1 + terminator_len;
         let max_length = target.len();
-        let smt_timeout = config
-            .symbolic
-            .solver_timeout
-            .unwrap_or(Duration::from_secs(5));
+        let smt_timeout = config.solver_timeout.unwrap_or(Duration::from_secs(5));
 
         for iteration in 0..config.stochastic.iterations {
             self.statistics.iterations = iteration + 1;
@@ -336,7 +333,7 @@ mod tests {
     use super::*;
     use crate::ir::{Operand, Register};
     use crate::isa::{AArch64, ISA, ISAMutator, InstructionType, OperandType, RegisterType, U64};
-    use crate::search::config::{StochasticConfig, SymbolicConfig};
+    use crate::search::config::StochasticConfig;
     use crate::semantics::cost::CostMetric;
     use crate::semantics::live_out::LiveOut;
 
@@ -603,18 +600,10 @@ mod tests {
         }
     }
 
-    fn run_timeout_probe_search(symbolic_config: SymbolicConfig) -> Option<u64> {
+    fn run_timeout_probe_search(config: SearchConfig) -> Option<u64> {
         RECORDED_SMT_TIMEOUT_MS.with(|recorded| recorded.set(None));
 
         let mut search: StochasticSearch<TimeoutProbeIsa> = StochasticSearch::new();
-        let config = SearchConfig::default()
-            .with_stochastic(
-                StochasticConfig::default()
-                    .with_iterations(1)
-                    .with_test_count(0)
-                    .with_seed(1),
-            )
-            .with_symbolic(symbolic_config);
         let target = [TimeoutProbeInstruction(1), TimeoutProbeInstruction(2)];
         let result = search.search(&target, &(), &config);
         assert_eq!(result.statistics.smt_queries, 1);
@@ -623,9 +612,16 @@ mod tests {
     }
 
     #[test]
-    fn stochastic_search_uses_symbolic_solver_timeout_for_smt() {
+    fn stochastic_search_uses_top_level_solver_timeout_for_smt() {
         let recorded_timeout = run_timeout_probe_search(
-            SymbolicConfig::default().with_timeout(Duration::from_millis(17)),
+            SearchConfig::default()
+                .with_stochastic(
+                    StochasticConfig::default()
+                        .with_iterations(1)
+                        .with_test_count(0)
+                        .with_seed(1),
+                )
+                .with_solver_timeout(Duration::from_millis(17)),
         );
 
         assert_eq!(recorded_timeout, Some(17));
@@ -633,12 +629,16 @@ mod tests {
 
     #[test]
     fn stochastic_search_falls_back_to_five_seconds_when_solver_timeout_unset() {
-        let symbolic_config = SymbolicConfig {
-            solver_timeout: None,
-            ..SymbolicConfig::default()
-        };
-
-        let recorded_timeout = run_timeout_probe_search(symbolic_config);
+        let recorded_timeout = run_timeout_probe_search(
+            SearchConfig::default()
+                .with_stochastic(
+                    StochasticConfig::default()
+                        .with_iterations(1)
+                        .with_test_count(0)
+                        .with_seed(1),
+                )
+                .with_solver_timeout_option(None),
+        );
 
         assert_eq!(recorded_timeout, Some(5000));
     }

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -303,10 +303,7 @@ where
         live_out: &<I as SymbolicBackend<I>>::LiveOut,
         config: &SearchConfig,
     ) -> bool {
-        let timeout = config
-            .symbolic
-            .solver_timeout
-            .unwrap_or(Duration::from_secs(5));
+        let timeout = config.solver_timeout.unwrap_or(Duration::from_secs(5));
         let width = <I as SymbolicBackend<I>>::width(config);
 
         let (verdict, metrics) = <I as SymbolicBackend<I>>::check_equivalence(
@@ -422,6 +419,7 @@ mod tests {
     static TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK: AtomicUsize = AtomicUsize::new(0);
     static TEST_EQUIVALENCE_FAST_FAILURE: AtomicBool = AtomicBool::new(false);
     static TEST_EQUIVALENCE_SMT_CALLED: AtomicBool = AtomicBool::new(false);
+    static TEST_EQUIVALENCE_TIMEOUT_MS: AtomicU64 = AtomicU64::new(u64::MAX);
     static TEST_SEQUENCE_COST_DELAY_MS: AtomicU64 = AtomicU64::new(0);
     static TEST_STOP_FLAG: Mutex<Option<Arc<AtomicBool>>> = Mutex::new(None);
     static SYMBOLIC_INNER_LOOP_TEST_LOCK: Mutex<()> = Mutex::new(());
@@ -447,6 +445,7 @@ mod tests {
         TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK.store(0, Ordering::SeqCst);
         TEST_EQUIVALENCE_FAST_FAILURE.store(false, Ordering::SeqCst);
         TEST_EQUIVALENCE_SMT_CALLED.store(false, Ordering::SeqCst);
+        TEST_EQUIVALENCE_TIMEOUT_MS.store(u64::MAX, Ordering::SeqCst);
         TEST_SEQUENCE_COST_DELAY_MS.store(0, Ordering::SeqCst);
         let mut slot = TEST_STOP_FLAG.lock().expect("test stop flag lock poisoned");
         *slot = None;
@@ -622,8 +621,9 @@ mod tests {
             _proposal: &[TestInstruction],
             _live_out: &Self::LiveOut,
             _width: u32,
-            _timeout: Duration,
+            timeout: Duration,
         ) -> (EquivalenceResult, EquivalenceMetrics) {
+            TEST_EQUIVALENCE_TIMEOUT_MS.store(timeout.as_millis() as u64, Ordering::SeqCst);
             let check_number = TEST_EQUIVALENCE_CHECKS.fetch_add(1, Ordering::SeqCst) + 1;
             if check_number == 1 {
                 let slot = TEST_STOP_FLAG.lock().expect("test stop flag lock poisoned");
@@ -707,7 +707,7 @@ mod tests {
         let mut search: SymbolicSearch<AArch64> = SymbolicSearch::new();
 
         let config = SearchConfig::default()
-            .with_symbolic(SymbolicConfig::default().with_timeout(Duration::from_secs(10)))
+            .with_solver_timeout(Duration::from_secs(10))
             .with_registers(vec![Register::X0, Register::X1, Register::X2])
             .with_immediates(vec![-1, 0, 1, 2]);
 
@@ -732,7 +732,7 @@ mod tests {
     #[test]
     fn symbolic_search_drops_flag_writer_only_when_flags_are_dead() {
         let config = SearchConfig::default()
-            .with_symbolic(SymbolicConfig::default().with_timeout(Duration::from_secs(5)))
+            .with_solver_timeout(Duration::from_secs(5))
             .with_registers(vec![Register::X0, Register::X1])
             .with_immediates(vec![0, 7]);
         let target = vec![
@@ -835,7 +835,7 @@ mod tests {
             let config = SearchConfig::default()
                 .with_timeout_option(None)
                 .with_stop_flag(flag_for_search)
-                .with_symbolic(SymbolicConfig::default().with_timeout(Duration::from_secs(60)))
+                .with_solver_timeout(Duration::from_secs(60))
                 .with_registers(vec![
                     Register::X0,
                     Register::X1,
@@ -1169,6 +1169,23 @@ mod tests {
         assert_eq!(stats.smt_queries, 1);
         assert_eq!(stats.candidates_passed_fast, 1);
         assert_eq!(stats.smt_equivalent, 0);
+    }
+
+    #[test]
+    fn symbolic_search_uses_top_level_solver_timeout_for_smt() {
+        let _guard = SYMBOLIC_INNER_LOOP_TEST_LOCK
+            .lock()
+            .expect("symbolic inner-loop test lock poisoned");
+        reset_symbolic_inner_loop_test_state();
+
+        let mut search: SymbolicSearch<TestIsa> = SymbolicSearch::new();
+        let config = SearchConfig::default().with_solver_timeout(Duration::from_millis(31));
+        let target = [TestInstruction(1)];
+        let candidate = [TestInstruction(2)];
+
+        let _ = search.verify_equivalence(&target, &candidate, &(), &config);
+
+        assert_eq!(TEST_EQUIVALENCE_TIMEOUT_MS.load(Ordering::SeqCst), 31);
     }
 
     #[test]

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- promote the SMT query timeout from SymbolicConfig to SearchConfig
- propagate --solver-timeout through enumerative, stochastic, symbolic, hybrid, x86, and LLM search configs
- update docs and timeout-focused tests for the shared verifier/synthesis query cap
- fix current clippy needless-borrow warnings in SMT lowering

Validation:
- cargo fmt --all
- cargo clippy --all -- -D warnings
- ./build_tests.sh
- cargo test --all
- ./ci_check.sh
- scripts/full_test.sh was requested by the generic run contract but is absent in this s11 repo

Closes #157

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**