### PR TITLE
fix(symbolic): search x86 same-count code-size candidates

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2418,7 +2418,7 @@ fn main() {
 mod cli_helper_tests {
     use super::*;
     use ir::Operand;
-    use isa::x86::{X86Instruction, X86Register};
+    use isa::x86::{X86Condition, X86Instruction, X86Register};
     use parser::x86::{parse_x86_operand, parse_x86_register};
     use search::llm::LlmTimings;
     use search::llm::ledger::UnsupportedMnemonicLedger;
@@ -3415,6 +3415,35 @@ mod cli_helper_tests {
                 .unwrap()
                 .is_none(),
             "x86-64 symbolic search must not same-count rewrite a partial-width source operand"
+        );
+
+        let partial_with_jcc_instructions = cs
+            .disasm_all(&[0x66, 0x83, 0xe0, 0x00, 0x74, 0x00], 0x1000)
+            .unwrap();
+        let partial_with_jcc_ir = backend.convert_ir(&partial_with_jcc_instructions).unwrap();
+        assert_eq!(
+            partial_with_jcc_ir,
+            vec![
+                X86Instruction::AndImm {
+                    rd: X86Register::RAX,
+                    imm: 0
+                },
+                X86Instruction::Jcc {
+                    cond: X86Condition::E
+                }
+            ]
+        );
+        assert!(
+            backend
+                .run_search(
+                    &partial_with_jcc_ir,
+                    &partial_with_jcc_instructions,
+                    &opts,
+                    context
+                )
+                .unwrap()
+                .is_none(),
+            "the operand-width gate must also suppress same-prefix-count rewrites before a pinned Jcc"
         );
 
         let full_instructions = cs

--- a/src/main.rs
+++ b/src/main.rs
@@ -471,6 +471,9 @@ trait ElfOptimizationBackend {
 
     fn validate_window_ir(&self, ir: &[Self::Instruction]) -> Result<(), String>;
 
+    /// Run the selected search. `capstone_instructions` preserves source
+    /// operand spelling for backends whose IR collapses aliases; backends
+    /// that do not need that syntax metadata can ignore it.
     fn run_search(
         &self,
         ir: &[Self::Instruction],
@@ -966,6 +969,9 @@ fn build_x86_symbolic_search_config(
     target: &[isa::x86::X86Instruction],
     width: u32,
     options: &OptimizationOptions,
+    // Binary-patching guard: direct IR callers can allow same-count CodeSize
+    // search, but the ELF frontend disables it when Capstone exposed
+    // partial-register operands that the x86 IR cannot model.
     same_count_code_size_allowed: bool,
 ) -> SearchConfig {
     let symbolic_config = SymbolicConfig::default()
@@ -1769,6 +1775,11 @@ fn x86_capstone_window_uses_only_full_width_register_operands(
             .all(
                 |operand| match parse_x86_register_with_width(operand.trim()) {
                     Ok((_reg, alias_width)) => alias_width == width,
+                    // Non-register syntax (immediates, memory operands,
+                    // unsupported forms) does not participate in this direct
+                    // register-width guard. Supported instructions naming an
+                    // unknown register such as `ah` are rejected by
+                    // `convert_to_x86_ir` before this helper is used.
                     Err(_) => true,
                 },
             )
@@ -3307,6 +3318,7 @@ mod cli_helper_tests {
         assert!(parse_x86_operand("not-an-operand").is_err());
         assert!(x86_ir_from_mnemonic("add", "rax").unwrap().is_none());
         assert!(x86_ir_from_mnemonic("add", "rax, nope").is_err());
+        assert!(x86_ir_from_mnemonic("mov", "ah, 0").is_err());
 
         let mut opts = options_for(Algorithm::Enumerative);
         opts.timeout = Some(Duration::from_secs(5));
@@ -3400,6 +3412,7 @@ mod cli_helper_tests {
             downstream_flags_live: false,
         };
 
+        // 66 b8 00 00 = mov ax, 0
         let partial_instructions = cs.disasm_all(&[0x66, 0xb8, 0x00, 0x00], 0x1000).unwrap();
         let partial_ir = backend.convert_ir(&partial_instructions).unwrap();
         assert_eq!(
@@ -3417,6 +3430,7 @@ mod cli_helper_tests {
             "x86-64 symbolic search must not same-count rewrite a partial-width source operand"
         );
 
+        // 66 83 e0 00 = and ax, 0; 74 00 = je +0
         let partial_with_jcc_instructions = cs
             .disasm_all(&[0x66, 0x83, 0xe0, 0x00, 0x74, 0x00], 0x1000)
             .unwrap();
@@ -3446,6 +3460,7 @@ mod cli_helper_tests {
             "the operand-width gate must also suppress same-prefix-count rewrites before a pinned Jcc"
         );
 
+        // 48 c7 c0 00 00 00 00 = mov rax, 0
         let full_instructions = cs
             .disasm_all(&[0x48, 0xc7, 0xc0, 0x00, 0x00, 0x00, 0x00], 0x1000)
             .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -474,6 +474,7 @@ trait ElfOptimizationBackend {
     fn run_search(
         &self,
         ir: &[Self::Instruction],
+        capstone_instructions: &capstone::Instructions,
         options: &OptimizationOptions,
         context: OptimizationContext,
     ) -> Result<Option<Vec<Self::Instruction>>, Box<dyn std::error::Error>>;
@@ -522,6 +523,7 @@ impl ElfOptimizationBackend for AArch64OptimizationBackend {
     fn run_search(
         &self,
         ir: &[Self::Instruction],
+        _capstone_instructions: &capstone::Instructions,
         options: &OptimizationOptions,
         context: OptimizationContext,
     ) -> Result<Option<Vec<Self::Instruction>>, Box<dyn std::error::Error>> {
@@ -606,6 +608,7 @@ impl ElfOptimizationBackend for X86OptimizationBackend {
     fn run_search(
         &self,
         ir: &[Self::Instruction],
+        capstone_instructions: &capstone::Instructions,
         options: &OptimizationOptions,
         context: OptimizationContext,
     ) -> Result<Option<Vec<Self::Instruction>>, Box<dyn std::error::Error>> {
@@ -616,9 +619,16 @@ impl ElfOptimizationBackend for X86OptimizationBackend {
             Algorithm::Stochastic => {
                 run_x86_stochastic(ir, self.width, options, context.downstream_flags_live)
             }
-            Algorithm::Symbolic => {
-                run_x86_symbolic(ir, self.width, options, context.downstream_flags_live)
-            }
+            Algorithm::Symbolic => run_x86_symbolic(
+                ir,
+                self.width,
+                options,
+                context.downstream_flags_live,
+                x86_capstone_window_uses_only_full_width_register_operands(
+                    capstone_instructions,
+                    self.width,
+                ),
+            ),
             Algorithm::Hybrid | Algorithm::Llm => {
                 // Rejected upstream at the CLI layer; defensive check here
                 // in case a programmatic caller bypasses it.
@@ -807,8 +817,12 @@ fn optimize_elf_binary_with_backend<B: ElfOptimizationBackend>(
         optimization_context_for_backend(backend.arch(), patcher, &section, end_addr, &cs);
 
     // Run optimization based on selected algorithm
-    let optimized_instructions =
-        backend.run_search(&ir_instructions, options, optimization_context)?;
+    let optimized_instructions = backend.run_search(
+        &ir_instructions,
+        &instructions,
+        options,
+        optimization_context,
+    )?;
 
     // Use optimized instructions if found, otherwise use original
     let final_instructions = optimized_instructions
@@ -952,6 +966,7 @@ fn build_x86_symbolic_search_config(
     target: &[isa::x86::X86Instruction],
     width: u32,
     options: &OptimizationOptions,
+    same_count_code_size_allowed: bool,
 ) -> SearchConfig {
     let symbolic_config = SymbolicConfig::default()
         .with_search_mode(options.search_mode)
@@ -965,6 +980,7 @@ fn build_x86_symbolic_search_config(
         .with_x86_registers(x86_registers_from_target(target))
         .with_immediates(isa::x86::default_x86_immediates())
         .with_x86_width(width)
+        .with_x86_same_count_code_size_allowed(same_count_code_size_allowed)
 }
 
 /// Run optimization using the selected algorithm.
@@ -1716,7 +1732,7 @@ fn validate_basic_block(ir: &[Instruction]) -> Result<(), String> {
 // (`convert_to_x86_ir`) and the length-1 enumerator used by the
 // enumerative x86 pipeline.
 
-use parser::x86::x86_ir_from_mnemonic;
+use parser::x86::{parse_x86_register_with_width, x86_ir_from_mnemonic};
 
 /// Reject any non-terminal Jcc in an x86 optimization window. The
 /// optimizer only special-cases a trailing Jcc (peeled by
@@ -1739,6 +1755,24 @@ fn validate_x86_window_terminator_placement(ir: &[isa::x86::X86Instruction]) -> 
         }
     }
     Ok(())
+}
+
+fn x86_capstone_window_uses_only_full_width_register_operands(
+    instructions: &capstone::Instructions,
+    width: u32,
+) -> bool {
+    instructions.iter().all(|instruction| {
+        instruction
+            .op_str()
+            .unwrap_or("")
+            .split(',')
+            .all(
+                |operand| match parse_x86_register_with_width(operand.trim()) {
+                    Ok((_reg, alias_width)) => alias_width == width,
+                    Err(_) => true,
+                },
+            )
+    })
 }
 
 fn convert_to_x86_ir(
@@ -1946,11 +1980,13 @@ fn run_x86_symbolic(
     width: u32,
     options: &OptimizationOptions,
     downstream_flags_live: bool,
+    same_count_code_size_allowed: bool,
 ) -> Option<Vec<isa::x86::X86Instruction>> {
     use search::SearchAlgorithm;
     use search::symbolic::SymbolicSearch;
 
-    let config = build_x86_symbolic_search_config(target, width, options);
+    let config =
+        build_x86_symbolic_search_config(target, width, options, same_count_code_size_allowed);
     let live_out = x86_live_out_for_optimization(target, downstream_flags_live);
 
     let (optimized, statistics) = if width == 32 {
@@ -3219,6 +3255,53 @@ mod cli_helper_tests {
         }
     }
 
+    fn x86_disassembled_operands_are_full_width_for_test(
+        bytes: &[u8],
+        mode: capstone::arch::x86::ArchMode,
+        width: u32,
+    ) -> bool {
+        let cs = Capstone::new()
+            .x86()
+            .mode(mode)
+            .syntax(capstone::arch::x86::ArchSyntax::Intel)
+            .build()
+            .unwrap();
+        let instructions = cs.disasm_all(bytes, 0x1000).unwrap();
+        x86_capstone_window_uses_only_full_width_register_operands(&instructions, width)
+    }
+
+    #[test]
+    fn x86_full_width_operand_detector() {
+        let mode64 = capstone::arch::x86::ArchMode::Mode64;
+        let mode32 = capstone::arch::x86::ArchMode::Mode32;
+
+        assert!(!x86_disassembled_operands_are_full_width_for_test(
+            &[0x66, 0xb8, 0x00, 0x00],
+            mode64,
+            64
+        ));
+        assert!(!x86_disassembled_operands_are_full_width_for_test(
+            &[0xb0, 0x00],
+            mode64,
+            64
+        ));
+        assert!(!x86_disassembled_operands_are_full_width_for_test(
+            &[0xb8, 0x00, 0x00, 0x00, 0x00],
+            mode64,
+            64
+        ));
+        assert!(x86_disassembled_operands_are_full_width_for_test(
+            &[0x48, 0xc7, 0xc0, 0x00, 0x00, 0x00, 0x00],
+            mode64,
+            64
+        ));
+        assert!(x86_disassembled_operands_are_full_width_for_test(
+            &[0xb8, 0x00, 0x00, 0x00, 0x00],
+            mode32,
+            32
+        ));
+    }
+
     #[test]
     fn x86_helpers_cover_error_and_optimization_paths() {
         assert!(parse_x86_operand("not-an-operand").is_err());
@@ -3289,14 +3372,61 @@ mod cli_helper_tests {
             imm: 0,
         }];
 
-        let flags_dead = run_x86_symbolic(&target, 64, &opts, false)
+        let flags_dead = run_x86_symbolic(&target, 64, &opts, false, true)
             .expect("flags-dead one-instruction MOV can use an x86 code-size rewrite");
         assert_eq!(flags_dead.len(), 1);
         assert_ne!(flags_dead, target.to_vec());
 
         assert!(
-            run_x86_symbolic(&target, 64, &opts, true).is_none(),
+            run_x86_symbolic(&target, 64, &opts, false, false).is_none(),
+            "the ELF frontend can disable same-count symbolic code-size rewrites when source operand widths are unsafe"
+        );
+
+        assert!(
+            run_x86_symbolic(&target, 64, &opts, true, true).is_none(),
             "a same-count code-size rewrite must preserve EFLAGS when the following code reads them"
+        );
+    }
+
+    #[test]
+    fn x86_symbolic_backend_gates_same_count_code_size_from_capstone_operands() {
+        let backend = X86OptimizationBackend::new(DetectedArch::X86_64).unwrap();
+        let cs = backend.disassembler().unwrap();
+        let mut opts = options_for(Algorithm::Symbolic);
+        opts.timeout = Some(Duration::from_secs(5));
+        opts.solver_timeout = Duration::from_secs(5);
+        opts.cost_metric = CostMetric::CodeSize;
+        let context = OptimizationContext {
+            downstream_flags_live: false,
+        };
+
+        let partial_instructions = cs.disasm_all(&[0x66, 0xb8, 0x00, 0x00], 0x1000).unwrap();
+        let partial_ir = backend.convert_ir(&partial_instructions).unwrap();
+        assert_eq!(
+            partial_ir,
+            vec![X86Instruction::MovImm {
+                rd: X86Register::RAX,
+                imm: 0
+            }]
+        );
+        assert!(
+            backend
+                .run_search(&partial_ir, &partial_instructions, &opts, context)
+                .unwrap()
+                .is_none(),
+            "x86-64 symbolic search must not same-count rewrite a partial-width source operand"
+        );
+
+        let full_instructions = cs
+            .disasm_all(&[0x48, 0xc7, 0xc0, 0x00, 0x00, 0x00, 0x00], 0x1000)
+            .unwrap();
+        let full_ir = backend.convert_ir(&full_instructions).unwrap();
+        assert!(
+            backend
+                .run_search(&full_ir, &full_instructions, &opts, context)
+                .unwrap()
+                .is_some(),
+            "full-width x86-64 operands should keep the same-count code-size rewrite"
         );
     }
 
@@ -3766,7 +3896,7 @@ mod cli_helper_tests {
                 imm: 0,
             },
         ];
-        let config = build_x86_symbolic_search_config(&target, 64, &opts);
+        let config = build_x86_symbolic_search_config(&target, 64, &opts, true);
 
         assert_eq!(config.x86_available_registers, vec![X86Register::R12]);
         assert!(
@@ -3800,6 +3930,7 @@ mod cli_helper_tests {
                 ],
                 64,
                 &opts,
+                true,
             )
             .x86_available_registers
             .is_empty(),
@@ -3819,6 +3950,11 @@ mod cli_helper_tests {
         );
         assert_eq!(config.x86_width, 64);
         assert_eq!(config.x86_mode, assembler::x86::X86Mode::Mode64);
+        assert!(config.x86_same_count_code_size_allowed);
+        assert!(
+            !build_x86_symbolic_search_config(&target, 64, &opts, false)
+                .x86_same_count_code_size_allowed
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3877,7 +3877,7 @@ mod cli_helper_tests {
         opts.seed = Some(7);
 
         let target = r10_zeroing_target();
-        let optimized = run_x86_stochastic(&target, 64, &opts)
+        let optimized = run_x86_stochastic(&target, 64, &opts, false)
             .expect("two identical R10 zeroing writes must collapse to one");
 
         assert_single_r10_rewrite(&optimized);
@@ -3896,7 +3896,7 @@ mod cli_helper_tests {
         opts.cost_metric = CostMetric::InstructionCount;
 
         let target = r10_zeroing_target();
-        let optimized = run_x86_symbolic(&target, 64, &opts)
+        let optimized = run_x86_symbolic(&target, 64, &opts, false, false)
             .expect("two identical R10 zeroing writes must collapse to one");
 
         assert_single_r10_rewrite(&optimized);

--- a/src/main.rs
+++ b/src/main.rs
@@ -607,12 +607,18 @@ impl ElfOptimizationBackend for X86OptimizationBackend {
         &self,
         ir: &[Self::Instruction],
         options: &OptimizationOptions,
-        _context: OptimizationContext,
+        context: OptimizationContext,
     ) -> Result<Option<Vec<Self::Instruction>>, Box<dyn std::error::Error>> {
         let optimized = match options.algorithm {
-            Algorithm::Enumerative => run_x86_enumerative(ir, self.width, options),
-            Algorithm::Stochastic => run_x86_stochastic(ir, self.width, options),
-            Algorithm::Symbolic => run_x86_symbolic(ir, self.width, options),
+            Algorithm::Enumerative => {
+                run_x86_enumerative(ir, self.width, options, context.downstream_flags_live)
+            }
+            Algorithm::Stochastic => {
+                run_x86_stochastic(ir, self.width, options, context.downstream_flags_live)
+            }
+            Algorithm::Symbolic => {
+                run_x86_symbolic(ir, self.width, options, context.downstream_flags_live)
+            }
             Algorithm::Hybrid | Algorithm::Llm => {
                 // Rejected upstream at the CLI layer; defensive check here
                 // in case a programmatic caller bypasses it.
@@ -1575,6 +1581,86 @@ fn aarch64_downstream_flags_live_from_section(
     aarch64_downstream_flags_live_from_bytes(cs, &bytes, end_addr)
 }
 
+fn x86_downstream_flags_live_from_bytes<I>(cs: &Capstone, bytes: &[u8], start_addr: u64) -> bool
+where
+    I: isa::FlagsAnalysis<isa::x86::X86Instruction>,
+{
+    if bytes.is_empty() {
+        return true;
+    }
+
+    let mut remaining = bytes;
+    let mut address = start_addr;
+
+    while !remaining.is_empty() {
+        let Ok(instructions) = cs.disasm_count(remaining, address, 1) else {
+            return true;
+        };
+        let Some(instruction) = instructions.iter().next() else {
+            return true;
+        };
+        let instruction_len = instruction.bytes().len();
+        if instruction_len == 0 || instruction_len > remaining.len() {
+            return true;
+        }
+
+        let mnemonic = instruction.mnemonic().unwrap_or("");
+        let op_str = instruction.op_str().unwrap_or("");
+        match x86_ir_from_mnemonic(mnemonic, op_str) {
+            Ok(Some(instr)) => {
+                if <I as isa::FlagsAnalysis<isa::x86::X86Instruction>>::reads_flags(&instr) {
+                    return true;
+                }
+                if <I as isa::FlagsAnalysis<isa::x86::X86Instruction>>::modifies_flags(&instr) {
+                    return false;
+                }
+                if instr.is_terminator() {
+                    return true;
+                }
+            }
+            Ok(None) if mnemonic.eq_ignore_ascii_case("nop") => {}
+            Ok(None) => return true,
+            Err(_) => return true,
+        }
+
+        remaining = &remaining[instruction_len..];
+        address += instruction_len as u64;
+    }
+
+    false
+}
+
+fn x86_downstream_flags_live_from_section(
+    arch: DetectedArch,
+    patcher: &ElfPatcher,
+    section: &TextSection,
+    end_addr: u64,
+    cs: &Capstone,
+) -> bool {
+    let section_end = section.virtual_addr + section.size;
+    if end_addr >= section_end {
+        return true;
+    }
+
+    let suffix_window = AddressWindow {
+        start: end_addr,
+        end: section_end,
+    };
+    let Ok(bytes) = patcher.get_instructions_in_window(&suffix_window) else {
+        return true;
+    };
+
+    match arch {
+        DetectedArch::X86_64 => {
+            x86_downstream_flags_live_from_bytes::<isa::X86_64>(cs, &bytes, end_addr)
+        }
+        DetectedArch::X86_32 => {
+            x86_downstream_flags_live_from_bytes::<isa::X86_32>(cs, &bytes, end_addr)
+        }
+        DetectedArch::Aarch64 => true,
+    }
+}
+
 fn optimization_context_for_backend(
     arch: DetectedArch,
     patcher: &ElfPatcher,
@@ -1586,6 +1672,14 @@ fn optimization_context_for_backend(
         return OptimizationContext {
             downstream_flags_live: aarch64_downstream_flags_live_from_section(
                 patcher, section, end_addr, cs,
+            ),
+        };
+    }
+
+    if matches!(arch, DetectedArch::X86_64 | DetectedArch::X86_32) {
+        return OptimizationContext {
+            downstream_flags_live: x86_downstream_flags_live_from_section(
+                arch, patcher, section, end_addr, cs,
             ),
         };
     }
@@ -1736,6 +1830,15 @@ fn x86_enumerative_immediates_from_target(target: &[isa::x86::X86Instruction]) -
     imms
 }
 
+fn x86_live_out_for_optimization(
+    target: &[isa::x86::X86Instruction],
+    downstream_flags_live: bool,
+) -> semantics::live_out::X86LiveOut {
+    let live_out = validation::live_out::x86_live_out_from_target(target);
+    let flags_live = live_out.flags_live() || downstream_flags_live;
+    live_out.with_flags(flags_live)
+}
+
 /// Build the search config for the x86 *enumerative* path. Like stochastic and
 /// symbolic search, enumerative search draws candidates from the target's own
 /// registers; it additionally derives immediates from the target and honours
@@ -1755,12 +1858,12 @@ fn run_x86_enumerative(
     target: &[isa::x86::X86Instruction],
     width: u32,
     options: &OptimizationOptions,
+    downstream_flags_live: bool,
 ) -> Option<Vec<isa::x86::X86Instruction>> {
     use search::SearchAlgorithm;
-    use validation::live_out::x86_live_out_from_target;
 
     let config = build_x86_enumerative_search_config(target, width, options);
-    let live_out = x86_live_out_from_target(target);
+    let live_out = x86_live_out_for_optimization(target, downstream_flags_live);
 
     let (optimized, statistics) = if width == 32 {
         let mut search: EnumerativeSearch<isa::X86_32> = EnumerativeSearch::new();
@@ -1796,16 +1899,16 @@ fn run_x86_stochastic(
     target: &[isa::x86::X86Instruction],
     width: u32,
     options: &OptimizationOptions,
+    downstream_flags_live: bool,
 ) -> Option<Vec<isa::x86::X86Instruction>> {
     use search::SearchAlgorithm;
     use search::stochastic::StochasticSearch;
-    use validation::live_out::x86_live_out_from_target;
 
     let config = build_x86_stochastic_search_config(target, width, options);
     if config.x86_available_registers.is_empty() {
         return None;
     }
-    let live_out = x86_live_out_from_target(target);
+    let live_out = x86_live_out_for_optimization(target, downstream_flags_live);
 
     // Extract (optimized, statistics) in each width branch separately:
     // the two `SearchResultFor<X86_64>` / `SearchResultFor<X86_32>`
@@ -1842,13 +1945,13 @@ fn run_x86_symbolic(
     target: &[isa::x86::X86Instruction],
     width: u32,
     options: &OptimizationOptions,
+    downstream_flags_live: bool,
 ) -> Option<Vec<isa::x86::X86Instruction>> {
     use search::SearchAlgorithm;
     use search::symbolic::SymbolicSearch;
-    use validation::live_out::x86_live_out_from_target;
 
     let config = build_x86_symbolic_search_config(target, width, options);
-    let live_out = x86_live_out_from_target(target);
+    let live_out = x86_live_out_for_optimization(target, downstream_flags_live);
 
     let (optimized, statistics) = if width == 32 {
         let mut search: SymbolicSearch<isa::X86_32> = SymbolicSearch::new();
@@ -2864,6 +2967,21 @@ mod cli_helper_tests {
             .expect("test capstone should build")
     }
 
+    fn assemble_x86_64_test_bytes(instructions: &[X86Instruction]) -> Vec<u8> {
+        assembler::x86::X86Assembler::new_64()
+            .assemble_instructions(instructions)
+            .expect("test instruction should assemble")
+    }
+
+    fn x86_64_test_capstone() -> Capstone {
+        Capstone::new()
+            .x86()
+            .mode(capstone::arch::x86::ArchMode::Mode64)
+            .syntax(capstone::arch::x86::ArchSyntax::Intel)
+            .build()
+            .expect("test capstone should build")
+    }
+
     #[test]
     fn downstream_flags_live_scan_marks_dead_when_first_flag_event_writes() {
         let bytes = assemble_aarch64_test_bytes(&[
@@ -2942,6 +3060,73 @@ mod cli_helper_tests {
 
         assert!(aarch64_downstream_flags_live_from_bytes(
             &cs, &bytes, 0x1000
+        ));
+    }
+
+    #[test]
+    fn x86_downstream_flags_live_scan_marks_live_when_first_flag_event_reads() {
+        use isa::x86::X86Condition;
+
+        let bytes = assemble_x86_64_test_bytes(&[X86Instruction::Jcc {
+            cond: X86Condition::E,
+        }]);
+        let cs = x86_64_test_capstone();
+
+        assert!(x86_downstream_flags_live_from_bytes::<isa::X86_64>(
+            &cs, &bytes, 0x1000
+        ));
+    }
+
+    #[test]
+    fn x86_downstream_flags_live_scan_marks_dead_when_first_flag_event_writes() {
+        let bytes = assemble_x86_64_test_bytes(&[
+            X86Instruction::CmpReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            X86Instruction::MovImm {
+                rd: X86Register::RAX,
+                imm: 0,
+            },
+        ]);
+        let cs = x86_64_test_capstone();
+
+        assert!(!x86_downstream_flags_live_from_bytes::<isa::X86_64>(
+            &cs, &bytes, 0x1000
+        ));
+    }
+
+    #[test]
+    fn x86_downstream_flags_live_scan_marks_dead_for_known_non_flag_suffix() {
+        let bytes = assemble_x86_64_test_bytes(&[X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: 0,
+        }]);
+        let cs = x86_64_test_capstone();
+
+        assert!(!x86_downstream_flags_live_from_bytes::<isa::X86_64>(
+            &cs, &bytes, 0x1000
+        ));
+    }
+
+    #[test]
+    fn x86_downstream_flags_live_scan_is_conservative_for_unknown_context() {
+        let cs = x86_64_test_capstone();
+
+        assert!(x86_downstream_flags_live_from_bytes::<isa::X86_64>(
+            &cs,
+            &[],
+            0x1000
+        ));
+        assert!(x86_downstream_flags_live_from_bytes::<isa::X86_64>(
+            &cs,
+            &[0xff],
+            0x1000
+        ));
+        assert!(x86_downstream_flags_live_from_bytes::<isa::X86_64>(
+            &cs,
+            &[0xc3],
+            0x1000
         ));
     }
 
@@ -3044,7 +3229,7 @@ mod cli_helper_tests {
         opts.timeout = Some(Duration::from_secs(5));
         opts.solver_timeout = Duration::from_secs(5);
         opts.cost_metric = CostMetric::CodeSize;
-        assert!(run_x86_enumerative(&[], 64, &opts).is_none());
+        assert!(run_x86_enumerative(&[], 64, &opts, false).is_none());
         assert!(
             run_x86_enumerative(
                 &[X86Instruction::MovImm {
@@ -3052,7 +3237,8 @@ mod cli_helper_tests {
                     imm: 1,
                 }],
                 64,
-                &opts
+                &opts,
+                false,
             )
             .is_none()
         );
@@ -3069,9 +3255,49 @@ mod cli_helper_tests {
             ],
             64,
             &opts,
+            false,
         )
         .expect("two identical writes can be shortened");
         assert_eq!(optimized.len(), 1);
+    }
+
+    #[test]
+    fn x86_live_out_for_optimization_includes_downstream_flags() {
+        let mov_only = [X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: 0,
+        }];
+
+        assert!(!x86_live_out_for_optimization(&mov_only, false).flags_live());
+        assert!(x86_live_out_for_optimization(&mov_only, true).flags_live());
+
+        let flag_writer = [X86Instruction::XorReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RAX,
+        }];
+        assert!(x86_live_out_for_optimization(&flag_writer, false).flags_live());
+    }
+
+    #[test]
+    fn x86_symbolic_code_size_preserves_downstream_flags_live() {
+        let mut opts = options_for(Algorithm::Symbolic);
+        opts.timeout = Some(Duration::from_secs(5));
+        opts.solver_timeout = Duration::from_secs(5);
+        opts.cost_metric = CostMetric::CodeSize;
+        let target = [X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: 0,
+        }];
+
+        let flags_dead = run_x86_symbolic(&target, 64, &opts, false)
+            .expect("flags-dead one-instruction MOV can use an x86 code-size rewrite");
+        assert_eq!(flags_dead.len(), 1);
+        assert_ne!(flags_dead, target.to_vec());
+
+        assert!(
+            run_x86_symbolic(&target, 64, &opts, true).is_none(),
+            "a same-count code-size rewrite must preserve EFLAGS when the following code reads them"
+        );
     }
 
     #[test]
@@ -3151,6 +3377,7 @@ mod cli_helper_tests {
             ],
             64,
             &opts,
+            false,
         )
         .expect("redundant prefix + Jcc must be optimizable");
         // Expect: [MovImm RBX, 1, Jcc E].
@@ -3189,6 +3416,7 @@ mod cli_helper_tests {
             ],
             64,
             &opts,
+            false,
         )
         .expect("two identical RBX writes can be shortened");
         assert_eq!(optimized.len(), 1);
@@ -3227,6 +3455,7 @@ mod cli_helper_tests {
             ],
             64,
             &opts,
+            false,
         )
         .expect("two identical R10/-1 writes must collapse to one");
         assert_eq!(optimized.len(), 1);

--- a/src/parser/x86.rs
+++ b/src/parser/x86.rs
@@ -47,23 +47,80 @@ pub fn parse_x86_condition(suffix: &str) -> Result<X86Condition, String> {
 /// intentionally excluded because the minimal x86 IR models the
 /// low-byte/REX alias set.
 pub fn parse_x86_register(reg_str: &str) -> Result<X86Register, String> {
+    parse_x86_register_with_width(reg_str).map(|(reg, _width)| reg)
+}
+
+/// Parse a single x86 register name and report the textual alias width.
+///
+/// This is syntax metadata only: the returned register is still the
+/// canonical minimal-IR register, while the width preserves whether the
+/// source text named `rax`, `eax`, `ax`, or `al`.
+pub fn parse_x86_register_with_width(reg_str: &str) -> Result<(X86Register, u32), String> {
     match reg_str.trim().to_lowercase().as_str() {
-        "rax" | "eax" | "ax" | "al" => Ok(X86Register::RAX),
-        "rcx" | "ecx" | "cx" | "cl" => Ok(X86Register::RCX),
-        "rdx" | "edx" | "dx" | "dl" => Ok(X86Register::RDX),
-        "rbx" | "ebx" | "bx" | "bl" => Ok(X86Register::RBX),
-        "rsp" | "esp" | "sp" | "spl" => Ok(X86Register::RSP),
-        "rbp" | "ebp" | "bp" | "bpl" => Ok(X86Register::RBP),
-        "rsi" | "esi" | "si" | "sil" => Ok(X86Register::RSI),
-        "rdi" | "edi" | "di" | "dil" => Ok(X86Register::RDI),
-        "r8" | "r8d" | "r8w" | "r8b" => Ok(X86Register::R8),
-        "r9" | "r9d" | "r9w" | "r9b" => Ok(X86Register::R9),
-        "r10" | "r10d" | "r10w" | "r10b" => Ok(X86Register::R10),
-        "r11" | "r11d" | "r11w" | "r11b" => Ok(X86Register::R11),
-        "r12" | "r12d" | "r12w" | "r12b" => Ok(X86Register::R12),
-        "r13" | "r13d" | "r13w" | "r13b" => Ok(X86Register::R13),
-        "r14" | "r14d" | "r14w" | "r14b" => Ok(X86Register::R14),
-        "r15" | "r15d" | "r15w" | "r15b" => Ok(X86Register::R15),
+        "rax" => Ok((X86Register::RAX, 64)),
+        "eax" => Ok((X86Register::RAX, 32)),
+        "ax" => Ok((X86Register::RAX, 16)),
+        "al" => Ok((X86Register::RAX, 8)),
+        "rcx" => Ok((X86Register::RCX, 64)),
+        "ecx" => Ok((X86Register::RCX, 32)),
+        "cx" => Ok((X86Register::RCX, 16)),
+        "cl" => Ok((X86Register::RCX, 8)),
+        "rdx" => Ok((X86Register::RDX, 64)),
+        "edx" => Ok((X86Register::RDX, 32)),
+        "dx" => Ok((X86Register::RDX, 16)),
+        "dl" => Ok((X86Register::RDX, 8)),
+        "rbx" => Ok((X86Register::RBX, 64)),
+        "ebx" => Ok((X86Register::RBX, 32)),
+        "bx" => Ok((X86Register::RBX, 16)),
+        "bl" => Ok((X86Register::RBX, 8)),
+        "rsp" => Ok((X86Register::RSP, 64)),
+        "esp" => Ok((X86Register::RSP, 32)),
+        "sp" => Ok((X86Register::RSP, 16)),
+        "spl" => Ok((X86Register::RSP, 8)),
+        "rbp" => Ok((X86Register::RBP, 64)),
+        "ebp" => Ok((X86Register::RBP, 32)),
+        "bp" => Ok((X86Register::RBP, 16)),
+        "bpl" => Ok((X86Register::RBP, 8)),
+        "rsi" => Ok((X86Register::RSI, 64)),
+        "esi" => Ok((X86Register::RSI, 32)),
+        "si" => Ok((X86Register::RSI, 16)),
+        "sil" => Ok((X86Register::RSI, 8)),
+        "rdi" => Ok((X86Register::RDI, 64)),
+        "edi" => Ok((X86Register::RDI, 32)),
+        "di" => Ok((X86Register::RDI, 16)),
+        "dil" => Ok((X86Register::RDI, 8)),
+        "r8" => Ok((X86Register::R8, 64)),
+        "r8d" => Ok((X86Register::R8, 32)),
+        "r8w" => Ok((X86Register::R8, 16)),
+        "r8b" => Ok((X86Register::R8, 8)),
+        "r9" => Ok((X86Register::R9, 64)),
+        "r9d" => Ok((X86Register::R9, 32)),
+        "r9w" => Ok((X86Register::R9, 16)),
+        "r9b" => Ok((X86Register::R9, 8)),
+        "r10" => Ok((X86Register::R10, 64)),
+        "r10d" => Ok((X86Register::R10, 32)),
+        "r10w" => Ok((X86Register::R10, 16)),
+        "r10b" => Ok((X86Register::R10, 8)),
+        "r11" => Ok((X86Register::R11, 64)),
+        "r11d" => Ok((X86Register::R11, 32)),
+        "r11w" => Ok((X86Register::R11, 16)),
+        "r11b" => Ok((X86Register::R11, 8)),
+        "r12" => Ok((X86Register::R12, 64)),
+        "r12d" => Ok((X86Register::R12, 32)),
+        "r12w" => Ok((X86Register::R12, 16)),
+        "r12b" => Ok((X86Register::R12, 8)),
+        "r13" => Ok((X86Register::R13, 64)),
+        "r13d" => Ok((X86Register::R13, 32)),
+        "r13w" => Ok((X86Register::R13, 16)),
+        "r13b" => Ok((X86Register::R13, 8)),
+        "r14" => Ok((X86Register::R14, 64)),
+        "r14d" => Ok((X86Register::R14, 32)),
+        "r14w" => Ok((X86Register::R14, 16)),
+        "r14b" => Ok((X86Register::R14, 8)),
+        "r15" => Ok((X86Register::R15, 64)),
+        "r15d" => Ok((X86Register::R15, 32)),
+        "r15w" => Ok((X86Register::R15, 16)),
+        "r15b" => Ok((X86Register::R15, 8)),
         _ => Err(format!("Unknown x86 register: {}", reg_str)),
     }
 }
@@ -309,6 +366,29 @@ mod tests {
         assert_eq!(parse_x86_register("r10").unwrap(), X86Register::R10);
         assert_eq!(parse_x86_register("r10d").unwrap(), X86Register::R10);
         assert!(parse_x86_register("zmm0").is_err());
+    }
+
+    #[test]
+    fn parse_register_reports_alias_widths() {
+        let cases = [
+            ("rax", X86Register::RAX, 64),
+            ("r8", X86Register::R8, 64),
+            ("eax", X86Register::RAX, 32),
+            ("r8d", X86Register::R8, 32),
+            ("ax", X86Register::RAX, 16),
+            ("r8w", X86Register::R8, 16),
+            ("al", X86Register::RAX, 8),
+            ("r8b", X86Register::R8, 8),
+        ];
+
+        for (alias, expected_register, expected_width) in cases {
+            assert_eq!(
+                parse_x86_register_with_width(alias).unwrap(),
+                (expected_register, expected_width),
+                "{alias}"
+            );
+        }
+        assert!(parse_x86_register_with_width("zmm0").is_err());
     }
 
     #[test]

--- a/src/search/config.rs
+++ b/src/search/config.rs
@@ -338,6 +338,11 @@ pub struct SearchConfig {
     pub x86_width: u32,
     /// x86 assembler mode. Mirrors `x86_width`.
     pub x86_mode: crate::assembler::x86::X86Mode,
+    /// Whether x86 symbolic code-size search may consider same-instruction-count
+    /// candidates. Direct IR callers default to true; the ELF frontend can
+    /// disable this when source operands used partial-register aliases that the
+    /// current x86 IR collapses to full-width registers.
+    pub x86_same_count_code_size_allowed: bool,
     /// Stochastic-specific configuration
     pub stochastic: StochasticConfig,
     /// Symbolic-specific configuration
@@ -376,6 +381,7 @@ impl Default for SearchConfig {
             x86_available_registers: crate::isa::x86::default_x86_registers(),
             x86_width: 64,
             x86_mode: crate::assembler::x86::X86Mode::Mode64,
+            x86_same_count_code_size_allowed: true,
             stochastic: StochasticConfig::default(),
             symbolic: SymbolicConfig::default(),
             llm: LlmConfig::default(),
@@ -483,6 +489,11 @@ impl SearchConfig {
         } else {
             crate::assembler::x86::X86Mode::Mode64
         };
+        self
+    }
+
+    pub fn with_x86_same_count_code_size_allowed(mut self, allowed: bool) -> Self {
+        self.x86_same_count_code_size_allowed = allowed;
         self
     }
 }

--- a/src/search/symbolic/backend.rs
+++ b/src/search/symbolic/backend.rs
@@ -37,6 +37,12 @@ pub trait SymbolicBackend<I: ISA>: Sized {
         None
     }
 
+    /// Whether this backend can find a strict metric improvement without
+    /// reducing the number of rewritable instructions.
+    fn can_improve_at_same_instruction_count(_metric: &CostMetric) -> bool {
+        false
+    }
+
     /// Sum the cost of every instruction in the sequence.
     fn sequence_cost(seq: &[I::Instruction], metric: &CostMetric, width: u32) -> u64;
 
@@ -135,6 +141,10 @@ impl SymbolicBackend<crate::isa::X86_64> for crate::isa::X86_64 {
             .copied()
     }
 
+    fn can_improve_at_same_instruction_count(metric: &CostMetric) -> bool {
+        matches!(metric, CostMetric::CodeSize)
+    }
+
     fn sequence_cost(
         seq: &[crate::isa::x86::X86Instruction],
         metric: &CostMetric,
@@ -203,6 +213,10 @@ impl SymbolicBackend<crate::isa::X86_32> for crate::isa::X86_32 {
         crate::ir::instructions::split_terminator_x86(target)
             .1
             .copied()
+    }
+
+    fn can_improve_at_same_instruction_count(metric: &CostMetric) -> bool {
+        matches!(metric, CostMetric::CodeSize)
     }
 
     fn sequence_cost(

--- a/src/search/symbolic/backend.rs
+++ b/src/search/symbolic/backend.rs
@@ -37,9 +37,17 @@ pub trait SymbolicBackend<I: ISA>: Sized {
         None
     }
 
-    /// Whether this backend can find a strict metric improvement without
-    /// reducing the number of rewritable instructions.
-    fn can_improve_at_same_instruction_count(_metric: &CostMetric) -> bool {
+    /// Whether this backend may find a strict metric improvement without
+    /// reducing the number of rewritable instructions for this target/config.
+    ///
+    /// For x86 code-size search, the config flag is a binary-patching guard:
+    /// the current x86 IR collapses partial-register aliases to full-width
+    /// registers, so the ELF frontend disables same-count rewrites when the
+    /// original Capstone operands were not full-width for the binary mode.
+    fn can_improve_at_same_instruction_count(
+        _target: &[I::Instruction],
+        _config: &SearchConfig,
+    ) -> bool {
         false
     }
 
@@ -141,8 +149,12 @@ impl SymbolicBackend<crate::isa::X86_64> for crate::isa::X86_64 {
             .copied()
     }
 
-    fn can_improve_at_same_instruction_count(metric: &CostMetric) -> bool {
-        matches!(metric, CostMetric::CodeSize)
+    fn can_improve_at_same_instruction_count(
+        _target: &[crate::isa::x86::X86Instruction],
+        config: &SearchConfig,
+    ) -> bool {
+        matches!(config.cost_metric, CostMetric::CodeSize)
+            && config.x86_same_count_code_size_allowed
     }
 
     fn sequence_cost(
@@ -215,8 +227,12 @@ impl SymbolicBackend<crate::isa::X86_32> for crate::isa::X86_32 {
             .copied()
     }
 
-    fn can_improve_at_same_instruction_count(metric: &CostMetric) -> bool {
-        matches!(metric, CostMetric::CodeSize)
+    fn can_improve_at_same_instruction_count(
+        _target: &[crate::isa::x86::X86Instruction],
+        config: &SearchConfig,
+    ) -> bool {
+        matches!(config.cost_metric, CostMetric::CodeSize)
+            && config.x86_same_count_code_size_allowed
     }
 
     fn sequence_cost(

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -41,7 +41,7 @@ where
     I: ISA + SymbolicBackend<I>,
 {
     let can_search_same_count =
-        <I as SymbolicBackend<I>>::can_improve_at_same_instruction_count(&config.cost_metric)
+        <I as SymbolicBackend<I>>::can_improve_at_same_instruction_count(target, config)
             && <I as SymbolicBackend<I>>::target_terminator(target).is_none();
     target.len() + usize::from(can_search_same_count)
 }
@@ -1275,6 +1275,37 @@ mod tests {
         assert_eq!(optimized.len(), 1);
         assert_ne!(optimized, target);
         assert!(result.statistics.original_cost > result.statistics.best_cost_found);
+    }
+
+    #[test]
+    fn x86_symbolic_code_size_can_disable_same_length_zero_idiom() {
+        use crate::isa::X86_64;
+        use crate::isa::x86::{X86Instruction, X86Register};
+        use crate::semantics::live_out::X86LiveOut;
+
+        let mut search: SymbolicSearch<X86_64> = SymbolicSearch::new();
+        let config = SearchConfig::default()
+            .with_x86_registers(vec![X86Register::RAX])
+            .with_immediates(vec![0])
+            .with_x86_width(64)
+            .with_x86_same_count_code_size_allowed(false)
+            .with_cost_metric(CostMetric::CodeSize)
+            .with_timeout_option(Some(Duration::from_secs(5)));
+
+        let live_out = X86LiveOut::from_registers(vec![X86Register::RAX]).with_flags(false);
+        let target = vec![X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: 0,
+        }];
+
+        let result = search.search(&target, &live_out, &config);
+
+        assert!(!result.found_optimization);
+        assert_eq!(result.statistics.candidates_evaluated, 0);
+        assert_eq!(
+            result.statistics.original_cost,
+            result.statistics.best_cost_found
+        );
     }
 
     #[test]

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -40,10 +40,14 @@ fn candidate_length_exclusive_end<I>(target: &[I::Instruction], config: &SearchC
 where
     I: ISA + SymbolicBackend<I>,
 {
+    let target_terminator = <I as SymbolicBackend<I>>::target_terminator(target);
+    // `search_at_length` reattaches pinned terminators itself, so the
+    // enumerable length is the mutable prefix length, not total target length.
+    let rewritable_len = target.len() - usize::from(target_terminator.is_some());
     let can_search_same_count =
-        <I as SymbolicBackend<I>>::can_improve_at_same_instruction_count(target, config)
-            && <I as SymbolicBackend<I>>::target_terminator(target).is_none();
-    target.len() + usize::from(can_search_same_count)
+        <I as SymbolicBackend<I>>::can_improve_at_same_instruction_count(target, config);
+
+    rewritable_len + usize::from(can_search_same_count)
 }
 
 /// Symbolic search using SMT-based synthesis, generic over ISA.
@@ -1362,6 +1366,41 @@ mod tests {
             candidate_length_exclusive_end::<X86_64>(&target, &config),
             target.len(),
             "Jcc terminators are appended by search_at_length, so the prefix range must not include target.len()"
+        );
+    }
+
+    #[test]
+    fn x86_symbolic_code_size_can_disable_same_prefix_count_before_jcc() {
+        use crate::isa::X86_64;
+        use crate::isa::x86::{X86Condition, X86Instruction, X86Register};
+        use crate::semantics::live_out::X86LiveOut;
+
+        let mut search: SymbolicSearch<X86_64> = SymbolicSearch::new();
+        let config = SearchConfig::default()
+            .with_x86_registers(vec![X86Register::RAX])
+            .with_immediates(vec![0])
+            .with_x86_width(64)
+            .with_x86_same_count_code_size_allowed(false)
+            .with_cost_metric(CostMetric::CodeSize)
+            .with_timeout_option(Some(Duration::from_secs(5)));
+        let target = vec![
+            X86Instruction::AndImm {
+                rd: X86Register::RAX,
+                imm: 0,
+            },
+            X86Instruction::Jcc {
+                cond: X86Condition::E,
+            },
+        ];
+        let live_out = X86LiveOut::from_registers(vec![X86Register::RAX]).with_flags(true);
+
+        let result = search.search(&target, &live_out, &config);
+
+        assert!(!result.found_optimization);
+        assert_eq!(result.statistics.candidates_evaluated, 0);
+        assert_eq!(
+            result.statistics.original_cost,
+            result.statistics.best_cost_found
         );
     }
 

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -1,8 +1,8 @@
 //! SMT-based synthesis for superoptimization
 //!
 //! This module implements symbolic search using Z3 for equivalence verification.
-//! The approach uses linear cost search: try sequences of length 1, 2, ... up to
-//! the target length - 1, and for each length, enumerate candidates and verify
+//! The approach uses linear cost search: try candidate prefix lengths in
+//! ascending order, and for each length, enumerate candidates and verify
 //! equivalence with SMT.
 //!
 //! Note: Full symbolic synthesis with symbolic opcodes/operands is very complex.
@@ -36,6 +36,16 @@ fn should_stop(config: &SearchConfig, start_time: Instant) -> bool {
         .is_some_and(|f| f.load(Ordering::Relaxed))
 }
 
+fn candidate_length_exclusive_end<I>(target: &[I::Instruction], config: &SearchConfig) -> usize
+where
+    I: ISA + SymbolicBackend<I>,
+{
+    let can_search_same_count =
+        <I as SymbolicBackend<I>>::can_improve_at_same_instruction_count(&config.cost_metric)
+            && <I as SymbolicBackend<I>>::target_terminator(target).is_none();
+    target.len() + usize::from(can_search_same_count)
+}
+
 /// Symbolic search using SMT-based synthesis, generic over ISA.
 ///
 /// Routes through `SymbolicBackend<I>` for every ISA-specific operation:
@@ -60,7 +70,8 @@ impl<I> SymbolicSearch<I>
 where
     I: ISA + SymbolicBackend<I>,
 {
-    /// Linear cost search: try each length from 1 to target length - 1
+    /// Linear cost search: try each candidate prefix length that can still
+    /// produce a strict metric improvement.
     fn linear_search(
         &mut self,
         target: &[I::Instruction],
@@ -78,8 +89,8 @@ where
         let mut best_solution: Option<Vec<I::Instruction>> = None;
         let mut best_cost = original_cost;
 
-        // Try sequences of increasing length
-        for length in 1..target.len() {
+        // Try sequences of increasing length.
+        for length in 1..candidate_length_exclusive_end::<I>(target, config) {
             if config.verbose {
                 println!("Searching for equivalent sequences of length {}...", length);
             }
@@ -371,7 +382,7 @@ where
         self.statistics.original_cost = original_cost;
         self.statistics.best_cost_found = original_cost;
 
-        if target.is_empty() || target.len() == 1 {
+        if target.is_empty() || candidate_length_exclusive_end::<I>(target, config) <= 1 {
             self.statistics.elapsed_time = start_time.elapsed();
             return SearchResultFor::no_optimization(target.to_vec(), self.statistics.clone());
         }
@@ -1235,6 +1246,94 @@ mod tests {
         assert!(result.statistics.elapsed_time.as_nanos() > 0);
     }
 
+    #[test]
+    fn x86_symbolic_code_size_considers_same_length_zero_idiom() {
+        use crate::isa::X86_64;
+        use crate::isa::x86::{X86Instruction, X86Register};
+        use crate::semantics::live_out::X86LiveOut;
+
+        let mut search: SymbolicSearch<X86_64> = SymbolicSearch::new();
+        let config = SearchConfig::default()
+            .with_x86_registers(vec![X86Register::RAX])
+            .with_immediates(vec![0])
+            .with_x86_width(64)
+            .with_cost_metric(CostMetric::CodeSize)
+            .with_timeout_option(Some(Duration::from_secs(5)));
+
+        let live_out = X86LiveOut::from_registers(vec![X86Register::RAX]).with_flags(false);
+        let target = vec![X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: 0,
+        }];
+
+        let result = search.search(&target, &live_out, &config);
+
+        assert!(result.found_optimization);
+        let optimized = result
+            .optimized_sequence
+            .expect("code-size optimization should be present");
+        assert_eq!(optimized.len(), 1);
+        assert_ne!(optimized, target);
+        assert!(result.statistics.original_cost > result.statistics.best_cost_found);
+    }
+
+    #[test]
+    fn x86_symbolic_instruction_count_keeps_single_instruction_fast_noop() {
+        use crate::isa::X86_64;
+        use crate::isa::x86::{X86Instruction, X86Register};
+        use crate::semantics::live_out::X86LiveOut;
+
+        let mut search: SymbolicSearch<X86_64> = SymbolicSearch::new();
+        let config = SearchConfig::default()
+            .with_x86_registers(vec![X86Register::RAX])
+            .with_immediates(vec![0])
+            .with_x86_width(64)
+            .with_cost_metric(CostMetric::InstructionCount)
+            .with_timeout_option(Some(Duration::from_secs(5)));
+
+        let live_out = X86LiveOut::from_registers(vec![X86Register::RAX]).with_flags(false);
+        let target = vec![X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: 0,
+        }];
+
+        let result = search.search(&target, &live_out, &config);
+
+        assert!(!result.found_optimization);
+        assert_eq!(result.statistics.candidates_evaluated, 0);
+        assert_eq!(
+            result.statistics.original_cost,
+            result.statistics.best_cost_found
+        );
+    }
+
+    #[test]
+    fn x86_symbolic_same_length_code_size_preserves_terminator_prefix_bound() {
+        use crate::isa::X86_64;
+        use crate::isa::x86::{X86Condition, X86Instruction, X86Register};
+
+        let config = SearchConfig::default()
+            .with_x86_registers(vec![X86Register::RAX])
+            .with_immediates(vec![0])
+            .with_x86_width(64)
+            .with_cost_metric(CostMetric::CodeSize);
+        let target = vec![
+            X86Instruction::MovImm {
+                rd: X86Register::RAX,
+                imm: 0,
+            },
+            X86Instruction::Jcc {
+                cond: X86Condition::E,
+            },
+        ];
+
+        assert_eq!(
+            candidate_length_exclusive_end::<X86_64>(&target, &config),
+            target.len(),
+            "Jcc terminators are appended by search_at_length, so the prefix range must not include target.len()"
+        );
+    }
+
     /// Mirror of `x86_symbolic_runs_end_to_end` for x86-32. Covers the
     /// `SymbolicBackend<X86_32>` impl methods, including the width-32
     /// backend path through cost and equivalence checking.
@@ -1267,5 +1366,36 @@ mod tests {
         let result = search.search(&target, &live_out, &config);
         assert_eq!(result.statistics.algorithm, Algorithm::Symbolic);
         assert!(result.statistics.elapsed_time.as_nanos() > 0);
+    }
+
+    #[test]
+    fn x86_symbolic_mode32_code_size_considers_same_length_zero_idiom() {
+        use crate::isa::X86_32;
+        use crate::isa::x86::{X86Instruction, X86Register};
+        use crate::semantics::live_out::X86LiveOut;
+
+        let mut search: SymbolicSearch<X86_32> = SymbolicSearch::new();
+        let config = SearchConfig::default()
+            .with_x86_registers(vec![X86Register::RAX])
+            .with_immediates(vec![0])
+            .with_x86_width(32)
+            .with_cost_metric(CostMetric::CodeSize)
+            .with_timeout_option(Some(Duration::from_secs(5)));
+
+        let live_out = X86LiveOut::from_registers(vec![X86Register::RAX]).with_flags(false);
+        let target = vec![X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: 0,
+        }];
+
+        let result = search.search(&target, &live_out, &config);
+
+        assert!(result.found_optimization);
+        let optimized = result
+            .optimized_sequence
+            .expect("code-size optimization should be present");
+        assert_eq!(optimized.len(), 1);
+        assert_ne!(optimized, target);
+        assert!(result.statistics.original_cost > result.statistics.best_cost_found);
     }
 }

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- Allow x86 symbolic CodeSize search to enumerate same-instruction-count candidates when byte cost can still improve.
- Preserve AArch64 and x86 InstructionCount searches on the shorter-only path.
- Gate x86 ELF symbolic same-count code-size rewrites on full-width Capstone register operands so collapsed partial aliases like ax/al/eax in x86-64 are not re-emitted as full-width operations.
- Keep full-width x86-64 and x86-32 zero-idiom regressions covered, including downstream EFLAGS liveness and Jcc prefix-bound guards.
- Clean up current clippy needless-borrow warnings in AArch64 SMT lowering so the required clippy gate stays green.

Tests:
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test --all
- ./ci_check.sh

Note: this repo does not have scripts/full_test.sh or docs/spec/; ci_check.sh ran the repo-local test_all.sh.

Closes #249

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**