### PR TITLE
refactor(search): derive x86 mode from width

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3503,7 +3503,7 @@ mod cli_helper_tests {
             isa::x86::default_x86_immediates()
         );
         assert_eq!(config.x86_width, 32);
-        assert_eq!(config.x86_mode, assembler::x86::X86Mode::Mode32);
+        assert_eq!(config.x86_mode(), assembler::x86::X86Mode::Mode32);
     }
 
     #[test]
@@ -3589,7 +3589,7 @@ mod cli_helper_tests {
             isa::x86::default_x86_immediates()
         );
         assert_eq!(config.x86_width, 64);
-        assert_eq!(config.x86_mode, assembler::x86::X86Mode::Mode64);
+        assert_eq!(config.x86_mode(), assembler::x86::X86Mode::Mode64);
     }
 
     #[test]

--- a/src/search/config.rs
+++ b/src/search/config.rs
@@ -336,8 +336,6 @@ pub struct SearchConfig {
     pub x86_available_registers: Vec<crate::isa::x86::X86Register>,
     /// x86 operand width: 64 for x86-64, 32 for x86-32.
     pub x86_width: u32,
-    /// x86 assembler mode. Mirrors `x86_width`.
-    pub x86_mode: crate::assembler::x86::X86Mode,
     /// Stochastic-specific configuration
     pub stochastic: StochasticConfig,
     /// Symbolic-specific configuration
@@ -375,7 +373,6 @@ impl Default for SearchConfig {
             ],
             x86_available_registers: crate::isa::x86::default_x86_registers(),
             x86_width: 64,
-            x86_mode: crate::assembler::x86::X86Mode::Mode64,
             stochastic: StochasticConfig::default(),
             symbolic: SymbolicConfig::default(),
             llm: LlmConfig::default(),
@@ -468,22 +465,26 @@ impl SearchConfig {
         self
     }
 
-    /// Set the x86 width (32 or 64) and matching assembler mode.
+    /// Set the x86 operand width (32 or 64).
     pub fn with_x86_width(mut self, width: u32) -> Self {
-        // Only 32 and 64 are valid x86 widths; any other value would
-        // be silently coerced to Mode64 below, which is a misuse trap.
+        // Only 32 and 64 are valid x86 widths. Other values currently
+        // fall back to Mode64 through `x86_mode()`, which is a misuse trap.
         debug_assert!(
             width == 32 || width == 64,
             "with_x86_width: only 32 or 64 are valid; got {}",
             width
         );
         self.x86_width = width;
-        self.x86_mode = if width == 32 {
+        self
+    }
+
+    /// Return the x86 assembler mode derived from `x86_width`.
+    pub fn x86_mode(&self) -> crate::assembler::x86::X86Mode {
+        if self.x86_width == 32 {
             crate::assembler::x86::X86Mode::Mode32
         } else {
             crate::assembler::x86::X86Mode::Mode64
-        };
-        self
+        }
     }
 }
 
@@ -583,6 +584,22 @@ mod tests {
         assert_eq!(config.available_registers, vec![Register::X0, Register::X1]);
         assert_eq!(config.available_immediates, vec![0, 42]);
         assert!(config.verbose);
+    }
+
+    #[test]
+    fn search_config_derives_x86_mode_from_width() {
+        assert_eq!(
+            SearchConfig::default().x86_mode(),
+            crate::assembler::x86::X86Mode::Mode64
+        );
+        assert_eq!(
+            SearchConfig::default().with_x86_width(32).x86_mode(),
+            crate::assembler::x86::X86Mode::Mode32
+        );
+        assert_eq!(
+            SearchConfig::default().with_x86_width(64).x86_mode(),
+            crate::assembler::x86::X86Mode::Mode64
+        );
     }
 
     #[test]

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- remove the redundant public SearchConfig x86_mode field
- add x86_mode() derived from x86_width and update in-tree callers
- fix current clippy needless-borrow warnings in SMT helpers so the required gate stays green

Verification:
- cargo test search::config
- cargo test build_x86_stochastic_search_config
- cargo test build_x86_symbolic_search_config
- cargo test x86_32_
- cargo fmt --all
- cargo clippy --all -- -D warnings
- ./build_tests.sh
- cargo test --all
- ./ci_check.sh

Note: scripts/full_test.sh is not present in this s11 checkout; ./ci_check.sh is the repo-documented full local gate in CLAUDE.md.

Closes #250

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**