### PR TITLE
refactor(ir): restrict pair memory widths

### DIFF
--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -3,7 +3,8 @@ pub mod x86;
 use crate::ir::aarch64_encoding::logical_imm64_encodable;
 use crate::ir::instructions::logical_imm32_value;
 use crate::ir::types::{
-    AccessWidth, AddressOperand, Condition, ExtendKind, IndexMode, LabelId, ShiftKind,
+    AccessWidth, AddressOperand, Condition, ExtendKind, IndexMode, LabelId, PairAccessWidth,
+    ShiftKind,
 };
 use crate::ir::{Instruction, Operand, Register, RegisterWidth};
 use dynasmrt::{DynasmApi, dynasm};
@@ -587,9 +588,9 @@ macro_rules! encode_load_or_store_with {
     }};
 }
 
-/// Pair load/store dispatcher (LDP/STP/LDPSW). Pair operations support
-/// only the three immediate addressing modes; Reg/Ext are rejected at the
-/// IR layer (`is_encodable_pair`).
+/// Pair load/store dispatcher (LDP/STP/LDPSW). Pair operations support only
+/// Word/Extended transfer widths and the three immediate addressing modes;
+/// Reg/Ext addressing is rejected at the IR layer (`is_encodable_pair`).
 macro_rules! encode_pair_with {
     ($ops:expr, $addr:expr, $rt1_n:expr, $rt2_n:expr, $base_n:expr,
      $mnem:ident, $rt_tok:ident) => {{
@@ -2073,23 +2074,19 @@ impl AArch64Assembler {
                 let rt1_n = register_to_dynasm(*rt1)?;
                 let rt2_n = register_to_dynasm(*rt2)?;
                 let base_n = register_to_dynasm_xsp(address_base_of(addr))?;
-                match (width, signed) {
-                    (AccessWidth::Word, false) => {
+                match (*width, *signed) {
+                    (PairAccessWidth::Word, false) => {
                         encode_pair_with!(ops, addr, rt1_n, rt2_n, base_n, ldp, W)
                     }
-                    (AccessWidth::Word, true) => {
+                    (PairAccessWidth::Word, true) => {
                         encode_pair_with!(ops, addr, rt1_n, rt2_n, base_n, ldpsw, X)
                     }
-                    (AccessWidth::Extended, false) => {
+                    (PairAccessWidth::Extended, false) => {
                         encode_pair_with!(ops, addr, rt1_n, rt2_n, base_n, ldp, X)
                     }
-                    (AccessWidth::Extended, true) => {
+                    (PairAccessWidth::Extended, true) => {
                         Err("LDPSW only supports 32-bit access width".into())
                     }
-                    (AccessWidth::Byte, _) | (AccessWidth::Half, _) => Err(format!(
-                        "LDP {:?} access width not supported (Word/Extended only)",
-                        width
-                    )),
                 }
             }
             Instruction::Stp {
@@ -2101,17 +2098,13 @@ impl AArch64Assembler {
                 let rt1_n = register_to_dynasm(*rt1)?;
                 let rt2_n = register_to_dynasm(*rt2)?;
                 let base_n = register_to_dynasm_xsp(address_base_of(addr))?;
-                match width {
-                    AccessWidth::Word => {
+                match *width {
+                    PairAccessWidth::Word => {
                         encode_pair_with!(ops, addr, rt1_n, rt2_n, base_n, stp, W)
                     }
-                    AccessWidth::Extended => {
+                    PairAccessWidth::Extended => {
                         encode_pair_with!(ops, addr, rt1_n, rt2_n, base_n, stp, X)
                     }
-                    AccessWidth::Byte | AccessWidth::Half => Err(format!(
-                        "STP {:?} access width not supported (Word/Extended only)",
-                        width
-                    )),
                 }
             }
         }
@@ -5181,7 +5174,7 @@ mod tests {
                 offset: 0,
                 mode: IndexMode::Offset,
             },
-            width: AccessWidth::Extended,
+            width: PairAccessWidth::Extended,
             signed: false,
         });
         let (m, op) = disasm_mnem_op(&bytes);
@@ -5199,7 +5192,7 @@ mod tests {
                 offset: -16,
                 mode: IndexMode::PreIndex,
             },
-            width: AccessWidth::Extended,
+            width: PairAccessWidth::Extended,
             signed: false,
         });
         let (m, op) = disasm_mnem_op(&bytes);
@@ -5217,7 +5210,7 @@ mod tests {
                 offset: 16,
                 mode: IndexMode::PostIndex,
             },
-            width: AccessWidth::Extended,
+            width: PairAccessWidth::Extended,
         });
         let (m, op) = disasm_mnem_op(&bytes);
         assert_eq!(m, "stp");
@@ -5234,7 +5227,7 @@ mod tests {
                 offset: 0,
                 mode: IndexMode::Offset,
             },
-            width: AccessWidth::Word,
+            width: PairAccessWidth::Word,
             signed: true,
         });
         let (m, op) = disasm_mnem_op(&bytes);
@@ -5252,7 +5245,7 @@ mod tests {
                 offset: 8,
                 mode: IndexMode::Offset,
             },
-            width: AccessWidth::Word,
+            width: PairAccessWidth::Word,
             signed: false,
         });
         let (m, op) = disasm_mnem_op(&bytes);
@@ -5282,22 +5275,10 @@ mod tests {
     }
 
     #[test]
-    fn ldp_byte_width_is_rejected() {
-        let mut a = AArch64Assembler::new();
-        let res = a.assemble_instructions(
-            &[Instruction::Ldp {
-                rt1: Register::X0,
-                rt2: Register::X1,
-                addr: AddressOperand::Imm {
-                    base: Register::X2,
-                    offset: 0,
-                    mode: IndexMode::Offset,
-                },
-                width: AccessWidth::Byte,
-                signed: false,
-            }],
-            0,
+    fn ldp_byte_width_is_rejected_at_construction_boundary() {
+        assert!(
+            PairAccessWidth::try_from(AccessWidth::Byte).is_err(),
+            "LDP only supports Word/Extended widths"
         );
-        assert!(res.is_err(), "LDP only supports Word/Extended widths");
     }
 }

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -2,8 +2,8 @@
 
 use crate::ir::aarch64_encoding::logical_imm64_encodable;
 use crate::ir::types::{
-    AccessWidth, AddressOperand, Condition, ExtendKind, IndexMode, LabelId, Operand, Register,
-    RegisterWidth, ShiftKind,
+    AccessWidth, AddressOperand, Condition, ExtendKind, IndexMode, LabelId, Operand,
+    PairAccessWidth, Register, RegisterWidth, ShiftKind,
 };
 use std::fmt;
 
@@ -557,7 +557,7 @@ pub enum Instruction {
         rt1: Register,
         rt2: Register,
         addr: AddressOperand,
-        width: AccessWidth,
+        width: PairAccessWidth,
         signed: bool,
     },
     /// STP — store a pair of registers. `rt1`/`rt2` are read; writeback
@@ -566,7 +566,7 @@ pub enum Instruction {
         rt1: Register,
         rt2: Register,
         addr: AddressOperand,
-        width: AccessWidth,
+        width: PairAccessWidth,
     },
 }
 
@@ -1382,7 +1382,7 @@ fn is_encodable_pair(
     rt1: Register,
     rt2: Register,
     addr: &AddressOperand,
-    width: AccessWidth,
+    width: PairAccessWidth,
     signed: bool,
 ) -> bool {
     if !is_plain_x(rt1) || !is_plain_x(rt2) {
@@ -1394,15 +1394,8 @@ fn is_encodable_pair(
     // LDP rejects rt1 == rt2 (UNPREDICTABLE per ARM ARM). STP allows it —
     // stores the same value twice — so this rule fires only for the
     // load-pair caller.
-    if signed && width != AccessWidth::Word {
+    if signed && width != PairAccessWidth::Word {
         // LDPSW is the only "signed pair" form; it is always 32→64.
-        return false;
-    }
-    // LDP/STP only have Word and Extended forms at the architecture level
-    // (no LDPB/LDPH/STPB/STPH). Byte/Half pair widths construct cleanly
-    // but the assembler errors at emit time — reject at the IR gate so
-    // parser and search candidates can't smuggle them through.
-    if !matches!(width, AccessWidth::Word | AccessWidth::Extended) {
         return false;
     }
     // LDP/STP have no register-offset / register-extend addressing form.
@@ -1951,7 +1944,7 @@ mod tests {
                 offset: 16,
                 mode: IndexMode::Offset,
             },
-            width: AccessWidth::Extended,
+            width: PairAccessWidth::Extended,
             signed: false,
         };
         assert_eq!(ldp.destinations(), vec![Register::X0, Register::X1]);
@@ -1967,7 +1960,7 @@ mod tests {
                 offset: -16,
                 mode: IndexMode::PreIndex,
             },
-            width: AccessWidth::Extended,
+            width: PairAccessWidth::Extended,
             signed: false,
         };
         assert_eq!(
@@ -1986,7 +1979,7 @@ mod tests {
                 offset: 0,
                 mode: IndexMode::Offset,
             },
-            width: AccessWidth::Word,
+            width: PairAccessWidth::Word,
             signed: true,
         };
         assert_eq!(format!("{}", ldp), "ldpsw x0, x1, [sp]");
@@ -2002,7 +1995,7 @@ mod tests {
                 offset: 16,
                 mode: IndexMode::Offset,
             },
-            width: AccessWidth::Extended,
+            width: PairAccessWidth::Extended,
             signed: false,
         };
         assert_eq!(format!("{}", ldp), "ldp x0, x1, [sp, #16]");
@@ -2154,35 +2147,13 @@ mod tests {
     }
 
     #[test]
-    fn pair_byte_width_rejected_at_encodability() {
-        // LDP/STP have no Byte form at the architecture level.
-        let stp_byte = Instruction::Stp {
-            rt1: Register::X0,
-            rt2: Register::X1,
-            addr: AddressOperand::Imm {
-                base: Register::X2,
-                offset: 0,
-                mode: IndexMode::Offset,
-            },
-            width: AccessWidth::Byte,
-        };
-        assert!(!stp_byte.is_encodable_aarch64());
+    fn pair_byte_width_rejected_at_construction_boundary() {
+        assert!(PairAccessWidth::try_from(AccessWidth::Byte).is_err());
     }
 
     #[test]
-    fn pair_half_width_rejected_at_encodability() {
-        let ldp_half = Instruction::Ldp {
-            rt1: Register::X0,
-            rt2: Register::X1,
-            addr: AddressOperand::Imm {
-                base: Register::X2,
-                offset: 0,
-                mode: IndexMode::Offset,
-            },
-            width: AccessWidth::Half,
-            signed: false,
-        };
-        assert!(!ldp_half.is_encodable_aarch64());
+    fn pair_half_width_rejected_at_construction_boundary() {
+        assert!(PairAccessWidth::try_from(AccessWidth::Half).is_err());
     }
 
     #[test]
@@ -2195,7 +2166,7 @@ mod tests {
                 idx: Register::X3,
                 shift: 0,
             },
-            width: AccessWidth::Extended,
+            width: PairAccessWidth::Extended,
             signed: false,
         };
         assert!(!ldp.is_encodable_aarch64());
@@ -2207,7 +2178,7 @@ mod tests {
                 idx: Register::X3,
                 shift: 3,
             },
-            width: AccessWidth::Word,
+            width: PairAccessWidth::Word,
         };
         assert!(!stp.is_encodable_aarch64());
     }
@@ -2224,7 +2195,7 @@ mod tests {
                 kind: ExtendKind::Uxtw,
                 shift: 0,
             },
-            width: AccessWidth::Extended,
+            width: PairAccessWidth::Extended,
             signed: false,
         };
         assert!(!ldp.is_encodable_aarch64());
