### PR TITLE
feat(x86): mutate cmov condition operands

### DIFF
--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -784,13 +784,17 @@ impl X86Mutator {
         }
     }
 
+    fn pick_condition<R: rand::RngExt>(&self, rng: &mut R) -> X86Condition {
+        X86Condition::ALL[rng.random_range(0..X86Condition::ALL.len())]
+    }
+
     fn random_instruction<R: rand::RngExt>(&self, rng: &mut R) -> Option<X86Instruction> {
         // Rewritable variants only: 7 reg-reg + 7 reg-imm + CMOVcc.
         let opcode = rng.random_range(0..u32::from(X86_REWRITABLE_OPCODE_COUNT));
         let rd = self.pick_register(rng)?;
         let rs = self.pick_register(rng)?;
         let imm = self.pick_immediate(rng);
-        let cond = X86Condition::ALL[rng.random_range(0..X86Condition::ALL.len())];
+        let cond = self.pick_condition(rng);
         Some(match opcode {
             0 => X86Instruction::MovReg { rd, rs },
             1 => X86Instruction::MovImm { rd, imm },
@@ -831,8 +835,8 @@ impl X86Mutator {
                 | X86Instruction::OrReg { .. }
                 | X86Instruction::XorReg { .. }
                 | X86Instruction::CmpReg { .. }
-                | X86Instruction::Cmov { .. }
                 | X86Instruction::Jcc { .. } => {}
+                X86Instruction::Cmov { cond, .. } => *cond = self.pick_condition(rng),
             }
             return;
         }
@@ -887,13 +891,13 @@ impl X86Mutator {
                     *imm = self.pick_immediate(rng);
                 }
             }
-            X86Instruction::Cmov { rd, rs, .. } => {
-                // Cond stays fixed — stochastic mutation only swaps registers
-                // for now; cycle 16+ may add condition-bridging.
-                if rng.random_bool(0.5) {
-                    *rd = self.pick_register(rng).expect("register pool is non-empty");
-                } else {
-                    *rs = self.pick_register(rng).expect("register pool is non-empty");
+            X86Instruction::Cmov { rd, rs, cond } => {
+                // Treat the condition code as a mutable operand alongside
+                // the destination and source registers.
+                match rng.random_range(0..3u32) {
+                    0 => *rd = self.pick_register(rng).expect("register pool is non-empty"),
+                    1 => *rs = self.pick_register(rng).expect("register pool is non-empty"),
+                    _ => *cond = self.pick_condition(rng),
                 }
             }
             // Jcc is a terminator; mutation never reaches it because the
@@ -2138,6 +2142,103 @@ mod tests {
         let mut rng = ChaCha8Rng::seed_from_u64(7);
 
         assert_eq!(mutator.mutate(&mut rng, &target), target);
+    }
+
+    #[test]
+    fn x86_mutator_cmov_operand_mutates_condition_with_empty_register_pool() {
+        use crate::isa::traits::ISAMutator;
+        use crate::search::config::MutationWeights;
+        use rand::SeedableRng;
+        use rand_chacha::ChaCha8Rng;
+
+        let mutator = X86Mutator::new(
+            Vec::new(),
+            vec![0],
+            MutationWeights {
+                operand: 1.0,
+                opcode: 0.0,
+                swap: 0.0,
+                instruction: 0.0,
+            },
+            crate::assembler::x86::X86Mode::Mode64,
+        );
+        let target = vec![X86Instruction::Cmov {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+            cond: X86Condition::E,
+        }];
+        let mut rng = ChaCha8Rng::seed_from_u64(7);
+        let mut changed = None;
+
+        for _ in 0..200 {
+            let mutated = mutator.mutate(&mut rng, &target);
+            match mutated.as_slice() {
+                [X86Instruction::Cmov { rd, rs, cond }]
+                    if *rd == X86Register::RAX && *rs == X86Register::RBX =>
+                {
+                    if *cond != X86Condition::E {
+                        changed = Some(*cond);
+                        break;
+                    }
+                }
+                other => panic!("unexpected CMOV mutation with empty register pool: {other:?}"),
+            }
+        }
+
+        assert!(
+            changed.is_some(),
+            "CMOV condition did not change after repeated operand mutations"
+        );
+    }
+
+    #[test]
+    fn x86_mutator_cmov_operand_reaches_all_conditions() {
+        use crate::isa::traits::ISAMutator;
+        use crate::search::config::MutationWeights;
+        use rand::SeedableRng;
+        use rand_chacha::ChaCha8Rng;
+        use std::collections::HashSet;
+
+        let pool = vec![X86Register::RAX, X86Register::RBX, X86Register::RCX];
+        let mutator = X86Mutator::new(
+            pool.clone(),
+            vec![0],
+            MutationWeights {
+                operand: 1.0,
+                opcode: 0.0,
+                swap: 0.0,
+                instruction: 0.0,
+            },
+            crate::assembler::x86::X86Mode::Mode64,
+        );
+        let mut seq = vec![X86Instruction::Cmov {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+            cond: X86Condition::E,
+        }];
+        let mut rng = ChaCha8Rng::seed_from_u64(11);
+        let mut observed = HashSet::from([X86Condition::E]);
+
+        for _ in 0..2_000 {
+            seq = mutator.mutate(&mut rng, &seq);
+            match seq.as_slice() {
+                [X86Instruction::Cmov { rd, rs, cond }] => {
+                    assert!(pool.contains(rd), "CMOV rd left mutator pool: {rd:?}");
+                    assert!(pool.contains(rs), "CMOV rs left mutator pool: {rs:?}");
+                    observed.insert(*cond);
+                }
+                other => panic!("CMOV operand mutation changed instruction shape: {other:?}"),
+            }
+            if observed.len() == X86Condition::ALL.len() {
+                break;
+            }
+        }
+
+        assert_eq!(
+            observed.len(),
+            X86Condition::ALL.len(),
+            "CMOV operand mutation reached only {observed:?}"
+        );
     }
 
     #[test]

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
## Summary
- let x86 CMOV operand mutation change condition codes, including empty register pools
- add seeded mutator regressions covering condition changes and all X86Condition::ALL values
- remove clippy needless BV borrows exposed by cargo clippy --all -- -D warnings

## Tests
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test --all (after ./build_tests.sh fixtures)
- ./ci_check.sh

Closes #285

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**