### PR TITLE
refactor(validation): hide live-out parse error message

### DIFF
--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {

--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -9,7 +9,15 @@ use std::str::FromStr;
 /// Error type for parsing live-out register sets and live-out contracts.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ParseRegisterSetError {
-    pub message: String,
+    message: String,
+}
+
+impl ParseRegisterSetError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
 }
 
 impl std::fmt::Display for ParseRegisterSetError {
@@ -49,9 +57,10 @@ fn parse_register(s: &str) -> Result<Register, ParseRegisterSetError> {
         return Ok(reg);
     }
 
-    Err(ParseRegisterSetError {
-        message: format!("invalid register name: '{}'", s),
-    })
+    Err(ParseRegisterSetError::new(format!(
+        "invalid register name: '{}'",
+        s
+    )))
 }
 
 impl FromStr for RegisterSet<Register> {
@@ -106,7 +115,7 @@ fn misplaced_flag_token_error(token: &str, input: &str) -> ParseRegisterSetError
             token, input
         )
     };
-    ParseRegisterSetError { message }
+    ParseRegisterSetError::new(message)
 }
 
 /// Parse the CLI `--live-out` contract string.
@@ -126,18 +135,17 @@ pub fn parse_live_out_contract(s: &str) -> Result<LiveOut, ParseLiveOutError> {
     let trimmed = s.trim();
     let semicolon_count = trimmed.matches(';').count();
     if semicolon_count > 1 {
-        return Err(ParseRegisterSetError {
-            message: format!("--live-out accepts at most one ';' (got: '{}')", s),
-        });
+        return Err(ParseRegisterSetError::new(format!(
+            "--live-out accepts at most one ';' (got: '{}')",
+            s
+        )));
     }
     if semicolon_count == 0 {
         if trimmed.eq_ignore_ascii_case("nzcv") {
-            return Err(ParseRegisterSetError {
-                message: format!(
-                    "flag-only live-out requires a leading ';' (e.g. \";nzcv\"); got '{}'",
-                    s
-                ),
-            });
+            return Err(ParseRegisterSetError::new(format!(
+                "flag-only live-out requires a leading ';' (e.g. \";nzcv\"); got '{}'",
+                s
+            )));
         }
         if let Some(token) = misplaced_flag_token_in_register_list(trimmed) {
             return Err(misplaced_flag_token_error(token, s));
@@ -155,17 +163,16 @@ pub fn parse_live_out_contract(s: &str) -> Result<LiveOut, ParseLiveOutError> {
         "" => false,
         "nzcv" => true,
         "n" | "z" | "c" | "v" => {
-            return Err(ParseRegisterSetError {
-                message: format!(
-                    "per-flag token '{}' is reserved for a future extension; use 'nzcv' for all flags",
-                    flags_tok
-                ),
-            });
+            return Err(ParseRegisterSetError::new(format!(
+                "per-flag token '{}' is reserved for a future extension; use 'nzcv' for all flags",
+                flags_tok
+            )));
         }
         other => {
-            return Err(ParseRegisterSetError {
-                message: format!("unknown flag token '{}'; expected 'nzcv'", other),
-            });
+            return Err(ParseRegisterSetError::new(format!(
+                "unknown flag token '{}'; expected 'nzcv'",
+                other
+            )));
         }
     };
     Ok(regs.with_flags(flags_live))
@@ -783,11 +790,11 @@ mod tests {
     #[test]
     fn test_parse_live_out_contract_bareword_nzcv_rejected() {
         let err = parse_live_out_contract("nzcv").unwrap_err();
+        let message = err.to_string();
         assert!(
-            err.message
-                .contains("flag-only live-out requires a leading ';'"),
+            message.contains("flag-only live-out requires a leading ';'"),
             "got: {}",
-            err.message
+            message
         );
     }
 
@@ -801,23 +808,24 @@ mod tests {
             "x0,nzcv;nzcv",
         ] {
             let err = parse_live_out_contract(input).unwrap_err();
+            let message = err.to_string();
             assert!(
-                err.message.contains("'nzcv'"),
+                message.contains("'nzcv'"),
                 "expected error to name misplaced flag token in '{}', got: {}",
                 input,
-                err.message
+                message
             );
             assert!(
-                err.message.contains(";nzcv"),
+                message.contains(";nzcv"),
                 "expected error to hint at ';nzcv' syntax for '{}', got: {}",
                 input,
-                err.message
+                message
             );
             assert!(
-                !err.message.contains("invalid register name"),
+                !message.contains("invalid register name"),
                 "expected live-out grammar diagnostic for '{}', got: {}",
                 input,
-                err.message
+                message
             );
         }
     }
@@ -827,23 +835,24 @@ mod tests {
         for tok in ["n", "z", "c", "v"] {
             for input in [format!("{},x0", tok), format!("{} x0", tok)] {
                 let err = parse_live_out_contract(&input).unwrap_err();
+                let message = err.to_string();
                 assert!(
-                    err.message.contains(&format!("'{}'", tok)),
+                    message.contains(&format!("'{}'", tok)),
                     "expected error to name misplaced flag token in '{}', got: {}",
                     input,
-                    err.message
+                    message
                 );
                 assert!(
-                    err.message.contains("reserved") || err.message.contains(";nzcv"),
+                    message.contains("reserved") || message.contains(";nzcv"),
                     "expected error to hint at reserved flag syntax for '{}', got: {}",
                     input,
-                    err.message
+                    message
                 );
                 assert!(
-                    !err.message.contains("invalid register name"),
+                    !message.contains("invalid register name"),
                     "expected live-out grammar diagnostic for '{}', got: {}",
                     input,
-                    err.message
+                    message
                 );
             }
         }
@@ -867,11 +876,8 @@ mod tests {
     #[test]
     fn test_parse_live_out_contract_unknown_flag_rejected() {
         let err: ParseLiveOutError = parse_live_out_contract("x0;bogus").unwrap_err();
-        assert!(
-            err.message.contains("unknown flag token"),
-            "got: {}",
-            err.message
-        );
+        let message = err.to_string();
+        assert!(message.contains("unknown flag token"), "got: {}", message);
     }
 
     #[test]
@@ -879,17 +885,18 @@ mod tests {
         for tok in ["n", "z", "c", "v"] {
             let s = format!("x0;{}", tok);
             let err = parse_live_out_contract(&s).unwrap_err();
+            let message = err.to_string();
             assert!(
-                err.message.contains("reserved for a future extension"),
+                message.contains("reserved for a future extension"),
                 "expected '{}' to be rejected as reserved, got: {}",
                 s,
-                err.message
+                message
             );
             assert!(
-                err.message.contains(&format!("per-flag token '{}'", tok)),
+                message.contains(&format!("per-flag token '{}'", tok)),
                 "expected reserved-token error to name '{}', got: {}",
                 tok,
-                err.message
+                message
             );
         }
     }


### PR DESCRIPTION
Summary:
- Make ParseRegisterSetError.message private and route internal construction through a private constructor.
- Keep live-out parse diagnostics observable through Display-only tests.
- Remove Clippy-reported needless SMT borrows so the local warning gate stays green.

Closes #275

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**