### PR TITLE
feat(bench): polish harness schema and fixture live-outs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,8 @@ and how to add a fixture.
   harness sets `spec.seed + sample_index` per record so runs are
   deterministic given the pair.
 - Phase 2 fixtures are not committed; run
-  `scripts/harvest_llvm_codegen.sh` to populate them.
+  `scripts/harvest_llvm_codegen.sh` to populate them; see
+  `benches/llvm_codegen/README.md` for refresh and review notes.
 
 ### Mutation Testing (informational, local-only)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ repository = "https://github.com/pmatos/s11"
 readme = "README.md"
 keywords = ["aarch64", "s11", "compiler", "optimization", "smt"]
 categories = ["compilers", "development-tools::testing", "science"]
+# Benchmarks are declared explicitly via [[bench]] below; disabling
+# auto-discovery keeps the shared `benches/common.rs` helper from being
+# built as its own libtest target (which would reject Criterion CLI args
+# like `--save-baseline`).
+autobenches = false
 
 [dependencies]
 elf = "0.8"

--- a/benches/README.md
+++ b/benches/README.md
@@ -37,6 +37,7 @@ benches/
 ├── llvm_codegen/          # Phase 2 fixtures — populated by the harvester
 ├── algebraic_fusion.rs    # Phase 3 driver
 ├── algebraic_fusion/*.s   # Phase 3 fixtures (~15, textbook identities)
+├── common.rs              # Shared Criterion phase driver
 ├── smt_clz.rs             # Direct CLZ/CLS SMT formula timing
 ├── results/results.jsonl  # JSONL accumulator (gitignored)
 └── README.md              # you are here
@@ -47,6 +48,8 @@ The shared harness (`load_sequence`, `run_bench`, `append_json`,
 lives in `src/bench_support.rs` because criterion's `harness = false`
 mode prevents `#[test]` blocks under `benches/` from running — putting
 the helpers in the library gives them a normal unit-test path.
+Criterion-specific phase plumbing lives in `benches/common.rs` because
+`criterion` is a dev-dependency.
 
 ## Adding a fixture
 
@@ -67,12 +70,16 @@ the helpers in the library gives them a normal unit-test path.
    automatically.
 
 A missing `// Live-out:` header panics with a pointer to this file.
+The AArch64 bench harness derives its candidate register pool from the
+fixture's source and destination operands, unioned with the default
+`x0..x5` pool, so Phase 2 fixtures using registers such as `x8`/`x9`
+remain expressible by the search.
 
 ## JSON record schema
 
 One record per fixture per `cargo bench` run. Bench drivers emit the
-JSON before driving criterion's `iter_custom`, so warm-up iterations
-never appear in the file. Criterion's HTML report under
+JSON from a de-duplicated `iter_custom` loop, so Criterion warm-up and
+measurement repeats never create extra lines. Criterion's HTML report under
 `target/criterion/<group>/<fixture>/` owns the per-sample variance; the
 JSON record below is the canonical snapshot downstream tooling diffs
 across commits.
@@ -89,7 +96,9 @@ across commits.
   "original_cost": 2,
   "best_cost": 1,
   "search_elapsed_ms": 22,
+  "search_elapsed_us": 22134,
   "smt_elapsed_ms": 0,
+  "smt_measured": true,
   "smt_queries": 73000,
   "smt_equivalent": 1,
   "candidates_evaluated": 85000,
@@ -110,7 +119,9 @@ across commits.
 | `original_length` / `found_length` | Target length and optimized length (or `null` if no optimization). |
 | `original_cost` / `best_cost` | Cost under the chosen metric. |
 | `search_elapsed_ms` | Wall time of the search itself, truncated to milliseconds for legibility. Sub-millisecond runs serialise as `0`; the bench driver uses the precise `Duration` internally so criterion's timing analysis sees real values. |
-| `smt_elapsed_ms` | Cumulative Z3 `solver.check()` time. Often zero — the pre-SMT guard rejects most flag-divergent candidates before reaching the solver. |
+| `search_elapsed_us` | Same wall time truncated to microseconds for downstream tools that diff fast fixtures. |
+| `smt_elapsed_ms` | Cumulative Z3 `solver.check()` time. Often zero — the pre-SMT guard rejects most flag-divergent candidates before reaching the solver, and very fast measured calls can still round to `0`. |
+| `smt_measured` | Whether the current bench backend populates SMT metrics. `true` plus `smt_elapsed_ms = 0` means metrics were available but rounded/truly zero or no solver call occurred; `false` is reserved for future uninstrumented backends. |
 | `smt_queries` / `smt_equivalent` | SMT call count (net of fast-path rollbacks) and how many proved equivalence. |
 | `candidates_evaluated` | Total candidates considered. |
 | `improved` / `timeout` | `improved`: whether the search returned a strictly cheaper sequence than the target — **not** "search completed without error" (a clean timeout that finds nothing also reports `improved: false`). Combine with `timeout` to distinguish "explored fully, no win" from "ran out of time." |
@@ -126,11 +137,16 @@ The script shallow-clones `llvm-project`, samples `.ll` files
 deterministically, drives them through `llc -mtriple=aarch64-linux-gnu
 -O2`, filters output blocks to s11-supported mnemonics, and writes
 each survivor as `benches/llvm_codegen/<basename>.s` with `// Source:`
-provenance.
+provenance. `// Live-out:` headers are inferred from destination
+operands, with 32-bit register names normalized to their 64-bit
+counterparts (`w9` -> `x9`) and `fp`/`lr` normalized to `x29`/`x30`.
+Blocks with no destination registers are skipped instead of falling
+back to `x0`.
 
 Maintainer-run only. Review `git status -- benches/llvm_codegen` and
-commit fixtures you want to keep. Re-run with the same `SEED` for a
-deterministic refresh.
+commit fixtures you want to keep. Generated live-outs are conservative
+operand-derived headers, not a substitute for human review. Re-run with
+the same `SEED` for a deterministic refresh.
 
 ## Caveats
 
@@ -140,6 +156,7 @@ deterministic refresh.
 - **`smt_elapsed_ms = 0` is normal**. For most Phase 1 targets the
   pre-SMT guard catches flag-divergence early and the solver never
   fires. Use `smt_queries` to see how many candidates reached the
-  solver (net of fast-path rollbacks).
+  solver (net of fast-path rollbacks), and `smt_measured` to distinguish
+  measured-zero from a future uninstrumented backend.
 - **Phase 2 emptiness is normal**. The harvester is opt-in; the bench
   driver skips the group when the fixture directory is empty.

--- a/benches/algebraic_fusion.rs
+++ b/benches/algebraic_fusion.rs
@@ -1,54 +1,19 @@
 //! Phase 3 — algebraic identities & fusion catalog.
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use s11::bench_support::{append_json, discover_specs_in, run_bench, run_provenance};
-use std::cell::Cell;
-use std::path::PathBuf;
-use std::time::Duration;
+
+mod common;
 
 fn phase3(c: &mut Criterion) {
-    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/algebraic_fusion");
-    let specs = discover_specs_in(&dir, 3);
-    if specs.is_empty() {
-        eprintln!("no Phase 3 fixtures under {}; skipping", dir.display());
-        return;
-    }
-    let (git_sha, timestamp_utc) = run_provenance();
-    let out = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/results/results.jsonl");
-
-    let mut group = c.benchmark_group("algebraic_fusion");
-    group.sample_size(10);
-    group.measurement_time(Duration::from_secs(10));
-
-    for spec in &specs {
-        let spec_owned = spec.clone();
-        let sha = git_sha.clone();
-        let ts = timestamp_utc.clone();
-        let out = out.clone();
-        group.bench_function(spec_owned.id.clone(), |b| {
-            // See benches/hackers_delight.rs for the rationale: JSON
-            // emission inside iter_custom so filtered runs only emit
-            // for selected fixtures; Cell<bool> dedups warm-up +
-            // measurement repeats. PR #269 review.
-            let emitted = Cell::new(false);
-            b.iter_custom(|iters| {
-                let mut total = Duration::ZERO;
-                for _ in 0..iters {
-                    let mut record = run_bench(&spec_owned);
-                    total += record.search_elapsed;
-                    if !emitted.get() {
-                        record.git_sha = sha.clone();
-                        record.timestamp_utc = ts.clone();
-                        append_json(&record, &out);
-                        emitted.set(true);
-                    }
-                }
-                total
-            });
-        });
-    }
-
-    group.finish();
+    common::run_phase(
+        c,
+        common::PhaseConfig {
+            group_name: "algebraic_fusion",
+            phase: 3,
+            fixture_subdir: "benches/algebraic_fusion",
+            empty_hint: None,
+        },
+    );
 }
 
 criterion_group!(benches, phase3);

--- a/benches/common.rs
+++ b/benches/common.rs
@@ -1,0 +1,67 @@
+use criterion::Criterion;
+use s11::bench_support::{append_json, discover_specs_in, run_bench, run_provenance};
+use std::cell::Cell;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+pub struct PhaseConfig<'a> {
+    pub group_name: &'a str,
+    pub phase: u8,
+    pub fixture_subdir: &'a str,
+    pub empty_hint: Option<&'a str>,
+}
+
+pub fn run_phase(c: &mut Criterion, config: PhaseConfig<'_>) {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(config.fixture_subdir);
+    let specs = discover_specs_in(&dir, config.phase);
+    if specs.is_empty() {
+        print_empty_message(config.phase, &dir, config.empty_hint);
+        return;
+    }
+    let (git_sha, timestamp_utc) = run_provenance();
+    let out = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/results/results.jsonl");
+
+    let mut group = c.benchmark_group(config.group_name);
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(10));
+
+    for spec in &specs {
+        let spec_owned = spec.clone();
+        let sha = git_sha.clone();
+        let ts = timestamp_utc.clone();
+        let out = out.clone();
+        group.bench_function(spec_owned.id.clone(), |b| {
+            let emitted = Cell::new(false);
+            b.iter_custom(|iters| {
+                let mut total = Duration::ZERO;
+                for _ in 0..iters {
+                    let mut record = run_bench(&spec_owned);
+                    total += record.criterion_elapsed();
+                    if !emitted.get() {
+                        record.git_sha = sha.clone();
+                        record.timestamp_utc = ts.clone();
+                        append_json(&record, &out);
+                        emitted.set(true);
+                    }
+                }
+                total
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn print_empty_message(phase: u8, dir: &Path, hint: Option<&str>) {
+    if let Some(hint) = hint {
+        eprintln!(
+            "no Phase {phase} fixtures under {} — {hint}. Skipping.",
+            dir.display()
+        );
+    } else {
+        eprintln!(
+            "no Phase {phase} fixtures under {}; skipping",
+            dir.display()
+        );
+    }
+}

--- a/benches/hackers_delight.rs
+++ b/benches/hackers_delight.rs
@@ -1,56 +1,19 @@
 //! Phase 1 — Hacker's Delight micro-suite.
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use s11::bench_support::{append_json, discover_specs_in, run_bench, run_provenance};
-use std::cell::Cell;
-use std::path::PathBuf;
-use std::time::Duration;
+
+mod common;
 
 fn phase1(c: &mut Criterion) {
-    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/hackers_delight");
-    let specs = discover_specs_in(&dir, 1);
-    if specs.is_empty() {
-        eprintln!("no Phase 1 fixtures under {}; skipping", dir.display());
-        return;
-    }
-    let (git_sha, timestamp_utc) = run_provenance();
-    let out = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/results/results.jsonl");
-
-    let mut group = c.benchmark_group("hackers_delight");
-    group.sample_size(10);
-    group.measurement_time(Duration::from_secs(10));
-
-    for spec in &specs {
-        let spec_owned = spec.clone();
-        let sha = git_sha.clone();
-        let ts = timestamp_utc.clone();
-        let out = out.clone();
-        group.bench_function(spec_owned.id.clone(), |b| {
-            // JSON emission lives inside the closure so a filtered run
-            // (`cargo bench -- max`) only produces rows for fixtures
-            // criterion actually selects. Cell<bool> dedups across
-            // criterion's repeated iter_custom calls (warm-up +
-            // measurement) — exactly one record per fixture per
-            // `cargo bench` invocation. PR #269 review.
-            let emitted = Cell::new(false);
-            b.iter_custom(|iters| {
-                let mut total = Duration::ZERO;
-                for _ in 0..iters {
-                    let mut record = run_bench(&spec_owned);
-                    total += record.search_elapsed;
-                    if !emitted.get() {
-                        record.git_sha = sha.clone();
-                        record.timestamp_utc = ts.clone();
-                        append_json(&record, &out);
-                        emitted.set(true);
-                    }
-                }
-                total
-            });
-        });
-    }
-
-    group.finish();
+    common::run_phase(
+        c,
+        common::PhaseConfig {
+            group_name: "hackers_delight",
+            phase: 1,
+            fixture_subdir: "benches/hackers_delight",
+            empty_hint: None,
+        },
+    );
 }
 
 criterion_group!(benches, phase1);

--- a/benches/llvm_codegen.rs
+++ b/benches/llvm_codegen.rs
@@ -3,58 +3,19 @@
 //! `benches/llvm_codegen/` is empty.
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use s11::bench_support::{append_json, discover_specs_in, run_bench, run_provenance};
-use std::cell::Cell;
-use std::path::PathBuf;
-use std::time::Duration;
+
+mod common;
 
 fn phase2(c: &mut Criterion) {
-    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/llvm_codegen");
-    let specs = discover_specs_in(&dir, 2);
-    if specs.is_empty() {
-        eprintln!(
-            "no Phase 2 fixtures under {} — run scripts/harvest_llvm_codegen.sh to populate. \
-             Skipping.",
-            dir.display()
-        );
-        return;
-    }
-    let (git_sha, timestamp_utc) = run_provenance();
-    let out = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/results/results.jsonl");
-
-    let mut group = c.benchmark_group("llvm_codegen");
-    group.sample_size(10);
-    group.measurement_time(Duration::from_secs(10));
-
-    for spec in &specs {
-        let spec_owned = spec.clone();
-        let sha = git_sha.clone();
-        let ts = timestamp_utc.clone();
-        let out = out.clone();
-        group.bench_function(spec_owned.id.clone(), |b| {
-            // See benches/hackers_delight.rs for the rationale: JSON
-            // emission inside iter_custom so filtered runs only emit
-            // for selected fixtures; Cell<bool> dedups warm-up +
-            // measurement repeats. PR #269 review.
-            let emitted = Cell::new(false);
-            b.iter_custom(|iters| {
-                let mut total = Duration::ZERO;
-                for _ in 0..iters {
-                    let mut record = run_bench(&spec_owned);
-                    total += record.search_elapsed;
-                    if !emitted.get() {
-                        record.git_sha = sha.clone();
-                        record.timestamp_utc = ts.clone();
-                        append_json(&record, &out);
-                        emitted.set(true);
-                    }
-                }
-                total
-            });
-        });
-    }
-
-    group.finish();
+    common::run_phase(
+        c,
+        common::PhaseConfig {
+            group_name: "llvm_codegen",
+            phase: 2,
+            fixture_subdir: "benches/llvm_codegen",
+            empty_hint: Some("run scripts/harvest_llvm_codegen.sh to populate"),
+        },
+    );
 }
 
 criterion_group!(benches, phase2);

--- a/benches/llvm_codegen/README.md
+++ b/benches/llvm_codegen/README.md
@@ -11,8 +11,15 @@ scripts/harvest_llvm_codegen.sh [SEED] [SAMPLE_SIZE]
 The script shallow-clones llvm-project, samples `.ll` files
 deterministically, runs `llc -mtriple=aarch64-linux-gnu -O2`, filters
 output to s11-supported mnemonics (see `CLAUDE.md:11`), and writes
-each surviving block as `<sha>_<offset>.s` with `// Source:` and
+each surviving block as `<basename>.s` with `// Source:` and inferred
 `// Live-out:` headers.
+
+Live-out inference is operand-based: destination registers from the
+straight-line block are de-duplicated, sorted, and normalized to
+parser-accepted names (`w9` becomes `x9`, `fp` becomes `x29`, and `sp`
+stays `sp`). Compare/test-only instructions such as `cmp` and `tst`
+do not contribute their first operand, and blocks with no destination
+registers are skipped rather than defaulting to `x0`.
 
 Review with `git status -- benches/llvm_codegen` and commit the
 generated `.s` files. The Phase 2 criterion bench
@@ -23,4 +30,5 @@ empty, so CI / `just bench` still passes on a fresh checkout.
 
 Re-run the harvester with the same seed to deterministically refresh,
 or pick a new seed to draw a different sample. Diff the result, drop
-fixtures that look uninteresting, and commit.
+fixtures that look uninteresting, verify the inferred live-out headers
+against the block intent, and commit.

--- a/scripts/harvest_llvm_codegen.sh
+++ b/scripts/harvest_llvm_codegen.sh
@@ -22,6 +22,153 @@ SEED="${1:-42}"
 SAMPLE_SIZE="${2:-30}"
 LLVM_CACHE="${LLVM_CACHE:-/tmp/s11-llvm}"
 
+# Supported AArch64 mnemonics — keep in sync with CLAUDE.md:11 and the
+# top-level mnemonic dispatch in src/parser/mod.rs. `uxtw` is intentionally
+# omitted: the parser handles it as an extend-operand modifier only, not
+# as a standalone instruction, so a harvested block containing it would
+# panic in load_sequence at bench time.
+SUPPORTED_MNEMONICS=(
+    mov add sub and orr eor lsl lsr asr mul sdiv udiv cmp cmn tst
+    csel csinc csinv csneg madd msub mneg smulh umulh ccmp ccmn
+    ubfx sbfx bfi bfxil ubfiz sbfiz
+    sxtb sxth sxtw uxtb uxth
+)
+
+build_mnemonic_re() {
+    local re="^[[:space:]]*("
+    local m
+    for m in "${SUPPORTED_MNEMONICS[@]}"; do
+        re+="$m|"
+    done
+    re="${re%|})[[:space:]]"
+    printf '%s\n' "$re"
+}
+
+extract_basic_block() {
+    local mnemonic_re="$1"
+    awk -v mnemonic_re="$mnemonic_re" '
+        BEGIN { block = ""; count = 0; supported = 1; done = 0 }
+        function trim(s) {
+            sub(/^[[:space:]]+/, "", s)
+            sub(/[[:space:]]+$/, "", s)
+            return s
+        }
+        function clear_live(k) {
+            for (k in live) {
+                delete live[k]
+            }
+        }
+        function reset() {
+            block = ""; count = 0; supported = 1; clear_live()
+        }
+        function writes_destination(mnemonic) {
+            return mnemonic != "cmp" && mnemonic != "cmn" && mnemonic != "tst" &&
+                mnemonic != "ccmp" && mnemonic != "ccmn"
+        }
+        function normalize_reg(raw, reg, n) {
+            reg = tolower(trim(raw))
+            sub(/[[:space:]].*$/, "", reg)
+            sub(/!$/, "", reg)
+
+            if (reg == "xzr" || reg == "wzr") {
+                return ""
+            }
+            if (reg == "fp") {
+                return "x29"
+            }
+            if (reg == "lr") {
+                return "x30"
+            }
+            if (reg == "sp" || reg == "wsp") {
+                return "sp"
+            }
+            if (reg ~ /^x([0-9]|[12][0-9]|30)$/) {
+                return reg
+            }
+            if (reg ~ /^w([0-9]|[12][0-9]|30)$/) {
+                n = substr(reg, 2)
+                return "x" n
+            }
+            return ""
+        }
+        function record_destination(line, tmp, mnemonic, rest, operands, dest) {
+            tmp = line
+            sub(/^[[:space:]]+/, "", tmp)
+            mnemonic = tolower(tmp)
+            sub(/[[:space:]].*$/, "", mnemonic)
+            if (!writes_destination(mnemonic)) {
+                return
+            }
+
+            rest = tmp
+            sub(/^[^[:space:]]+[[:space:]]+/, "", rest)
+            split(rest, operands, ",")
+            dest = normalize_reg(operands[1])
+            if (dest != "") {
+                live[dest] = 1
+            }
+        }
+        function live_count(k, n) {
+            n = 0
+            for (k in live) {
+                n++
+            }
+            return n
+        }
+        function live_out_list(i, reg, sep, out) {
+            sep = ""; out = ""
+            for (i = 0; i <= 30; i++) {
+                reg = "x" i
+                if (reg in live) {
+                    out = out sep reg
+                    sep = ","
+                }
+            }
+            if ("sp" in live) {
+                out = out sep "sp"
+            }
+            return out
+        }
+        function finish() {
+            if (supported && count >= 2 && count <= 32 && live_count() > 0) {
+                print "// Live-out: " live_out_list()
+                print block
+                done = 1
+                exit 0
+            }
+            reset()
+        }
+        # Blank lines and stripped comments — keep accumulating.
+        /^[[:space:]]*$/ { next }
+        /^[[:space:]]*\/\// { next }
+        # Assembler directives (.text, .cfi_*, etc.) — keep accumulating.
+        /^[[:space:]]*\./ { next }
+        # Labels close the current block.
+        /^[[:space:]]*[A-Za-z_.][A-Za-z0-9_.]*:/ { finish(); next }
+        # Branch / return terminators close the current block.
+        /^[[:space:]]*(b|br|bl|blr|ret|cbz|cbnz|tbz|tbnz)([[:space:]]|$)/ { finish(); next }
+        /^[[:space:]]*b\.[a-z]+([[:space:]]|$)/ { finish(); next }
+        # Supported instruction — append to the in-flight block.
+        $0 ~ mnemonic_re {
+            block = (count == 0 ? $0 : block "\n" $0)
+            record_destination($0)
+            count++
+            next
+        }
+        # Any other instruction disqualifies the block.
+        { supported = 0 }
+        # END fires even after `exit 0`, so guard against double-emit.
+        END { if (!done) finish() }
+    '
+}
+
+MNEMONIC_RE="$(build_mnemonic_re)"
+
+if [[ "${S11_HARVEST_EXTRACT_ONLY:-0}" == "1" ]]; then
+    extract_basic_block "$MNEMONIC_RE"
+    exit 0
+fi
+
 # 1. Precheck: llc must include the AArch64 backend.
 if ! llc --version 2>/dev/null | grep -qE '^\s*aarch64\b'; then
     echo "error: llc lacks the AArch64 backend" >&2
@@ -63,25 +210,6 @@ mapfile -t SAMPLES < <(
 OUT_DIR="$(git rev-parse --show-toplevel)/benches/llvm_codegen"
 mkdir -p "$OUT_DIR"
 
-# Supported AArch64 mnemonics — keep in sync with CLAUDE.md:11 and the
-# top-level mnemonic dispatch in src/parser/mod.rs. `uxtw` is intentionally
-# omitted: the parser handles it as an extend-operand modifier only, not
-# as a standalone instruction, so a harvested block containing it would
-# panic in load_sequence at bench time.
-SUPPORTED_MNEMONICS=(
-    mov add sub and orr eor lsl lsr asr mul sdiv udiv cmp cmn tst
-    csel csinc csinv csneg madd msub mneg smulh umulh ccmp ccmn
-    ubfx sbfx bfi bfxil ubfiz sbfiz
-    sxtb sxth sxtw uxtb uxth
-)
-
-# Build a regex matching exactly one supported mnemonic at line start.
-MNEMONIC_RE="^[[:space:]]*("
-for m in "${SUPPORTED_MNEMONICS[@]}"; do
-    MNEMONIC_RE+="$m|"
-done
-MNEMONIC_RE="${MNEMONIC_RE%|})[[:space:]]"
-
 # 4. Run llc on each sample, emit .s blocks the s11 parser can consume.
 #
 # The body extractor is an awk state machine. It walks the llc output
@@ -95,51 +223,22 @@ MNEMONIC_RE="${MNEMONIC_RE%|})[[:space:]]"
 # disqualifies the currently-accumulating block — the harvester does
 # not silently splice supported lines across an unsupported one.
 #
-# The first qualifying block (2..32 supported instructions) is emitted
-# and awk exits. This guarantees one straight-line block per fixture,
-# preventing the previous behaviour of grep'ing across multiple basic
-# blocks / functions and gluing unrelated paths together (PR #269 review).
+# The first qualifying block (2..32 supported instructions, with at
+# least one inferred destination register) is emitted and awk exits.
+# This guarantees one straight-line block per fixture, preventing the
+# previous behaviour of grep'ing across multiple basic blocks / functions
+# and gluing unrelated paths together (PR #269 review).
 echo "[3/4] running llc and extracting basic blocks..."
 kept=0
 for ll in "${SAMPLES[@]}"; do
     base="$(basename "${ll%.ll}")"
     asm="$(llc -mtriple=aarch64-linux-gnu -O2 -filetype=asm -o - "$ll" 2>/dev/null)" || continue
 
-    body="$(printf '%s\n' "$asm" | awk -v mnemonic_re="$MNEMONIC_RE" '
-        BEGIN { block = ""; count = 0; supported = 1; done = 0 }
-        function finish() {
-            if (supported && count >= 2 && count <= 32) {
-                print block
-                done = 1
-                exit 0
-            }
-            block = ""; count = 0; supported = 1
-        }
-        # Blank lines and stripped comments — keep accumulating.
-        /^[[:space:]]*$/ { next }
-        /^[[:space:]]*\/\// { next }
-        # Assembler directives (.text, .cfi_*, etc.) — keep accumulating.
-        /^[[:space:]]*\./ { next }
-        # Labels close the current block.
-        /^[[:space:]]*[A-Za-z_.][A-Za-z0-9_.]*:/ { finish(); next }
-        # Branch / return terminators close the current block.
-        /^[[:space:]]*(b|br|bl|blr|ret|cbz|cbnz|tbz|tbnz)([[:space:]]|$)/ { finish(); next }
-        /^[[:space:]]*b\.[a-z]+([[:space:]]|$)/ { finish(); next }
-        # Supported instruction — append to the in-flight block.
-        $0 ~ mnemonic_re {
-            block = (count == 0 ? $0 : block "\n" $0)
-            count++
-            next
-        }
-        # Any other instruction disqualifies the block.
-        { supported = 0 }
-        # END fires even after `exit 0`, so guard against double-emit.
-        END { if (!done) finish() }
-    ')"
+    fixture="$(printf '%s\n' "$asm" | extract_basic_block "$MNEMONIC_RE")"
 
-    # awk emits a block only on success; an empty body means no
-    # qualifying block was found in this .ll.
-    if [[ -z "$body" ]]; then
+    # awk emits a block only on success; an empty fixture means no
+    # qualifying block with inferred live-out destinations was found.
+    if [[ -z "$fixture" ]]; then
         continue
     fi
 
@@ -147,18 +246,11 @@ for ll in "${SAMPLES[@]}"; do
     {
         printf '// Source: llvm-project/llvm/test/CodeGen/AArch64/%s\n' "$(basename "$ll")"
         printf '// Live-in: x0, x1\n'
-        printf '// Live-out: x0\n'
-        printf '%s\n' "$body"
+        printf '%s\n' "$fixture"
     } > "$out"
     kept=$((kept+1))
 done
 
 echo "[4/4] wrote $kept fixtures to $OUT_DIR"
 echo "Review them with:   git -C $(git rev-parse --show-toplevel) status -- benches/llvm_codegen"
-echo
-echo "WARNING: every fixture inherits a hardcoded \`// Live-out: x0\` header."
-echo "         If the underlying basic block writes its result to a different"
-echo "         register (e.g. x8, x9, or a callee-saved reg), hand-edit the"
-echo "         header before committing — otherwise the benchmark will be"
-echo "         observing the wrong state. Per-block live-out inference is"
-echo "         tracked in https://github.com/pmatos/s11/issues/287."
+echo "Live-out headers are inferred from destination operands; review them before committing."

--- a/scripts/test_harvest_llvm_codegen.sh
+++ b/scripts/test_harvest_llvm_codegen.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+actual="$(
+    S11_HARVEST_EXTRACT_ONLY=1 "$ROOT/scripts/harvest_llvm_codegen.sh" <<'ASM'
+    cmp x0, x1
+    tst x10, x11
+    add x8, x0, #1
+    mov w9, w8
+    mov fp, x9
+    add sp, sp, #16
+ASM
+)"
+
+expected="$(cat <<'EOF'
+// Live-out: x8,x9,x29,sp
+    cmp x0, x1
+    tst x10, x11
+    add x8, x0, #1
+    mov w9, w8
+    mov fp, x9
+    add sp, sp, #16
+EOF
+)"
+
+if [[ "$actual" != "$expected" ]]; then
+    diff -u <(printf '%s\n' "$expected") <(printf '%s\n' "$actual")
+    exit 1
+fi
+
+no_dest="$(
+    S11_HARVEST_EXTRACT_ONLY=1 "$ROOT/scripts/harvest_llvm_codegen.sh" <<'ASM'
+    cmp x0, x1
+    tst x2, x3
+ASM
+)"
+
+if [[ -n "$no_dest" ]]; then
+    echo "expected a block with no destination registers to be skipped; got:" >&2
+    printf '%s\n' "$no_dest" >&2
+    exit 1
+fi

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -1,12 +1,11 @@
 //! Shared harness for the criterion benchmark suite (issue #70).
 //!
-//! Each bench file under `benches/` brings these helpers in via
-//! `use s11::bench_support::*;`. The module lives in the library —
-//! not under `benches/common/` — because `harness = false` benchmarks
-//! cannot run `#[test]` blocks; we need a regular lib-test path to
-//! exercise the helpers under TDD.
+//! Criterion-specific driver code lives under `benches/`, but these
+//! parser/search/JSON helpers live in the library because `harness = false`
+//! benchmarks cannot run `#[test]` blocks; we need a regular lib-test path
+//! to exercise the helpers under TDD.
 
-use crate::ir::Instruction;
+use crate::ir::{Instruction, Register};
 use crate::parser::{LineResult, parse_line};
 use crate::search::SearchAlgorithm;
 use crate::search::config::{Algorithm, SearchConfig};
@@ -16,6 +15,30 @@ use crate::validation::live_out::parse_live_out_contract;
 use serde::Serialize;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
+
+fn duration_micros_u64(duration: Duration) -> u64 {
+    duration.as_micros().min(u128::from(u64::MAX)) as u64
+}
+
+fn register_pool_for_target(target: &[Instruction], default: &[Register]) -> Vec<Register> {
+    let mut registers = default.to_vec();
+    for reg in target.iter().flat_map(|instr| {
+        instr
+            .source_registers()
+            .into_iter()
+            .chain(instr.destinations())
+    }) {
+        if reg != Register::XZR && !registers.contains(&reg) {
+            registers.push(reg);
+        }
+    }
+    registers.sort_by_key(register_sort_key);
+    registers
+}
+
+fn register_sort_key(reg: &Register) -> u8 {
+    reg.index().unwrap_or(32)
+}
 
 /// Short git SHA + a unix-epoch-seconds timestamp, captured once per
 /// process and stamped onto every `BenchRecord` emitted in this run.
@@ -130,11 +153,10 @@ pub fn load_sequence(path: &Path) -> (Vec<Instruction>, LiveOut) {
 
 /// One canonical record per `(benchmark_id, cargo bench invocation)`.
 ///
-/// JSON emission is gated to a single call site outside criterion's
-/// `iter_custom`, so the JSONL accumulator contains exactly one row
-/// per fixture per `cargo bench` run. Criterion's HTML report owns the
-/// per-sample variance; this record is the snapshot downstream tooling
-/// diffs across commits.
+/// JSON emission is gated by the Criterion driver, so the JSONL accumulator
+/// contains exactly one row per fixture per `cargo bench` run. Criterion's
+/// HTML report owns the per-sample variance; this record is the snapshot
+/// downstream tooling diffs across commits.
 #[derive(Debug, Clone, Serialize)]
 pub struct BenchRecord {
     pub benchmark_id: String,
@@ -147,16 +169,23 @@ pub struct BenchRecord {
     pub original_cost: u64,
     pub best_cost: u64,
     /// Truncated to milliseconds for the JSON-Lines record so the file
-    /// is easy to skim. Bench files MUST use [`BenchRecord::search_elapsed`]
+    /// is easy to skim. Bench files MUST use [`BenchRecord::criterion_elapsed`]
     /// (precise `Duration`) when feeding criterion's `iter_custom`, or
     /// sub-millisecond samples round to zero — see PR #269 review.
     pub search_elapsed_ms: u64,
+    /// Same wall time as `search_elapsed_ms`, truncated to microseconds.
+    /// This keeps the JSON record useful for fast fixtures while preserving
+    /// the existing millisecond field for schema compatibility.
+    pub search_elapsed_us: u64,
     /// Full-precision wall time of the search. Excluded from the JSON
     /// serialization because `search_elapsed_ms` is the documented
     /// schema field; this is the value criterion's timing model needs.
     #[serde(skip)]
-    pub search_elapsed: Duration,
+    search_elapsed: Duration,
     pub smt_elapsed_ms: u64,
+    /// Whether SMT timing/counter metrics are populated by this bench
+    /// adapter. `false` is reserved for future uninstrumented backends.
+    pub smt_measured: bool,
     pub smt_queries: u64,
     pub smt_equivalent: u64,
     pub candidates_evaluated: u64,
@@ -169,6 +198,13 @@ pub struct BenchRecord {
     pub timeout: bool,
     pub git_sha: Option<String>,
     pub timestamp_utc: Option<String>,
+}
+
+impl BenchRecord {
+    /// Precise elapsed time for Criterion's `iter_custom` timing model.
+    pub fn criterion_elapsed(&self) -> Duration {
+        self.search_elapsed
+    }
 }
 
 /// Append one `BenchRecord` as a JSON line to `path`, creating the
@@ -216,30 +252,22 @@ pub struct BenchSpec {
 
 /// Run the optimizer against one fixture and synthesise a `BenchRecord`.
 ///
-/// Deterministic given `spec.seed`. Bench drivers call this **once per
-/// `cargo bench` invocation** outside criterion's `iter_custom` so the
-/// JSON-Lines accumulator stays exactly one record per fixture —
-/// criterion's warmup phase would otherwise emit unmeasured records
-/// (PR #269 review). Inside `iter_custom`, drivers re-call `run_bench`
-/// just to read `search_elapsed` for criterion's timing model.
+/// Deterministic given `spec.seed`. Bench drivers call this from a
+/// de-duplicated Criterion loop so the JSON-Lines accumulator stays exactly
+/// one record per fixture per `cargo bench` invocation — criterion's warmup
+/// phase would otherwise emit unmeasured records (PR #269 review).
 pub fn run_bench(spec: &BenchSpec) -> BenchRecord {
-    // NOTE: The AArch64 backends invoked below hardcode `.with_flags(true)`
-    // (`src/search/enumerative/search.rs`, `src/search/stochastic/backend.rs`,
-    // `src/search/symbolic/backend.rs`). The fixture's `flags_live` bit
-    // (carried on the returned `LiveOut`) is therefore not consulted here:
-    // every benched candidate is verified under "NZCV is observable"
-    // semantics regardless of the header. This is conservative
-    // (pessimises rewrites that drop flag-setters when the fixture
-    // declares NZCV dead) but never unsound. Tracked for proper plumbing
-    // in #287.
     let (target, live_out) = load_sequence(&spec.fixture);
     let original_length = target.len();
     let original_cost = sequence_cost(&target, &spec.cost_metric);
 
-    let mut config = SearchConfig::default()
+    let default_config = SearchConfig::default();
+    let register_pool = register_pool_for_target(&target, &default_config.available_registers);
+    let mut config = default_config
         .with_algorithm(spec.algorithm)
         .with_cost_metric(spec.cost_metric)
-        .with_timeout(spec.timeout);
+        .with_timeout(spec.timeout)
+        .with_registers(register_pool);
     config.stochastic.seed = Some(spec.seed);
 
     let (statistics, optimized) = match spec.algorithm {
@@ -282,8 +310,10 @@ pub fn run_bench(spec: &BenchSpec) -> BenchRecord {
         original_cost,
         best_cost,
         search_elapsed_ms: statistics.elapsed_time.as_millis() as u64,
+        search_elapsed_us: duration_micros_u64(statistics.elapsed_time),
         search_elapsed: statistics.elapsed_time,
         smt_elapsed_ms: statistics.smt_elapsed.as_millis() as u64,
+        smt_measured: true,
         smt_queries: statistics.smt_queries,
         smt_equivalent: statistics.smt_equivalent,
         candidates_evaluated: statistics.candidates_evaluated,
@@ -361,8 +391,10 @@ mod tests {
             original_cost: 2,
             best_cost: 1,
             search_elapsed_ms: 5,
-            search_elapsed: Duration::from_millis(5),
+            search_elapsed_us: 5_123,
+            search_elapsed: Duration::from_micros(5_123),
             smt_elapsed_ms: 1,
+            smt_measured: true,
             smt_queries: 3,
             smt_equivalent: 1,
             candidates_evaluated: 20,
@@ -385,6 +417,13 @@ mod tests {
             .collect();
         assert_eq!(parsed[0]["benchmark_id"], "demo");
         assert_eq!(parsed[1]["benchmark_id"], "demo-2");
+        assert_eq!(parsed[0]["search_elapsed_ms"], 5);
+        assert_eq!(parsed[0]["search_elapsed_us"], 5_123);
+        assert_eq!(parsed[0]["smt_measured"], true);
+        assert!(
+            parsed[0].get("search_elapsed").is_none(),
+            "precise Duration must stay internal to the bench driver"
+        );
     }
 
     /// Smoke-test every shipped fixture (Phase 1 + Phase 3): each
@@ -460,5 +499,95 @@ mod tests {
         assert!(record.smt_queries > 0, "enumerative search must hit SMT");
         assert!(record.candidates_evaluated > 0);
         assert!(!record.timeout);
+    }
+
+    #[test]
+    fn run_bench_honours_fixture_flags_dead_header() {
+        let f = write_fixture(
+            "// Live-out: x0\n\
+             cmp x1, x2\n\
+             add x0, x3, #1\n",
+        );
+        let spec = BenchSpec {
+            id: "dead_cmp".to_string(),
+            fixture: f.path().to_path_buf(),
+            phase: 3,
+            algorithm: Algorithm::Enumerative,
+            cost_metric: CostMetric::InstructionCount,
+            seed: 42,
+            timeout: Duration::from_secs(120),
+        };
+
+        let record = run_bench(&spec);
+
+        assert!(
+            record.improved,
+            "fixture omits ;nzcv, so a dead compare may be dropped"
+        );
+        assert_eq!(record.original_length, 2);
+        assert_eq!(record.found_length, Some(1));
+        assert_eq!(record.best_cost, 1);
+    }
+
+    #[test]
+    fn register_pool_for_target_unions_default_with_fixture_operands() {
+        let f = write_fixture(
+            "// Live-out: x8\n\
+             add x8, x9, #1\n\
+             eor x9, x9, xzr\n",
+        );
+        let (target, _) = load_sequence(f.path());
+        let pool = register_pool_for_target(
+            &target,
+            &[
+                crate::ir::Register::X0,
+                crate::ir::Register::X1,
+                crate::ir::Register::X2,
+                crate::ir::Register::X3,
+                crate::ir::Register::X4,
+                crate::ir::Register::X5,
+            ],
+        );
+
+        assert_eq!(
+            pool,
+            vec![
+                crate::ir::Register::X0,
+                crate::ir::Register::X1,
+                crate::ir::Register::X2,
+                crate::ir::Register::X3,
+                crate::ir::Register::X4,
+                crate::ir::Register::X5,
+                crate::ir::Register::X8,
+                crate::ir::Register::X9,
+            ]
+        );
+    }
+
+    #[test]
+    fn run_bench_register_pool_includes_nondefault_fixture_operands() {
+        let f = write_fixture(
+            "// Live-out: x8\n\
+             mov x8, x9\n\
+             add x8, x8, #1\n",
+        );
+        let spec = BenchSpec {
+            id: "x8_mov_add_fuse".to_string(),
+            fixture: f.path().to_path_buf(),
+            phase: 2,
+            algorithm: Algorithm::Enumerative,
+            cost_metric: CostMetric::InstructionCount,
+            seed: 42,
+            timeout: Duration::from_secs(120),
+        };
+
+        let record = run_bench(&spec);
+
+        assert!(
+            record.improved,
+            "bench register pool must include x8/x9 from the fixture"
+        );
+        assert_eq!(record.found_length, Some(1));
+        assert_eq!(record.best_cost, 1);
     }
 }

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- Add `search_elapsed_us` and `smt_measured` to bench JSON records while keeping the existing millisecond field.
- Move repeated Criterion phase-driver logic into `benches/common.rs` and expose `BenchRecord::criterion_elapsed()` so drivers no longer touch the skipped raw duration field.
- Thread fixture realities into the bench harness with flags-dead regression coverage and target-derived AArch64 register pools.
- Infer Phase 2 LLVM fixture `// Live-out:` headers from destination operands, with a shell self-test and maintainer docs.
- Include the narrow SMT borrow cleanup needed for the current `cargo clippy --all -- -D warnings` gate.

Validation:
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `scripts/test_harvest_llvm_codegen.sh`
- `cargo bench --bench hackers_delight --no-run`
- `cargo bench --bench llvm_codegen --no-run`
- `cargo bench --bench algebraic_fusion --no-run`
- `./build_tests.sh`
- `cargo test --all`
- `./ci_check.sh`

Note: `scripts/full_test.sh` from the generic run contract does not exist in this repository; `./ci_check.sh` runs the repo-local `test_all.sh`.

Closes #287

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**