### PR TITLE
refactor(ir): reject invalid LDRS extended display

### DIFF
--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -1702,7 +1702,9 @@ fn ldrs_mnemonic(width: AccessWidth) -> &'static str {
         AccessWidth::Byte => "ldrsb",
         AccessWidth::Half => "ldrsh",
         AccessWidth::Word => "ldrsw",
-        AccessWidth::Extended => "ldrsw", // Should be rejected by is_encodable
+        AccessWidth::Extended => {
+            unreachable!("LDRS Extended width rejected by is_encodable_aarch64")
+        }
     }
 }
 
@@ -1881,6 +1883,21 @@ mod tests {
             width: AccessWidth::Word,
         };
         assert_eq!(format!("{}", ldrs), "ldrsw x0, [x1]");
+    }
+
+    #[test]
+    #[should_panic(expected = "LDRS Extended width rejected by is_encodable_aarch64")]
+    fn ldrs_extended_width_display_panics() {
+        let ldrs = Instruction::Ldrs {
+            rt: Register::X0,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+        };
+        let _ = format!("{}", ldrs);
     }
 
     #[test]

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- Make `Ldrs { width: Extended }` display fail loudly instead of silently emitting `ldrsw`.
- Add a regression test for the manually constructed invalid IR shape.
- Remove clippy-only needless SMT temporary borrows surfaced by the current toolchain.

Notes:
- Treated the checked-in `PLAN.md` as the approved design because this autonomous run cannot pause for operator approval.
- No docs/spec update: this is defensive hardening for already-unencodable IR, not a language or capability change.
- `scripts/full_test.sh` is absent in this Rust repo; `./ci_check.sh` ran the repo-local `test_all.sh`.

Verification:
- `cargo test ldrs_extended_width_display_panics` (failed before implementation, passed after)
- `cargo test ldrs`
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `./build_tests.sh`
- `cargo test --all`
- `./ci_check.sh`

Closes #293

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**