### PR TITLE
fix(aarch64): promote semantic family random slots

### DIFF
--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -721,22 +721,127 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
         registers: &[Register],
         immediates: &[i64],
     ) -> Instruction {
-        // 38 opcode slots: 0..=12 original, 13..=23 Tier 1, 24 = MOVZ,
-        // 25 = MOVK, 26..=31 = CLZ/CLS/RBIT/REV/REV32/REV16 as separate
-        // top-level slots, 32 = multiply-accumulate family (issue #56:
-        // 5-way sub-multiplexer for MADD/MSUB/MNEG/SMULH/UMULH), 33 =
-        // conditional-compare family (issue #57: 2-way sub-multiplexer
-        // for CCMP/CCMN), 34 = bit-field aliases (issue #61: 6-way
-        // sub-multiplexer for UBFX/SBFX/BFI/BFXIL/UBFIZ/SBFIZ), 35 = CSET,
-        // 36 = CSETM, 37 = ROR.
+        // 48 opcode slots: 0..=12 original, 13..=23 Tier 1, 24 = MOVZ,
+        // 25 = MOVK, 26..=31 = CLZ/CLS/RBIT/REV/REV32/REV16, 32 =
+        // MADD, 33 = CCMP, 34 = UBFX, 35 = CSET, 36 = CSETM, 37 = ROR,
+        // 38..=41 = MSUB/MNEG/SMULH/UMULH, 42 = CCMN, and 43..=47 =
+        // SBFX/BFI/BFXIL/UBFIZ/SBFIZ.
         // See also `src/search/candidate.rs::generate_random_instruction`:
-        // it is a parallel 38-slot sampler, but its slot numbers differ
+        // it is a parallel 48-slot sampler, but its slot numbers differ
         // (notably, ROR is slot 23 there and slot 37 here).
-        let opcode = rng.random_range(0..38);
+        let opcode = rng.random_range(0..48);
         let rd = registers[rng.random_range(0..registers.len())];
         let rn = registers[rng.random_range(0..registers.len())];
         let pick_reg = |rng: &mut R| registers[rng.random_range(0..registers.len())];
         let pick_imm = |rng: &mut R| immediates[rng.random_range(0..immediates.len())];
+        let random_madd_like = |rng: &mut R, variant: u8| {
+            let rm = pick_reg(rng);
+            match variant {
+                0 => {
+                    let ra = pick_reg(rng);
+                    Instruction::Madd { rd, rn, rm, ra }
+                }
+                1 => {
+                    let ra = pick_reg(rng);
+                    Instruction::Msub { rd, rn, rm, ra }
+                }
+                2 => Instruction::Mneg { rd, rn, rm },
+                3 => Instruction::Smulh { rd, rn, rm },
+                4 => Instruction::Umulh { rd, rn, rm },
+                _ => unreachable!(),
+            }
+        };
+        let random_cond_compare = |rng: &mut R, negative: bool| {
+            let non_sp: Vec<Register> = registers
+                .iter()
+                .copied()
+                .filter(|r| *r != Register::SP)
+                .collect();
+            if non_sp.is_empty() {
+                let rm = pick_reg(rng);
+                return Instruction::Mneg { rd, rn, rm };
+            }
+            let pick_non_sp = |rng: &mut R| non_sp[rng.random_range(0..non_sp.len())];
+            let ccmp_rn = pick_non_sp(rng);
+            let rm = if rng.random_bool(0.5) {
+                Operand::Register(pick_non_sp(rng))
+            } else {
+                Operand::Immediate(pick_imm(rng).rem_euclid(32))
+            };
+            let nzcv = (rng.random::<u32>() & 0x0F) as u8;
+            let cond = Condition::random_normal(rng);
+            if negative {
+                Instruction::Ccmn {
+                    rn: ccmp_rn,
+                    rm,
+                    nzcv,
+                    cond,
+                }
+            } else {
+                Instruction::Ccmp {
+                    rn: ccmp_rn,
+                    rm,
+                    nzcv,
+                    cond,
+                }
+            }
+        };
+        let random_bitfield = |rng: &mut R, variant: u8| {
+            let non_sp: Vec<Register> = registers
+                .iter()
+                .copied()
+                .filter(|r| *r != Register::SP)
+                .collect();
+            if non_sp.is_empty() {
+                let rm = pick_reg(rng);
+                return Instruction::Mneg { rd, rn, rm };
+            }
+            let pick_non_sp = |rng: &mut R| non_sp[rng.random_range(0..non_sp.len())];
+            let bf_rd = pick_non_sp(rng);
+            let bf_rn = pick_non_sp(rng);
+            let lsb = (rng.random::<u32>() & 0x3F) as u8;
+            let max_w = 64 - lsb as u32;
+            let width = ((rng.random::<u32>() % max_w) + 1) as u8;
+            match variant {
+                0 => Instruction::Ubfx {
+                    rd: bf_rd,
+                    rn: bf_rn,
+                    lsb,
+                    width,
+                },
+                1 => Instruction::Sbfx {
+                    rd: bf_rd,
+                    rn: bf_rn,
+                    lsb,
+                    width,
+                },
+                2 => Instruction::Bfi {
+                    rd: bf_rd,
+                    rn: bf_rn,
+                    lsb,
+                    width,
+                },
+                3 => Instruction::Bfxil {
+                    rd: bf_rd,
+                    rn: bf_rn,
+                    lsb,
+                    width,
+                },
+                4 => Instruction::Ubfiz {
+                    rd: bf_rd,
+                    rn: bf_rn,
+                    lsb,
+                    width,
+                },
+                5 => Instruction::Sbfiz {
+                    rd: bf_rd,
+                    rn: bf_rn,
+                    lsb,
+                    width,
+                },
+                _ => unreachable!(),
+            }
+        };
 
         match opcode {
             0 => Instruction::MovReg { rd, rn },
@@ -909,68 +1014,16 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                 rd,
                 rn: pick_reg(rng),
             },
-            // Multiply-accumulate family.
-            32 => {
-                let rm = pick_reg(rng);
-                match rng.random_range(0..5) {
-                    0 => {
-                        let ra = pick_reg(rng);
-                        Instruction::Madd { rd, rn, rm, ra }
-                    }
-                    1 => {
-                        let ra = pick_reg(rng);
-                        Instruction::Msub { rd, rn, rm, ra }
-                    }
-                    2 => Instruction::Mneg { rd, rn, rm },
-                    3 => Instruction::Smulh { rd, rn, rm },
-                    _ => Instruction::Umulh { rd, rn, rm },
-                }
-            }
-            // Conditional-compare family (CCMP/CCMN). `is_encodable_aarch64`
+            // Multiply-accumulate variants.
+            32 => random_madd_like(rng, 0),
+            // Conditional-compare variants (CCMP/CCMN). `is_encodable_aarch64`
             // forbids SP in `rn` and forbids AL/NV; mirror those in the
             // sampler to keep the emitted candidates encodable. Build a
             // SP-filtered slice up front so the picker is a single
             // bounded sample (no retry loop, no infinite-spin risk in
             // release builds on a degenerate `[SP]`-only pool — that
             // case falls back to the next opcode).
-            33 => {
-                let non_sp: Vec<Register> = registers
-                    .iter()
-                    .copied()
-                    .filter(|r| *r != Register::SP)
-                    .collect();
-                if non_sp.is_empty() {
-                    // No encodable CCMP/CCMN candidates with this pool —
-                    // fall back to the multiply-accumulate family which
-                    // tolerates any register.
-                    let rm = pick_reg(rng);
-                    return Instruction::Mneg { rd, rn, rm };
-                }
-                let pick_non_sp = |rng: &mut R| non_sp[rng.random_range(0..non_sp.len())];
-                let ccmp_rn = pick_non_sp(rng);
-                let rm = if rng.random_bool(0.5) {
-                    Operand::Register(pick_non_sp(rng))
-                } else {
-                    Operand::Immediate(pick_imm(rng).rem_euclid(32))
-                };
-                let nzcv = (rng.random::<u32>() & 0x0F) as u8;
-                let cond = Condition::random_normal(rng);
-                if rng.random_bool(0.5) {
-                    Instruction::Ccmp {
-                        rn: ccmp_rn,
-                        rm,
-                        nzcv,
-                        cond,
-                    }
-                } else {
-                    Instruction::Ccmn {
-                        rn: ccmp_rn,
-                        rm,
-                        nzcv,
-                        cond,
-                    }
-                }
-            }
+            33 => random_cond_compare(rng, false),
             // Bit-field aliases (issue #61: UBFX/SBFX/BFI/BFXIL/UBFIZ/SBFIZ).
             // SP is illegal in both rd and rn; we pre-filter rather than retry
             // so the release build has no infinite-spin path on a degenerate
@@ -978,61 +1031,7 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
             // family (which tolerates any register). The 2D constraint
             // `lsb + width <= 64` is enforced by sampling width AFTER lsb so
             // width is bounded by `64 - lsb`.
-            34 => {
-                let non_sp: Vec<Register> = registers
-                    .iter()
-                    .copied()
-                    .filter(|r| *r != Register::SP)
-                    .collect();
-                if non_sp.is_empty() {
-                    let rm = pick_reg(rng);
-                    return Instruction::Mneg { rd, rn, rm };
-                }
-                let pick_non_sp = |rng: &mut R| non_sp[rng.random_range(0..non_sp.len())];
-                let bf_rd = pick_non_sp(rng);
-                let bf_rn = pick_non_sp(rng);
-                let lsb = (rng.random::<u32>() & 0x3F) as u8;
-                let max_w = 64 - lsb as u32;
-                let width = ((rng.random::<u32>() % max_w) + 1) as u8;
-                match rng.random_range(0..6) {
-                    0 => Instruction::Ubfx {
-                        rd: bf_rd,
-                        rn: bf_rn,
-                        lsb,
-                        width,
-                    },
-                    1 => Instruction::Sbfx {
-                        rd: bf_rd,
-                        rn: bf_rn,
-                        lsb,
-                        width,
-                    },
-                    2 => Instruction::Bfi {
-                        rd: bf_rd,
-                        rn: bf_rn,
-                        lsb,
-                        width,
-                    },
-                    3 => Instruction::Bfxil {
-                        rd: bf_rd,
-                        rn: bf_rn,
-                        lsb,
-                        width,
-                    },
-                    4 => Instruction::Ubfiz {
-                        rd: bf_rd,
-                        rn: bf_rn,
-                        lsb,
-                        width,
-                    },
-                    _ => Instruction::Sbfiz {
-                        rd: bf_rd,
-                        rn: bf_rn,
-                        lsb,
-                        width,
-                    },
-                }
-            }
+            34 => random_bitfield(rng, 0),
             35 => Instruction::Cset {
                 rd,
                 cond: Condition::random_normal(rng),
@@ -1050,6 +1049,16 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
                 };
                 Instruction::Ror { rd, rn, shift }
             }
