### PR TITLE
refactor(aarch64): centralize memory instruction classification

### DIFF
--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -571,6 +571,18 @@ pub enum Instruction {
 }
 
 impl Instruction {
+    /// Returns true for instructions that read from or write to memory.
+    pub fn is_memory_op(&self) -> bool {
+        matches!(
+            self,
+            Instruction::Ldr { .. }
+                | Instruction::Ldrs { .. }
+                | Instruction::Str { .. }
+                | Instruction::Ldp { .. }
+                | Instruction::Stp { .. }
+        )
+    }
+
     /// Registers this instruction writes (in canonical order). Empty for
     /// pure flag-setters and branches; one entry for single-destination
     /// arithmetic and logical ops; two entries for LDP and writeback
@@ -1811,6 +1823,62 @@ mod tests {
             rm: Operand::Register(Register::X1),
         };
         assert!(cmp.destinations().is_empty());
+    }
+
+    #[test]
+    fn instruction_is_memory_op_classifies_aarch64_memory_variants() {
+        let addr = AddressOperand::Imm {
+            base: Register::X1,
+            offset: 8,
+            mode: IndexMode::Offset,
+        };
+        let ldr = Instruction::Ldr {
+            rt: Register::X0,
+            addr,
+            width: AccessWidth::Extended,
+        };
+        let ldrs = Instruction::Ldrs {
+            rt: Register::X0,
+            addr,
+            width: AccessWidth::Word,
+        };
+        let str_ = Instruction::Str {
+            rt: Register::X0,
+            addr,
+            width: AccessWidth::Extended,
+        };
+        let ldp = Instruction::Ldp {
+            rt1: Register::X0,
+            rt2: Register::X2,
+            addr,
+            width: AccessWidth::Extended,
+            signed: false,
+        };
+        let stp = Instruction::Stp {
+            rt1: Register::X0,
+            rt2: Register::X2,
+            addr,
+            width: AccessWidth::Extended,
+        };
+
+        for instr in [ldr, ldrs, str_, ldp, stp] {
+            assert!(instr.is_memory_op(), "{instr:?}");
+        }
+
+        let add = Instruction::Add {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        };
+        let cmp = Instruction::Cmp {
+            rn: Register::X0,
+            rm: Operand::Register(Register::X1),
+        };
+        let ret = Instruction::Ret { rn: Register::X30 };
+
+        for instr in [add, cmp, ret] {
+            assert!(!instr.is_memory_op(), "{instr:?}");
+        }
     }
 
     #[test]

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -401,15 +401,7 @@ impl InstructionType for Instruction {
         // Memory ops have observable side effects beyond NZCV: stores write
         // memory, writeback modes mutate the base register, loads read from
         // potentially-aliased memory. See ADR-0007.
-        self.modifies_flags()
-            || matches!(
-                self,
-                Instruction::Ldr { .. }
-                    | Instruction::Ldrs { .. }
-                    | Instruction::Str { .. }
-                    | Instruction::Ldp { .. }
-                    | Instruction::Stp { .. }
-            )
+        self.modifies_flags() || self.is_memory_op()
     }
 }
 
@@ -1827,6 +1819,7 @@ fn mutate_shift_operand<R: RngExt>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ir::types::{AccessWidth, AddressOperand, IndexMode};
     use rand::SeedableRng;
     use rand_chacha::ChaCha8Rng;
     use std::collections::BTreeSet;
@@ -2223,6 +2216,17 @@ mod tests {
             rm: Operand::Register(Register::X2),
         };
         assert!(cmp.has_side_effects());
+
+        let ldr = Instruction::Ldr {
+            rt: Register::X0,
+            addr: AddressOperand::Imm {
+                base: Register::X1,
+                offset: 0,
+                mode: IndexMode::Offset,
+            },
+            width: AccessWidth::Extended,
+        };
+        assert!(ldr.has_side_effects());
     }
 
     #[test]

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {

--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -188,16 +188,7 @@ pub fn compute_written_registers(instructions: &[Instruction]) -> RegisterSet<Re
 /// Drives the auto-derivation of `EquivalenceConfig::memory_live` (and the
 /// `fast_only` carve-out) in `check_equivalence_with_config`. See ADR-0007.
 pub fn touches_memory(instructions: &[Instruction]) -> bool {
-    instructions.iter().any(|i| {
-        matches!(
-            i,
-            Instruction::Ldr { .. }
-                | Instruction::Ldrs { .. }
-                | Instruction::Str { .. }
-                | Instruction::Ldp { .. }
-                | Instruction::Stp { .. }
-        )
-    })
+    instructions.iter().any(Instruction::is_memory_op)
 }
 
 /// Returns true if NZCV may be observable after the sequence executes.
@@ -307,6 +298,7 @@ pub fn x86_live_out_from_target(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ir::types::{AccessWidth, AddressOperand, IndexMode};
     use crate::ir::{Condition, LabelId, Operand};
 
     #[test]
@@ -420,6 +412,44 @@ mod tests {
     fn test_compute_written_registers_empty() {
         let mask = compute_written_registers(&[]);
         assert!(mask.is_empty());
+    }
+
+    #[test]
+    fn touches_memory_matches_instruction_memory_classifier() {
+        assert!(!touches_memory(&[]));
+
+        let arithmetic_only = vec![Instruction::Add {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Register(Register::X2),
+        }];
+        assert!(!touches_memory(&arithmetic_only));
+        assert_eq!(
+            touches_memory(&arithmetic_only),
+            arithmetic_only.iter().any(Instruction::is_memory_op)
+        );
+
+        let memory_and_arithmetic = vec![
+            Instruction::Add {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Register(Register::X2),
+            },
+            Instruction::Ldr {
+                rt: Register::X3,
+                addr: AddressOperand::Imm {
+                    base: Register::X4,
+                    offset: 16,
+                    mode: IndexMode::Offset,
+                },
+                width: AccessWidth::Extended,
+            },
+        ];
+        assert!(touches_memory(&memory_and_arithmetic));
+        assert_eq!(
+            touches_memory(&memory_and_arithmetic),
+            memory_and_arithmetic.iter().any(Instruction::is_memory_op)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- add Instruction::is_memory_op as the single AArch64 IR memory classifier
- delegate AArch64 has_side_effects and live_out::touches_memory to that helper
- add focused tests for memory classification, side effects, and live-out memory detection
- remove pre-existing needless SMT borrows so local clippy -D warnings passes

Verification:
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test --all (after ./build_tests.sh generated fixtures)
- ./test_all.sh
- ./ci_check.sh

Closes #304

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**