### PR TITLE
test(cli): polish opt error context and NOP coverage

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -785,6 +785,8 @@ fn optimize_elf_binary_with_backend<B: ElfOptimizationBackend>(
 
     // Convert to IR
     let ir_instructions = backend.convert_ir(&instructions)?;
+    // An all-NOP AArch64 window can legitimately convert to empty IR: NOPs are
+    // skipped and the patcher pads the original byte window back out with NOPs.
     println!(
         "Converted {} instructions to {}:",
         ir_instructions.len(),
@@ -1461,10 +1463,16 @@ fn ensure_window_fully_decoded_for_arch(
     use std::cmp::Ordering;
     match decoded_bytes.cmp(&window_bytes) {
         Ordering::Equal => Ok(()),
-        Ordering::Less => Err(format!(
-            "{} window 0x{:x}-0x{:x} ({} bytes) was not fully decoded by Capstone; decoded only {} bytes",
-            arch_label, start_addr, end_addr, window_bytes, decoded_bytes
-        )),
+        Ordering::Less => {
+            let first_undecoded = start_addr
+                .saturating_add(decoded_bytes as u64)
+                .min(end_addr);
+            Err(format!(
+                "{} window 0x{:x}-0x{:x} ({} bytes) was not fully decoded by Capstone; \
+                 decoded only {} bytes, first undecoded byte at 0x{:x}",
+                arch_label, start_addr, end_addr, window_bytes, decoded_bytes, first_undecoded
+            ))
+        }
         // Defensive: cs.disasm_all only emits bytes it was given, so this
         // branch is an internal-invariant guard, not a user-facing condition.
         Ordering::Greater => Err(format!(
@@ -1481,10 +1489,16 @@ fn convert_capstone_op_for_optimization(
 ) -> Result<Option<Instruction>, String> {
     match convert_capstone_op(mnemonic, op_str) {
         ConvertOutcome::Instruction(instr) => Ok(Some(instr)),
-        ConvertOutcome::Skip => Ok(None),
+        ConvertOutcome::Skip => {
+            // `Skip` is intentionally narrower than `Unsupported`: today it is
+            // only used for NOP-equivalent instructions, which the patcher can
+            // re-pad after rewriting the whole byte window. Unsupported
+            // instructions must still abort so side effects are never dropped.
+            Ok(None)
+        }
         ConvertOutcome::Unsupported(line) => Err(format!(
             "AArch64 window contains unsupported instruction '{}' at 0x{:x}; \
-             cannot optimize. Narrow the --start-addr/--end-addr range to \
+             narrow the --start-addr/--end-addr range to \
              exclude it, or add the mnemonic to the supported set.",
             line, address
         )),
@@ -1663,7 +1677,7 @@ fn convert_to_x86_ir(
                 // `call`, etc. would lose its side effect from the binary.
                 return Err(format!(
                     "x86 window contains unsupported mnemonic '{} {}' at 0x{:x}; \
-                     cannot optimize. Narrow the --start-addr/--end-addr range \
+                     narrow the --start-addr/--end-addr range \
                      to exclude it, or add the mnemonic to the supported set.",
                     mn,
                     ops,
@@ -2814,6 +2828,48 @@ mod cli_helper_tests {
     }
 
     #[test]
+    fn convert_to_ir_returns_empty_for_pure_nop_window() {
+        let cs = aarch64_test_capstone();
+        let bytes = [
+            0x1f, 0x20, 0x03, 0xd5, // nop
+            0x1f, 0x20, 0x03, 0xd5, // nop
+        ];
+        let instructions = cs
+            .disasm_all(&bytes, 0x1000)
+            .expect("test NOP bytes should disassemble");
+
+        let ir = convert_to_ir(&instructions).expect("pure-NOP window should convert");
+
+        assert!(ir.is_empty(), "pure-NOP windows should produce empty IR");
+    }
+
+    #[test]
+    fn convert_to_ir_treats_nop_add_nop_as_add() {
+        let cs = aarch64_test_capstone();
+        let mut bytes = vec![0x1f, 0x20, 0x03, 0xd5]; // nop
+        bytes.extend(assemble_aarch64_test_bytes(&[Instruction::Add {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Immediate(1),
+        }]));
+        bytes.extend([0x1f, 0x20, 0x03, 0xd5]); // nop
+        let instructions = cs
+            .disasm_all(&bytes, 0x1000)
+            .expect("test NOP/ADD bytes should disassemble");
+
+        let ir = convert_to_ir(&instructions).expect("NOP/ADD/NOP window should convert");
+
+        assert_eq!(
+            ir,
+            vec![Instruction::Add {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Immediate(1),
+            }]
+        );
+    }
+
+    #[test]
     fn convert_capstone_op_flags_unknown_mnemonic_as_unsupported() {
         // NEON FADD is not parsed; memory ops were promoted to supported in
         // issue #68. See ADR-0007.
@@ -2952,7 +3008,8 @@ mod cli_helper_tests {
 
         assert!(err.contains("fadd v0.4s, v1.4s, v2.4s"));
         assert!(err.contains("0x1234"));
-        assert!(err.contains("cannot optimize"));
+        assert!(err.contains("--start-addr/--end-addr"));
+        assert!(!err.contains("cannot optimize"));
     }
 
     #[test]
@@ -2962,7 +3019,8 @@ mod cli_helper_tests {
 
         assert!(err.contains("mov x0, #0x12345678"));
         assert!(err.contains("0x4444"));
-        assert!(err.contains("cannot optimize"));
+        assert!(err.contains("--start-addr/--end-addr"));
+        assert!(!err.contains("cannot optimize"));
     }
 
     #[test]
@@ -2978,6 +3036,7 @@ mod cli_helper_tests {
 
         assert!(err.contains("0x1000"));
         assert!(err.contains("0x1008"));
+        assert!(err.contains("first undecoded byte at 0x1004"));
         assert!(err.contains("8 bytes"));
         assert!(err.contains("decoded only 4 bytes"));
     }

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {

--- a/tests/integration/opt_test.rs
+++ b/tests/integration/opt_test.rs
@@ -45,7 +45,12 @@ fn find_encoding_masked(elf_path: &Path, expected: &[u8; 4], mask: &[u8; 4], lab
         if size < expected.len() {
             continue;
         }
-        let bytes = &data[file_start..file_start + size];
+        let file_end = file_start
+            .checked_add(size)
+            .expect("executable section range should not overflow usize");
+        let bytes = data
+            .get(file_start..file_end)
+            .expect("executable section range should be present in ELF data");
         for off in (0..size - expected.len() + 1).step_by(4) {
             if (0..4).all(|i| bytes[off + i] & mask[i] == expected[i] & mask[i]) {
                 return section.sh_addr + off as u64;
@@ -77,6 +82,38 @@ fn executable_window(path: &Path, width: u64) -> (u64, u64) {
     }
 
     panic!("no executable window of {width} bytes found in {path:?}");
+}
+
+fn file_offset_for_executable_addr(path: &Path, addr: u64) -> usize {
+    let data = std::fs::read(path).expect("read test ELF");
+    let elf =
+        elf::ElfBytes::<elf::endian::AnyEndian>::minimal_parse(&data).expect("parse test ELF");
+    let section_headers = elf.section_headers().expect("read section headers");
+
+    for section in section_headers.iter() {
+        if section.sh_flags & elf::abi::SHF_EXECINSTR as u64 == 0 {
+            continue;
+        }
+
+        let section_end = section
+            .sh_addr
+            .checked_add(section.sh_size)
+            .expect("executable section address range should not overflow");
+        if !(section.sh_addr..section_end).contains(&addr) {
+            continue;
+        }
+
+        let file_offset = section
+            .sh_offset
+            .checked_add(addr - section.sh_addr)
+            .expect("executable section file range should not overflow")
+            as usize;
+        data.get(file_offset..file_offset + 4)
+            .expect("executable address should map to bytes in ELF data");
+        return file_offset;
+    }
+
+    panic!("executable address 0x{addr:x} not found in {path:?}");
 }
 
 fn assert_opt_arch_mismatch_rejected(test_elf: &Path, arch: &str) {
@@ -390,6 +427,60 @@ fn test_opt_address_alignment() {
 }
 
 #[test]
+fn test_opt_rejects_partially_decoded_window_with_first_bad_address() {
+    let binary = get_binary_path();
+    let source_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("binaries")
+        .join("loops_debug");
+    check_test_binary(&source_elf);
+
+    let (start_addr, end_addr) = executable_window(&source_elf, 8);
+    let first_bad_addr = start_addr + 4;
+
+    let tmp_dir = tempfile::tempdir().expect("create temp fixture dir");
+    let test_elf = tmp_dir.path().join("loops_debug");
+    fs::copy(&source_elf, &test_elf).expect("copy ELF fixture to tmp");
+
+    let bad_offset = file_offset_for_executable_addr(&test_elf, first_bad_addr);
+    let mut data = fs::read(&test_elf).expect("read temp ELF");
+    data[bad_offset..bad_offset + 4].copy_from_slice(&[0xff, 0xff, 0xff, 0xff]);
+    fs::write(&test_elf, data).expect("write corrupted temp ELF");
+
+    let optimized_path = tmp_dir.path().join("loops_debug_optimized");
+    let output = Command::new(binary)
+        .arg("opt")
+        .arg(&test_elf)
+        .arg("--start-addr")
+        .arg(format!("0x{start_addr:x}"))
+        .arg("--end-addr")
+        .arg(format!("0x{end_addr:x}"))
+        .output()
+        .expect("Failed to execute s11");
+
+    assert!(
+        !output.status.success(),
+        "opt must reject an AArch64 window Capstone only partially decoded.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not fully decoded"),
+        "stderr should report the byte-coverage failure; got: {stderr}",
+    );
+    assert!(
+        stderr.contains(&format!("0x{first_bad_addr:x}")),
+        "stderr should report the first undecoded address 0x{first_bad_addr:x}; got: {stderr}",
+    );
+    assert!(
+        !optimized_path.exists(),
+        "no optimized binary should be written when decode coverage fails: {:?}",
+        optimized_path,
+    );
+}
+
+#[test]
 fn test_opt_rejects_unsupported_instruction_window() {
     let binary = get_binary_path();
     let test_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -440,6 +531,10 @@ fn test_opt_rejects_unsupported_instruction_window() {
     assert!(
         stderr.contains(&format!("0x{start_addr:x}")),
         "stderr should report the offending address 0x{start_addr:x}; got: {stderr}",
+    );
+    assert!(
+        !stderr.contains("cannot optimize"),
+        "stderr should avoid redundant optimization framing; got: {stderr}",
     );
 
     assert!(


### PR DESCRIPTION
Summary:
- report the first undecoded address when Capstone only partially decodes an optimization window
- pin NOP skip behavior with empty-IR and NOP-wrapped-window tests, and trim redundant unsupported-instruction wording
- add a pipeline byte-coverage regression and harden the ELF pattern-scan test helper
- remove clippy-only needless SMT BV borrows so the required warning gate stays green

Verification:
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test --all
- ./ci_check.sh

Closes #200

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**