### PR TITLE
docs(search): clarify AArch64 random slot numbering

### DIFF
--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -721,14 +721,17 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
         registers: &[Register],
         immediates: &[i64],
     ) -> Instruction {
-        // 38 opcode slots: 0..=12 original, 13..=23 Tier 1, 24 = MOVZ,
-        // 25 = MOVK, 26..=31 = CLZ/CLS/RBIT/REV/REV32/REV16 as separate
-        // top-level slots, 32 = multiply-accumulate family (issue #56:
-        // 5-way sub-multiplexer for MADD/MSUB/MNEG/SMULH/UMULH), 33 =
-        // conditional-compare family (issue #57: 2-way sub-multiplexer
-        // for CCMP/CCMN), 34 = bit-field aliases (issue #61: 6-way
-        // sub-multiplexer for UBFX/SBFX/BFI/BFXIL/UBFIZ/SBFIZ), 35 = CSET,
-        // 36 = CSETM, 37 = ROR.
+        // 38 random-generation slots: 0..=12 original, 13..=23 Tier 1,
+        // 24 = MOVZ, 25 = MOVK, 26..=31 = CLZ/CLS/RBIT/REV/REV32/REV16 as
+        // separate top-level slots, 32 = multiply-accumulate family (issue
+        // #56: 5-way sub-multiplexer for MADD/MSUB/MNEG/SMULH/UMULH), 33 =
+        // conditional-compare family (issue #57: 2-way sub-multiplexer for
+        // CCMP/CCMN), 34 = bit-field aliases (issue #61: 6-way sub-multiplexer
+        // for UBFX/SBFX/BFI/BFXIL/UBFIZ/SBFIZ), 35 = CSET, 36 = CSETM,
+        // 37 = ROR.
+        // These sampler slots are independent from `opcode_id()` values; for
+        // example, CSET/CSETM/ROR are slots 35/36/37 here but opcode IDs
+        // 31/32/33.
         // See also `src/search/candidate.rs::generate_random_instruction`:
         // it is a parallel 38-slot sampler, but its slot numbers differ
         // (notably, ROR is slot 23 there and slot 37 here).

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- Clarify that `AArch64InstructionGenerator::generate_random` uses random-generation slots, not opcode IDs.
- Add the CSET/CSETM/ROR example showing slots 35/36/37 versus opcode IDs 31/32/33.
- Remove current clippy needless-borrow warnings in SMT Z3 AST builder calls so the required local gate passes.

Verification:
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `./build_tests.sh`
- `cargo test --all`
- `scripts/full_test.sh` was requested by the run contract but is not present in this s11 checkout.
- `./ci_check.sh`

Closes #256

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**