### PR TITLE
fix(x86): address backend hygiene follow-ups

### DIFF
--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -68,11 +68,9 @@ impl X86Condition {
         Self::P,
         Self::NP,
     ];
-}
 
-impl fmt::Display for X86Condition {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = match self {
+    pub const fn suffix(self) -> &'static str {
+        match self {
             X86Condition::E => "e",
             X86Condition::NE => "ne",
             X86Condition::B => "b",
@@ -89,8 +87,55 @@ impl fmt::Display for X86Condition {
             X86Condition::NO => "no",
             X86Condition::P => "p",
             X86Condition::NP => "np",
-        };
-        f.write_str(s)
+        }
+    }
+
+    pub const fn cmov_mnemonic(self) -> &'static str {
+        match self {
+            X86Condition::E => "cmove",
+            X86Condition::NE => "cmovne",
+            X86Condition::B => "cmovb",
+            X86Condition::AE => "cmovae",
+            X86Condition::BE => "cmovbe",
+            X86Condition::A => "cmova",
+            X86Condition::L => "cmovl",
+            X86Condition::GE => "cmovge",
+            X86Condition::LE => "cmovle",
+            X86Condition::G => "cmovg",
+            X86Condition::S => "cmovs",
+            X86Condition::NS => "cmovns",
+            X86Condition::O => "cmovo",
+            X86Condition::NO => "cmovno",
+            X86Condition::P => "cmovp",
+            X86Condition::NP => "cmovnp",
+        }
+    }
+
+    pub const fn jcc_mnemonic(self) -> &'static str {
+        match self {
+            X86Condition::E => "je",
+            X86Condition::NE => "jne",
+            X86Condition::B => "jb",
+            X86Condition::AE => "jae",
+            X86Condition::BE => "jbe",
+            X86Condition::A => "ja",
+            X86Condition::L => "jl",
+            X86Condition::GE => "jge",
+            X86Condition::LE => "jle",
+            X86Condition::G => "jg",
+            X86Condition::S => "js",
+            X86Condition::NS => "jns",
+            X86Condition::O => "jo",
+            X86Condition::NO => "jno",
+            X86Condition::P => "jp",
+            X86Condition::NP => "jnp",
+        }
+    }
+}
+
+impl fmt::Display for X86Condition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.suffix())
     }
 }
 
@@ -307,8 +352,8 @@ impl X86Instruction {
             X86Instruction::OrReg { .. } | X86Instruction::OrImm { .. } => "or",
             X86Instruction::XorReg { .. } | X86Instruction::XorImm { .. } => "xor",
             X86Instruction::CmpReg { .. } | X86Instruction::CmpImm { .. } => "cmp",
-            X86Instruction::Cmov { .. } => "cmov",
-            X86Instruction::Jcc { .. } => "jcc",
+            X86Instruction::Cmov { cond, .. } => cond.cmov_mnemonic(),
+            X86Instruction::Jcc { cond } => cond.jcc_mnemonic(),
         }
     }
 
@@ -418,10 +463,9 @@ impl fmt::Display for X86Instruction {
             | X86Instruction::XorImm { rd, imm } => write!(f, "{} {}, {}", mn, rd, imm),
             X86Instruction::CmpReg { rn, rs } => write!(f, "{} {}, {}", mn, rn, rs),
             X86Instruction::CmpImm { rn, imm } => write!(f, "{} {}, {}", mn, rn, imm),
-            // Render as e.g. `cmove rax, rbx` (mnemonic + condition suffix).
-            X86Instruction::Cmov { rd, rs, cond } => write!(f, "cmov{} {}, {}", cond, rd, rs),
+            X86Instruction::Cmov { rd, rs, .. } => write!(f, "{} {}, {}", mn, rd, rs),
             // Target is opaque to the IR; render with a placeholder.
-            X86Instruction::Jcc { cond } => write!(f, "j{} <target>", cond),
+            X86Instruction::Jcc { .. } => write!(f, "{} <target>", mn),
         }
     }
 }
