### PR TITLE
fix(parser): report empty assembly input at line 1

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2125,7 +2125,7 @@ pub fn parse_assembly_string(
 
     if instructions.is_empty() {
         return Err(ParseError::new(
-            0,
+            1,
             "no instructions found in file",
             source_name,
         ));
@@ -2719,9 +2719,16 @@ mod tests {
 
     #[test]
     fn test_parse_assembly_string_empty() {
-        let asm = "// just a comment\n.text\n";
-        let result = parse_assembly_string(asm, "test".to_string());
-        assert!(result.is_err());
+        let empty_err = parse_assembly_string("", "test".to_string()).unwrap_err();
+        assert_eq!(empty_err.line_number, 1);
+        assert_eq!(empty_err.message, "no instructions found in file");
+        assert_eq!(empty_err.line_content, "test");
+
+        let skipped_err =
+            parse_assembly_string("// just a comment\n.text\n", "test".to_string()).unwrap_err();
+        assert_eq!(skipped_err.line_number, 1);
+        assert_eq!(skipped_err.message, "no instructions found in file");
+        assert_eq!(skipped_err.line_content, "test");
     }
 
     /// Round-trip Display → parser for every Tier 1 mnemonic.

--- a/src/parser/x86.rs
+++ b/src/parser/x86.rs
@@ -264,7 +264,7 @@ pub fn parse_x86_assembly_string(
     }
     if instructions.is_empty() {
         return Err(ParseError::new(
-            0,
+            1,
             "no instructions found in input",
             source_name,
         ));
@@ -522,8 +522,16 @@ mod tests {
 
     #[test]
     fn assembly_string_rejects_empty_input() {
-        assert!(parse_x86_assembly_string("", "t".to_string()).is_err());
-        assert!(parse_x86_assembly_string("   \n\n; only comments\n", "t".to_string()).is_err());
+        let empty_err = parse_x86_assembly_string("", "t".to_string()).unwrap_err();
+        assert_eq!(empty_err.line_number, 1);
+        assert_eq!(empty_err.message, "no instructions found in input");
+        assert_eq!(empty_err.line_content, "t");
+
+        let skipped_err =
+            parse_x86_assembly_string("   \n\n; only comments\n", "t".to_string()).unwrap_err();
+        assert_eq!(skipped_err.line_number, 1);
+        assert_eq!(skipped_err.message, "no instructions found in input");
+        assert_eq!(skipped_err.line_content, "t");
     }
 
     #[test]

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- Report whole-input empty assembly diagnostics at line 1 for both AArch64 and x86 assembly-string parsers.
- Strengthen parser tests for truly empty input and empty-after-skipping comments/directives.
- Remove pre-existing needless Z3 AST borrows that failed the required local clippy gate.

Implementation note: chose line 1 rather than a new sentinel so ParseError keeps its existing API and empty-input diagnostics stay aligned with the parser's 1-indexed line-number convention.

Validation:
- cargo fmt --all
- cargo clippy --all -- -D warnings
- ./build_tests.sh
- cargo test --all
- ./ci_check.sh

Note: scripts/full_test.sh is not present in this s11 workspace.

Closes #251

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**
