### PR TITLE
refactor(aarch64): drop zero from random shift pools

### DIFF
--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -13,6 +13,10 @@ use std::fmt;
 /// out of sync across the codebase.
 pub const MOVW_LEGAL_SHIFTS: [u8; 4] = [0, 16, 32, 48];
 
+/// Representative nonzero immediate shifts sampled by AArch64 random and
+/// mutation helpers for LSL/LSR/ASR/ROR.
+pub(crate) const AARCH64_RANDOM_SHIFT_IMMEDIATES: [i64; 6] = [1, 2, 4, 8, 16, 32];
+
 pub(crate) fn logical_imm32_value(imm: i64) -> Option<u32> {
     if imm >= 0 {
         u32::try_from(imm).ok()

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -4,7 +4,7 @@
 
 #![allow(dead_code)]
 
-use crate::ir::instructions::MOVW_LEGAL_SHIFTS;
+use crate::ir::instructions::{AARCH64_RANDOM_SHIFT_IMMEDIATES, MOVW_LEGAL_SHIFTS};
 use crate::ir::types::Condition;
 use crate::ir::{Instruction, Operand, Register, RegisterWidth};
 use crate::isa::traits::{ISA, InstructionGenerator, InstructionType, OperandType, RegisterType};
@@ -778,7 +778,7 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
             7..=9 => {
                 let use_imm = rng.random_bool(0.5);
                 let shift = if use_imm {
-                    let amounts = [0i64, 1, 2, 4, 8, 16, 32];
+                    let amounts = AARCH64_RANDOM_SHIFT_IMMEDIATES;
                     Operand::Immediate(amounts[rng.random_range(0..amounts.len())])
                 } else {
                     Operand::Register(pick_reg(rng))
@@ -1043,7 +1043,7 @@ impl InstructionGenerator<Instruction> for AArch64InstructionGenerator {
             },
             37 => {
                 let shift = if rng.random_bool(0.5) {
-                    let amounts = [0i64, 1, 2, 4, 8, 16, 32];
+                    let amounts = AARCH64_RANDOM_SHIFT_IMMEDIATES;
                     Operand::Immediate(amounts[rng.random_range(0..amounts.len())])
                 } else {
                     Operand::Register(pick_reg(rng))
@@ -1803,7 +1803,7 @@ fn mutate_shift_operand<R: RngExt>(
     operand: Operand,
     registers: &[Register],
 ) -> Operand {
-    let shift_amounts: [i64; 7] = [0, 1, 2, 4, 8, 16, 32];
+    let shift_amounts = AARCH64_RANDOM_SHIFT_IMMEDIATES;
     match operand {
         Operand::Register(_)
         | Operand::ShiftedRegister { .. }
@@ -2567,6 +2567,45 @@ mod tests {
         }
     }
 
+    #[test]
+    fn random_shift_immediates_never_sample_zero() {
+        let generator = AArch64InstructionGenerator;
+        let regs = vec![Register::X0, Register::X1, Register::X2];
+        let imms = vec![0, 1, 2, 16, 32];
+        let mut rng = ChaCha8Rng::seed_from_u64(0x263);
+        let mut seen = BTreeSet::new();
+
+        for _ in 0..50_000 {
+            let instr = generator.generate_random(&mut rng, &regs, &imms);
+            let sampled = match instr {
+                Instruction::Lsl {
+                    shift: Operand::Immediate(amount),
+                    ..
+                } => Some(("lsl", amount)),
+                Instruction::Lsr {
+                    shift: Operand::Immediate(amount),
+                    ..
+                } => Some(("lsr", amount)),
+                Instruction::Asr {
+                    shift: Operand::Immediate(amount),
+                    ..
+                } => Some(("asr", amount)),
+                Instruction::Ror {
+                    shift: Operand::Immediate(amount),
+                    ..
+                } => Some(("ror", amount)),
+                _ => None,
+            };
+
+            if let Some((mnemonic, amount)) = sampled {
+                assert_ne!(amount, 0, "random {mnemonic} sampled immediate shift #0");
+                seen.insert(mnemonic);
+            }
+        }
+
+        assert_eq!(seen, BTreeSet::from(["asr", "lsl", "lsr", "ror"]));
+    }
+
     /// Termination guard for the CCMP/CCMN random-generator arm:
     /// before the slot-28 rewrite this test would have hung in release
     /// builds because `pick_non_sp` retried forever on a `[SP]`-only
@@ -2718,6 +2757,32 @@ mod tests {
                 id,
                 N,
                 count,
+            );
+        }
+    }
+
+    #[test]
+    fn mutate_shift_operand_never_samples_zero_immediate() {
+        let regs = vec![Register::X0, Register::X1, Register::X2];
+
+        for (seed, operand) in [
+            (0x2630, Operand::Immediate(1)),
+            (0x2631, Operand::Register(Register::X1)),
+        ] {
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            let mut saw_immediate = false;
+
+            for _ in 0..2_000 {
+                let mutated = super::mutate_shift_operand(&mut rng, operand, &regs);
+                if let Operand::Immediate(amount) = mutated {
+                    assert_ne!(amount, 0, "mutate_shift_operand sampled shift #0");
+                    saw_immediate = true;
+                }
+            }
+
+            assert!(
+                saw_immediate,
+                "mutate_shift_operand never returned an immediate"
             );
         }
     }

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -1,6 +1,6 @@
 //! Instruction generation utilities for search algorithms
 
-use crate::ir::instructions::MOVW_LEGAL_SHIFTS;
+use crate::ir::instructions::{AARCH64_RANDOM_SHIFT_IMMEDIATES, MOVW_LEGAL_SHIFTS};
 use crate::ir::{Instruction, Operand, Register, RegisterWidth, ShiftKind};
 use crate::isa::{AArch64, Assembler, InstructionType};
 
@@ -1196,7 +1196,7 @@ fn random_operand<R: rand::RngExt>(
 fn random_shift_operand<R: rand::RngExt>(rng: &mut R, registers: &[Register]) -> Operand {
     if rng.random_bool(0.7) {
         // Prefer immediate shifts
-        let shifts = [0, 1, 2, 4, 8, 16, 32];
+        let shifts = AARCH64_RANDOM_SHIFT_IMMEDIATES;
         Operand::Immediate(shifts[rng.random_range(0..shifts.len())])
     } else if !registers.is_empty() {
         Operand::Register(registers[rng.random_range(0..registers.len())])
@@ -2253,6 +2253,50 @@ mod tests {
                 assert!(regs.contains(&dest));
             }
         }
+    }
+
+    #[test]
+    fn generate_random_instruction_never_samples_zero_shift_immediates() {
+        use rand::SeedableRng;
+        use rand_chacha::ChaCha8Rng;
+
+        let regs = default_registers();
+        let imms = default_immediates();
+        let mut rng = ChaCha8Rng::seed_from_u64(0x263);
+        let mut seen = std::collections::BTreeSet::new();
+
+        for _ in 0..50_000 {
+            let instr = generate_random_instruction(&mut rng, &regs, &imms);
+            let sampled = match instr {
+                Instruction::Lsl {
+                    shift: Operand::Immediate(amount),
+                    ..
+                } => Some(("lsl", amount)),
+                Instruction::Lsr {
+                    shift: Operand::Immediate(amount),
+                    ..
+                } => Some(("lsr", amount)),
+                Instruction::Asr {
+                    shift: Operand::Immediate(amount),
+                    ..
+                } => Some(("asr", amount)),
+                Instruction::Ror {
+                    shift: Operand::Immediate(amount),
+                    ..
+                } => Some(("ror", amount)),
+                _ => None,
+            };
+
+            if let Some((mnemonic, amount)) = sampled {
+                assert_ne!(amount, 0, "random {mnemonic} sampled immediate shift #0");
+                seen.insert(mnemonic);
+            }
+        }
+
+        assert_eq!(
+            seen,
+            std::collections::BTreeSet::from(["asr", "lsl", "lsr", "ror"])
+        );
     }
 
     #[test]

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -14,7 +14,7 @@
 
 #![allow(dead_code)]
 
-use crate::ir::instructions::MOVW_LEGAL_SHIFTS;
+use crate::ir::instructions::{AARCH64_RANDOM_SHIFT_IMMEDIATES, MOVW_LEGAL_SHIFTS};
 use crate::ir::types::Condition;
 use crate::ir::{ExtendKind, Instruction, Operand, Register, RegisterWidth};
 use crate::search::candidate::generate_random_instruction;
@@ -1354,7 +1354,7 @@ impl Mutator {
 
     fn random_shift_operand<R: RngExt>(&self, rng: &mut R) -> Operand {
         if rng.random_bool(0.7) {
-            let shifts = [0, 1, 2, 4, 8, 16, 32];
+            let shifts = AARCH64_RANDOM_SHIFT_IMMEDIATES;
             Operand::Immediate(shifts[rng.random_range(0..shifts.len())])
         } else if !self.registers.is_empty() {
             Operand::Register(self.random_register(rng))
@@ -1576,6 +1576,26 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn random_shift_operand_never_samples_zero_immediate() {
+        let mutator = default_mutator();
+        let mut rng = ChaCha8Rng::seed_from_u64(0x263);
+        let mut saw_immediate = false;
+
+        for _ in 0..2_000 {
+            let operand = mutator.random_shift_operand(&mut rng);
+            if let Operand::Immediate(amount) = operand {
+                assert_ne!(amount, 0, "random_shift_operand sampled shift #0");
+                saw_immediate = true;
+            }
+        }
+
+        assert!(
+            saw_immediate,
+            "random_shift_operand never returned an immediate"
+        );
     }
 
     #[test]

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- Add a shared nonzero AArch64 random shift-immediate pool for LSL/LSR/ASR/ROR sampling.
- Use it from the ISA generator, parallel candidate sampler, ISA mutation helper, and stochastic mutator.
- Add deterministic regressions proving random shift immediates no longer sample #0, while leaving exhaustive enumerators unchanged.
- Include a mechanical SMT clippy cleanup needed for the local zero-warning gate.

Tests:
- cargo fmt --all -- --check
- cargo clippy --all -- -D warnings
- cargo test --all
- ./ci_check.sh

Closes #263

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**