@@ -2242,7 +2213,7 @@ mod tests {
                 offset: 512,
                 mode: IndexMode::Offset,
             },
-            width: AccessWidth::Extended,
+            width: PairAccessWidth::Extended,
             signed: false,
         };
         assert!(!ldp.is_encodable_aarch64());
@@ -2259,7 +2230,7 @@ mod tests {
                 offset: 12,
                 mode: IndexMode::Offset,
             },
-            width: AccessWidth::Extended,
+            width: PairAccessWidth::Extended,
             signed: false,
         };
         assert!(!ldp.is_encodable_aarch64());
@@ -2276,7 +2247,7 @@ mod tests {
                 offset: 504,
                 mode: IndexMode::Offset,
             },
-            width: AccessWidth::Extended,
+            width: PairAccessWidth::Extended,
             signed: false,
         };
         assert!(ldp.is_encodable_aarch64());
@@ -2292,7 +2263,7 @@ mod tests {
                 offset: 16,
                 mode: IndexMode::Offset,
             },
-            width: AccessWidth::Extended,
+            width: PairAccessWidth::Extended,
         };
         assert!(stp.destinations().is_empty());
     }
@@ -2307,7 +2278,7 @@ mod tests {
                 offset: -16,
                 mode: IndexMode::PreIndex,
             },