@@ -1743,6 +1787,43 @@ mod tests {
         ];
         for (instr, expected) in cases {
             assert_eq!(instr.mnemonic(), *expected);
+        }
+    }
+
+    #[test]
+    fn x86_condition_mnemonics_include_suffixes() {
+        use crate::isa::traits::InstructionType;
+        let cmove = X86Instruction::Cmov {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+            cond: X86Condition::E,
+        };
+        let cmovne = X86Instruction::Cmov {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+            cond: X86Condition::NE,
+        };
+        let je = X86Instruction::Jcc {
+            cond: X86Condition::E,
+        };
+        let jne = X86Instruction::Jcc {
+            cond: X86Condition::NE,
+        };
+
+        let cases = [
+            (cmove, "cmove", "cmove rax, rbx"),
+            (cmovne, "cmovne", "cmovne rax, rbx"),
+            (je, "je", "je <target>"),
+            (jne, "jne", "jne <target>"),
+        ];
+
+        for (instr, mnemonic, display) in cases {
+            assert_eq!(instr.mnemonic(), mnemonic);
+            assert_eq!(
+                <X86Instruction as InstructionType>::mnemonic(&instr),
+                mnemonic
+            );
+            assert_eq!(instr.to_string(), display);
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -660,15 +660,34 @@ impl ElfOptimizationBackend for X86OptimizationBackend {
             )
             .into());
         }
-        let pinned_terminator_bytes: Option<Vec<u8>> = if original_terminator.is_some() {
-            let last = capstone_instructions
-                .iter()
-                .last()
-                .ok_or("expected non-empty disassembly when peeling terminator")?;
-            Some(last.bytes().to_vec())
-        } else {
-            None
-        };
+        let pinned_terminator_bytes: Option<Vec<u8>> =
+            if let Some(expected_terminator) = original_terminator {
+                let last = capstone_instructions
+                    .iter()
+                    .last()
+                    .ok_or("expected non-empty disassembly when peeling terminator")?;
+                #[cfg(debug_assertions)]
+                {
+                    let mn = last.mnemonic().unwrap_or("");
+                    let ops = last.op_str().unwrap_or("");
+                    let parsed_last = match x86_ir_from_mnemonic(mn, ops) {
+                        Ok(Some(instr)) => instr,
+                        Ok(None) => panic!(
+                            "last Capstone instruction must yield x86 IR when original IR has a Jcc"
+                        ),
+                        Err(err) => panic!(
+                            "last Capstone instruction must parse when original IR has a Jcc: {err}"
+                        ),
+                    };
+                    debug_assert_eq!(
+                        parsed_last, *expected_terminator,
+                        "peeled x86 Jcc terminator must correspond to the last Capstone instruction"
+                    );
+                }
+                Some(last.bytes().to_vec())
+            } else {
+                None
+            };
         let original_prefix_byte_size =
             original_bytes.len() - pinned_terminator_bytes.as_ref().map_or(0, |b| b.len());
 
@@ -1919,27 +1938,43 @@ fn reassemble_x86_prefix_with_pinned_terminator(
         ));
     }
 
