### PR TITLE
refactor(semantics): deduplicate register mask flag liveness

### DIFF
--- a/src/search/stochastic/backend.rs
+++ b/src/search/stochastic/backend.rs
@@ -60,11 +60,9 @@ pub trait StochasticBackend<I: ISA>: Sized {
     /// call path is ever rearranged so stochastic compares states without
     /// passing through the upstream guard, this invariant has to be revisited.
     ///
-    /// This is the only known caller in the codebase that intentionally
-    /// passes `flags_live=false` to `concrete::states_equal_for_live_out`
-    /// regardless of the mask's `flags_live()` value; the cleanup tracked in
-    /// issue #282 must preserve this exception (e.g. by routing every other
-    /// caller through `live_out.flags_live()` and leaving this one explicit).
+    /// AArch64 preserves this exception by routing through
+    /// `concrete::states_equal_for_live_out_ignoring_flags`; ordinary
+    /// concrete comparisons read `live_out.flags_live()` directly.
     fn states_equal(s1: &Self::State, s2: &Self::State, live_out: &Self::LiveOut) -> bool;
 
     /// Sum the cost of every instruction in the sequence.
@@ -152,14 +150,16 @@ impl StochasticBackend<crate::isa::AArch64> for crate::isa::AArch64 {
     }
 
     fn states_equal(s1: &Self::State, s2: &Self::State, live_out: &Self::LiveOut) -> bool {
-        // Pass `flags_live = false` deliberately: the over-approximate
-        // flag-writer guard in equivalence.rs pre-SMT already handles flag
-        // divergence before stochastic comparison is reached. The mask may
-        // carry `flags_live = true`, but it is honoured upstream, not here.
+        // Ignore flags deliberately: the over-approximate flag-writer guard in
+        // equivalence.rs pre-SMT already handles flag divergence before
+        // stochastic comparison is reached. The mask may carry
+        // `flags_live = true`, but it is honoured upstream, not here.
         // `memory_live = false` here for the same reason — equivalence.rs
         // force-enables it via `touches_memory()` before calling this path.
         // Mirrors mcmc.rs's existing call site.
-        crate::semantics::concrete::states_equal_for_live_out(s1, s2, live_out, false, false)
+        crate::semantics::concrete::states_equal_for_live_out_ignoring_flags(
+            s1, s2, live_out, false,
+        )
     }
 
     fn sequence_cost(seq: &[crate::ir::Instruction], metric: &CostMetric, _width: u32) -> u64 {
@@ -462,6 +462,7 @@ mod tests {
     use crate::isa::x86::{X86Instruction, X86Register};
     use crate::semantics::live_out::LiveOut;
     use crate::semantics::live_out::X86LiveOut;
+    use crate::semantics::state::{ConcreteMachineState, ConcreteValue, ConditionFlags};
 
     #[test]
     fn aarch64_backend_honors_flags_dead_live_out_mask() {
@@ -500,6 +501,31 @@ mod tests {
         );
 
         assert_ne!(flags_live_result.0, EquivalenceResult::Equivalent);
+    }
+
+    #[test]
+    fn aarch64_backend_states_equal_ignores_flags_even_when_mask_flags_live() {
+        let mut state1 = ConcreteMachineState::new_zeroed();
+        let mut state2 = ConcreteMachineState::new_zeroed();
+        state1.set_register(Register::X0, ConcreteValue(42));
+        state2.set_register(Register::X0, ConcreteValue(42));
+        state1.set_flags(ConditionFlags {
+            n: true,
+            z: false,
+            c: false,
+            v: false,
+        });
+        state2.set_flags(ConditionFlags {
+            n: false,
+            z: true,
+            c: false,
+            v: false,
+        });
+        let live_out = LiveOut::from_registers(vec![Register::X0]).with_flags(true);
+
+        assert!(<AArch64 as StochasticBackend<AArch64>>::states_equal(
+            &state1, &state2, &live_out
+        ));
     }
 
     #[test]

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -24,7 +24,9 @@ use crate::search::stochastic::acceptance::AcceptanceCriterion;
 use crate::search::stochastic::backend::StochasticBackend;
 use crate::search::{Algorithm, SearchAlgorithm};
 use crate::semantics::EquivalenceResult;
-use crate::semantics::concrete::{apply_sequence_concrete, states_equal_for_live_out};
+use crate::semantics::concrete::{
+    apply_sequence_concrete, states_equal_for_live_out_ignoring_flags,
+};
 use crate::semantics::live_out::RegisterSet;
 use crate::semantics::state::ConcreteMachineState;
 use rand::{RngExt, SeedableRng};
@@ -316,7 +318,12 @@ pub fn evaluate_with_tests(
 
     for (input, target_output) in test_inputs.iter().zip(target_outputs.iter()) {
         let proposal_output = apply_sequence_concrete(input.clone(), proposal);
-        if !states_equal_for_live_out(&proposal_output, target_output, live_out, false, false) {
+        if !states_equal_for_live_out_ignoring_flags(
+            &proposal_output,
+            target_output,
+            live_out,
+            false,
+        ) {
             passes_all = false;
             break;
         }
@@ -339,6 +346,7 @@ mod tests {
     use crate::search::config::{StochasticConfig, SymbolicConfig};
     use crate::semantics::cost::CostMetric;
     use crate::semantics::live_out::LiveOut;
+    use crate::semantics::state::{ConcreteValue, ConditionFlags};
 
     fn mov_add_sequence() -> Vec<Instruction> {
         vec![
@@ -746,6 +754,36 @@ mod tests {
 
         assert!(!passes);
         assert!(cost > 100); // High penalty
+    }
+
+    #[test]
+    fn test_evaluate_with_tests_ignores_flags_even_when_mask_flags_live() {
+        let target = Vec::new();
+        let proposal = Vec::new();
+
+        let mut input = ConcreteMachineState::new_zeroed();
+        input.set_register(Register::X0, ConcreteValue(42));
+        input.set_flags(ConditionFlags {
+            n: true,
+            z: false,
+            c: false,
+            v: false,
+        });
+
+        let mut target_output = input.clone();
+        target_output.set_flags(ConditionFlags {
+            n: false,
+            z: true,
+            c: false,
+            v: false,
+        });
+
+        let live_out = RegisterSet::<Register>::from_registers(vec![Register::X0]).with_flags(true);
+        let (cost, passes) =
+            evaluate_with_tests(&proposal, &target, &[input], &[target_output], &live_out);
+
+        assert!(passes);
+        assert_eq!(cost, 0);
     }
 
     #[test]

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -809,19 +809,42 @@ pub fn apply_sequence_concrete(
     state
 }
 
-/// Check if two concrete states are equal for the specified live-out registers,
-/// optionally including the NZCV condition flags and the whole memory map.
+/// Check if two concrete states are equal for the specified live-out contract,
+/// including the NZCV condition flags when `live_out.flags_live()` is set and
+/// the whole memory map when `memory_live` is set.
 ///
 /// `memory_live` is derived automatically by callers from whether either
 /// sequence touches memory (see ADR-0007). When set, every memory cell
 /// must agree between the two states — equivalently, the two `BTreeMap`s
 /// must be structurally equal (prune-on-write guarantees structural ==
 /// semantic equality).
-///
-/// TODO(#282): The explicit `flags_live` parameter is now redundant with
-/// `live_out.flags_live()` for every caller except the stochastic backend
-/// (which deliberately passes `false`). Tracked for cleanup in issue #282.
 pub fn states_equal_for_live_out(
+    state1: &ConcreteMachineState,
+    state2: &ConcreteMachineState,
+    live_out: &RegisterSet<Register>,
+    memory_live: bool,
+) -> bool {
+    states_equal_for_live_out_with_flags(
+        state1,
+        state2,
+        live_out,
+        live_out.flags_live(),
+        memory_live,
+    )
+}
+
+/// Check two concrete states over the live-out registers and memory while
+/// deliberately ignoring NZCV, even if `live_out.flags_live()` is set.
+pub fn states_equal_for_live_out_ignoring_flags(
+    state1: &ConcreteMachineState,
+    state2: &ConcreteMachineState,
+    live_out: &RegisterSet<Register>,
+    memory_live: bool,
+) -> bool {
+    states_equal_for_live_out_with_flags(state1, state2, live_out, false, memory_live)
+}
+
+fn states_equal_for_live_out_with_flags(
     state1: &ConcreteMachineState,
     state2: &ConcreteMachineState,
     live_out: &RegisterSet<Register>,
@@ -845,14 +868,10 @@ pub fn states_equal_for_live_out(
 /// Find the first differing register between two states for live-out registers.
 /// Flag divergence (when `flags_live` is set) is reported via the `XZR`
 /// sentinel since the function signature is register-typed.
-///
-/// TODO(#282): see `states_equal_for_live_out` — the same `flags_live`
-/// redundancy applies here. Tracked for follow-up cleanup.
 pub fn find_first_difference(
     state1: &ConcreteMachineState,
     state2: &ConcreteMachineState,
     live_out: &RegisterSet<Register>,
-    flags_live: bool,
 ) -> Option<(Register, ConcreteValue, ConcreteValue)> {
     for reg in live_out.iter() {
         let v1 = state1.get_register(*reg);
@@ -861,7 +880,7 @@ pub fn find_first_difference(
             return Some((*reg, v1, v2));
         }
     }
-    if flags_live {
+    if live_out.flags_live() {
         let f1 = state1.get_flags();
         let f2 = state2.get_flags();
         if f1 != f2 {
@@ -1323,7 +1342,7 @@ mod tests {
 
         let live_out = RegisterSet::<Register>::from_registers(vec![Register::X0]);
         assert!(states_equal_for_live_out(
-            &state1, &state2, &live_out, false, false
+            &state1, &state2, &live_out, false
         ));
     }
 
@@ -1334,7 +1353,39 @@ mod tests {
 
         let live_out = RegisterSet::<Register>::from_registers(vec![Register::X0]);
         assert!(!states_equal_for_live_out(
-            &state1, &state2, &live_out, false, false
+            &state1, &state2, &live_out, false
+        ));
+    }
+
+    #[test]
+    fn test_states_equal_for_live_out_reads_flags_from_mask() {
+        let mut state1 = state_with(vec![(Register::X0, 42)]);
+        let mut state2 = state_with(vec![(Register::X0, 42)]);
+        state1.set_flags(ConditionFlags {
+            n: true,
+            z: false,
+            c: false,
+            v: false,
+        });
+        state2.set_flags(ConditionFlags {
+            n: false,
+            z: true,
+            c: false,
+            v: false,
+        });
+
+        let live_out = RegisterSet::<Register>::from_registers(vec![Register::X0]);
+        assert!(states_equal_for_live_out(
+            &state1,
+            &state2,
+            &live_out.clone().with_flags(false),
+            false
+        ));
+        assert!(!states_equal_for_live_out(
+            &state1,
+            &state2,
+            &live_out.with_flags(true),
+            false
         ));
     }
 
@@ -1344,7 +1395,7 @@ mod tests {
         let state2 = state_with(vec![(Register::X0, 42), (Register::X1, 200)]);
 
         let live_out = RegisterSet::<Register>::from_registers(vec![Register::X0, Register::X1]);
-        let diff = find_first_difference(&state1, &state2, &live_out, false);
+        let diff = find_first_difference(&state1, &state2, &live_out);
         assert!(diff.is_some());
         let (reg, v1, v2) = diff.unwrap();
         assert_eq!(reg, Register::X1);
@@ -1358,7 +1409,7 @@ mod tests {
         let state2 = state_with(vec![(Register::X0, 42)]);
 
         let live_out = RegisterSet::<Register>::from_registers(vec![Register::X0]);
-        let diff = find_first_difference(&state1, &state2, &live_out, false);
+        let diff = find_first_difference(&state1, &state2, &live_out);
         assert!(diff.is_none());
     }
 
@@ -1381,13 +1432,10 @@ mod tests {
 
         let live_out = RegisterSet::<Register>::from_registers(vec![Register::X0]);
         assert_eq!(
-            find_first_difference(&state1, &state2, &live_out, true),
+            find_first_difference(&state1, &state2, &live_out.clone().with_flags(true)),
             Some((Register::XZR, ConcreteValue(8), ConcreteValue(4)))
         );
-        assert_eq!(
-            find_first_difference(&state1, &state2, &live_out, false),
-            None
-        );
+        assert_eq!(find_first_difference(&state1, &state2, &live_out), None);
     }
 
     #[test]
@@ -1410,7 +1458,7 @@ mod tests {
 
         let live_out = RegisterSet::<Register>::from_registers(vec![Register::X0]);
         assert!(states_equal_for_live_out(
-            &state1, &state2, &live_out, false, false
+            &state1, &state2, &live_out, false
         ));
     }
 

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -609,13 +609,7 @@ fn run_fast_path(
         let state1 = apply_sequence_concrete(input.clone(), seq1);
         let state2 = apply_sequence_concrete(input.clone(), seq2);
 
-        if !states_equal_for_live_out(
-            &state1,
-            &state2,
-            live_out_registers,
-            config.live_out.flags_live(),
-            config.memory_live,
-        ) {
+        if !states_equal_for_live_out(&state1, &state2, live_out_registers, config.memory_live) {
             return Some(EquivalenceResult::NotEquivalentFast(input.clone()));
         }
     }
@@ -625,13 +619,7 @@ fn run_fast_path(
         let state1 = apply_sequence_concrete(input.clone(), seq1);
         let state2 = apply_sequence_concrete(input.clone(), seq2);
 
-        if !states_equal_for_live_out(
-            &state1,
-            &state2,
-            live_out_registers,
-            config.live_out.flags_live(),
-            config.memory_live,
-        ) {
+        if !states_equal_for_live_out(&state1, &state2, live_out_registers, config.memory_live) {
             return Some(EquivalenceResult::NotEquivalentFast(input.clone()));
         }
     }
@@ -651,13 +639,8 @@ fn run_fast_path(
         for input in &fast_path_initial_nzcv_variants(&input_regs) {
             let state1 = apply_sequence_concrete(input.clone(), seq1);
             let state2 = apply_sequence_concrete(input.clone(), seq2);
-            if !states_equal_for_live_out(
-                &state1,
-                &state2,
-                live_out_registers,
-                config.live_out.flags_live(),
-                config.memory_live,
-            ) {
+            if !states_equal_for_live_out(&state1, &state2, live_out_registers, config.memory_live)
+            {
                 return Some(EquivalenceResult::NotEquivalentFast(input.clone()));
             }
         }
@@ -825,7 +808,6 @@ fn build_smt_solver(
         &final_state1,
         &final_state2,
         &config.live_out,
-        config.live_out.flags_live(),
         config.memory_live,
     ));
     solver
@@ -915,12 +897,7 @@ pub fn find_counterexample_concrete(
         let state1 = apply_sequence_concrete(input.clone(), seq1);
         let state2 = apply_sequence_concrete(input.clone(), seq2);
 
-        if let Some(diff) = find_first_difference(
-            &state1,
-            &state2,
-            live_out_registers,
-            config.live_out.flags_live(),
-        ) {
+        if let Some(diff) = find_first_difference(&state1, &state2, live_out_registers) {
             return Some(diff);
         }
     }
@@ -930,12 +907,7 @@ pub fn find_counterexample_concrete(
         let state1 = apply_sequence_concrete(input.clone(), seq1);
         let state2 = apply_sequence_concrete(input.clone(), seq2);
 
-        if let Some(diff) = find_first_difference(
-            &state1,
-            &state2,
-            live_out_registers,
-            config.live_out.flags_live(),
-        ) {
+        if let Some(diff) = find_first_difference(&state1, &state2, live_out_registers) {
             return Some(diff);
         }
     }

--- a/src/semantics/live_out.rs
+++ b/src/semantics/live_out.rs
@@ -120,17 +120,23 @@ impl RegisterSet<Register> {
     }
 }
 
-/// Self-documenting Display: `LiveOut { registers={x0, x1} }`.
+/// Self-documenting Display for the neutral register-set carrier.
 ///
-/// Format from PR #79: wrapping the register slice in a labelled outer
-/// keeps the rendering forward-compatible with extra state slices
-/// (flags_live today, memory/PC tomorrow) without breaking log readers.
+/// `RegisterSet` is used for both live-in and live-out contexts, so the
+/// rendering names the carrier itself and includes the NZCV liveness bit
+/// explicitly instead of implying a live-out-only role.
 impl fmt::Display for RegisterSet<Register> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut regs: Vec<_> = self.iter().collect();
         regs.sort_by_key(|r| r.index().unwrap_or(255));
         let names: Vec<_> = regs.iter().map(|r| format!("{}", r)).collect();
-        write!(f, "LiveOut {{ registers={{{}}} }}", names.join(", "))
+        let flags = if self.flags_live() { "nzcv" } else { "none" };
+        write!(
+            f,
+            "RegisterSet {{ registers={{{}}}, flags={} }}",
+            names.join(", "),
+            flags
+        )
     }
 }
 
@@ -224,19 +230,28 @@ mod tests {
     #[test]
     fn test_live_out_display_single_register() {
         let live_out = LiveOut::from_registers(vec![Register::X0]);
-        assert_eq!(format!("{}", live_out), "LiveOut { registers={x0} }");
+        assert_eq!(
+            format!("{}", live_out),
+            "RegisterSet { registers={x0}, flags=none }"
+        );
     }
 
     #[test]
     fn test_live_out_display_multiple_registers_sorted() {
         let live_out = LiveOut::from_registers(vec![Register::X1, Register::X0]);
-        assert_eq!(format!("{}", live_out), "LiveOut { registers={x0, x1} }");
+        assert_eq!(
+            format!("{}", live_out),
+            "RegisterSet { registers={x0, x1}, flags=none }"
+        );
     }
 
     #[test]
     fn test_live_out_display_empty() {
         let live_out = LiveOut::from_registers(vec![]);
-        assert_eq!(format!("{}", live_out), "LiveOut { registers={} }");
+        assert_eq!(
+            format!("{}", live_out),
+            "RegisterSet { registers={}, flags=none }"
+        );
     }
 
     #[test]
@@ -292,6 +307,19 @@ mod tests {
     fn test_register_set_aarch64_display_sorted() {
         let mask: RegisterSet<Register> =
             RegisterSet::from_registers(vec![Register::X5, Register::X1, Register::X3]);
-        assert_eq!(format!("{}", mask), "LiveOut { registers={x1, x3, x5} }");
+        assert_eq!(
+            format!("{}", mask),
+            "RegisterSet { registers={x1, x3, x5}, flags=none }"
+        );
+    }
+
+    #[test]
+    fn test_register_set_display_includes_live_flags() {
+        let mask: RegisterSet<Register> =
+            RegisterSet::from_registers(vec![Register::X1]).with_flags(true);
+        assert_eq!(
+            format!("{}", mask),
+            "RegisterSet { registers={x1}, flags=nzcv }"
+        );
     }
 }

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {
@@ -1298,17 +1292,12 @@ pub fn states_not_equal(state1: &MachineState, state2: &MachineState) -> z3::ast
 }
 
 /// Check if two machine states are not equal for the specified live-out
-/// registers, optionally including the NZCV flag bits and the whole memory
-/// image (see ADR-0007).
-///
-/// TODO(#282): The explicit `flags_live` parameter duplicates
-/// `live_out.flags_live()` for every non-stochastic caller. Tracked for
-/// cleanup in issue #282.
+/// contract, including the NZCV flag bits when `live_out.flags_live()` is set
+/// and the whole memory image when `memory_live` is set (see ADR-0007).
 pub fn states_not_equal_for_live_out(
     state1: &MachineState,
     state2: &MachineState,
     live_out: &RegisterSet<Register>,
-    flags_live: bool,
     memory_live: bool,
 ) -> z3::ast::Bool {
     let mut not_equal = z3::ast::Bool::from_bool(false);
@@ -1320,7 +1309,7 @@ pub fn states_not_equal_for_live_out(
         not_equal = z3::ast::Bool::or(&[&not_equal, &reg_not_equal]);
     }
 
-    if flags_live {
+    if live_out.flags_live() {
         not_equal = z3::ast::Bool::or(&[&not_equal, &flags_not_equal(state1, state2)]);
     }
 
@@ -1665,13 +1654,35 @@ mod tests {
 
         let solver = Solver::new();
         let diseq =
-            states_not_equal_for_live_out(&state_cls, &state_signfold_clz, &live_out, false, false);
+            states_not_equal_for_live_out(&state_cls, &state_signfold_clz, &live_out, false);
         solver.assert(diseq);
         assert_eq!(
             solver.check(),
             SatResult::Unsat,
             "CLS(x) should match CLZ(x XOR (x ASR 63)) - 1 for live-out X0"
         );
+    }
+
+    #[test]
+    fn test_states_not_equal_for_live_out_reads_flags_from_mask() {
+        let state1 = MachineState::new_symbolic("flag_mask_a");
+        let state2 = MachineState::new_symbolic("flag_mask_b");
+        let live_out = RegisterSet::<Register>::empty();
+
+        let solver = Solver::new();
+        solver.assert(states_not_equal_for_live_out(
+            &state1, &state2, &live_out, false,
+        ));
+        assert_eq!(solver.check(), SatResult::Unsat);
+
+        let solver = Solver::new();
+        solver.assert(states_not_equal_for_live_out(
+            &state1,
+            &state2,
+            &live_out.with_flags(true),
+            false,
+        ));
+        assert_eq!(solver.check(), SatResult::Sat);
     }
 
     #[test]


### PR DESCRIPTION
Summary
- render AArch64 RegisterSet displays with a neutral name and explicit NZCV liveness
- remove duplicate flags_live parameters from concrete/SMT live-out comparators
- preserve stochastic fast-test flag ignoring through a named helper and targeted tests

Closes #282

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**