### PR TITLE
fix(elf-patcher): handle x86 nop zero length explicitly

### DIFF
--- a/src/elf_patcher/mod.rs
+++ b/src/elf_patcher/mod.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::Path;
 
 /// Intel SDM canonical multi-byte NOP sequences, indexed by length.
-/// Index 0 is the empty slice (fallback for `len == 0`); indices 1..=9
+/// Index 0 is the empty slice; indices 1..=9
 /// are the recommended sequences from the Intel optimization reference.
 const X86_NOP_TABLE: [&[u8]; 10] = [
     &[],
@@ -68,7 +68,13 @@ impl DetectedArch {
                     &[0x1f, 0x20, 0x03, 0xd5]
                 }
             }
-            DetectedArch::X86_64 => X86_NOP_TABLE[len.min(9)],
+            DetectedArch::X86_64 => {
+                if len == 0 {
+                    &[]
+                } else {
+                    X86_NOP_TABLE[len.min(9)]
+                }
+            }
             DetectedArch::X86_32 => {
                 if len == 0 {
                     &[]
@@ -295,9 +301,11 @@ mod tests {
     }
 
     #[test]
-    fn x86_64_nop_sequence_canonical_lengths_one_through_nine() {
-        let canonical: [&[u8]; 10] = [
-            &[],
+    fn x86_64_nop_sequence_canonical_lengths_zero_through_nine() {
+        let empty: &[u8] = &[];
+        assert_eq!(DetectedArch::X86_64.nop_sequence(0), empty);
+
+        let canonical: [&[u8]; 9] = [
             &[0x90],
             &[0x66, 0x90],
             &[0x0f, 0x1f, 0x00],
@@ -308,7 +316,8 @@ mod tests {
             &[0x0f, 0x1f, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00],
             &[0x66, 0x0f, 0x1f, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00],
         ];
-        for (len, expected) in canonical.iter().enumerate() {
+        for (idx, expected) in canonical.iter().enumerate() {
+            let len = idx + 1;
             assert_eq!(
                 DetectedArch::X86_64.nop_sequence(len),
                 *expected,

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- Handle X86_64 `nop_sequence(0)` with an explicit empty-slice branch to match the AArch64 and X86_32 zero-length handling.
- Clarify the x86-64 NOP test so zero through nine lengths are covered directly.
- Remove current Clippy needless-borrow warnings in SMT BV code so `cargo clippy --all -- -D warnings` remains green.

Verification:
- `cargo test elf_patcher::tests::x86_64_nop_sequence`
- `cargo test elf_patcher::tests::x86_32_nop_sequence`
- `cargo test elf_patcher::tests::create_patched_copy_emits_canonical_x86_nop_padding`
- `cargo test elf_patcher::tests::create_patched_copy_pads_gap_larger_than_nine_bytes_with_two_nops`
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `./build_tests.sh`
- `cargo test --all` (initial run failed before fixture binaries existed; passed after `./build_tests.sh`)
- `./ci_check.sh`

Note: `scripts/full_test.sh` is not present in this s11 checkout; the repo-local full script is `test_all.sh`, which ran through `./ci_check.sh`.

Closes #166

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**