### PR TITLE
refactor(smt): assert ldr extension raw widths

### DIFF
--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -1229,6 +1229,10 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
 /// Zero-extend the low `width.bytes() * 8` bits of `raw` to `target_width`.
 fn ldr_zero_extend(raw: &BV, width: AccessWidth, target_width: u32) -> BV {
     let raw_bits = width.bytes() * 8;
+    assert!(
+        raw_bits <= target_width,
+        "raw load width {raw_bits} exceeds target register width {target_width}"
+    );
     let pad = target_width - raw_bits;
     if pad == 0 {
         raw.clone()
@@ -1240,6 +1244,10 @@ fn ldr_zero_extend(raw: &BV, width: AccessWidth, target_width: u32) -> BV {
 /// Sign-extend the low `width.bytes() * 8` bits of `raw` to `target_width`.
 fn ldr_sign_extend(raw: &BV, width: AccessWidth, target_width: u32) -> BV {
     let raw_bits = width.bytes() * 8;
+    assert!(
+        raw_bits <= target_width,
+        "raw load width {raw_bits} exceeds target register width {target_width}"
+    );
     let pad = target_width - raw_bits;
     if pad == 0 {
         raw.clone()
@@ -3905,6 +3913,24 @@ mod tests {
     }
 
     // ---- Memory ops (issue #68 step 7) ----
+
+    #[test]
+    #[should_panic(expected = "raw load width 64 exceeds target register width 32")]
+    fn ldr_zero_extend_rejects_raw_width_above_target() {
+        use crate::ir::types::AccessWidth;
+
+        let raw = BV::from_u64(0, 64);
+        let _ = ldr_zero_extend(&raw, AccessWidth::Extended, 32);
+    }
+
+    #[test]
+    #[should_panic(expected = "raw load width 64 exceeds target register width 32")]
+    fn ldr_sign_extend_rejects_raw_width_above_target() {
+        use crate::ir::types::AccessWidth;
+
+        let raw = BV::from_u64(0, 64);
+        let _ = ldr_sign_extend(&raw, AccessWidth::Extended, 32);
+    }
 
     /// `STR x0, [x1]; LDR x2, [x1]` must yield `x2 == x0` under Z3 array
     /// extensionality, even with arbitrary aliasing of `x1` against other

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- add runtime assertions before LDR zero/sign extension width subtraction
- add panic regressions for raw load widths wider than the target register
- clean up existing BV temporary borrows so clippy stays green

Verification:
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test --all (after ./build_tests.sh for integration fixtures)
- ./ci_check.sh
- scripts/full_test.sh was requested by the generic workflow but is not present in this repository

Closes #290

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**