### PR TITLE
test(parallel): decouple symbolic stats test from worker id

### DIFF
--- a/src/search/parallel/coordinator.rs
+++ b/src/search/parallel/coordinator.rs
@@ -744,8 +744,21 @@ mod tests {
 
         let result = run_parallel_search(&target, &live_out, &search_config, &parallel_config);
 
-        // Per the coordinator's worker-spawn logic, worker_id 0 runs the
-        // symbolic search and the remaining workers run stochastic.
+        // This regression protects statistics propagation by algorithm. Worker
+        // id dispatch order is covered separately by
+        // `test_two_workers_with_symbolic_reports_one_symbolic_one_stochastic`.
+        let mut worker_labels: Vec<(usize, Algorithm)> = result
+            .worker_statistics
+            .iter()
+            .map(|(id, alg, _)| (*id, *alg))
+            .collect();
+        worker_labels.sort_by_key(|(id, _)| *id);
+        assert_eq!(
+            result.worker_statistics.len(),
+            parallel_config.num_workers,
+            "expected one worker_statistics entry per configured worker, got {:?}",
+            worker_labels,
+        );
         let symbolic_entries: Vec<_> = result
             .worker_statistics
             .iter()
@@ -755,27 +768,17 @@ mod tests {
             symbolic_entries.len(),
             1,
             "expected exactly one Algorithm::Symbolic entry in worker_statistics, got {:?}",
-            result
-                .worker_statistics
-                .iter()
-                .map(|(id, alg, _)| (*id, *alg))
-                .collect::<Vec<_>>(),
+            worker_labels,
         );
         assert_eq!(
-            symbolic_entries[0].0, 0,
-            "symbolic worker should be worker_id 0",
+            worker_labels
+                .iter()
+                .filter(|(_, alg)| *alg == Algorithm::Stochastic)
+                .count(),
+            result.worker_statistics.len() - symbolic_entries.len(),
+            "expected all non-symbolic worker entries to be Stochastic, got {:?}",
+            worker_labels,
         );
-        for (id, alg, _) in &result.worker_statistics {
-            if *id != 0 {
-                assert_eq!(
-                    *alg,
-                    Algorithm::Stochastic,
-                    "non-symbolic workers must be labeled Stochastic, got {:?} for id {}",
-                    alg,
-                    id,
-                );
-            }
-        }
 
         // Symbolic worker reaches the solver to verify candidates, so
         // total_statistics.smt_queries must be nonzero — proving the

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- Relax the symbolic statistics propagation regression so it asserts worker labels by algorithm rather than hard-coding worker_id 0.
- Keep the current worker-id dispatch contract covered by the dedicated coordinator test.
- Remove current Clippy needless-borrow failures in SMT lowering so the local gate stays green.

Verification:
- cargo test search::parallel::coordinator::tests::test_parallel_search_symbolic_worker_statistics_are_propagated --lib
- cargo test search::parallel::coordinator::tests --lib
- cargo fmt --all
- cargo clippy --all -- -D warnings
- ./build_tests.sh
- cargo test --all
- ./ci_check.sh

Closes #322

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**