### PR TITLE
refactor(x86): replace swap retry loop with modular pick

### DIFF
--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -966,11 +966,10 @@ impl X86Mutator {
         if sequence.len() < 2 {
             return;
         }
-        let a = rng.random_range(0..sequence.len());
-        let mut b = rng.random_range(0..sequence.len());
-        while b == a {
-            b = rng.random_range(0..sequence.len());
-        }
+        let n = sequence.len();
+        let a = rng.random_range(0..n);
+        let offset = rng.random_range(0..(n - 1));
+        let b = (a + 1 + offset) % n;
         sequence.swap(a, b);
     }
 
@@ -2005,6 +2004,101 @@ mod tests {
     }
 
     // ---- X86Mutator (issue #73 Phase B) ----
+
+    struct BudgetedRng {
+        words: Vec<u32>,
+        next_word: usize,
+    }
+
+    impl BudgetedRng {
+        fn new(words: Vec<u32>) -> Self {
+            Self {
+                words,
+                next_word: 0,
+            }
+        }
+
+        fn draw_word(&mut self) -> u32 {
+            let word = self
+                .words
+                .get(self.next_word)
+                .copied()
+                .expect("random generator exceeded its draw budget");
+            self.next_word += 1;
+            word
+        }
+    }
+
+    impl rand::TryRng for BudgetedRng {
+        type Error = std::convert::Infallible;
+
+        fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+            Ok(self.draw_word())
+        }
+
+        fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+            let low = u64::from(self.draw_word());
+            let high = u64::from(self.draw_word());
+            Ok(low | (high << 32))
+        }
+
+        fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
+            for chunk in dst.chunks_mut(4) {
+                let bytes = self.draw_word().to_le_bytes();
+                chunk.copy_from_slice(&bytes[..chunk.len()]);
+            }
+            Ok(())
+        }
+    }
+
+    fn word_for_range(range: u32, value: u32) -> u32 {
+        assert!(range > 0);
+        assert!(value < range);
+        let numerator = (u128::from(value)) << 32;
+        let word = numerator.div_ceil(u128::from(range)) as u32;
+        debug_assert_eq!(((u64::from(word) * u64::from(range)) >> 32) as u32, value);
+        word
+    }
+
+    #[test]
+    fn x86_mutator_swap_uses_two_draws_with_modular_second_index() {
+        let mutator = X86Mutator::default();
+        let mut sequence = vec![
+            X86Instruction::MovImm {
+                rd: X86Register::RAX,
+                imm: 0,
+            },
+            X86Instruction::AddReg {
+                rd: X86Register::RBX,
+                rs: X86Register::RCX,
+            },
+            X86Instruction::SubImm {
+                rd: X86Register::RDX,
+                imm: 1,
+            },
+        ];
+        let mut rng = BudgetedRng::new(vec![word_for_range(3, 1), word_for_range(2, 1)]);
+
+        mutator.mutate_swap(&mut rng, &mut sequence);
+
+        assert_eq!(
+            sequence,
+            vec![
+                X86Instruction::AddReg {
+                    rd: X86Register::RBX,
+                    rs: X86Register::RCX,
+                },
+                X86Instruction::MovImm {
+                    rd: X86Register::RAX,
+                    imm: 0,
+                },
+                X86Instruction::SubImm {
+                    rd: X86Register::RDX,
+                    imm: 1,
+                },
+            ]
+        );
+    }
 
     #[test]
     fn x86_mutator_eventually_changes_the_sequence() {

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- Replace X86Mutator::mutate_swap rejection sampling with the modular distinct-index pick from issue #194.
- Add a budgeted-RNG regression that fails if the collision path asks for a third bounded draw.
- Apply clippy's existing SMT needless-borrow suggestions so the required all-target clippy gate stays green.

Tests:
- cargo test x86_mutator_swap_uses_two_draws_with_modular_second_index
- cargo test x86_mutator
- cargo fmt --all
- cargo clippy --all -- -D warnings
- ./build_tests.sh
- cargo test --all
- ./ci_check.sh

Closes #194

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**