### PR TITLE
test(aarch64): cover shift-mask follow-ups

### DIFF
--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -3111,6 +3111,93 @@ mod tests {
         );
     }
 
+    /// Issue #241 regression: variable LSR also masks the shift register before
+    /// applying Z3's `bvlshr`. Without the mask, this target would match a
+    /// candidate that forces x0 to zero whenever x2 >= 64.
+    #[test]
+    fn test_lsr_reg_shift_amount_masked_for_equivalence() {
+        use crate::ir::types::Condition;
+
+        let target = vec![Instruction::Lsr {
+            rd: Register::X0,
+            rn: Register::X1,
+            shift: Operand::Register(Register::X2),
+        }];
+        let candidate = vec![
+            Instruction::Lsr {
+                rd: Register::X0,
+                rn: Register::X1,
+                shift: Operand::Register(Register::X2),
+            },
+            Instruction::Cmp {
+                rn: Register::X2,
+                rm: Operand::Immediate(64),
+            },
+            Instruction::Csel {
+                rd: Register::X0,
+                rn: Register::XZR,
+                rm: Register::X0,
+                cond: Condition::CS,
+            },
+        ];
+        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
+        let result = check_equivalence_with_config(&target, &candidate, &config);
+        assert!(
+            matches!(
+                result,
+                EquivalenceResult::NotEquivalent | EquivalenceResult::NotEquivalentFast(_)
+            ),
+            "expected NotEquivalent or NotEquivalentFast for shift-mask divergence, got {:?}",
+            result
+        );
+    }
+
+    /// Issue #241 regression: variable ASR masks the shift register before
+    /// applying Z3's `bvashr`. The candidate models the unmasked overshift case
+    /// by selecting the sign-fill value (`asr x1, #63`) when x2 >= 64.
+    #[test]
+    fn test_asr_reg_shift_amount_masked_for_equivalence() {
+        use crate::ir::types::Condition;
+
+        let target = vec![Instruction::Asr {
+            rd: Register::X0,
+            rn: Register::X1,
+            shift: Operand::Register(Register::X2),
+        }];
+        let candidate = vec![
+            Instruction::Asr {
+                rd: Register::X0,
+                rn: Register::X1,
+                shift: Operand::Register(Register::X2),
+            },
+            Instruction::Cmp {
+                rn: Register::X2,
+                rm: Operand::Immediate(64),
+            },
+            Instruction::Asr {
+                rd: Register::X3,
+                rn: Register::X1,
+                shift: Operand::Immediate(63),
+            },
+            Instruction::Csel {
+                rd: Register::X0,
+                rn: Register::X3,
+                rm: Register::X0,
+                cond: Condition::CS,
+            },
+        ];
+        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
+        let result = check_equivalence_with_config(&target, &candidate, &config);
+        assert!(
+            matches!(
+                result,
+                EquivalenceResult::NotEquivalent | EquivalenceResult::NotEquivalentFast(_)
+            ),
+            "expected NotEquivalent or NotEquivalentFast for shift-mask divergence, got {:?}",
+            result
+        );
+    }
+
     // ===== Issue #69: terminator-identity precheck =====
 
     use crate::ir::LabelId;

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -30,6 +30,10 @@ fn bv_swap_bytes(value: &BV, width: u32) -> BV {
     result
 }
 
+fn bv_shift_mask(width: u32) -> BV {
+    BV::from_u64((width - 1) as u64, width)
+}
+
 /// `width`-bit ROR composed as `(value lshr n) | (value shl (width - n))`.
 /// Caller is responsible for masking `n` to `log2(width)` bits when needed
 /// (immediate callers with `n` already in `0..width` may skip the mask).