-            width: AccessWidth::Extended,
+            width: PairAccessWidth::Extended,
         };
         assert_eq!(stp.destinations(), vec![Register::SP]);
     }
@@ -2322,7 +2293,7 @@ mod tests {
                 offset: 0,
                 mode: IndexMode::Offset,
             },
-            width: AccessWidth::Extended,
+            width: PairAccessWidth::Extended,
         };
         let sources = stp.source_registers();
         assert!(sources.contains(&Register::X29));
@@ -2340,7 +2311,7 @@ mod tests {
                 offset: -16,
                 mode: IndexMode::PreIndex,
             },
-            width: AccessWidth::Extended,
+            width: PairAccessWidth::Extended,
         };
         assert_eq!(format!("{}", stp), "stp x29, x30, [sp, #-16]!");
     }
@@ -2425,7 +2396,7 @@ mod tests {
                 offset: 0,
                 mode: IndexMode::Offset,
             },
-            width: AccessWidth::Extended,
+            width: PairAccessWidth::Extended,
             signed: false,
         };
         assert!(!ldp.is_encodable_aarch64());
@@ -2442,7 +2413,7 @@ mod tests {
                 offset: 0,
                 mode: IndexMode::Offset,
             },
-            width: AccessWidth::Extended,
+            width: PairAccessWidth::Extended,
         };
         assert!(stp.is_encodable_aarch64());
     }
