### PR TITLE
test(cli): pin invalid live-out stderr

### DIFF
--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {

--- a/tests/integration/live_out_cli_test.rs
+++ b/tests/integration/live_out_cli_test.rs
@@ -1,0 +1,84 @@
+use std::process::{Command, Output};
+
+fn get_binary_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_s11"))
+}
+
+fn run_equiv_with_live_out(live_out: &str) -> Output {
+    let dir = tempfile::tempdir().expect("create temp dir for equiv fixtures");
+    let seq1 = dir.path().join("seq1.s");
+    let seq2 = dir.path().join("seq2.s");
+    std::fs::write(&seq1, "mov x0, x1\n").expect("write first sequence");
+    std::fs::write(&seq2, "mov x0, x1\n").expect("write second sequence");
+
+    Command::new(get_binary_path())
+        .arg("equiv")
+        .arg(&seq1)
+        .arg(&seq2)
+        .arg("--fast-only")
+        .arg("--live-out")
+        .arg(live_out)
+        .arg("--timeout")
+        .arg("5")
+        .output()
+        .expect("execute s11 equiv")
+}
+
+fn run_llm_opt_with_live_out(live_out: &str) -> Output {
+    let dir = tempfile::tempdir().expect("create temp dir for llm-opt fixture");
+    let target = dir.path().join("target.s");
+    std::fs::write(&target, "mov x0, x1\n").expect("write target sequence");
+
+    Command::new(get_binary_path())
+        .arg("llm-opt")
+        .arg("--asm")
+        .arg(&target)
+        .arg("--live-out")
+        .arg(live_out)
+        .arg("--max-calls")
+        .arg("0")
+        .arg("--timeout")
+        .arg("0")
+        .output()
+        .expect("execute s11 llm-opt")
+}
+
+#[test]
+fn equiv_invalid_live_out_reports_full_user_facing_error() {
+    let output = run_equiv_with_live_out("foo");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "s11 equiv should reject invalid live-out, status: {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        stdout,
+        stderr
+    );
+    assert_eq!("", stdout);
+    assert_eq!(
+        "Error: invalid live-out: invalid register name: 'foo'\n",
+        stderr
+    );
+}
+
+#[test]
+fn llm_opt_invalid_live_out_reports_full_user_facing_error() {
+    let output = run_llm_opt_with_live_out("foo");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "s11 llm-opt should reject invalid live-out, status: {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        stdout,
+        stderr
+    );
+    assert_eq!("", stdout);
+    assert_eq!(
+        "llm-opt: invalid live-out: invalid register name: 'foo'\n",
+        stderr
+    );
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -2,4 +2,5 @@ mod carry_chain;
 mod disasm_test;
 mod docs_capability;
 mod equiv_test;
+mod live_out_cli_test;
 mod opt_test;


### PR DESCRIPTION
Adds CLI-level integration coverage for malformed --live-out values on both s11 equiv and s11 llm-opt, asserting the full user-facing stderr strings. Also includes a mechanical SMT borrow cleanup required by the current clippy gate.

Closes #274

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**