### PR TITLE
test(cli): cover x86 optimization context default

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2404,6 +2404,32 @@ mod cli_helper_tests {
     }
 
     #[test]
+    fn optimization_context_for_x86_64_backend_uses_conservative_default() {
+        let elf_bytes = build_minimal_elf64(&[0xc3], 0x1000, elf::abi::EM_X86_64);
+        let input = TempFile::new_bytes("s11-opt-context-x86-64", "elf", &elf_bytes);
+        let patcher = ElfPatcher::new(input.path()).expect("x86-64 ELF should parse");
+        let section = patcher
+            .get_text_sections()
+            .expect("x86-64 ELF should expose executable section")
+            .into_iter()
+            .next()
+            .expect("minimal ELF should contain .text");
+        let backend =
+            X86OptimizationBackend::new(DetectedArch::X86_64).expect("x86-64 backend should build");
+        let cs = backend
+            .disassembler()
+            .expect("x86-64 disassembler should build");
+
+        let context =
+            optimization_context_for_backend(backend.arch(), &patcher, &section, 0x1001, &cs);
+
+        assert!(
+            context.downstream_flags_live,
+            "non-AArch64 optimization context should stay conservative"
+        );
+    }
+
+    #[test]
     fn opt_help_mentions_enumerative_candidate_pool_growth() {
         use clap::CommandFactory;
 

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary

- Adds an x86-64 ELF-backed unit test pinning `optimization_context_for_backend` to `OptimizationContext::default()` for non-AArch64 backends.
- Removes baseline needless-borrow Clippy warnings in `src/semantics/smt.rs` so `cargo clippy --all -- -D warnings` passes on this toolchain.

Tests

- Red check: temporarily flipped non-AArch64 context to `downstream_flags_live: false`; `cargo test --bin s11 optimization_context_for_x86_64_backend_uses_conservative_default` failed as expected.
- `cargo test --bin s11 optimization_context_for_x86_64_backend_uses_conservative_default`
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `./ci_check.sh`
- `cargo test --all`

Note: `scripts/full_test.sh` is not present in this repo; `./ci_check.sh` runs the s11 full local suite, including fixture binary generation.

Closes #429

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**