+    let gap = original_prefix_byte_size - out.len();
+    append_nop_padding(&mut out, gap, arch, |remaining| {
+        arch.nop_sequence(remaining)
+    })?;
+    out.extend_from_slice(jcc_bytes);
+    Ok(out)
+}
+
+fn append_nop_padding<F>(
+    out: &mut Vec<u8>,
+    gap: usize,
+    arch: DetectedArch,
+    mut nop_sequence: F,
+) -> Result<(), String>
+where
+    F: FnMut(usize) -> &'static [u8],
+{
     // Pad NOPs so the Jcc lands at the same offset as in the original
     // window. `nop_sequence` may return fewer than the requested bytes;
     // loop until the gap is filled. Return Err on an empty NOP slice
     // (debug-assert alone would let release builds spin forever).
-    let gap = original_prefix_byte_size - out.len();
     let mut padded = 0;
     while padded < gap {
-        let nop = arch.nop_sequence(gap - padded);
+        let remaining = gap - padded;
+        let nop = nop_sequence(remaining);
         if nop.is_empty() {
             return Err(format!(
                 "nop_sequence returned an empty slice while padding {} bytes \
                  for arch {:?}; refusing to spin forever",
-                gap - padded,
-                arch
+                remaining, arch
             ));
         }
-        out.extend_from_slice(nop);
-        padded += nop.len();
+        let take = nop.len().min(remaining);
+        out.extend_from_slice(&nop[..take]);
+        padded += take;
     }
-    out.extend_from_slice(jcc_bytes);
-    Ok(out)
+    Ok(())
 }
 
 // --- Equivalence Checking Command ---
@@ -4201,6 +4236,19 @@ mod cli_helper_tests {
         assert_eq!(&out[5..7], &original_jcc_bytes);
         // Bytes [2..5] are NOP-padding; x86-32 nop_sequence emits 0x90.
         assert_eq!(&out[2..5], &[0x90u8; 3]);
+    }
+
+    #[test]
+    fn append_nop_padding_clamps_overlong_nop_provider() {
+        let mut out = vec![0xcc];
+
+        append_nop_padding(&mut out, 3, DetectedArch::X86_64, |_| {
+            &[0x90, 0x90, 0x90, 0x90]
+        })
+        .expect("padding succeeds");
+
+        assert_eq!(out.len(), 4, "padding must not overshoot the requested gap");
+        assert_eq!(&out[1..], &[0x90, 0x90, 0x90]);
     }
 
     #[test]

