### PR TITLE
test(aarch64): bound random opcode distribution

### DIFF
--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -2666,28 +2666,45 @@ mod tests {
     }
 
     /// Regression test for issue #93: ANDS/CSET/CSETM/ROR used to share
-    /// slot 23 via a 4-way sub-multiplexer, giving each ~1/120 vs ~1/30
-    /// for the rest of the old 30-slot table. Each should now hold its
-    /// own top-level slot so the sampler is roughly uniform across the
-    /// new 33-slot table (~1/33). With N = 30_000 ChaCha8-seeded draws
-    /// each is expected near 909 hits; the old sub-mux would give ~250.
-    /// The 600 threshold sits ~10σ below the new expected and ~22σ above
-    /// the old.
+    /// slot 23 via a 4-way sub-multiplexer, giving each ~1/152 vs ~1/38
+    /// for singleton top-level slots. Each should now hold its own slot.
+    /// With N = 30_000 ChaCha8-seeded draws each singleton-slot opcode is
+    /// expected near 789 hits; the old sub-mux would give ~197. The lower
+    /// threshold catches under-sampling, while the wide 3x upper bound catches
+    /// accidental over-weighting without treating every opcode family as
+    /// uniformly distributed.
     #[test]
     fn slot_23_sub_multiplexer_removed_for_issue_93() {
-        use std::collections::HashMap;
+        use std::collections::BTreeMap;
         let generator = AArch64InstructionGenerator;
         let regs = vec![Register::X0, Register::X1, Register::X2];
         let imms = vec![0, 1, 2, 16, 32];
         let mut rng = ChaCha8Rng::seed_from_u64(0x9300);
-        let mut counts: HashMap<u8, u32> = HashMap::new();
+        let mut counts: BTreeMap<u8, u32> = BTreeMap::new();
         const N: u32 = 30_000;
+        const TOP_LEVEL_SLOT_COUNT: u32 = 38;
+        const EXPECTED_TOP_LEVEL_COUNT: u32 = N / TOP_LEVEL_SLOT_COUNT;
+        const MAX_REASONABLE_TOP_LEVEL_COUNT: u32 = 3 * N / TOP_LEVEL_SLOT_COUNT;
         for _ in 0..N {
             let id = generator
                 .generate_random(&mut rng, &regs, &imms)
                 .opcode_id();
             *counts.entry(id).or_default() += 1;
         }
+
+        for (&id, &count) in &counts {
+            assert!(
+                count <= MAX_REASONABLE_TOP_LEVEL_COUNT,
+                "expected opcode id {} to stay <= {} samples in {} draws; got {} (single top-level expected {}, {} slots)",
+                id,
+                MAX_REASONABLE_TOP_LEVEL_COUNT,
+                N,
+                count,
+                EXPECTED_TOP_LEVEL_COUNT,
+                TOP_LEVEL_SLOT_COUNT,
+            );
+        }
+
         for instr in [
             Instruction::Ands {
                 rd: Register::X0,
@@ -2718,6 +2735,17 @@ mod tests {
                 id,
                 N,
                 count,
+            );
+            assert!(
+                count <= MAX_REASONABLE_TOP_LEVEL_COUNT,
+                "expected <= {} samples for {} (id {}) in {} draws, got {} (single top-level expected {}, {} slots)",
+                MAX_REASONABLE_TOP_LEVEL_COUNT,
+                instr,
+                id,
+                N,
+                count,
+                EXPECTED_TOP_LEVEL_COUNT,
+                TOP_LEVEL_SLOT_COUNT,
             );
         }
     }

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- Add a wide upper-bound distribution assertion to the AArch64 issue #93 random-generator regression test.
- Keep affected-opcode lower bounds and add explicit upper-bound diagnostics using the 38-slot sampler model.
- Remove current clippy needless-borrow warnings in SMT bitvector code so the local clippy gate stays green.

Tests:
- cargo test slot_23_sub_multiplexer_removed_for_issue_93
- cargo test aarch64_random_generation
- cargo fmt --all
- cargo clippy --all -- -D warnings
- ./build_tests.sh
- cargo test --all
- ./ci_check.sh

Note: scripts/full_test.sh is not present in this repository; ./ci_check.sh runs the repo's full local gate, including test_all.sh.

Closes #258

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**