+            38 => random_madd_like(rng, 1),
+            39 => random_madd_like(rng, 2),
+            40 => random_madd_like(rng, 3),
+            41 => random_madd_like(rng, 4),
+            42 => random_cond_compare(rng, true),
+            43 => random_bitfield(rng, 1),
+            44 => random_bitfield(rng, 2),
+            45 => random_bitfield(rng, 3),
+            46 => random_bitfield(rng, 4),
+            47 => random_bitfield(rng, 5),
             _ => unreachable!(),
         }
     }
@@ -1742,14 +1751,12 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
         }
     }
 
-    /// Total number of distinct opcode *families* (the upper bound on
-    /// `opcode_id()`). Not the same as `generate_random`'s slot count —
-    /// `generate_random` samples 38 top-level slots and still folds several
-    /// families into sub-multiplexers (e.g. the five multiply-accumulate ops,
-    /// the two conditional-compare ops, the five standalone extend aliases,
-    /// and the six bit-field aliases). So `opcode_id < opcode_count` always
-    /// holds for generated arithmetic/logical families, but the
-    /// random-generation distribution is not uniform across all 60 IDs.
+    /// Total number of canonical AArch64 opcode IDs below the branch/terminator
+    /// range. Not the same as `generate_random`'s 48-slot sampler: those random
+    /// slots cover the generated arithmetic/logical variants promoted for
+    /// stochastic sampling fairness, while compare/test, conditional-select,
+    /// and standalone extend aliases still have canonical IDs without dedicated
+    /// `AArch64InstructionGenerator::generate_random` slots.
     fn opcode_count(&self) -> u8 {
         60 // 20 original + 14 Tier 1 (MVN, NEG, NEGS, MovN, BIC, BICS, ORN,
         //  EON, ADDS, SUBS, ANDS, CSET, CSETM, ROR) + 2 MOVK/MOVZ (issue
@@ -2573,10 +2580,10 @@ mod tests {
     /// pool. The current code collects the non-SP registers up front
     /// and falls back to `Mneg` when the filter yields an empty slice,
     /// so every call must return a valid `Instruction` in finite time.
-    /// Not asserting which opcode comes back — both slot 32 (the
-    /// multiply-accumulate sub-multiplexer) and slot 33's fallback can
-    /// emit Mneg, so any "did the conditional-compare slot fire?" proxy gives false
-    /// confidence. The 10000 samples + bounded loop is the contract:
+    /// Not asserting which opcode comes back — direct MNEG and the CCMP/CCMN
+    /// and bit-field fallbacks can all emit Mneg, so any "did the
+    /// conditional-compare slot fire?" proxy gives false confidence. The 10000
+    /// samples + bounded loop is the contract:
     /// completing the loop without panicking or hanging is the test.
     #[test]
     fn random_generator_handles_sp_only_register_pool() {
@@ -2665,14 +2672,160 @@ mod tests {
         }
     }
 
+    #[test]
+    fn aarch64_random_generation_promotes_semantic_family_variants_to_top_level_slots() {
+        use std::collections::HashMap;
+
+        let generator = AArch64InstructionGenerator;
+        let regs = vec![Register::X0, Register::X1, Register::X2];
+        let imms = vec![0, 1, 2, 16, 32];
+        let mut rng = ChaCha8Rng::seed_from_u64(0x257);
+        let mut counts: HashMap<u8, u32> = HashMap::new();
+        const EXPECTED_PER_TOP_LEVEL_SLOT: u32 = 2_000;
+        const RANDOM_SLOT_COUNT: u32 = 48;
+        const N: u32 = RANDOM_SLOT_COUNT * EXPECTED_PER_TOP_LEVEL_SLOT;
+        const MIN_TOP_LEVEL_SAMPLES: u32 = 1_500;
+
+        for _ in 0..N {
+            let id = generator
+                .generate_random(&mut rng, &regs, &imms)
+                .opcode_id();
+            *counts.entry(id).or_default() += 1;
+        }
+
+        for (label, instr) in [
+            (
+                "Madd",
+                Instruction::Madd {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Register::X2,
+                    ra: Register::X0,
+                },
+            ),
+            (
+                "Msub",
+                Instruction::Msub {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Register::X2,
+                    ra: Register::X0,
+                },
+            ),
+            (
+                "Mneg",
+                Instruction::Mneg {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Register::X2,
+                },
+            ),
+            (
+                "Smulh",
+                Instruction::Smulh {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Register::X2,
+                },
+            ),
+            (
+                "Umulh",
+                Instruction::Umulh {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Register::X2,
+                },
+            ),
+            (
+                "Ccmp",
+                Instruction::Ccmp {
+                    rn: Register::X0,
+                    rm: Operand::Register(Register::X1),
+                    nzcv: 0,
+                    cond: Condition::EQ,
+                },
+            ),
+            (
+                "Ccmn",
+                Instruction::Ccmn {
+                    rn: Register::X0,
+                    rm: Operand::Register(Register::X1),
+                    nzcv: 0,
+                    cond: Condition::EQ,
+                },
+            ),
+            (
+                "Ubfx",
+                Instruction::Ubfx {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    lsb: 0,
+                    width: 1,
+                },
+            ),
+            (
+                "Sbfx",
+                Instruction::Sbfx {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    lsb: 0,
+                    width: 1,
+                },
+            ),
+            (
+                "Bfi",
+                Instruction::Bfi {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    lsb: 0,
+                    width: 1,
+                },
+            ),
+            (
+                "Bfxil",
+                Instruction::Bfxil {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    lsb: 0,
+                    width: 1,
+                },
+            ),
+            (
+                "Ubfiz",
+                Instruction::Ubfiz {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    lsb: 0,
+                    width: 1,
+                },
+            ),
+            (
+                "Sbfiz",
+                Instruction::Sbfiz {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    lsb: 0,
+                    width: 1,
+                },
+            ),
+        ] {
+            let id = instr.opcode_id();
+            let count = counts.get(&id).copied().unwrap_or(0);
+            assert!(
+                count >= MIN_TOP_LEVEL_SAMPLES,
+                "expected >= {MIN_TOP_LEVEL_SAMPLES} samples for {label} (id {id}) in {N} draws, got {count}",
+            );
+        }
+    }
+
     /// Regression test for issue #93: ANDS/CSET/CSETM/ROR used to share
     /// slot 23 via a 4-way sub-multiplexer, giving each ~1/120 vs ~1/30
     /// for the rest of the old 30-slot table. Each should now hold its
     /// own top-level slot so the sampler is roughly uniform across the
-    /// new 33-slot table (~1/33). With N = 30_000 ChaCha8-seeded draws
-    /// each is expected near 909 hits; the old sub-mux would give ~250.
-    /// The 600 threshold sits ~10σ below the new expected and ~22σ above
-    /// the old.
+    /// current 48-slot table (~1/48). With N = 48_000 ChaCha8-seeded draws
+    /// each is expected near 1000 hits; the old sub-mux would give ~400.
+    /// The 750 threshold sits several sigma below the current expected and well
+    /// above the old nested rate.
     #[test]
     fn slot_23_sub_multiplexer_removed_for_issue_93() {
         use std::collections::HashMap;
@@ -2681,7 +2834,7 @@ mod tests {
         let imms = vec![0, 1, 2, 16, 32];
         let mut rng = ChaCha8Rng::seed_from_u64(0x9300);
         let mut counts: HashMap<u8, u32> = HashMap::new();
-        const N: u32 = 30_000;
+        const N: u32 = 48_000;
         for _ in 0..N {
             let id = generator
                 .generate_random(&mut rng, &regs, &imms)
@@ -2712,8 +2865,8 @@ mod tests {
             let id = instr.opcode_id();
             let count = counts.get(&id).copied().unwrap_or(0);
             assert!(
-                count >= 600,
-                "expected >= 600 samples for {} (id {}) in {} draws, got {}",
+                count >= 750,
+                "expected >= 750 samples for {} (id {}) in {} draws, got {}",
                 instr,
                 id,
                 N,

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -684,9 +684,9 @@ pub fn generate_random_instruction<R: rand::RngExt>(
     let pick_reg = |rng: &mut R| registers[rng.random_range(0..registers.len())];
 
     // See also `src/isa/aarch64.rs::AArch64InstructionGenerator::generate_random`:
-    // this is a parallel 38-slot sampler, but its slot numbers differ
+    // this is a parallel 48-slot sampler, but its slot numbers differ
     // (notably, ROR is slot 37 there and slot 23 here).
-    match rng.random_range(0..38) {
+    match rng.random_range(0..48) {
         0 => {
             let imm = if immediates.is_empty() {
                 0
@@ -872,135 +872,18 @@ pub fn generate_random_instruction<R: rand::RngExt>(
             rd,
             rn: pick_reg(rng),
         },
-        // CCMP / CCMN: conditional compare. The dispatch picks Ccmp or Ccmn
-        // uniformly; the rm operand is sampled via random_operand and then
-        // clamped/coerced to a valid 5-bit immediate if it lands on the
-        // immediate side. nzcv is a 4-bit literal; cond from NORMAL_CONDITIONS.
-        32 => {
-            // CCMP/CCMN forbid SP in `rn` and in the register form of `rm`
-            // (encoded in the Xn slot, not XSP). `generate_all_instructions`
-            // filters SP at enumeration time; mirror that here so the
-            // mutator does not bleed avoidable is_encodable_aarch64
-            // rejections. Build a filtered pool up front so pathological
-            // SP-only inputs fall back finitely instead of retrying forever.
-            let non_sp: Vec<Register> = registers
-                .iter()
-                .copied()
-                .filter(|r| *r != Register::SP)
-                .collect();
-            if non_sp.is_empty() {
-                return Instruction::Mneg {
-                    rd,
-                    rn: pick_reg(rng),
-                    rm: pick_reg(rng),
-                };
-            }
-            let pick_non_sp = |rng: &mut R| non_sp[rng.random_range(0..non_sp.len())];
-            let rn = pick_non_sp(rng);
-            let rm = match random_operand(rng, registers, immediates) {
-                Operand::Register(Register::SP) => Operand::Register(pick_non_sp(rng)),
-                Operand::Register(r) => Operand::Register(r),
-                Operand::Immediate(v) => Operand::Immediate(v.rem_euclid(32)),
-                // random_operand only returns Register/Immediate, but the
-                // compiler can't prove that — drop ShiftedRegister/Extended-
-                // Register to a plain register (CCMP rejects both forms).
-                Operand::ShiftedRegister { reg, .. } | Operand::ExtendedRegister { reg, .. }
-                    if reg != Register::SP =>
-                {
-                    Operand::Register(reg)
-                }
-                Operand::ShiftedRegister { .. } | Operand::ExtendedRegister { .. } => {
-                    Operand::Register(pick_non_sp(rng))
-                }
-            };
-            let nzcv = (rng.random::<u32>() & 0x0F) as u8;
-            let cond = crate::ir::types::Condition::random_normal(rng);
-            if rng.random_bool(0.5) {
-                Instruction::Ccmp { rn, rm, nzcv, cond }
-            } else {
-                Instruction::Ccmn { rn, rm, nzcv, cond }
-            }
-        }
+        // CCMP: conditional compare. CCMP/CCMN forbid SP in `rn` and in
+        // the register form of `rm`; the helper mirrors the enumeration filter
+        // and falls back finitely on SP-only pools.
+        32 => random_cond_compare_instruction(rng, registers, immediates, rd, false),
         // Bit-field manipulation (UBFX/SBFX/BFI/BFXIL/UBFIZ/SBFIZ).
         // SP rejected in rd and rn (matches `generate_all_instructions` and
         // `is_encodable_aarch64`); 2D constraint on (lsb, width) enforced by
         // sampling width AFTER lsb so width is bounded by `64-lsb`.
-        33 => {
-            let non_sp: Vec<Register> = registers
-                .iter()
-                .copied()
-                .filter(|r| *r != Register::SP)
-                .collect();
-            if non_sp.is_empty() {
-                return Instruction::Mneg {
-                    rd,
-                    rn: pick_reg(rng),
-                    rm: pick_reg(rng),
-                };
-            }
-            let pick_non_sp = |rng: &mut R| non_sp[rng.random_range(0..non_sp.len())];
-            let rd_local = pick_non_sp(rng);
-            let rn = pick_non_sp(rng);
-            let lsb = (rng.random::<u32>() & 0x3F) as u8;
-            let max_w = 64 - lsb as u32;
-            let width = ((rng.random::<u32>() % max_w) + 1) as u8;
-            match rng.random_range(0..6) {
-                0 => Instruction::Ubfx {
-                    rd: rd_local,
-                    rn,
-                    lsb,
-                    width,
-                },
-                1 => Instruction::Sbfx {
-                    rd: rd_local,
-                    rn,
-                    lsb,
-                    width,
-                },
-                2 => Instruction::Bfi {
-                    rd: rd_local,
-                    rn,
-                    lsb,
-                    width,
-                },
-                3 => Instruction::Bfxil {
-                    rd: rd_local,
-                    rn,
-                    lsb,
-                    width,
-                },
-                4 => Instruction::Ubfiz {
-                    rd: rd_local,
-                    rn,
-                    lsb,
-                    width,
-                },
-                _ => Instruction::Sbfiz {
-                    rd: rd_local,
-                    rn,
-                    lsb,
-                    width,
-                },
-            }
-        }
-        // Multiply-accumulate family: MADD/MSUB (4-operand) and MNEG/SMULH/UMULH (3-operand).
-        34 => {
-            let rn = pick_reg(rng);
-            let rm = pick_reg(rng);
-            match rng.random_range(0..5) {
-                0 => {
-                    let ra = pick_reg(rng);
-                    Instruction::Madd { rd, rn, rm, ra }
-                }
-                1 => {
-                    let ra = pick_reg(rng);
-                    Instruction::Msub { rd, rn, rm, ra }
-                }
-                2 => Instruction::Mneg { rd, rn, rm },
-                3 => Instruction::Smulh { rd, rn, rm },
-                _ => Instruction::Umulh { rd, rn, rm },
-            }
-        }
+        33 => random_bitfield_instruction(rng, registers, rd, 0),
+        // MADD representative slot; the rest of the multiply-accumulate
+        // variants are appended as top-level slots below.
+        34 => random_madd_like_instruction(rng, registers, rd, 0),
         // Issue #66 multiply / divide: MUL/SDIV/UDIV. All register-only.
         35 => {
             let rn = pick_reg(rng);
@@ -1030,6 +913,143 @@ pub fn generate_random_instruction<R: rand::RngExt>(
                 _ => Instruction::Csneg { rd, rn, rm, cond },
             }
         }
+        38 => random_cond_compare_instruction(rng, registers, immediates, rd, true),
+        39 => random_bitfield_instruction(rng, registers, rd, 1),
+        40 => random_bitfield_instruction(rng, registers, rd, 2),
+        41 => random_bitfield_instruction(rng, registers, rd, 3),
+        42 => random_bitfield_instruction(rng, registers, rd, 4),
+        43 => random_bitfield_instruction(rng, registers, rd, 5),
+        44 => random_madd_like_instruction(rng, registers, rd, 1),
+        45 => random_madd_like_instruction(rng, registers, rd, 2),
+        46 => random_madd_like_instruction(rng, registers, rd, 3),
+        47 => random_madd_like_instruction(rng, registers, rd, 4),
+        _ => unreachable!(),
+    }
+}
+
+fn random_cond_compare_instruction<R: rand::RngExt>(
+    rng: &mut R,
+    registers: &[Register],
+    immediates: &[i64],
+    rd: Register,
+    negative: bool,
+) -> Instruction {
+    let non_sp = non_sp_registers(registers);
+    if non_sp.is_empty() {
+        return Instruction::Mneg {
+            rd,
+            rn: pick_register(rng, registers),
+            rm: pick_register(rng, registers),
+        };
+    }
+    let pick_non_sp = |rng: &mut R| non_sp[rng.random_range(0..non_sp.len())];
+    let rn = pick_non_sp(rng);
+    let rm = match random_operand(rng, registers, immediates) {
+        Operand::Register(Register::SP) => Operand::Register(pick_non_sp(rng)),
+        Operand::Register(r) => Operand::Register(r),
+        Operand::Immediate(v) => Operand::Immediate(v.rem_euclid(32)),
+        // random_operand only returns Register/Immediate, but the compiler can't
+        // prove that. Drop shifted/extended forms to a plain register; CCMP and
+        // CCMN reject both forms.
+        Operand::ShiftedRegister { reg, .. } | Operand::ExtendedRegister { reg, .. }
+            if reg != Register::SP =>
+        {
+            Operand::Register(reg)
+        }
+        Operand::ShiftedRegister { .. } | Operand::ExtendedRegister { .. } => {
+            Operand::Register(pick_non_sp(rng))
+        }
+    };
+    let nzcv = (rng.random::<u32>() & 0x0F) as u8;
+    let cond = crate::ir::types::Condition::random_normal(rng);
+    if negative {
+        Instruction::Ccmn { rn, rm, nzcv, cond }
+    } else {
+        Instruction::Ccmp { rn, rm, nzcv, cond }
+    }
+}
+
+fn random_bitfield_instruction<R: rand::RngExt>(
+    rng: &mut R,
+    registers: &[Register],
+    rd: Register,
+    variant: u8,
+) -> Instruction {
+    let non_sp = non_sp_registers(registers);
+    if non_sp.is_empty() {
+        return Instruction::Mneg {
+            rd,
+            rn: pick_register(rng, registers),
+            rm: pick_register(rng, registers),
+        };
+    }
+    let pick_non_sp = |rng: &mut R| non_sp[rng.random_range(0..non_sp.len())];
+    let rd_local = pick_non_sp(rng);
+    let rn = pick_non_sp(rng);
+    let lsb = (rng.random::<u32>() & 0x3F) as u8;
+    let max_w = 64 - lsb as u32;
+    let width = ((rng.random::<u32>() % max_w) + 1) as u8;
+    match variant {
+        0 => Instruction::Ubfx {
+            rd: rd_local,
+            rn,
+            lsb,
+            width,
+        },
+        1 => Instruction::Sbfx {
+            rd: rd_local,
+            rn,
+            lsb,
+            width,
+        },
+        2 => Instruction::Bfi {
+            rd: rd_local,
+            rn,
+            lsb,
+            width,
+        },
+        3 => Instruction::Bfxil {
+            rd: rd_local,
+            rn,
+            lsb,
+            width,
+        },
+        4 => Instruction::Ubfiz {
+            rd: rd_local,
+            rn,
+            lsb,
+            width,
+        },
+        5 => Instruction::Sbfiz {
+            rd: rd_local,
+            rn,
+            lsb,
+            width,
+        },
+        _ => unreachable!(),
+    }
+}
+
+fn random_madd_like_instruction<R: rand::RngExt>(
+    rng: &mut R,
+    registers: &[Register],
+    rd: Register,
+    variant: u8,
+) -> Instruction {
+    let rn = pick_register(rng, registers);
+    let rm = pick_register(rng, registers);
+    match variant {
+        0 => {
+            let ra = pick_register(rng, registers);
+            Instruction::Madd { rd, rn, rm, ra }
+        }
+        1 => {
+            let ra = pick_register(rng, registers);
+            Instruction::Msub { rd, rn, rm, ra }
+        }
+        2 => Instruction::Mneg { rd, rn, rm },
+        3 => Instruction::Smulh { rd, rn, rm },
+        4 => Instruction::Umulh { rd, rn, rm },
         _ => unreachable!(),
     }
 }
@@ -1370,16 +1390,17 @@ mod tests {
     // Primes a `BudgetedRng` to steer `generate_random_instruction` down a
     // chosen opcode arm: the first draw is the `rd` index (`random_range(0..2)`
     // for these 2-register pools), the second is the opcode slot
-    // (`random_range(0..38)`). Slot 32 = CCMP/CCMN arm, slot 33 = bit-field arm
-    // — keep these in sync with the match in `generate_random_instruction`.
+    // (`random_range(0..48)`). Slots 32/38 = CCMP/CCMN, and slots
+    // 33/39..=43 = bit-field aliases — keep these in sync with the match in
+    // `generate_random_instruction`.
     fn rng_for_opcode_slot(slot: u32, rd_index: u32) -> BudgetedRng {
-        BudgetedRng::new(vec![word_for_range(2, rd_index), word_for_range(38, slot)])
+        BudgetedRng::new(vec![word_for_range(2, rd_index), word_for_range(48, slot)])
     }
 
     fn rng_for_compare_slot(family: u32, shape: u32, tail: Vec<u32>) -> BudgetedRng {
         let mut words = vec![
             word_for_range(2, 0),
-            word_for_range(38, 36),
+            word_for_range(48, 36),
             word_for_range(3, family),
             word_for_range(3, shape),
         ];
@@ -1828,64 +1849,146 @@ mod tests {
     }
 
     #[test]
-    fn generate_random_instruction_samples_bitfield_and_madd_families_evenly() {
+    fn generate_random_instruction_promotes_semantic_family_variants_to_top_level_slots() {
         use rand::SeedableRng;
         use rand_chacha::ChaCha8Rng;
+        use std::collections::HashMap;
 
         let regs = default_registers();
         let imms = default_immediates();
-        let mut rng = ChaCha8Rng::seed_from_u64(0x153);
-        let mut bitfield_count = 0u32;
-        let mut madd_count = 0u32;
-
-        // Both families occupy exactly one top-level slot in the
-        // `rng.random_range(0..SLOTS)` dispatch, so "equal sampling weight" means
-        // equal probability of *entering* the slot (~1/SLOTS), not equal per-variant
-        // weight: slot 33 makes a secondary 0..6 draw (plus SP-rejection retries) and
-        // slot 34 a 0..5 draw. DRAWS is sized so each family is expected EXPECTED_PER_FAMILY times.
-        const SLOTS: u32 = 38;
-        const EXPECTED_PER_FAMILY: u32 = 2_000;
-        const DRAWS: u32 = SLOTS * EXPECTED_PER_FAMILY;
+        let mut rng = ChaCha8Rng::seed_from_u64(0x257);
+        let mut counts: HashMap<u8, u32> = HashMap::new();
+        const EXPECTED_PER_TOP_LEVEL_SLOT: u32 = 2_000;
+        const RANDOM_SLOT_COUNT: u32 = 48;
+        const DRAWS: u32 = RANDOM_SLOT_COUNT * EXPECTED_PER_TOP_LEVEL_SLOT;
+        const MIN_TOP_LEVEL_SAMPLES: u32 = 1_500;
 
         for _ in 0..DRAWS {
-            let instr = generate_random_instruction(&mut rng, &regs, &imms);
-            match instr {
-                Instruction::Ubfx { .. }
-                | Instruction::Sbfx { .. }
-                | Instruction::Bfi { .. }
-                | Instruction::Bfxil { .. }
-                | Instruction::Ubfiz { .. }
-                | Instruction::Sbfiz { .. } => bitfield_count += 1,
-                Instruction::Madd { .. }
-                | Instruction::Msub { .. }
-                | Instruction::Mneg { .. }
-                | Instruction::Smulh { .. }
-                | Instruction::Umulh { .. } => madd_count += 1,
-                _ => {}
-            }
+            let id = generate_random_instruction(&mut rng, &regs, &imms).opcode_id();
+            *counts.entry(id).or_default() += 1;
         }
 
-        // Each count is ~Binomial(DRAWS, 1/SLOTS); the std-dev of their difference is
-        // sqrt(2 * DRAWS * (1/38) * (37/38)) ≈ 63, so a tolerance of 250 is ≈ 4σ
-        // (p_fail ≈ 1e-5) — tight enough to catch a slot-weight regression, loose
-        // enough not to flake.
-        let delta = bitfield_count.abs_diff(madd_count);
-        assert!(
-            delta <= 250,
-            "bit-field and multiply-accumulate should have equal top-level sampling weight \
-             over {DRAWS} draws, got bitfield={bitfield_count}, madd={madd_count}, delta={delta}",
-        );
-
-        // Delta alone would still pass if both families collapsed to the same wrong
-        // rate (e.g. ~500 each), so bound each absolute count near the expected value
-        // to also catch a degenerate dispatch.
-        for (name, count) in [
-            ("bit-field", bitfield_count),
-            ("multiply-accumulate", madd_count),
+        for (label, instr) in [
+            (
+                "Madd",
+                Instruction::Madd {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Register::X2,
+                    ra: Register::X0,
+                },
+            ),
+            (
+                "Msub",
+                Instruction::Msub {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Register::X2,
+                    ra: Register::X0,
+                },
+            ),
+            (
+                "Mneg",
+                Instruction::Mneg {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Register::X2,
+                },
+            ),
+            (
+                "Smulh",
+                Instruction::Smulh {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Register::X2,
+                },
+            ),
+            (
+                "Umulh",
+                Instruction::Umulh {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Register::X2,
+                },
+            ),
+            (
+                "Ccmp",
+                Instruction::Ccmp {
+                    rn: Register::X0,
+                    rm: Operand::Register(Register::X1),
+                    nzcv: 0,
+                    cond: crate::ir::types::Condition::EQ,
+                },
+            ),
+            (
+                "Ccmn",
+                Instruction::Ccmn {
+                    rn: Register::X0,
+                    rm: Operand::Register(Register::X1),
+                    nzcv: 0,
+                    cond: crate::ir::types::Condition::EQ,
+                },
+            ),
+            (
+                "Ubfx",
+                Instruction::Ubfx {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    lsb: 0,
+                    width: 1,
+                },
+            ),
+            (
+                "Sbfx",
+                Instruction::Sbfx {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    lsb: 0,
+                    width: 1,
+                },
+            ),
+            (
+                "Bfi",
+                Instruction::Bfi {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    lsb: 0,
+                    width: 1,
+                },
+            ),
+            (
+                "Bfxil",
+                Instruction::Bfxil {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    lsb: 0,
+                    width: 1,
+                },
+            ),
+            (
+                "Ubfiz",
+                Instruction::Ubfiz {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    lsb: 0,
+                    width: 1,
+                },
+            ),
+            (
+                "Sbfiz",
+                Instruction::Sbfiz {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    lsb: 0,
+                    width: 1,
+                },
+            ),
         ] {
+            let id = instr.opcode_id();
+            let count = counts.get(&id).copied().unwrap_or(0);
             assert!(
-                (1_500..=2_500).contains(&count),
-                "{name} family count {count} is far from the expected {EXPECTED_PER_FAMILY} over {DRAWS} draws",
+                count >= MIN_TOP_LEVEL_SAMPLES,
+                "expected >= {MIN_TOP_LEVEL_SAMPLES} samples for {label} (id {id}) in {DRAWS} draws, got {count}",
             );
         }
     }
@@ -2260,7 +2363,7 @@ mod tests {
         let regs = [Register::SP];
         let imms = default_immediates();
 
-        for slot in [32, 33] {
+        for slot in [32, 38, 33, 39, 43] {
             let mut rng = rng_for_opcode_slot(slot, 0);
             let instr = generate_random_instruction(&mut rng, &regs, &imms);
             assert!(
@@ -2282,38 +2385,50 @@ mod tests {
         let regs = [Register::SP, Register::X0];
         let imms = default_immediates();
 
-        let mut ccmp_rng = rng_for_opcode_slot(32, 0);
-        let ccmp = generate_random_instruction(&mut ccmp_rng, &regs, &imms);
-        match ccmp {
-            Instruction::Ccmp {
-                rn,
-                rm: Operand::Register(rm),
-                ..
+        for (slot, want_ccmn) in [(32, false), (38, true)] {
+            let mut rng = rng_for_opcode_slot(slot, 0);
+            let instr = generate_random_instruction(&mut rng, &regs, &imms);
+            match (instr, want_ccmn) {
+                (
+                    Instruction::Ccmp {
+                        rn,
+                        rm: Operand::Register(rm),
+                        ..
+                    },
+                    false,
+                )
+                | (
+                    Instruction::Ccmn {
+                        rn,
+                        rm: Operand::Register(rm),
+                        ..
+                    },
+                    true,
+                ) => {
+                    assert_eq!(rn, Register::X0);
+                    assert_eq!(rm, Register::X0);
+                }
+                (other, _) => {
+                    panic!("expected slot {slot} to emit filtered CCMP/CCMN, got {other:?}")
+                }
             }
-            | Instruction::Ccmn {
-                rn,
-                rm: Operand::Register(rm),
-                ..
-            } => {
-                assert_eq!(rn, Register::X0);
-                assert_eq!(rm, Register::X0);
-            }
-            other => panic!("expected register-form CCMP/CCMN, got {other:?}"),
         }
 
-        let mut bitfield_rng = rng_for_opcode_slot(33, 0);
-        let bitfield = generate_random_instruction(&mut bitfield_rng, &regs, &imms);
-        match bitfield {
-            Instruction::Ubfx { rd, rn, .. }
-            | Instruction::Sbfx { rd, rn, .. }
-            | Instruction::Bfi { rd, rn, .. }
-            | Instruction::Bfxil { rd, rn, .. }
-            | Instruction::Ubfiz { rd, rn, .. }
-            | Instruction::Sbfiz { rd, rn, .. } => {
-                assert_eq!(rd, Register::X0);
-                assert_eq!(rn, Register::X0);
+        for slot in [33, 39, 43] {
+            let mut rng = rng_for_opcode_slot(slot, 0);
+            let bitfield = generate_random_instruction(&mut rng, &regs, &imms);
+            match bitfield {
+                Instruction::Ubfx { rd, rn, .. }
+                | Instruction::Sbfx { rd, rn, .. }
+                | Instruction::Bfi { rd, rn, .. }
+                | Instruction::Bfxil { rd, rn, .. }
+                | Instruction::Ubfiz { rd, rn, .. }
+                | Instruction::Sbfiz { rd, rn, .. } => {
+                    assert_eq!(rd, Register::X0);
+                    assert_eq!(rn, Register::X0);
+                }
+                other => panic!("expected slot {slot} to emit filtered bit-field, got {other:?}"),
             }
-            other => panic!("expected bit-field instruction, got {other:?}"),
         }
     }
 

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- Promote AArch64 generate_random MADD/MSUB/MNEG/SMULH/UMULH, CCMP/CCMN, and bit-field aliases to top-level random slots in both samplers.
- Add deterministic fairness regressions and update slot-steering tests/comments for the 48-slot sampler.
- Remove current clippy needless-borrow warnings in SMT bitvector code so the required clippy gate passes.

Validation:
- cargo fmt --all -- --check
- ./build_tests.sh
- cargo test --all
- cargo clippy --all -- -D warnings
- ./ci_check.sh

Closes #257

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**