### PR TITLE
refactor(x86): name symbolic eflags bvs

### DIFF
--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {

--- a/src/semantics/smt_x86.rs
+++ b/src/semantics/smt_x86.rs
@@ -16,19 +16,32 @@ use crate::isa::x86::{X86Instruction, X86Register};
 use std::collections::HashMap;
 use z3::ast::BV;
 
-/// Symbolic EFLAGS quintuple `(cf, pf, zf, sf, of)`, mirroring
-/// `Eflags` minus the unmodelled AF (see module docs).
-pub type EflagsBvs = (BV, BV, BV, BV, BV);
+/// Symbolic EFLAGS BVs, mirroring `Eflags` minus the unmodelled AF
+/// (see module docs).
+#[derive(Clone)]
+pub struct EflagsBvs {
+    pub cf: BV,
+    pub pf: BV,
+    pub zf: BV,
+    pub sf: BV,
+    pub of: BV,
+}
+
+/// Borrowed view of symbolic EFLAGS.
+#[derive(Clone, Copy)]
+pub struct EflagsBvRefs<'a> {
+    pub cf: &'a BV,
+    pub pf: &'a BV,
+    pub zf: &'a BV,
+    pub sf: &'a BV,
+    pub of: &'a BV,
+}
 
 #[derive(Clone)]
 pub struct MachineStateX86 {
     pub registers: HashMap<X86Register, BV>,
     width: u32,
-    cf: BV,
-    pf: BV,
-    zf: BV,
-    sf: BV,
-    of: BV,
+    flags: EflagsBvs,
 }
 
 impl MachineStateX86 {
@@ -43,11 +56,13 @@ impl MachineStateX86 {
         MachineStateX86 {
             registers,
             width,
-            cf: BV::new_const(format!("{}_cf", prefix), 1),
-            pf: BV::new_const(format!("{}_pf", prefix), 1),
-            zf: BV::new_const(format!("{}_zf", prefix), 1),
-            sf: BV::new_const(format!("{}_sf", prefix), 1),
-            of: BV::new_const(format!("{}_of", prefix), 1),
+            flags: EflagsBvs {
+                cf: BV::new_const(format!("{}_cf", prefix), 1),
+                pf: BV::new_const(format!("{}_pf", prefix), 1),
+                zf: BV::new_const(format!("{}_zf", prefix), 1),
+                sf: BV::new_const(format!("{}_sf", prefix), 1),
+                of: BV::new_const(format!("{}_of", prefix), 1),
+            },
         }
     }
 
@@ -65,19 +80,20 @@ impl MachineStateX86 {
         self.registers.insert(reg, value);
     }
 
-    /// Return the five flag BVs as `(cf, pf, zf, sf, of)`.
-    pub fn get_flags(&self) -> (&BV, &BV, &BV, &BV, &BV) {
-        (&self.cf, &self.pf, &self.zf, &self.sf, &self.of)
+    /// Return the five tracked flag BVs.
+    pub fn get_flags(&self) -> EflagsBvRefs<'_> {
+        EflagsBvRefs {
+            cf: &self.flags.cf,
+            pf: &self.flags.pf,
+            zf: &self.flags.zf,
+            sf: &self.flags.sf,
+            of: &self.flags.of,
+        }
     }
 
     /// Replace all five flag BVs at once.
     pub fn set_flags(&mut self, flags: EflagsBvs) {
-        let (cf, pf, zf, sf, of) = flags;
-        self.cf = cf;
-        self.pf = pf;
-        self.zf = zf;
-        self.sf = sf;
-        self.of = of;
+        self.flags = flags;
     }
 
     fn imm_bv(&self, imm: i64) -> BV {
@@ -120,16 +136,15 @@ fn is_zero_bv(value: &BV, width: u32) -> BV {
 /// the supplied flag BVs. Mirrors `Eflags::evaluate` arm-for-arm.
 pub fn x86_condition_to_smt(
     cond: crate::isa::x86::X86Condition,
-    flags: (&BV, &BV, &BV, &BV, &BV),
+    flags: EflagsBvRefs<'_>,
 ) -> z3::ast::Bool {
     use crate::isa::x86::X86Condition;
-    let (cf, pf, zf, sf, of) = flags;
     let one = bv_one();
-    let cf1 = cf.eq(&one);
-    let pf1 = pf.eq(&one);
-    let zf1 = zf.eq(&one);
-    let sf1 = sf.eq(&one);
-    let of1 = of.eq(&one);
+    let cf1 = flags.cf.eq(&one);
+    let pf1 = flags.pf.eq(&one);
+    let zf1 = flags.zf.eq(&one);
+    let sf1 = flags.sf.eq(&one);
+    let of1 = flags.of.eq(&one);
     match cond {
         X86Condition::E => zf1,
         X86Condition::NE => zf1.not(),
@@ -171,7 +186,7 @@ pub fn compute_eflags_sub(lhs: &BV, rhs: &BV, width: u32) -> EflagsBvs {
     let of_bool = z3::ast::Bool::and(&[&signs_differ, &lhs_vs_res]);
     let of = of_bool.ite(&bv_one(), &bv_zero());
     let pf = parity8_bv(&result);
-    (cf, pf, zf, sf, of)
+    EflagsBvs { cf, pf, zf, sf, of }
 }
 
 /// Symbolic flags from `lhs + rhs` at the operand width.
@@ -191,7 +206,7 @@ pub fn compute_eflags_add(lhs: &BV, rhs: &BV, width: u32) -> EflagsBvs {
     let of_bool = z3::ast::Bool::and(&[&signs_match, &lhs_vs_res]);
     let of = of_bool.ite(&bv_one(), &bv_zero());
     let pf = parity8_bv(&result);
-    (cf, pf, zf, sf, of)
+    EflagsBvs { cf, pf, zf, sf, of }
 }
 
 /// Symbolic flags from a logical op (AND/OR/XOR). CF and OF are
@@ -200,7 +215,13 @@ pub fn compute_eflags_logical(result: &BV, width: u32) -> EflagsBvs {
     let zf = is_zero_bv(result, width);
     let sf = top_bit_bv(result, width);
     let pf = parity8_bv(result);
-    (bv_zero(), pf, zf, sf, bv_zero())
+    EflagsBvs {
+        cf: bv_zero(),
+        pf,
+        zf,
+        sf,
+        of: bv_zero(),
+    }
 }
 
 /// Apply a single x86 instruction symbolically. Arithmetic / logic /
@@ -341,14 +362,14 @@ pub fn apply_sequence(
 /// reject sequences whose flag effects diverge under `flags_live=true`.
 /// AF is intentionally excluded — see module docs.
 pub fn flags_not_equal_x86(a: &MachineStateX86, b: &MachineStateX86) -> z3::ast::Bool {
-    let (a_cf, a_pf, a_zf, a_sf, a_of) = a.get_flags();
-    let (b_cf, b_pf, b_zf, b_sf, b_of) = b.get_flags();
+    let a_flags = a.get_flags();
+    let b_flags = b.get_flags();
     z3::ast::Bool::or(&[
-        &a_cf.eq(b_cf).not(),
-        &a_pf.eq(b_pf).not(),
-        &a_zf.eq(b_zf).not(),
-        &a_sf.eq(b_sf).not(),
-        &a_of.eq(b_of).not(),
+        &a_flags.cf.eq(b_flags.cf).not(),
+        &a_flags.pf.eq(b_flags.pf).not(),
+        &a_flags.zf.eq(b_flags.zf).not(),
+        &a_flags.sf.eq(b_flags.sf).not(),
+        &a_flags.of.eq(b_flags.of).not(),
     ])
 }
 
@@ -459,7 +480,7 @@ mod tests {
                 rs: X86Register::RBX,
             },
         );
-        let zf = s1.get_flags().2; // (cf, pf, zf, sf, of) — zf at index 2
+        let zf = s1.get_flags().zf;
         let zf_one = BV::from_u64(1, 1);
         let solver = Solver::new();
         // Assert: NOT (zf == 1 <=> rax == rbx). If unsat, the bi-implication holds.
@@ -487,7 +508,7 @@ mod tests {
                 rs: X86Register::RBX,
             },
         );
-        let cf = s1.get_flags().0;
+        let cf = s1.get_flags().cf;
         let cf_one = BV::from_u64(1, 1);
         let solver = Solver::new();
         let unsigned_lt = rax.bvult(&rbx);
@@ -510,7 +531,7 @@ mod tests {
         let s0 = MachineStateX86::new_symbolic("s", 64);
         let rax_init = s0.get_register(X86Register::RAX).clone();
         let rbx_init = s0.get_register(X86Register::RBX).clone();
-        let zf_init = s0.get_flags().2.clone();
+        let zf_init = s0.get_flags().zf.clone();
         let s1 = apply_instruction(
             s0,
             &X86Instruction::Cmov {
@@ -544,15 +565,15 @@ mod tests {
                 rs: X86Register::RAX,
             },
         );
-        let (cf, pf, zf, _sf, of) = s1.get_flags();
+        let flags = s1.get_flags();
         let zero = BV::from_u64(0, 1);
         let one = BV::from_u64(1, 1);
         let solver = Solver::new();
         solver.assert(z3::ast::Bool::or(&[
-            &cf.eq(&zero).not(),
-            &of.eq(&zero).not(),
-            &zf.eq(&one).not(),
-            &pf.eq(&one).not(),
+            &flags.cf.eq(&zero).not(),
+            &flags.of.eq(&zero).not(),
+            &flags.zf.eq(&one).not(),
+            &flags.pf.eq(&one).not(),
         ]));
         assert_eq!(
             solver.check(),
@@ -574,7 +595,7 @@ mod tests {
                 rs: X86Register::RBX,
             },
         );
-        let zf = s1.get_flags().2;
+        let zf = s1.get_flags().zf;
         let zero = BV::from_u64(0, 64);
         let zf_one = BV::from_u64(1, 1);
         let solver = Solver::new();
@@ -597,7 +618,7 @@ mod tests {
                 rs: X86Register::RBX,
             },
         );
-        let cf = s1.get_flags().0;
+        let cf = s1.get_flags().cf;
         let cf_one = BV::from_u64(1, 1);
         let solver = Solver::new();
         let borrow = rax_init.bvult(&rbx_init);
@@ -635,13 +656,13 @@ mod tests {
         // Build inequality disjunct over all five tracked flags and rd
         // (when the instruction has one).
         let one_bit = |b: bool| BV::from_u64(b as u64, 1);
-        let (cf_s, pf_s, zf_s, sf_s, of_s) = symbolic_post.get_flags();
+        let symbolic_flags = symbolic_post.get_flags();
         let mut diffs: Vec<z3::ast::Bool> = vec![
-            cf_s.eq(one_bit(cf_post.cf)).not(),
-            pf_s.eq(one_bit(cf_post.pf)).not(),
-            zf_s.eq(one_bit(cf_post.zf)).not(),
-            sf_s.eq(one_bit(cf_post.sf)).not(),
-            of_s.eq(one_bit(cf_post.of)).not(),
+            symbolic_flags.cf.eq(one_bit(cf_post.cf)).not(),
+            symbolic_flags.pf.eq(one_bit(cf_post.pf)).not(),
+            symbolic_flags.zf.eq(one_bit(cf_post.zf)).not(),
+            symbolic_flags.sf.eq(one_bit(cf_post.sf)).not(),
+            symbolic_flags.of.eq(one_bit(cf_post.of)).not(),
         ];
         if let Some(rd) = instr.destination() {
             let expected = BV::from_u64(concrete_post.get_register(rd).as_u64(), 64);
@@ -745,9 +766,15 @@ mod tests {
         // Cmov must leave the five tracked flag BVs symbolically untouched.
         use crate::isa::x86::X86Condition;
         let s0 = MachineStateX86::new_symbolic("s", 64);
-        let (cf0, pf0, zf0, sf0, of0) = {
-            let (cf, pf, zf, sf, of) = s0.get_flags();
-            (cf.clone(), pf.clone(), zf.clone(), sf.clone(), of.clone())
+        let flags0 = {
+            let flags = s0.get_flags();
+            EflagsBvs {
+                cf: flags.cf.clone(),
+                pf: flags.pf.clone(),
+                zf: flags.zf.clone(),
+                sf: flags.sf.clone(),
+                of: flags.of.clone(),
+            }
         };
         let s1 = apply_instruction(
             s0,
@@ -758,14 +785,14 @@ mod tests {
             },
         );
         let solver = Solver::new();
-        let (cf1, pf1, zf1, sf1, of1) = s1.get_flags();
+        let flags1 = s1.get_flags();
         // Any flag differing means we touched flags.
         let diff = z3::ast::Bool::or(&[
-            &cf1.eq(&cf0).not(),
-            &pf1.eq(&pf0).not(),
-            &zf1.eq(&zf0).not(),
-            &sf1.eq(&sf0).not(),
-            &of1.eq(&of0).not(),
+            &flags1.cf.eq(&flags0.cf).not(),
+            &flags1.pf.eq(&flags0.pf).not(),
+            &flags1.zf.eq(&flags0.zf).not(),
+            &flags1.sf.eq(&flags0.sf).not(),
+            &flags1.of.eq(&flags0.of).not(),
         ]);
         solver.assert(&diff);
         assert_eq!(


### PR DESCRIPTION
Refactor x86 SMT symbolic EFLAGS from positional tuple access into named owned and borrowed structs, so callers read flags via cf/pf/zf/sf/of fields. Also removes clippy-rejected temporary BV borrows required to keep the local quality gate green.\n\nCloses #283\n\n**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**