### PR TITLE
test(x86): pin enumerative duplicate-rbx pool

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3176,21 +3176,33 @@ mod cli_helper_tests {
         opts.timeout = Some(Duration::from_secs(5));
         opts.solver_timeout = Duration::from_secs(5);
         opts.cost_metric = CostMetric::CodeSize;
-        let optimized = run_x86_enumerative(
-            &[
-                X86Instruction::MovImm {
-                    rd: X86Register::RBX,
-                    imm: 1,
-                },
-                X86Instruction::MovImm {
-                    rd: X86Register::RBX,
-                    imm: 1,
-                },
-            ],
-            64,
-            &opts,
-        )
-        .expect("two identical RBX writes can be shortened");
+        let target = vec![
+            X86Instruction::MovImm {
+                rd: X86Register::RBX,
+                imm: 1,
+            },
+            X86Instruction::MovImm {
+                rd: X86Register::RBX,
+                imm: 1,
+            },
+        ];
+        let config = build_x86_enumerative_search_config(&target, 64, &opts);
+        assert_eq!(config.x86_available_registers, vec![X86Register::RBX]);
+        assert!(
+            !config.x86_available_registers.contains(&X86Register::RAX),
+            "RAX must not be injected into the duplicate-RBX search pool"
+        );
+        assert!(
+            !config.x86_available_registers.contains(&X86Register::RDI),
+            "RDI must not be injected into the duplicate-RBX search pool"
+        );
+        assert!(
+            config.available_immediates.contains(&1),
+            "immediate pool must preserve the fixture immediate"
+        );
+
+        let optimized = run_x86_enumerative(&target, 64, &opts)
+            .expect("two identical RBX writes can be shortened");
         assert_eq!(optimized.len(), 1);
         match optimized[0] {
             X86Instruction::MovImm { rd, imm } => {

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary
- Strengthen the duplicate-RBX x86 enumerative regression to assert the exact target-derived register pool and immediate fixture.
- Keep the result-level one-instruction optimization assertion on the same target.
- Remove existing needless SMT bitvector borrows so the required clippy gate passes on this toolchain.

Verification
- cargo test x86_enumerative_collapses_without_rax_or_rdi_in_target --bin s11
- temporary RAX/RDI pool-inflation mutation failed on the new exact-pool assertion, then was reverted
- cargo test build_x86_enumerative_search_config_is_target_derived_and_honors_cores --bin s11
- cargo fmt --all
- cargo clippy --all -- -D warnings
- ./ci_check.sh
- cargo test --all

Note
- scripts/full_test.sh is not present in this s11 repo; ./ci_check.sh ran the repo's ./test_all.sh.

Closes #261

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**