### PR TITLE
test(assembler): cover all x86-32 cmov and jcc suffixes

### DIFF
--- a/src/assembler/x86.rs
+++ b/src/assembler/x86.rs
@@ -878,16 +878,36 @@ mod tests {
     }
 
     #[test]
-    fn cmove_x86_32_round_trips() {
-        check_x86_32(
-            X86Instruction::Cmov {
-                rd: X86Register::RAX,
-                rs: X86Register::RBX,
-                cond: X86Condition::E,
-            },
-            "cmove",
-            &["eax", "ebx"],
-        );
+    fn all_cmov_suffixes_round_trip_x86_32() {
+        let cases = [
+            (X86Condition::E, "cmove"),
+            (X86Condition::NE, "cmovne"),
+            (X86Condition::B, "cmovb"),
+            (X86Condition::AE, "cmovae"),
+            (X86Condition::BE, "cmovbe"),
+            (X86Condition::A, "cmova"),
+            (X86Condition::L, "cmovl"),
+            (X86Condition::GE, "cmovge"),
+            (X86Condition::LE, "cmovle"),
+            (X86Condition::G, "cmovg"),
+            (X86Condition::S, "cmovs"),
+            (X86Condition::NS, "cmovns"),
+            (X86Condition::O, "cmovo"),
+            (X86Condition::NO, "cmovno"),
+            (X86Condition::P, "cmovp"),
+            (X86Condition::NP, "cmovnp"),
+        ];
+        for (cond, mn) in cases {
+            check_x86_32(
+                X86Instruction::Cmov {
+                    rd: X86Register::RAX,
+                    rs: X86Register::RBX,
+                    cond,
+                },
+                mn,
+                &["eax", "ebx"],
+            );
+        }
     }
 
     // --- Jcc short-form encoding ---
@@ -938,15 +958,33 @@ mod tests {
     }
 
     #[test]
-    fn je_x86_32_round_trips() {
-        let mut asm = X86Assembler::new_32();
-        let bytes = asm
-            .assemble_instructions(&[X86Instruction::Jcc {
-                cond: X86Condition::E,
-            }])
-            .expect("encode je 32-bit");
-        let disasm = disasm_x86_32(&bytes);
-        assert_eq!(disasm.len(), 1);
-        assert_eq!(disasm[0].0, "je");
+    fn all_jcc_suffixes_round_trip_x86_32() {
+        let cases = [
+            (X86Condition::E, "je"),
+            (X86Condition::NE, "jne"),
+            (X86Condition::B, "jb"),
+            (X86Condition::AE, "jae"),
+            (X86Condition::BE, "jbe"),
+            (X86Condition::A, "ja"),
+            (X86Condition::L, "jl"),
+            (X86Condition::GE, "jge"),
+            (X86Condition::LE, "jle"),
+            (X86Condition::G, "jg"),
+            (X86Condition::S, "js"),
+            (X86Condition::NS, "jns"),
+            (X86Condition::O, "jo"),
+            (X86Condition::NO, "jno"),
+            (X86Condition::P, "jp"),
+            (X86Condition::NP, "jnp"),
+        ];
+        for (cond, mn) in cases {
+            let mut asm = X86Assembler::new_32();
+            let bytes = asm
+                .assemble_instructions(&[X86Instruction::Jcc { cond }])
+                .unwrap_or_else(|e| panic!("encode {}: {}", mn, e));
+            let disasm = disasm_x86_32(&bytes);
+            assert_eq!(disasm.len(), 1, "expected one instr for {}", mn);
+            assert_eq!(disasm[0].0, mn);
+        }
     }
 }

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- replace the single-condition x86-32 CMOVcc and Jcc round-trip tests with full 16-suffix matrices
- keep the round trips through X86Assembler::new_32() and Capstone 32-bit disassembly, matching x86-64 coverage
- remove current-toolchain clippy needless-borrow warnings in SMT BV code so the required local gate stays green

Verification:
- cargo test assembler::x86::tests::all_cmov_suffixes_round_trip_x86_32
- cargo test assembler::x86::tests::all_jcc_suffixes_round_trip_x86_32
- cargo fmt --all
- cargo clippy --all -- -D warnings
- ./build_tests.sh
- cargo test --all
- ./ci_check.sh

Note: scripts/full_test.sh from the generic run contract is not present in this s11 workspace; the repo-local ./ci_check.sh ran successfully and includes test_all.sh.

Closes #286

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**