### PR TITLE
refactor(parallel): centralize stochastic worker placement

### DIFF
--- a/src/search/parallel/config.rs
+++ b/src/search/parallel/config.rs
@@ -74,13 +74,24 @@ impl ParallelConfig {
         self
     }
 
-    /// Get the number of stochastic workers (excludes symbolic worker if present).
+    /// Get the number of stochastic workers.
+    ///
+    /// Stochastic workers occupy the trailing worker-id suffix. Any symbolic
+    /// worker occupies the leading prefix.
     pub fn num_stochastic_workers(&self) -> usize {
         if self.include_symbolic && self.num_workers > 1 {
             self.num_workers - 1
         } else {
             self.num_workers
         }
+    }
+
+    /// Return whether the worker id belongs to the stochastic suffix.
+    pub(crate) fn is_stochastic_worker(&self, worker_id: usize) -> bool {
+        let first_stochastic_worker = self
+            .num_workers
+            .saturating_sub(self.num_stochastic_workers());
+        worker_id >= first_stochastic_worker
     }
 }
 
@@ -131,6 +142,51 @@ mod tests {
             .with_workers(1)
             .with_symbolic(true);
         assert_eq!(config.num_stochastic_workers(), 1);
+    }
+
+    #[test]
+    fn test_is_stochastic_worker() {
+        let cases = [
+            (
+                ParallelConfig::default()
+                    .with_workers(1)
+                    .with_symbolic(true),
+                vec![true],
+            ),
+            (
+                ParallelConfig::default()
+                    .with_workers(2)
+                    .with_symbolic(true),
+                vec![false, true],
+            ),
+            (
+                ParallelConfig::default()
+                    .with_workers(4)
+                    .with_symbolic(true),
+                vec![false, true, true, true],
+            ),
+            (
+                ParallelConfig::default()
+                    .with_workers(4)
+                    .with_symbolic(false),
+                vec![true, true, true, true],
+            ),
+        ];
+
+        for (config, expected) in cases {
+            let actual: Vec<bool> = (0..config.num_workers)
+                .map(|worker_id| config.is_stochastic_worker(worker_id))
+                .collect();
+
+            assert_eq!(actual, expected);
+            assert_eq!(
+                actual
+                    .iter()
+                    .filter(|&&is_stochastic| is_stochastic)
+                    .count(),
+                config.num_stochastic_workers(),
+            );
+        }
     }
 
     #[test]

--- a/src/search/parallel/coordinator.rs
+++ b/src/search/parallel/coordinator.rs
@@ -288,18 +288,17 @@ fn run_coordinator(
     }
 }
 
-/// Single source of truth for which algorithm a worker runs.
+/// Map the config-owned worker placement to the algorithm a worker runs.
 ///
-/// Mirrors the contract encoded by [`ParallelConfig::num_stochastic_workers`]:
-/// a worker is symbolic only when `include_symbolic` is set, more than one
-/// worker is configured, and this is worker 0. With a single worker the lone
-/// worker is stochastic regardless of `include_symbolic`, so CLI knobs like
-/// `--beta`, `--iterations`, and `--seed` are not silently ignored.
+/// [`ParallelConfig::num_stochastic_workers`] defines the stochastic suffix
+/// length, and [`ParallelConfig::is_stochastic_worker`] owns worker-id
+/// placement. This function only maps that placement to the enum used by
+/// worker execution and statistics.
 fn worker_algorithm(worker_id: usize, parallel_config: &ParallelConfig) -> Algorithm {
-    if parallel_config.include_symbolic && parallel_config.num_workers > 1 && worker_id == 0 {
-        Algorithm::Symbolic
-    } else {
+    if parallel_config.is_stochastic_worker(worker_id) {
         Algorithm::Stochastic
+    } else {
+        Algorithm::Symbolic
     }
 }
 
@@ -457,10 +456,71 @@ mod tests {
         assert!(result.total_statistics.elapsed_time.as_nanos() > 0);
     }
 
-    // Issue #244 regression: hybrid dispatch must follow the contract pinned by
-    // ParallelConfig::num_stochastic_workers. Worker 0 is symbolic only when
-    // include_symbolic && num_workers > 1; otherwise the lone worker must run
+    // Issue #244 regression: hybrid dispatch must follow the config-owned
+    // stochastic suffix placement. With one worker, the lone worker must run
     // stochastic so the user's --beta/--iterations/--seed knobs take effect.
+
+    #[test]
+    fn test_worker_algorithm_matches_stochastic_worker_suffix_contract() {
+        let cases = [
+            (
+                ParallelConfig::default()
+                    .with_workers(1)
+                    .with_symbolic(true),
+                vec![Algorithm::Stochastic],
+            ),
+            (
+                ParallelConfig::default()
+                    .with_workers(2)
+                    .with_symbolic(true),
+                vec![Algorithm::Symbolic, Algorithm::Stochastic],
+            ),
+            (
+                ParallelConfig::default()
+                    .with_workers(4)
+                    .with_symbolic(true),
+                vec![
+                    Algorithm::Symbolic,
+                    Algorithm::Stochastic,
+                    Algorithm::Stochastic,
+                    Algorithm::Stochastic,
+                ],
+            ),
+            (
+                ParallelConfig::default()
+                    .with_workers(4)
+                    .with_symbolic(false),
+                vec![
+                    Algorithm::Stochastic,
+                    Algorithm::Stochastic,
+                    Algorithm::Stochastic,
+                    Algorithm::Stochastic,
+                ],
+            ),
+        ];
+
+        for (config, expected) in cases {
+            let actual: Vec<Algorithm> = (0..config.num_workers)
+                .map(|worker_id| worker_algorithm(worker_id, &config))
+                .collect();
+
+            assert_eq!(actual, expected);
+            assert_eq!(
+                actual
+                    .iter()
+                    .filter(|&&algorithm| algorithm == Algorithm::Stochastic)
+                    .count(),
+                config.num_stochastic_workers(),
+            );
+
+            for (worker_id, algorithm) in actual.iter().copied().enumerate() {
+                assert_eq!(
+                    algorithm == Algorithm::Stochastic,
+                    config.is_stochastic_worker(worker_id),
+                );
+            }
+        }
+    }
 
     #[test]
     fn test_two_workers_with_symbolic_reports_one_symbolic_one_stochastic() {
@@ -510,10 +570,10 @@ mod tests {
             .with_immediates(vec![0, 1, 2])
             .with_stochastic(StochasticConfig::default().with_iterations(200));
 
-        // include_symbolic = true but num_workers = 1: per the contract pinned
-        // by ParallelConfig::num_stochastic_workers, the lone worker must be
-        // stochastic. Before the fix, coordinator.rs dispatched worker 0 to
-        // SymbolicSearch and reported Stochastic anyway via a hardcoded label.
+        // include_symbolic = true but num_workers = 1: per the config-owned
+        // stochastic suffix placement, the lone worker must be stochastic.
+        // Before the fix, coordinator.rs dispatched worker 0 to SymbolicSearch
+        // and reported Stochastic anyway via a hardcoded label.
         let parallel_config = ParallelConfig::default()
             .with_workers(1)
             .with_symbolic(true)

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- Add ParallelConfig::is_stochastic_worker so stochastic-worker count and placement share one owner.
- Make worker_algorithm delegate to that helper while preserving symbolic-prefix/stochastic-suffix ordering.
- Add direct placement tests and clean up clippy's needless Z3 argument borrows so the required gate passes.

Closes #315

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**