### PR TITLE
docs(context): refresh live-out register glossary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,7 +20,7 @@ A candidate that is both **strictly cheaper** than the target and **proven equiv
 The observable architectural state whose values must agree between target and candidate after execution. Today this is represented by `LiveOut` in `src/semantics/live_out.rs`; it populates two slices — a register set (`RegisterSet<R>` per ADR-0004 §5) and the AArch64 NZCV `flags_live` bit (ADR-0006). The intended concept is still broader: memory and PC can also be live-out when downstream code observes them, and they remain unmodeled.
 
 ### Live-out registers
-The register slice of the live-out contract. Represented by `LiveOutRegisters`, a set of architectural registers whose values must agree between target and candidate after execution. This is not the whole live-out concept.
+The register slice of the live-out contract. In the AArch64 path this is the register set carried by the `LiveOut` alias (`RegisterSet<Register>`), containing architectural registers whose values must agree between target and candidate after execution. This is not the whole live-out concept; `LiveOut.flags_live` models NZCV separately.
 
 ### Observable state
 Any architectural state a downstream context can observe after the target executes. Registers and AArch64 condition state (NZCV) are modeled today (the latter via `LiveOut.flags_live`, ADR-0006). Memory and PC are intentionally reserved in the term so the live-out contract can grow without being renamed.

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- Refresh `CONTEXT.md` so the Live-out registers glossary entry uses `LiveOut` / `RegisterSet<Register>` terminology and drops `LiveOutRegisters`.
- Remove the exact needless-borrow Clippy warnings in `src/semantics/smt.rs` that blocked the required local warning gate.

Verification:
- `rg -n "\\b(LiveOutRegisters|LiveOutMask|X86LiveOutMask)\\b" CONTEXT.md` produced no matches.
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --all` (initial run failed before `./build_tests.sh` because fixture ELFs were missing; rerun passed after building fixtures)
- `./ci_check.sh`
- `scripts/full_test.sh` is not present in this repository; `./ci_check.sh` ran the repo's `test_all.sh` successfully.

Closes #316

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**