### PR TITLE
fix(search): use symbolic default for unset solver timeout

### DIFF
--- a/src/search/config.rs
+++ b/src/search/config.rs
@@ -211,6 +211,9 @@ impl std::str::FromStr for SearchMode {
     }
 }
 
+/// Default timeout for each symbolic SMT query.
+pub const DEFAULT_SYMBOLIC_SOLVER_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Configuration for symbolic (SMT) search
 #[derive(Debug, Clone)]
 pub struct SymbolicConfig {
@@ -230,7 +233,7 @@ impl Default for SymbolicConfig {
             window_size: 3,
             cost_bound: None,
             search_mode: SearchMode::Linear,
-            solver_timeout: Some(Duration::from_secs(30)),
+            solver_timeout: Some(DEFAULT_SYMBOLIC_SOLVER_TIMEOUT),
         }
     }
 }
@@ -254,6 +257,11 @@ impl SymbolicConfig {
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
         self.solver_timeout = Some(timeout);
         self
+    }
+
+    pub fn effective_solver_timeout(&self) -> Duration {
+        self.solver_timeout
+            .unwrap_or(DEFAULT_SYMBOLIC_SOLVER_TIMEOUT)
     }
 }
 
@@ -612,6 +620,27 @@ mod tests {
         assert_eq!(config.cost_bound, Some(2));
         assert_eq!(config.search_mode, SearchMode::Binary);
         assert_eq!(config.solver_timeout, Some(Duration::from_millis(250)));
+    }
+
+    #[test]
+    fn symbolic_solver_timeout_none_uses_default_timeout() {
+        assert_eq!(
+            SymbolicConfig::default().effective_solver_timeout(),
+            Duration::from_secs(30)
+        );
+        assert_eq!(
+            SymbolicConfig::default()
+                .with_timeout(Duration::from_millis(250))
+                .effective_solver_timeout(),
+            Duration::from_millis(250)
+        );
+
+        let config = SymbolicConfig {
+            solver_timeout: None,
+            ..SymbolicConfig::default()
+        };
+
+        assert_eq!(config.effective_solver_timeout(), Duration::from_secs(30));
     }
 
     #[test]

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -402,10 +402,7 @@ where
 }
 
 fn configured_solver_timeout(config: &SearchConfig) -> Duration {
-    config
-        .symbolic
-        .solver_timeout
-        .unwrap_or(Duration::from_secs(5))
+    config.symbolic.effective_solver_timeout()
 }
 
 fn candidate_solver_timeout_for_elapsed(
@@ -1454,7 +1451,7 @@ mod tests {
                 &no_search_timeout,
                 std::time::Duration::from_secs(999)
             ),
-            Some(std::time::Duration::from_secs(5))
+            Some(std::time::Duration::from_secs(30))
         );
     }
 

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -31,7 +31,7 @@ use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use std::marker::PhantomData;
 use std::sync::atomic::Ordering;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 /// Stochastic search using MCMC-style proposals and Metropolis cost
 /// acceptance, generic over ISA.
@@ -159,10 +159,7 @@ where
         // tail, so length-change proposals only vary the prefix length.
         let min_length = 1 + terminator_len;
         let max_length = target.len();
