### PR TITLE
test(enumerative): tighten length-two rewrite timeout

### DIFF
--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -1674,11 +1674,10 @@ mod tests {
         //   eor x2, x2, x2             ; x2 = 0
         // Live { X0, X2 }: post-state needs X0 = 0 AND X2 = 0. No single AArch64
         // instruction writes both registers, so length 1 is unreachable. The
-        // length-2 optimum (e.g. `mov x0, #0; mov x2, #0`) is found on the very
-        // first outer-loop iteration once length-2 search is implemented: both
-        // halves are MovImm — the first candidate the generator emits for each
-        // `rd` in `generate_all_encodable_instructions`. After the hit,
-        // cost-pruning collapses the remainder of the search to O(pool).
+        // minimal configured pool still contains the length-2 witness
+        // `mov x0, #0; mov x2, #0`, keeping this as an enabled regression for the
+        // real AArch64 length-2 enumerative path without the broader pool's CI
+        // runtime ceiling.
         let target = vec![
             Instruction::MovReg {
                 rd: Register::X0,
@@ -1700,9 +1699,13 @@ mod tests {
         let live_out = LiveOut::from_registers(vec![Register::X0, Register::X2]);
 
         let config = SearchConfig::default()
-            .with_registers(vec![Register::X0, Register::X1, Register::X2])
-            .with_immediates(vec![0, 1])
-            .with_timeout(std::time::Duration::from_secs(30));
+            .with_registers(vec![Register::X0, Register::X2])
+            .with_immediates(vec![0])
+            .with_cores(Some(1))
+            .with_symbolic(
+                SymbolicConfig::default().with_timeout(std::time::Duration::from_millis(250)),
+            )
+            .with_timeout(std::time::Duration::from_secs(10));
 
         let mut search = EnumerativeSearch::<crate::isa::AArch64>::new();
         let result = search.search(&target, &live_out, &config);

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- shrink `finds_length_two_rewrite` to the minimal real AArch64 pool that still requires a length-2 rewrite
- pin that regression to one worker, cap candidate solver checks at 250ms, and lower the search timeout to 10s
- remove current clippy-reported needless SMT temporary borrows so the local clippy gate stays green

Verification:
- `cargo test --lib search::enumerative::search::tests::finds_length_two_rewrite -- --exact`
- `cargo test --lib search::enumerative::search::tests::`
- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`
- `./build_tests.sh`
- `cargo test --all`
- `./ci_check.sh`
- `scripts/full_test.sh` is not present in this S11 repository

Closes #161

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**