### PR TITLE
test(search): assert x86 tracer bullets optimize

### DIFF
--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -846,11 +846,8 @@ mod tests {
     // ---- x86 stochastic search (issue #73 Phase C step 5) ----
 
     /// Tracer-bullet test that the generic `StochasticSearch<X86_64>`
-    /// instantiates, runs an MCMC loop end-to-end on a 2-instruction
-    /// x86 target, and finishes without panic. The target is the
-    /// canonical zeroing fusion `mov rax, 0; add rax, rbx` — the
-    /// search should at minimum *not crash*, and the iteration counter
-    /// should advance.
+    /// instantiates and discovers the dead-flags collapse for a
+    /// 2-instruction x86 target.
     #[test]
     fn x86_stochastic_runs_end_to_end() {
         use crate::isa::X86_64;
@@ -882,13 +879,20 @@ mod tests {
         ];
 
         let result = search.search(&target, &live_out, &config);
-        let stats = result.statistics;
+        let stats = &result.statistics;
 
         assert_eq!(stats.algorithm, Algorithm::Stochastic);
         assert_eq!(stats.iterations, 500);
-        // The search may or may not find an optimisation in 500
-        // iterations; we only require that the loop made progress.
         assert!(stats.candidates_evaluated > 0);
+        assert!(result.found_optimization);
+        assert_eq!(result.cost_savings(), 1);
+        assert_eq!(
+            result.optimized_sequence,
+            Some(vec![X86Instruction::MovReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            }])
+        );
     }
 
     /// Mirror of `x86_stochastic_runs_end_to_end` for x86-32 (Mode32 /

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -1195,8 +1195,8 @@ mod tests {
     // ---- x86 symbolic search (issue #73 Phase D step 7) ----
 
     /// Tracer-bullet test that the generic `SymbolicSearch<X86_64>`
-    /// instantiates and runs an end-to-end synthesis on a 2-instruction
-    /// x86 target without panic.
+    /// instantiates and discovers the dead-flags collapse for a
+    /// 2-instruction x86 target.
     #[test]
     fn x86_symbolic_runs_end_to_end() {
         use crate::isa::X86_64;
@@ -1229,10 +1229,15 @@ mod tests {
 
         let result = search.search(&target, &live_out, &config);
         assert_eq!(result.statistics.algorithm, Algorithm::Symbolic);
-        // We don't assert a specific optimization was found — the test
-        // just verifies the loop runs end-to-end through the generic
-        // backend without panicking.
-        assert!(result.statistics.elapsed_time.as_nanos() > 0);
+        assert!(result.found_optimization);
+        assert_eq!(result.cost_savings(), 1);
+        assert_eq!(
+            result.optimized_sequence,
+            Some(vec![X86Instruction::MovReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            }])
+        );
     }
 
     /// Mirror of `x86_symbolic_runs_end_to_end` for x86-32. Covers the

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Strengthens the x86-64 stochastic and symbolic tracer-bullet tests to assert that the dead-flags `mov rax, 0; add rax, rbx` case actually finds `mov rax, rbx` with one instruction of savings. Also applies a mechanical clippy cleanup in SMT lowering required by the local warning-free gate.\n\nCloses #196\n\n**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**