@@ -39,7 +43,7 @@ fn bv_swap_bytes(value: &BV, width: u32) -> BV {
 /// bit-width zeroes the value). So `hi = 0` and the result is just
 /// `value lshr 0 = value`.
 fn bv_ror(value: &BV, n: &BV, width: u32) -> BV {
-    let mask = BV::from_u64((width - 1) as u64, width);
+    let mask = bv_shift_mask(width);
     let n_masked = n.bvand(&mask);
     let width_const = BV::from_u64(width as u64, width);
     let complement = width_const.bvsub(&n_masked);
@@ -392,6 +396,9 @@ impl MachineState {
             Operand::Immediate(imm) => BV::from_i64(*imm, self.width),
             Operand::ShiftedRegister { reg, kind, amount } => {
                 let value = self.get_register(*reg).clone();
+                // `amount` is the compile-time modifier on a shifted-register
+                // operand and is bounded by parsing/encodability. Runtime
+                // masking belongs to register-form LSL/LSR/ASR shift operands.
                 let amt = BV::from_u64(*amount as u64, self.width);
                 match kind {
                     crate::ir::ShiftKind::Lsl => value.bvshl(&amt),
@@ -646,21 +653,21 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             // (concrete.rs masks with `& 63`). Z3's `bvshl` zeroes the result
             // when the shift amount is >= width, so we must mask first to
             // keep SMT and concrete in agreement (issue #241).
-            let mask = BV::from_u64((width - 1) as u64, width);
+            let mask = bv_shift_mask(width);
             let shift_amount = state.eval_operand(shift).bvand(&mask);
             let result = value.bvshl(&shift_amount);
             state.set_register(*rd, result);
         }
         Instruction::Lsr { rd, rn, shift } => {
             let value = state.get_register(*rn).clone();
-            let mask = BV::from_u64((width - 1) as u64, width);
+            let mask = bv_shift_mask(width);
             let shift_amount = state.eval_operand(shift).bvand(&mask);
             let result = value.bvlshr(&shift_amount);
             state.set_register(*rd, result);
         }
         Instruction::Asr { rd, rn, shift } => {
             let value = state.get_register(*rn).clone();
-            let mask = BV::from_u64((width - 1) as u64, width);
+            let mask = bv_shift_mask(width);
             let shift_amount = state.eval_operand(shift).bvand(&mask);
             let result = value.bvashr(&shift_amount);
             state.set_register(*rd, result);
@@ -2699,10 +2706,10 @@ mod tests {
 
     #[test]
     fn test_lsl_imm_concrete_smt_parity() {
-        // LSL is width-sensitive: concrete (concrete.rs:84-88) masks the shift
-        // amount with `& 63` before applying. After the issue-#241 fix the
-        // SMT lowering masks the shift operand with `width - 1` too, so the
-        // two paths agree for all shift values including >= 64.
+        // LSL is width-sensitive: concrete semantics mask the shift amount
+        // with `& 63` before applying. Immediate shifts >= 64 are rejected by
+        // parser/encodability paths, but these IR-only samples verify internal
+        // concrete/SMT parity for the same issue-#241 mask rule.
         let values: &[u64] = &[
             0,
             1,
@@ -2725,7 +2732,9 @@ mod tests {
 
     #[test]
     fn test_lsr_imm_concrete_smt_parity() {
-        // Mirror of LSL but logical right shift (no sign extension).
+        // Mirror of LSL but logical right shift (no sign extension). The
+        // extended immediate samples are IR-only; normal AArch64 input rejects
+        // them before optimization.
         let values: &[u64] = &[
             0,
             1,
@@ -3885,10 +3894,10 @@ mod tests {
 
     #[test]
     fn test_asr_imm_concrete_smt_parity() {
-        // ASR is sign-sensitive: concrete (concrete.rs:96-101) routes through
-        // `as_i64() >> shift` then back to u64; SMT uses Z3 `bvashr` which
-        // sign-preserves. Negative inputs (MSB set) must keep the sign bit.
-        // Shifts >= 64 exercise the issue-#241 mask path.
+        // ASR is sign-sensitive: concrete semantics route through signed
+        // shifting; SMT uses Z3 `bvashr`, which sign-preserves. Immediate
+        // shifts >= 64 are IR-only parity cases that exercise the issue-#241
+        // mask path; parser/encodability reject them in normal input.
         let values: &[u64] = &[
             0,
             1,

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -490,8 +490,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -501,7 +501,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -894,14 +894,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -909,20 +909,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- Add LSR and ASR equivalence regressions for masked variable shifts.
- Clarify IR-only immediate parity cases and the ShiftedRegister compile-time amount invariant.
- Extract `bv_shift_mask(width)` and remove existing needless Z3 AST borrows required by the Clippy gate.

Tests:
- `cargo clippy --all -- -D warnings`
- `cargo test --all` (after `./build_tests.sh` generated required ELF fixtures)
- `./ci_check.sh`

Closes #320

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**