--- a/src/semantics/cost_x86.rs
+++ b/src/semantics/cost_x86.rs
@@ -58,7 +58,8 @@ fn instruction_code_size(instr: &X86Instruction, width: u32) -> u64 {
         // Short-form Jcc is `7x rel8` = 2 bytes (no REX). Long-form
         // `0F 8x rel32` = 6 bytes is used when the displacement doesn't
         // fit. The optimizer never emits Jcc bytes (terminators stay
-        // pinned in the binary), so 2 is the conservative baseline.
+        // pinned in the binary), so this is only the IR accounting
+        // baseline; patching splices the original branch bytes back.
         X86Instruction::Jcc { .. } => 2,
     }
 }

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {

--- a/src/semantics/smt_x86.rs
+++ b/src/semantics/smt_x86.rs
@@ -87,6 +87,9 @@ impl MachineStateX86 {
 
 // --- symbolic EFLAGS helpers ---
 
+// z3 0.20 constructors use the thread-local context. Keep this helper
+// aligned with the AArch64 SMT module; an explicit-context refactor should
+// move both backends together.
 fn bv_one() -> BV {
     BV::from_u64(1, 1)
 }
@@ -659,6 +662,74 @@ mod tests {
         );
     }
 
+    fn assert_x86_cmov_concrete_smt_parity(
+        cond: crate::isa::x86::X86Condition,
+        input_flags: crate::semantics::state::Eflags,
+        lhs: u64,
+        rhs: u64,
+    ) {
+        use crate::semantics::concrete_x86::apply_instruction_concrete_x86;
+        use crate::semantics::state::{ConcreteValue, X86ConcreteMachineState};
+
+        let instr = X86Instruction::Cmov {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+            cond,
+        };
+
+        let mut concrete_pre = X86ConcreteMachineState::new_zeroed(64);
+        concrete_pre.set_register(X86Register::RAX, ConcreteValue::new(lhs));
+        concrete_pre.set_register(X86Register::RBX, ConcreteValue::new(rhs));
+        concrete_pre.set_flags(input_flags);
+        let concrete_post = apply_instruction_concrete_x86(concrete_pre, &instr);
+        let expected_flags = concrete_post.get_flags();
+
+        let symbolic_pre = MachineStateX86::new_symbolic("cmov_pre", 64);
+        let solver = Solver::new();
+        solver.assert(
+            symbolic_pre
+                .get_register(X86Register::RAX)
+                .eq(BV::from_u64(lhs, 64)),
+        );
+        solver.assert(
+            symbolic_pre
+                .get_register(X86Register::RBX)
+                .eq(BV::from_u64(rhs, 64)),
+        );
+
+        let one_bit = |b: bool| BV::from_u64(b as u64, 1);
+        let (cf_pre, pf_pre, zf_pre, sf_pre, of_pre) = symbolic_pre.get_flags();
+        solver.assert(cf_pre.eq(one_bit(input_flags.cf)));
+        solver.assert(pf_pre.eq(one_bit(input_flags.pf)));
+        solver.assert(zf_pre.eq(one_bit(input_flags.zf)));
+        solver.assert(sf_pre.eq(one_bit(input_flags.sf)));
+        solver.assert(of_pre.eq(one_bit(input_flags.of)));
+
+        let symbolic_post = apply_instruction(symbolic_pre, &instr);
+        let (cf_s, pf_s, zf_s, sf_s, of_s) = symbolic_post.get_flags();
+        let expected_rd = BV::from_u64(concrete_post.get_register(X86Register::RAX).as_u64(), 64);
+        let diffs = [
+            symbolic_post
+                .get_register(X86Register::RAX)
+                .eq(&expected_rd)
+                .not(),
+            cf_s.eq(one_bit(expected_flags.cf)).not(),
+            pf_s.eq(one_bit(expected_flags.pf)).not(),
+            zf_s.eq(one_bit(expected_flags.zf)).not(),
+            sf_s.eq(one_bit(expected_flags.sf)).not(),
+            of_s.eq(one_bit(expected_flags.of)).not(),
+        ];
+        let refs: Vec<&z3::ast::Bool> = diffs.iter().collect();
+        solver.assert(z3::ast::Bool::or(&refs));
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "CMOV concrete/SMT parity violation for {:?} with flags {:?}",
+            instr,
+            input_flags
+        );
+    }
+
     const PARITY_SAMPLES: &[(u64, u64)] = &[
         (0, 0),
         (0, 1),
@@ -738,6 +809,42 @@ mod tests {
         for &(a, b) in PARITY_SAMPLES {
             assert_x86_concrete_smt_parity(&instr, a, b);
         }
+    }
+
+    #[test]
+    fn parity_cmov_reg_taken_and_not_taken() {
+        use crate::isa::x86::X86Condition;
+        use crate::semantics::state::Eflags;
+
+        let taken_flags = Eflags {
+            cf: true,
+            pf: false,
+            af: true,
+            zf: true,
+            sf: false,
+            of: true,
+        };
+        assert_x86_cmov_concrete_smt_parity(
+            X86Condition::E,
+            taken_flags,
+            0x1111_2222_3333_4444,
+            0xAAAA_BBBB_CCCC_DDDD,
+        );
+
+        let not_taken_flags = Eflags {
+            cf: false,
+            pf: true,
+            af: true,
+            zf: false,
+            sf: true,
+            of: false,
+        };
+        assert_x86_cmov_concrete_smt_parity(
+            X86Condition::E,
+            not_taken_flags,
+            0x1111_2222_3333_4444,
+            0xAAAA_BBBB_CCCC_DDDD,
+        );
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- Return condition-suffixed x86 CMOV/Jcc mnemonics and keep Display aligned.
- Add CMOV concrete-vs-SMT parity coverage and document the deferred explicit Z3-context refactor.
- Harden pinned-Jcc reassembly NOP padding and add a debug invariant for the final Capstone Jcc.
- Include a small AArch64 SMT clippy cleanup needed for the local -D warnings gate.

Verification:
- cargo fmt -- --check
- cargo clippy --all -- -D warnings
- cargo test --all
- ./ci_check.sh

Closes #288

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**