@@ -2457,7 +2428,7 @@ mod tests {
                 offset: -16,
                 mode: IndexMode::PreIndex,
             },
-            width: AccessWidth::Extended,
+            width: PairAccessWidth::Extended,
             signed: false,
         };
         assert!(!ldp.is_encodable_aarch64());
@@ -2473,7 +2444,7 @@ mod tests {
                 offset: 0,
                 mode: IndexMode::Offset,
             },
-            width: AccessWidth::Word,
+            width: PairAccessWidth::Word,
             signed: true,
         };
         assert!(ldpsw_word.is_encodable_aarch64());
@@ -2486,7 +2457,7 @@ mod tests {
                 offset: 0,
                 mode: IndexMode::Offset,
             },
-            width: AccessWidth::Extended,
+            width: PairAccessWidth::Extended,
             signed: true,
         };
         assert!(!ldpsw_extended.is_encodable_aarch64());

--- a/src/ir/types.rs
+++ b/src/ir/types.rs
@@ -342,9 +342,9 @@ impl fmt::Display for LabelId {
     }
 }
 
-/// Access width for LDR/STR/LDP/STP families. Byte = 8 bits (LDRB/STRB),
-/// Half = 16 bits (LDRH/STRH), Word = 32 bits (LDR/STR W-form, LDRSW,
-/// LDPSW), Extended = 64 bits (LDR/STR X-form). See ADR-0007.
+/// Access width for single-register memory families. Byte = 8 bits
+/// (LDRB/STRB), Half = 16 bits (LDRH/STRH), Word = 32 bits (LDR/STR W-form,
+/// LDRSW), Extended = 64 bits (LDR/STR X-form). See ADR-0007.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[allow(dead_code)]
 pub enum AccessWidth {
@@ -375,6 +375,71 @@ impl AccessWidth {
             AccessWidth::Half => 1,
             AccessWidth::Word => 2,
             AccessWidth::Extended => 3,
+        }
+    }
+}
+
+/// Access width for LDP/STP-family pair transfers. AArch64 pair forms only
+/// encode 32-bit and 64-bit per-register accesses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PairAccessWidth {
+    Word,
+    Extended,
+}
+
+impl PairAccessWidth {
+    /// Convert to the shared single-register access width representation.
+    #[must_use]
+    pub fn as_access_width(self) -> AccessWidth {
+        self.into()
+    }
+
+    /// Number of bytes each register in the pair reads or writes.
+    #[must_use]
+    pub fn bytes(self) -> u32 {
+        self.as_access_width().bytes()
+    }
+
+    /// Log2 of the per-register transfer size in bytes.
+    #[must_use]
+    pub fn scale_shift(self) -> u8 {
+        self.as_access_width().scale_shift()
+    }
+}
+
+impl From<PairAccessWidth> for AccessWidth {
+    fn from(width: PairAccessWidth) -> Self {
+        match width {
+            PairAccessWidth::Word => AccessWidth::Word,
+            PairAccessWidth::Extended => AccessWidth::Extended,
+        }
+    }
+}
+
+/// Error returned when a byte or half-word access is used for a pair form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct InvalidPairAccessWidth(pub AccessWidth);
+
+impl fmt::Display for InvalidPairAccessWidth {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "pair access width {:?} is not supported (Word/Extended only)",
+            self.0
+        )
+    }
+}
+
+impl std::error::Error for InvalidPairAccessWidth {}
+
+impl TryFrom<AccessWidth> for PairAccessWidth {
+    type Error = InvalidPairAccessWidth;
+
+    fn try_from(width: AccessWidth) -> Result<Self, Self::Error> {
+        match width {
+            AccessWidth::Word => Ok(PairAccessWidth::Word),
+            AccessWidth::Extended => Ok(PairAccessWidth::Extended),
+            AccessWidth::Byte | AccessWidth::Half => Err(InvalidPairAccessWidth(width)),
         }
     }
 }
