### PR TITLE
test(aarch64): document slot 23 threshold baseline

### DIFF
--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -2669,10 +2669,10 @@ mod tests {
     /// slot 23 via a 4-way sub-multiplexer, giving each ~1/120 vs ~1/30
     /// for the rest of the old 30-slot table. Each should now hold its
     /// own top-level slot so the sampler is roughly uniform across the
-    /// new 33-slot table (~1/33). With N = 30_000 ChaCha8-seeded draws
-    /// each is expected near 909 hits; the old sub-mux would give ~250.
-    /// The 600 threshold sits ~10σ below the new expected and ~22σ above
-    /// the old.
+    /// current 38-slot table (~1/38). With N = 30_000 ChaCha8-seeded draws
+    /// each is expected near 789 hits; the old sub-mux would give ~250,
+    /// with the old branch measuring about 241 ANDS hits for this seed.
+    /// MIN_EXPECTED sits ~6.8σ below the new expected and ~22σ above the old.
     #[test]
     fn slot_23_sub_multiplexer_removed_for_issue_93() {
         use std::collections::HashMap;
@@ -2682,6 +2682,7 @@ mod tests {
         let mut rng = ChaCha8Rng::seed_from_u64(0x9300);
         let mut counts: HashMap<u8, u32> = HashMap::new();
         const N: u32 = 30_000;
+        const MIN_EXPECTED: u32 = 600;
         for _ in 0..N {
             let id = generator
                 .generate_random(&mut rng, &regs, &imms)
@@ -2712,8 +2713,9 @@ mod tests {
             let id = instr.opcode_id();
             let count = counts.get(&id).copied().unwrap_or(0);
             assert!(
-                count >= 600,
-                "expected >= 600 samples for {} (id {}) in {} draws, got {}",
+                count >= MIN_EXPECTED,
+                "expected >= {} samples for {} (id {}) in {} draws, got {}",
+                MIN_EXPECTED,
                 instr,
                 id,
                 N,

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- Promoted the slot-23 regression threshold to `MIN_EXPECTED`.
- Refreshed the test rationale for the current 38-slot sampler and added the old measured ANDS baseline (~241/30,000 for the same seed).
- Removed unrelated needless-borrow clippy warnings in SMT code so the requested local clippy gate passes on this toolchain.

Validation:
- `cargo test --lib slot_23_sub_multiplexer_removed_for_issue_93`
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `./build_tests.sh`
- `cargo test --all`
- `./ci_check.sh`

Note: the inherited run contract mentioned `scripts/full_test.sh`, but this repository has no such script. The repo-local `./ci_check.sh` ran the available `test_all.sh` gate successfully.

Closes #264

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**