### PR TITLE
test(elf-patcher): cover patched copy padding gaps

### DIFF
--- a/src/elf_patcher/mod.rs
+++ b/src/elf_patcher/mod.rs
@@ -537,7 +537,7 @@ mod tests {
         use crate::test_utils::TempFile;
 
         let text_vaddr: u64 = 0x100000;
-        let text_bytes = [0xd5u8; 16];
+        let text_bytes = [0xdeu8; 16];
         let elf_bytes = build_minimal_aarch64_elf(&text_bytes, text_vaddr);
 
         let input = TempFile::new_bytes("s11-elf-aarch64-padding-in", "elf", &elf_bytes);
@@ -563,6 +563,73 @@ mod tests {
             &patched_window[8..],
             &[0x1f, 0x20, 0x03, 0xd5, 0x1f, 0x20, 0x03, 0xd5][..],
             "padding should be repeated canonical AArch64 NOPs",
+        );
+    }
+
+    #[test]
+    fn create_patched_copy_emits_no_aarch64_padding_when_payload_fills_window() {
+        use crate::test_utils::TempFile;
+
+        let text_vaddr: u64 = 0x100000;
+        let text_bytes = [0xdeu8; 16];
+        let elf_bytes = build_minimal_aarch64_elf(&text_bytes, text_vaddr);
+
+        let input = TempFile::new_bytes("s11-elf-aarch64-no-padding-in", "elf", &elf_bytes);
+        let output = TempFile::new_bytes("s11-elf-aarch64-no-padding-out", "elf", &[]);
+
+        let patcher = ElfPatcher::new(input.path()).expect("patcher should accept minimal ELF");
+
+        let window = AddressWindow {
+            start: text_vaddr,
+            end: text_vaddr + 16,
+        };
+        let payload = [
+            0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x11, 0x22, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99,
+            0xab, 0xcd,
+        ];
+        patcher
+            .create_patched_copy(output.path(), &window, &payload)
+            .expect("patch should succeed");
+
+        let patched = std::fs::read(output.path()).expect("output should be readable");
+        let text_file_offset = 64usize;
+        let patched_window = &patched[text_file_offset..text_file_offset + 16];
+        assert_eq!(
+            patched_window,
+            &payload[..],
+            "payload that fills the window should not receive AArch64 padding",
+        );
+    }
+
+    #[test]
+    fn create_patched_copy_emits_no_x86_padding_when_payload_fills_window() {
+        use crate::test_utils::TempFile;
+
+        let text_vaddr: u64 = 0x100000;
+        let text_bytes = [0xc3u8; 8];
+        let elf_bytes = build_minimal_x86_64_elf(&text_bytes, text_vaddr);
+
+        let input = TempFile::new_bytes("s11-elf-x86-no-padding-in", "elf", &elf_bytes);
+        let output = TempFile::new_bytes("s11-elf-x86-no-padding-out", "elf", &[]);
+
+        let patcher = ElfPatcher::new(input.path()).expect("patcher should accept minimal ELF");
+
+        let window = AddressWindow {
+            start: text_vaddr,
+            end: text_vaddr + 8,
+        };
+        let payload = [0xcc, 0x31, 0xc0, 0x48, 0x83, 0xc0, 0x01, 0xc3];
+        patcher
+            .create_patched_copy(output.path(), &window, &payload)
+            .expect("patch should succeed");
+
+        let patched = std::fs::read(output.path()).expect("output should be readable");
+        let text_file_offset = 64usize;
+        let patched_window = &patched[text_file_offset..text_file_offset + 8];
+        assert_eq!(
+            patched_window,
+            &payload[..],
+            "payload that fills the window should not receive x86 padding",
         );
     }
 
@@ -603,6 +670,42 @@ mod tests {
             &patched_window[12..20],
             &[0x0f, 0x1f, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00][..],
             "second pad should be the canonical 8-byte Intel NOP",
+        );
+    }
+
+    #[test]
+    fn create_patched_copy_pads_large_aarch64_gap_with_repeated_nops() {
+        use crate::test_utils::TempFile;
+
+        let text_vaddr: u64 = 0x100000;
+        let text_bytes = [0xdeu8; 20];
+        let elf_bytes = build_minimal_aarch64_elf(&text_bytes, text_vaddr);
+
+        let input = TempFile::new_bytes("s11-elf-aarch64-padding-big-in", "elf", &elf_bytes);
+        let output = TempFile::new_bytes("s11-elf-aarch64-padding-big-out", "elf", &[]);
+
+        let patcher = ElfPatcher::new(input.path()).expect("patcher should accept minimal ELF");
+
+        let window = AddressWindow {
+            start: text_vaddr,
+            end: text_vaddr + 20,
+        };
+        let payload = [0xaa, 0xbb, 0xcc, 0xdd];
+        patcher
+            .create_patched_copy(output.path(), &window, &payload)
+            .expect("patch should succeed");
+
+        let patched = std::fs::read(output.path()).expect("output should be readable");
+        let text_file_offset = 64usize;
+        let patched_window = &patched[text_file_offset..text_file_offset + 20];
+        assert_eq!(&patched_window[..4], &payload[..], "payload bytes mismatch");
+        assert_eq!(
+            &patched_window[4..],
+            &[
+                0x1f, 0x20, 0x03, 0xd5, 0x1f, 0x20, 0x03, 0xd5, 0x1f, 0x20, 0x03, 0xd5, 0x1f, 0x20,
+                0x03, 0xd5,
+            ][..],
+            "padding should be four repeated canonical AArch64 NOPs",
         );
     }
 

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- Add create_patched_copy exact-window tests for x86-64 and AArch64 so zero padding is pinned.
- Add larger AArch64 repeated-NOP padding coverage and make the overwritten fixture bytes visibly dummy.
- Apply mechanical SMT clippy cleanup required by the local lint gate on this toolchain.

Verification:
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test --all (after ./build_tests.sh generated required integration binaries)
- ./ci_check.sh

Closes #430

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**