### PR TITLE
test(parallel): tighten symbolic stats timeout

### DIFF
--- a/src/search/parallel/coordinator.rs
+++ b/src/search/parallel/coordinator.rs
@@ -723,24 +723,26 @@ mod tests {
     // must flow through the parallel coordinator without being relabelled as
     // stochastic or having every field except `candidates_evaluated` zeroed.
     // Hyperparameters mirror `test_symbolic_finds_mov_add_fusion` in
-    // src/search/symbolic/synthesis.rs which is known to land the
-    // mov-add -> add fusion within a few seconds.
+    // src/search/symbolic/synthesis.rs. The happy path is sub-second locally;
+    // the 30s timeout is only a CI safety ceiling around the 10s solver budget.
     #[test]
     fn test_parallel_search_symbolic_worker_statistics_are_propagated() {
         let target = mov_add_sequence();
         let live_out = LiveOut::from_registers(vec![Register::X0]);
+        let ci_timeout = Duration::from_secs(30);
 
         let search_config = SearchConfig::default()
             .with_registers(vec![Register::X0, Register::X1, Register::X2])
             .with_immediates(vec![-1, 0, 1, 2])
             .with_symbolic(SymbolicConfig::default().with_timeout(Duration::from_secs(10)))
-            .with_stochastic(StochasticConfig::default().with_iterations(200));
+            .with_stochastic(StochasticConfig::default().with_iterations(200))
+            .with_timeout(ci_timeout);
 
         let parallel_config = ParallelConfig::default()
             .with_workers(2)
             .with_symbolic(true)
             .with_seed(42)
-            .with_timeout(Duration::from_secs(60));
+            .with_timeout(ci_timeout);
 
         let result = run_parallel_search(&target, &live_out, &search_config, &parallel_config);
 

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- Tighten the parallel symbolic statistics regression timeout from 60s to a documented 30s CI ceiling.
- Make the test search timeout explicit so it matches the parallel safety budget.
- Remove needless SMT BV borrows required by the local Clippy gate.

Verification:
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test search::parallel::coordinator::tests::test_parallel_search_symbolic_worker_statistics_are_propagated --lib -- --exact
- cargo test search::parallel::coordinator::tests --lib
- ./ci_check.sh
- cargo test --all

Closes #321

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**