### PR TITLE
fix(aarch64): sample shifted ADDS SUBS operands

### DIFF
--- a/docs/capability.md
+++ b/docs/capability.md
@@ -43,6 +43,8 @@ Rewritable straight-line mnemonics accepted by the parser and Capstone bridge:
   - Non-flag-setting `add` and `sub` support both 64-bit `X` and 32-bit `W`
     register/immediate/shifted-register forms. W extended-register arithmetic
     remains out of scope for now.
+  - X-form `adds` and `subs` support register, immediate, and non-ROR
+    shifted-register forms.
 - Logical and inverted-logical forms: `and`, `ands`, `orr`, `eor`, `bic`,
   `bics`, `orn`, `eon`
   - Logical-immediate forms for `and`, `ands`, `orr`, `eor`, and `tst`

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -1694,10 +1694,18 @@ impl AArch64Assembler {
                         dynasm!(ops ; .arch aarch64 ; adds X(rd_reg), XSP(rn_reg), imm);
                         Ok(())
                     }
-                    Operand::ShiftedRegister { .. } => {
-                        Err("ADDS shifted-register form not yet supported (issue #59 covers ADD without flags)".to_string())
+                    Operand::ShiftedRegister { reg, kind, amount } => {
+                        // Shifted-register form: all three slots are plain Xn,
+                        // so register 31 is XZR and SP is rejected.
+                        let rn_reg = register_to_dynasm(*rn)?;
+                        let rm_reg = register_to_dynasm(*reg)?;
+                        emit_shifted_reg_3op_arith!(
+                            ops, adds, rd_reg, rn_reg, rm_reg, kind, *amount
+                        )
                     }
-                    Operand::ExtendedRegister { .. } => Err("ExtendedRegister encoding not yet implemented".to_string()),
+                    Operand::ExtendedRegister { .. } => {
+                        Err("ExtendedRegister encoding not yet implemented".to_string())
+                    }
                 }
             }
             Instruction::Subs { rd, rn, rm } => {
@@ -1722,8 +1730,14 @@ impl AArch64Assembler {
                         dynasm!(ops ; .arch aarch64 ; subs X(rd_reg), XSP(rn_reg), imm);
                         Ok(())
                     }
-                    Operand::ShiftedRegister { .. } => {
-                        Err("SUBS shifted-register form not yet supported".to_string())
+                    Operand::ShiftedRegister { reg, kind, amount } => {
+                        // Shifted-register form: all three slots are plain Xn,
+                        // so register 31 is XZR and SP is rejected.
+                        let rn_reg = register_to_dynasm(*rn)?;
+                        let rm_reg = register_to_dynasm(*reg)?;
+                        emit_shifted_reg_3op_arith!(
+                            ops, subs, rd_reg, rn_reg, rm_reg, kind, *amount
+                        )
                     }
                     Operand::ExtendedRegister { .. } => {
                         Err("ExtendedRegister encoding not yet implemented".to_string())
@@ -4566,6 +4580,32 @@ mod tests {
                 vec!["x3".into(), "x4".into(), "x5".into(), "lsr #5".into()],
             ),
             (
+                Instruction::Adds {
+                    rd: Register::X21,
+                    rn: Register::X22,
+                    rm: Operand::ShiftedRegister {
+                        reg: Register::X23,
+                        kind: ShiftKind::Lsl,
+                        amount: 6,
+                    },
+                },
+                "adds",
+                vec!["x21".into(), "x22".into(), "x23".into(), "lsl #6".into()],
+            ),
+            (
+                Instruction::Subs {
+                    rd: Register::X24,
+                    rn: Register::X25,
+                    rm: Operand::ShiftedRegister {
+                        reg: Register::X26,
+                        kind: ShiftKind::Asr,
+                        amount: 9,
+                    },
+                },
+                "subs",
+                vec!["x24".into(), "x25".into(), "x26".into(), "asr #9".into()],
+            ),
+            (
                 Instruction::And {
                     rd: Register::X6,
                     rn: Register::X7,
@@ -4660,17 +4700,55 @@ mod tests {
     /// even if a caller bypasses `is_encodable_aarch64`.
     #[test]
     fn test_assemble_shifted_arith_rejects_ror() {
-        let mut assembler = AArch64Assembler::new();
-        let instr = Instruction::Add {
-            rd: Register::X0,
-            rn: Register::X1,
-            rm: Operand::ShiftedRegister {
-                reg: Register::X2,
-                kind: ShiftKind::Ror,
-                amount: 1,
+        let cases = [
+            Instruction::Add {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::ShiftedRegister {
+                    reg: Register::X2,
+                    kind: ShiftKind::Ror,
+                    amount: 1,
+                },
             },
-        };
-        assert!(assembler.assemble_instructions(&[instr], 0).is_err());
+            Instruction::Sub {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::ShiftedRegister {
+                    reg: Register::X2,
+                    kind: ShiftKind::Ror,
+                    amount: 1,
+                },
+            },
+            Instruction::Adds {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::ShiftedRegister {
+                    reg: Register::X2,
+                    kind: ShiftKind::Ror,
+                    amount: 1,
+                },
+            },
+            Instruction::Subs {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::ShiftedRegister {
+                    reg: Register::X2,
+                    kind: ShiftKind::Ror,
+                    amount: 1,
+                },
+            },
+        ];
+
+        for instr in cases {
+            let mut assembler = AArch64Assembler::new();
+            let err = assembler
+                .assemble_instructions(&[instr], 0)
+                .expect_err("ROR shifted arithmetic should fail");
+            assert!(
+                err.contains("ROR"),
+                "expected ROR-specific rejection, got: {err}"
+            );
+        }
     }
 
     // ===== Issue #69: branch / control-flow encoding =====

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -972,14 +972,20 @@ impl Instruction {
                 | Operand::ExtendedRegister { .. } => false,
             },
 
-            // ADDS/SUBS: imm 0..=0xFFF (same as ADD/SUB). ShiftedRegister form is
-            // out of scope for issue #59.
+            // ADDS/SUBS: register, imm 0..=0xFFF, or shifted-register
+            // (LSL/LSR/ASR only — ROR not encodable for arithmetic shifted-register form).
             Instruction::Adds { rd, rn, rm } | Instruction::Subs { rd, rn, rm } => match rm {
                 Operand::Register(reg) => is_x_or_xzr(*rd) && is_x_or_xzr(*rn) && is_x_or_xzr(*reg),
                 Operand::Immediate(imm) => {
                     *imm >= 0 && *imm <= 0xFFF && is_x_or_xzr(*rd) && is_xsp(*rn)
                 }
-                Operand::ShiftedRegister { .. } => false,
+                Operand::ShiftedRegister { reg, kind, amount } => {
+                    *kind != ShiftKind::Ror
+                        && *amount <= 63
+                        && is_x_or_xzr(*reg)
+                        && is_x_or_xzr(*rd)
+                        && is_x_or_xzr(*rn)
+                }
                 Operand::ExtendedRegister { .. } => false,
             },
             // ADC/ADCS/SBC/SBCS: register-only form, always encodable.
@@ -2788,7 +2794,7 @@ mod tests {
 
     #[test]
     fn test_is_encodable_shifted_register_arith_rejects_ror() {
-        // Add/Sub/Cmp/Cmn: LSL/LSR/ASR allowed; ROR rejected.
+        // Add/Sub/Adds/Subs/Cmp/Cmn: LSL/LSR/ASR allowed; ROR rejected.
         let mk_add = |kind| Instruction::Add {
             rd: Register::X0,
             rn: Register::X1,
@@ -2802,6 +2808,110 @@ mod tests {
         assert!(mk_add(ShiftKind::Lsr).is_encodable_aarch64());
         assert!(mk_add(ShiftKind::Asr).is_encodable_aarch64());
         assert!(!mk_add(ShiftKind::Ror).is_encodable_aarch64());
+
+        let mk_sub = |kind| Instruction::Sub {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::ShiftedRegister {
+                reg: Register::X2,
+                kind,
+                amount: 3,
+            },
+        };
+        assert!(mk_sub(ShiftKind::Lsl).is_encodable_aarch64());
+        assert!(!mk_sub(ShiftKind::Ror).is_encodable_aarch64());
+
+        let mk_adds = |kind, amount| Instruction::Adds {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::ShiftedRegister {
+                reg: Register::X2,
+                kind,
+                amount,
+            },
+        };
+        assert!(mk_adds(ShiftKind::Lsl, 3).is_encodable_aarch64());
+        assert!(mk_adds(ShiftKind::Lsr, 3).is_encodable_aarch64());
+        assert!(mk_adds(ShiftKind::Asr, 3).is_encodable_aarch64());
+        assert!(!mk_adds(ShiftKind::Ror, 3).is_encodable_aarch64());
+        assert!(!mk_adds(ShiftKind::Lsl, 64).is_encodable_aarch64());
+
+        let mk_subs = |kind, amount| Instruction::Subs {
+            rd: Register::X3,
+            rn: Register::X4,
+            rm: Operand::ShiftedRegister {
+                reg: Register::X5,
+                kind,
+                amount,
+            },
+        };
+        assert!(mk_subs(ShiftKind::Lsl, 3).is_encodable_aarch64());
+        assert!(mk_subs(ShiftKind::Lsr, 3).is_encodable_aarch64());
+        assert!(mk_subs(ShiftKind::Asr, 3).is_encodable_aarch64());
+        assert!(!mk_subs(ShiftKind::Ror, 3).is_encodable_aarch64());
+        assert!(!mk_subs(ShiftKind::Lsl, 64).is_encodable_aarch64());
+
+        for instr in [
+            Instruction::Adds {
+                rd: Register::SP,
+                rn: Register::X1,
+                rm: Operand::ShiftedRegister {
+                    reg: Register::X2,
+                    kind: ShiftKind::Lsl,
+                    amount: 1,
+                },
+            },
+            Instruction::Adds {
+                rd: Register::X0,
+                rn: Register::SP,
+                rm: Operand::ShiftedRegister {
+                    reg: Register::X2,
+                    kind: ShiftKind::Lsl,
+                    amount: 1,
+                },
+            },
+            Instruction::Adds {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::ShiftedRegister {
+                    reg: Register::SP,
+                    kind: ShiftKind::Lsl,
+                    amount: 1,
+                },
+            },
+            Instruction::Subs {
+                rd: Register::SP,
+                rn: Register::X4,
+                rm: Operand::ShiftedRegister {
+                    reg: Register::X5,
+                    kind: ShiftKind::Lsl,
+                    amount: 1,
+                },
+            },
+            Instruction::Subs {
+                rd: Register::X3,
+                rn: Register::SP,
+                rm: Operand::ShiftedRegister {
+                    reg: Register::X5,
+                    kind: ShiftKind::Lsl,
+                    amount: 1,
+                },
+            },
+            Instruction::Subs {
+                rd: Register::X3,
+                rn: Register::X4,
+                rm: Operand::ShiftedRegister {
+                    reg: Register::SP,
+                    kind: ShiftKind::Lsl,
+                    amount: 1,
+                },
+            },
+        ] {
+            assert!(
+                !instr.is_encodable_aarch64(),
+                "SP must be rejected in shifted-register flag-setting arithmetic: {instr}"
+            );
+        }
 
         let mk_cmp = |kind| Instruction::Cmp {
             rn: Register::X1,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -557,23 +557,29 @@ fn parse_eon(operands: &[&str]) -> Result<Instruction, String> {
 
 /// Parse ADDS instruction
 fn parse_adds(operands: &[&str]) -> Result<Instruction, String> {
-    if operands.len() != 3 {
-        return Err(format!("adds requires 3 operands, got {}", operands.len()));
+    if operands.len() != 3 && operands.len() != 4 {
+        return Err(format!(
+            "adds requires 3 or 4 operands, got {}",
+            operands.len()
+        ));
     }
     let rd = parse_register(operands[0])?;
     let rn = parse_register(operands[1])?;
-    let rm = parse_operand(operands[2])?;
+    let rm = parse_rm_3op("adds", operands)?;
     Ok(Instruction::Adds { rd, rn, rm })
 }
 
 /// Parse SUBS instruction
 fn parse_subs(operands: &[&str]) -> Result<Instruction, String> {
-    if operands.len() != 3 {
-        return Err(format!("subs requires 3 operands, got {}", operands.len()));
+    if operands.len() != 3 && operands.len() != 4 {
+        return Err(format!(
+            "subs requires 3 or 4 operands, got {}",
+            operands.len()
+        ));
     }
     let rd = parse_register(operands[0])?;
     let rn = parse_register(operands[1])?;
-    let rm = parse_operand(operands[2])?;
+    let rm = parse_rm_3op("subs", operands)?;
     Ok(Instruction::Subs { rd, rn, rm })
 }
 
@@ -2180,6 +2186,39 @@ mod tests {
         );
         // round-trip via Display
         assert_eq!(format!("{}", instr), "add x0, x1, x2, lsl #3");
+    }
+
+    #[test]
+    fn test_parse_shifted_register_flag_setting_arith() {
+        let instr = parse_one("adds x0, x1, x2, lsl #3");
+        assert_eq!(
+            instr,
+            Instruction::Adds {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::ShiftedRegister {
+                    reg: Register::X2,
+                    kind: ShiftKind::Lsl,
+                    amount: 3,
+                },
+            }
+        );
+        assert_eq!(format!("{}", instr), "adds x0, x1, x2, lsl #3");
+
+        let instr = parse_one("subs x3, x4, x5, asr #5");
+        assert_eq!(
+            instr,
+            Instruction::Subs {
+                rd: Register::X3,
+                rn: Register::X4,
+                rm: Operand::ShiftedRegister {
+                    reg: Register::X5,
+                    kind: ShiftKind::Asr,
+                    amount: 5,
+                },
+            }
+        );
+        assert_eq!(format!("{}", instr), "subs x3, x4, x5, asr #5");
     }
 
     #[test]

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -701,12 +701,12 @@ pub fn generate_random_instruction<R: rand::RngExt>(
         },
         2 => {
             let rn = pick_reg(rng);
-            let rm = random_operand(rng, registers, immediates);
+            let rm = random_arith_rm_operand(rng, registers, immediates);
             Instruction::Add { rd, rn, rm }
         }
         3 => {
             let rn = pick_reg(rng);
-            let rm = random_operand(rng, registers, immediates);
+            let rm = random_arith_rm_operand(rng, registers, immediates);
             Instruction::Sub { rd, rn, rm }
         }
         // AND / ORR / EOR are deliberately register-only here. The assembler
@@ -803,12 +803,12 @@ pub fn generate_random_instruction<R: rand::RngExt>(
         }
         18 => {
             let rn = pick_reg(rng);
-            let rm = random_operand(rng, registers, immediates);
+            let rm = random_arith_rm_operand(rng, registers, immediates);
             Instruction::Adds { rd, rn, rm }
         }
         19 => {
             let rn = pick_reg(rng);
-            let rm = random_operand(rng, registers, immediates);
+            let rm = random_arith_rm_operand(rng, registers, immediates);
             Instruction::Subs { rd, rn, rm }
         }
         20 => {
@@ -1193,6 +1193,22 @@ fn random_operand<R: rand::RngExt>(
     }
 }
 
+fn random_arith_rm_operand<R: rand::RngExt>(
+    rng: &mut R,
+    registers: &[Register],
+    immediates: &[i64],
+) -> Operand {
+    let non_sp = non_sp_registers(registers);
+    if !non_sp.is_empty() && rng.random_range(0..3) == 2 {
+        random_compare_shifted_operand(rng, &non_sp, false)
+    } else {
+        match random_operand(rng, registers, immediates) {
+            Operand::Immediate(imm) => Operand::Immediate(imm.rem_euclid(0x1000)),
+            other => other,
+        }
+    }
+}
+
 fn random_shift_operand<R: rand::RngExt>(rng: &mut R, registers: &[Register]) -> Operand {
     if rng.random_bool(0.7) {
         // Prefer immediate shifts
@@ -1385,6 +1401,18 @@ mod tests {
         ];
         words.extend(tail);
         BudgetedRng::new(words)
+    }
+
+    fn rng_for_shifted_arith_slot(slot: u32, kind_index: u32) -> BudgetedRng {
+        BudgetedRng::new(vec![
+            word_for_range(2, 0),
+            word_for_range(38, slot),
+            word_for_range(2, 0),
+            word_for_range(3, 2),
+            word_for_range(2, 1),
+            word_for_range(3, kind_index),
+            word_for_range(SHIFTED_OP_AMOUNTS.len() as u32, 0),
+        ])
     }
 
     #[test]
@@ -1721,6 +1749,41 @@ mod tests {
             }
         );
         assert!(tst_imm.is_encodable_aarch64());
+    }
+
+    #[test]
+    fn generate_random_instruction_samples_shifted_arith_forms() {
+        let regs = [Register::X0, Register::X1];
+        let cases = [
+            (2, 0, "ADD"),
+            (3, 1, "SUB"),
+            (18, 2, "ADDS"),
+            (19, 0, "SUBS"),
+        ];
+
+        for (slot, kind_index, name) in cases {
+            let mut rng = rng_for_shifted_arith_slot(slot, kind_index);
+            let instr = generate_random_instruction(&mut rng, &regs, &[0x1234]);
+            let rm = match instr {
+                Instruction::Add { rm, .. }
+                | Instruction::Sub { rm, .. }
+                | Instruction::Adds { rm, .. }
+                | Instruction::Subs { rm, .. } => rm,
+                other => panic!("slot {slot} should generate {name}, got {other:?}"),
+            };
+
+            match rm {
+                Operand::ShiftedRegister { kind, amount, .. } => {
+                    assert_ne!(kind, ShiftKind::Ror, "{name} must not sample ROR");
+                    assert_eq!(amount, 1);
+                }
+                other => panic!("{name} should sample shifted-register rm, got {other:?}"),
+            }
+            assert!(
+                instr.is_encodable_aarch64(),
+                "{name} shifted-register candidate must be encodable: {instr}"
+            );
+        }
     }
 
     #[test]

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -2503,12 +2503,21 @@ mod tests {
     }
 
     fn rng_for_arith_immediate_slot(slot: u32, imm_count: u32, imm_index: u32) -> BudgetedRng {
+        // ADD/SUB/ADDS/SUBS (slots 2, 3, 18, 19) consume, in order: `rd`, the
+        // opcode slot, `rn`, then `random_arith_rm_operand`. The latter first
+        // draws a 0..3 shape selector (2 = shifted register, issue #279) and,
+        // when that is not 2, falls through to `random_operand`, whose
+        // `random_bool(0.5)` register/immediate coin pulls a u64 (two words).
+        // Drive shape != 2 and bias the coin toward the immediate branch so the
+        // imm12 clamp is exercised. The high word governs the 0.5 split, so
+        // `u32::MAX, u32::MAX` selects the immediate (non-register) arm.
         BudgetedRng::new(vec![
-            word_for_range(3, 0),
+            word_for_range(3, 0), // rd register pick
             word_for_range(38, slot),
-            word_for_range(3, 0),
-            u32::MAX,
-            u32::MAX,
+            word_for_range(3, 0), // rn register pick
+            word_for_range(3, 0), // shape selector: != 2 → not shifted
+            u32::MAX,             // random_bool low word
+            u32::MAX,             // random_bool high word → false → immediate
             word_for_range(imm_count, imm_index),
         ])
     }

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -391,8 +391,15 @@ impl Mutator {
                 match choice {
                     0 => *rd = self.random_register(rng),
                     1 => *rn = self.random_register(rng),
-                    // Same 12-bit clamp as Add/Sub (issue #87).
-                    _ => *rm = Self::clamp_imm12(self.random_operand(rng)),
+                    // Same 12-bit clamp and non-ROR shifted-register coverage
+                    // as Add/Sub, without the extended-register branch.
+                    _ => {
+                        *rm = Self::clamp_imm12(self.random_arith_operand_no_extended(
+                            rng,
+                            false,
+                            RegisterWidth::X64,
+                        ));
+                    }
                 }
             }
             // ADC/ADCS/SBC/SBCS are register-only (rd, rn, rm all registers).
@@ -1285,6 +1292,23 @@ impl Mutator {
         }
     }
 
+    /// Random rm operand for flag-setting arithmetic. ADDS/SUBS support the
+    /// shifted-register arithmetic form, but this issue intentionally leaves
+    /// their extended-register form unsupported.
+    fn random_arith_operand_no_extended<R: RngExt>(
+        &self,
+        rng: &mut R,
+        allow_ror: bool,
+        width: RegisterWidth,
+    ) -> Operand {
+        let choice: f64 = rng.random();
+        if choice < SHIFTED_REGISTER_OPERAND_PROBABILITY && !self.registers.is_empty() {
+            self.random_shifted_register(rng, allow_ror, width)
+        } else {
+            self.random_operand(rng)
+        }
+    }
+
     fn random_shifted_register<R: RngExt>(
         &self,
         rng: &mut R,
@@ -2099,6 +2123,72 @@ mod tests {
             produced_shifted,
             "mutate_operand on Add must occasionally produce ShiftedRegister rm"
         );
+    }
+
+    #[test]
+    fn test_mutate_operand_can_produce_shifted_register_for_flag_setting_arith() {
+        let mutator = default_mutator();
+        let starts = [
+            (
+                "ADDS",
+                Instruction::Adds {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::Register(Register::X2),
+                },
+            ),
+            (
+                "SUBS",
+                Instruction::Subs {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::Register(Register::X2),
+                },
+            ),
+        ];
+
+        for (idx, (name, start)) in starts.into_iter().enumerate() {
+            let mut rng = ChaCha8Rng::seed_from_u64(0x2790 + idx as u64);
+            let mut saw_shifted = false;
+
+            for _ in 0..5000 {
+                let mut seq = vec![start];
+                mutator.mutate_operand(&mut rng, &mut seq);
+
+                let rm = match seq[0] {
+                    Instruction::Adds { rm, .. } | Instruction::Subs { rm, .. } => rm,
+                    other => panic!("mutate_operand changed {name} opcode: {other:?}"),
+                };
+
+                match rm {
+                    Operand::ShiftedRegister { kind, .. } => {
+                        assert_ne!(
+                            kind,
+                            crate::ir::ShiftKind::Ror,
+                            "{name} shifted-register rm must not use ROR"
+                        );
+                        assert!(
+                            seq[0].is_encodable_aarch64(),
+                            "mutated {name} must remain encodable: {}",
+                            seq[0]
+                        );
+                        saw_shifted = true;
+                        break;
+                    }
+                    Operand::ExtendedRegister { .. } => {
+                        panic!(
+                            "mutate_operand on {name} must not emit unsupported ExtendedRegister rm"
+                        )
+                    }
+                    _ => {}
+                }
+            }
+
+            assert!(
+                saw_shifted,
+                "mutate_operand on {name} did not produce ShiftedRegister rm"
+            );
+        }
     }
 
     #[test]

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- add parser, encodability, and assembler support for X-form ADDS/SUBS shifted-register operands while keeping ROR and extended-register forms rejected
- route stochastic mutation and random candidate generation through shifted-capable non-ROR arithmetic rm sampling for ADD/SUB/ADDS/SUBS
- update capability docs and add regression coverage for parser, assembler, mutation, and candidate generation
- include a mechanical SMT clippy cleanup required by the local warning-deny gate

Validation:
- cargo fmt --all -- --check
- cargo clippy --all -- -D warnings
- ./build_tests.sh
- cargo test --all
- ./ci_check.sh

Closes #279

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**