@@ -892,5 +957,25 @@ mod tests {
         assert_eq!(AccessWidth::Half.scale_shift(), 1);
         assert_eq!(AccessWidth::Word.scale_shift(), 2);
         assert_eq!(AccessWidth::Extended.scale_shift(), 3);
+    }
+
+    #[test]
+    fn pair_access_width_only_accepts_word_and_extended() {
+        assert_eq!(
+            PairAccessWidth::try_from(AccessWidth::Word),
+            Ok(PairAccessWidth::Word)
+        );
+        assert_eq!(
+            PairAccessWidth::try_from(AccessWidth::Extended),
+            Ok(PairAccessWidth::Extended)
+        );
+        assert_eq!(
+            PairAccessWidth::try_from(AccessWidth::Byte),
+            Err(InvalidPairAccessWidth(AccessWidth::Byte))
+        );
+        assert_eq!(
+            PairAccessWidth::try_from(AccessWidth::Half),
+            Err(InvalidPairAccessWidth(AccessWidth::Half))
+        );
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1176,6 +1176,8 @@ fn parse_pair_mem(
         }
         crate::ir::types::AddressOperand::Imm { .. } => {}
     }
+    let width = crate::ir::types::PairAccessWidth::try_from(width)
+        .map_err(|e| format!("{}: {}", mnem, e))?;
     if is_load {
         Ok(Instruction::Ldp {
             rt1,
@@ -4013,7 +4015,7 @@ mod tests {
 
     #[test]
     fn parse_ldp_yields_two_register_load() {
-        use crate::ir::types::{AccessWidth, AddressOperand, IndexMode};
+        use crate::ir::types::{AddressOperand, IndexMode, PairAccessWidth};
         let instr = parse_one("ldp x0, x1, [sp, #16]");
         assert_eq!(
             instr,
@@ -4025,7 +4027,7 @@ mod tests {
                     offset: 16,
                     mode: IndexMode::Offset,
                 },
-                width: AccessWidth::Extended,
+                width: PairAccessWidth::Extended,
                 signed: false,
             }
         );
@@ -4040,7 +4042,7 @@ mod tests {
                 width,
                 ..
             } => {
-                assert_eq!(width, crate::ir::types::AccessWidth::Word);
+                assert_eq!(width, crate::ir::types::PairAccessWidth::Word);
             }
             _ => panic!("expected Ldp with signed=true"),
         }

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -544,7 +544,7 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
     // the soundness argument; the SMT layer reasons over all widths
     // regardless of which forms search enumerates.
     {
-        use crate::ir::types::{AccessWidth, AddressOperand, IndexMode};
+        use crate::ir::types::{AccessWidth, AddressOperand, IndexMode, PairAccessWidth};
         const MEM_IMM_SAMPLES: [i64; 5] = [0, 8, 16, 32, -8];
         for &rt in registers {
             if rt == Register::SP || rt == Register::XZR {
@@ -619,14 +619,14 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
                             rt1,
                             rt2,
                             addr,
-                            width: AccessWidth::Extended,
+                            width: PairAccessWidth::Extended,
                             signed: false,
                         });
                         instrs.push(Instruction::Stp {
                             rt1,
                             rt2,
                             addr,
-                            width: AccessWidth::Extended,
+                            width: PairAccessWidth::Extended,
                         });
                     }
                 }

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -654,18 +654,19 @@ pub fn apply_instruction_concrete(
             signed,
         } => {
             let (effective, writeback) = compute_address(&state, addr);
+            let access_width = (*width).as_access_width();
             let bytes = width.bytes() as u64;
-            let raw1 = state.read_bytes(effective, *width);
-            let raw2 = state.read_bytes(effective.wrapping_add(bytes), *width);
+            let raw1 = state.read_bytes(effective, access_width);
+            let raw2 = state.read_bytes(effective.wrapping_add(bytes), access_width);
             let (v1, v2) = if *signed {
                 (
-                    sign_extend_load(raw1, *width),
-                    sign_extend_load(raw2, *width),
+                    sign_extend_load(raw1, access_width),
+                    sign_extend_load(raw2, access_width),
                 )
             } else {
                 (
-                    zero_extend_load(raw1, *width),
-                    zero_extend_load(raw2, *width),
+                    zero_extend_load(raw1, access_width),
+                    zero_extend_load(raw2, access_width),
                 )
             };
             state.set_register(*rt1, ConcreteValue::new(v1));
@@ -681,11 +682,12 @@ pub fn apply_instruction_concrete(
             width,
         } => {
             let (effective, writeback) = compute_address(&state, addr);
+            let access_width = (*width).as_access_width();
             let bytes = width.bytes() as u64;
             let v1 = state.get_register(*rt1).as_u64();
             let v2 = state.get_register(*rt2).as_u64();
-            state.write_bytes(effective, v1, *width);
-            state.write_bytes(effective.wrapping_add(bytes), v2, *width);
+            state.write_bytes(effective, v1, access_width);
+            state.write_bytes(effective.wrapping_add(bytes), v2, access_width);
             if let Some((base, new_base)) = writeback {
                 state.set_register(base, ConcreteValue::new(new_base));
             }
@@ -882,6 +884,7 @@ pub fn find_first_difference(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ir::types::PairAccessWidth;
     use std::collections::HashMap;
 
     fn state_with(values: Vec<(Register, u64)>) -> ConcreteMachineState {
@@ -2921,7 +2924,7 @@ mod tests {
                 offset: 0,
                 mode: IndexMode::Offset,
             },
-            width: AccessWidth::Extended,
+            width: PairAccessWidth::Extended,
             signed: false,
         };
         let after = apply_instruction_concrete(state, &instr);
@@ -2945,7 +2948,7 @@ mod tests {
                 offset: 0,
                 mode: IndexMode::Offset,
             },
-            width: AccessWidth::Extended,
+            width: PairAccessWidth::Extended,
         };
         let after = apply_instruction_concrete(state, &instr);
         assert_eq!(after.read_bytes(0x1000, AccessWidth::Extended), 0xAAAA);

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {
@@ -1185,6 +1179,7 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             signed,
         } => {
             let (effective, writeback) = state.eval_address(addr);
+            let access_width = (*width).as_access_width();
             let bytes = width.bytes();
             let raw1 = state.select_n(&effective, bytes);
             let offset = BV::from_u64(bytes as u64, 64);
@@ -1192,13 +1187,13 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let raw2 = state.select_n(&effective2, bytes);
             let (v1, v2) = if *signed {
                 (
-                    ldr_sign_extend(&raw1, *width, state.width),
-                    ldr_sign_extend(&raw2, *width, state.width),
+                    ldr_sign_extend(&raw1, access_width, state.width),
+                    ldr_sign_extend(&raw2, access_width, state.width),
                 )
             } else {
                 (
-                    ldr_zero_extend(&raw1, *width, state.width),
-                    ldr_zero_extend(&raw2, *width, state.width),
+                    ldr_zero_extend(&raw1, access_width, state.width),
+                    ldr_zero_extend(&raw2, access_width, state.width),
                 )
             };
             state.set_register(*rt1, v1);


### PR DESCRIPTION
Summary:
- add PairAccessWidth so AArch64 LDP/STP-family IR can only carry Word or Extended widths
- update parser, search generation, concrete/SMT semantics, and assembler dispatch to use the narrower pair-width type
- move Byte/Half rejection tests to the construction boundary and remove unreachable assembler Byte/Half pair arms
- apply current clippy needless-borrow fixes in SMT helpers so warning-deny verification passes

Verification:
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test --all
- ./ci_check.sh

Note: the generic run template referenced scripts/full_test.sh, but this s11 repo does not contain that script; ./ci_check.sh ran the repo's test_all.sh after building test binaries.

Closes #297

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**