-        let smt_timeout = config
-            .symbolic
-            .solver_timeout
-            .unwrap_or(Duration::from_secs(5));
+        let smt_timeout = config.symbolic.effective_solver_timeout();
 
         for iteration in 0..config.stochastic.iterations {
             self.statistics.iterations = iteration + 1;
@@ -339,6 +336,7 @@ mod tests {
     use crate::search::config::{StochasticConfig, SymbolicConfig};
     use crate::semantics::cost::CostMetric;
     use crate::semantics::live_out::LiveOut;
+    use std::time::Duration;
 
     fn mov_add_sequence() -> Vec<Instruction> {
         vec![
@@ -632,7 +630,7 @@ mod tests {
     }
 
     #[test]
-    fn stochastic_search_falls_back_to_five_seconds_when_solver_timeout_unset() {
+    fn stochastic_search_falls_back_to_symbolic_default_when_solver_timeout_unset() {
         let symbolic_config = SymbolicConfig {
             solver_timeout: None,
             ..SymbolicConfig::default()
@@ -640,7 +638,7 @@ mod tests {
 
         let recorded_timeout = run_timeout_probe_search(symbolic_config);
 
-        assert_eq!(recorded_timeout, Some(5000));
+        assert_eq!(recorded_timeout, Some(30000));
     }
 
     #[test]

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -17,7 +17,7 @@ use crate::search::{Algorithm, SearchAlgorithm};
 use crate::semantics::EquivalenceResult;
 use std::marker::PhantomData;
 use std::sync::atomic::Ordering;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 /// Whether the symbolic search loop should exit at the next checkpoint.
 ///
@@ -303,10 +303,7 @@ where
         live_out: &<I as SymbolicBackend<I>>::LiveOut,
         config: &SearchConfig,
     ) -> bool {
-        let timeout = config
-            .symbolic
-            .solver_timeout
-            .unwrap_or(Duration::from_secs(5));
+        let timeout = config.symbolic.effective_solver_timeout();
         let width = <I as SymbolicBackend<I>>::width(config);
 
         let (verdict, metrics) = <I as SymbolicBackend<I>>::check_equivalence(
@@ -422,6 +419,7 @@ mod tests {
     static TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK: AtomicUsize = AtomicUsize::new(0);
     static TEST_EQUIVALENCE_FAST_FAILURE: AtomicBool = AtomicBool::new(false);
     static TEST_EQUIVALENCE_SMT_CALLED: AtomicBool = AtomicBool::new(false);
+    static TEST_RECORDED_TIMEOUT_MS: AtomicU64 = AtomicU64::new(u64::MAX);
     static TEST_SEQUENCE_COST_DELAY_MS: AtomicU64 = AtomicU64::new(0);
     static TEST_STOP_FLAG: Mutex<Option<Arc<AtomicBool>>> = Mutex::new(None);
     static SYMBOLIC_INNER_LOOP_TEST_LOCK: Mutex<()> = Mutex::new(());
@@ -447,6 +445,7 @@ mod tests {
         TEST_EQUIVALENCE_EQUIVALENT_ON_CHECK.store(0, Ordering::SeqCst);
         TEST_EQUIVALENCE_FAST_FAILURE.store(false, Ordering::SeqCst);
         TEST_EQUIVALENCE_SMT_CALLED.store(false, Ordering::SeqCst);
+        TEST_RECORDED_TIMEOUT_MS.store(u64::MAX, Ordering::SeqCst);
         TEST_SEQUENCE_COST_DELAY_MS.store(0, Ordering::SeqCst);
         let mut slot = TEST_STOP_FLAG.lock().expect("test stop flag lock poisoned");
         *slot = None;
@@ -622,9 +621,10 @@ mod tests {
             _proposal: &[TestInstruction],
             _live_out: &Self::LiveOut,
             _width: u32,
-            _timeout: Duration,
+            timeout: Duration,
         ) -> (EquivalenceResult, EquivalenceMetrics) {
             let check_number = TEST_EQUIVALENCE_CHECKS.fetch_add(1, Ordering::SeqCst) + 1;
+            TEST_RECORDED_TIMEOUT_MS.store(timeout.as_millis() as u64, Ordering::SeqCst);
             if check_number == 1 {
                 let slot = TEST_STOP_FLAG.lock().expect("test stop flag lock poisoned");
                 if let Some(flag) = slot.as_ref() {
@@ -1169,6 +1169,31 @@ mod tests {
         assert_eq!(stats.smt_queries, 1);
         assert_eq!(stats.candidates_passed_fast, 1);
         assert_eq!(stats.smt_equivalent, 0);
+    }
+
+    #[test]
+    fn symbolic_verify_equivalence_uses_effective_solver_timeout() {
+        let _guard = SYMBOLIC_INNER_LOOP_TEST_LOCK
+            .lock()
+            .expect("symbolic inner-loop test lock poisoned");
+
+        let mut search: SymbolicSearch<TestIsa> = SymbolicSearch::new();
+        let target = [TestInstruction(1)];
+        let candidate = [TestInstruction(2)];
+
+        reset_symbolic_inner_loop_test_state();
+        let explicit_config = SearchConfig::default()
+            .with_symbolic(SymbolicConfig::default().with_timeout(Duration::from_millis(17)));
+        assert!(!search.verify_equivalence(&target, &candidate, &(), &explicit_config));
+        assert_eq!(TEST_RECORDED_TIMEOUT_MS.load(Ordering::SeqCst), 17);
+
+        reset_symbolic_inner_loop_test_state();
+        let defaulted_config = SearchConfig::default().with_symbolic(SymbolicConfig {
+            solver_timeout: None,
+            ..SymbolicConfig::default()
+        });
+        assert!(!search.verify_equivalence(&target, &candidate, &(), &defaulted_config));
+        assert_eq!(TEST_RECORDED_TIMEOUT_MS.load(Ordering::SeqCst), 30000);
     }
 
     #[test]

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
## Summary
- add a single DEFAULT_SYMBOLIC_SOLVER_TIMEOUT and effective_solver_timeout helper on SymbolicConfig
- route enumerative, stochastic, and symbolic SMT verification through that helper so solver_timeout: None uses 30s
- include a mechanical clippy cleanup in src/semantics/smt.rs because the local clippy gate failed on pre-existing needless BV borrows

Closes #281

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**

## Validation
- cargo fmt --all
- cargo clippy --all -- -D warnings
- ./build_tests.sh
- cargo test --all
- ./ci_check.sh
- scripts/full_test.sh was requested by the runner template but is not present in this s11 repo

## Note
Created with `gh api` REST after `gh pr create` failed because the account GraphQL rate limit was exhausted; REST core quota remained available.