### PR TITLE
test(equiv): cover bitfield alias boundary widths

### DIFF
--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -2866,40 +2866,47 @@ mod tests {
     /// `LSR tmp,rn,#lsb; LSL tmp,tmp,#(64-width); ASR rd,tmp,#(64-width)`.
     #[test]
     fn test_sbfx_equivalent_to_lsr_lsl_asr() {
-        let lsb = 4i64;
-        let width = 8u8;
-        let sign_extend_shift = 64i64 - width as i64;
+        fn assert_sbfx_equivalent_to_lsr_lsl_asr(lsb: u8, width: u8) {
+            let lsb = lsb as i64;
+            let sign_extend_shift = 64i64 - width as i64;
 
-        let sbfx = vec![Instruction::Sbfx {
-            rd: Register::X0,
-            rn: Register::X1,
-            lsb: lsb as u8,
-            width,
-        }];
-
-        let lsr_lsl_asr = vec![
-            Instruction::Lsr {
-                rd: Register::X2,
-                rn: Register::X1,
-                shift: Operand::Immediate(lsb),
-            },
-            Instruction::Lsl {
-                rd: Register::X2,
-                rn: Register::X2,
-                shift: Operand::Immediate(sign_extend_shift),
-            },
-            Instruction::Asr {
+            let sbfx = vec![Instruction::Sbfx {
                 rd: Register::X0,
-                rn: Register::X2,
-                shift: Operand::Immediate(sign_extend_shift),
-            },
-        ];
+                rn: Register::X1,
+                lsb: lsb as u8,
+                width,
+            }];
 
-        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
-        assert_eq!(
-            check_equivalence_with_config(&sbfx, &lsr_lsl_asr, &config),
-            EquivalenceResult::Equivalent
-        );
+            let lsr_lsl_asr = vec![
+                Instruction::Lsr {
+                    rd: Register::X2,
+                    rn: Register::X1,
+                    shift: Operand::Immediate(lsb),
+                },
+                Instruction::Lsl {
+                    rd: Register::X2,
+                    rn: Register::X2,
+                    shift: Operand::Immediate(sign_extend_shift),
+                },
+                Instruction::Asr {
+                    rd: Register::X0,
+                    rn: Register::X2,
+                    shift: Operand::Immediate(sign_extend_shift),
+                },
+            ];
+
+            let config =
+                EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
+            assert_eq!(
+                check_equivalence_with_config(&sbfx, &lsr_lsl_asr, &config),
+                EquivalenceResult::Equivalent,
+                "SBFX equivalence failed for lsb={lsb}, width={width}"
+            );
+        }
+
+        for (lsb, width) in [(4, 8), (0, 1), (60, 4), (0, 64)] {
+            assert_sbfx_equivalent_to_lsr_lsl_asr(lsb, width);
+        }
     }
 
     /// Acceptance criterion #1 from issue #61:
@@ -2938,131 +2945,160 @@ mod tests {
         );
     }
 
+    fn low_bit_mask(width: u8) -> i64 {
+        if width == 64 {
+            -1
+        } else {
+            ((1u64 << width) - 1) as i64
+        }
+    }
+
     /// SMT proves `BFXIL rd,rn,#lsb,#width` ≡ {
     ///   LSR tmp,rn,#lsb; AND tmp,tmp,#low_mask;
     ///   AND clear,rd,#!low_mask; ORR rd,clear,tmp
     /// }.
     #[test]
     fn test_bfxil_equivalent_to_lsr_mask_clear_or() {
-        let lsb = 8i64;
-        let width = 8u8;
-        let low_mask = (1i64 << width) - 1;
-        let clear_mask = !low_mask;
+        fn assert_bfxil_equivalent_to_lsr_mask_clear_or(lsb: u8, width: u8) {
+            let lsb = lsb as i64;
+            let low_mask = low_bit_mask(width);
+            let clear_mask = !low_mask;
 
-        let bfxil = vec![Instruction::Bfxil {
-            rd: Register::X0,
-            rn: Register::X1,
-            lsb: lsb as u8,
-            width,
-        }];
-
-        let expanded = vec![
-            Instruction::Lsr {
-                rd: Register::X2,
-                rn: Register::X1,
-                shift: Operand::Immediate(lsb),
-            },
-            Instruction::And {
-                rd: Register::X2,
-                rn: Register::X2,
-                rm: Operand::Immediate(low_mask),
-                width: crate::ir::RegisterWidth::X64,
-            },
-            Instruction::And {
-                rd: Register::X3,
-                rn: Register::X0,
-                rm: Operand::Immediate(clear_mask),
-                width: crate::ir::RegisterWidth::X64,
-            },
-            Instruction::Orr {
+            let bfxil = vec![Instruction::Bfxil {
                 rd: Register::X0,
-                rn: Register::X3,
-                rm: Operand::Register(Register::X2),
-                width: crate::ir::RegisterWidth::X64,
-            },
-        ];
+                rn: Register::X1,
+                lsb: lsb as u8,
+                width,
+            }];
 
-        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
-        assert_eq!(
-            check_equivalence_with_config(&bfxil, &expanded, &config),
-            EquivalenceResult::Equivalent
-        );
+            let expanded = vec![
+                Instruction::Lsr {
+                    rd: Register::X2,
+                    rn: Register::X1,
+                    shift: Operand::Immediate(lsb),
+                },
+                Instruction::And {
+                    rd: Register::X2,
+                    rn: Register::X2,
+                    rm: Operand::Immediate(low_mask),
+                    width: crate::ir::RegisterWidth::X64,
+                },
+                Instruction::And {
+                    rd: Register::X3,
+                    rn: Register::X0,
+                    rm: Operand::Immediate(clear_mask),
+                    width: crate::ir::RegisterWidth::X64,
+                },
+                Instruction::Orr {
+                    rd: Register::X0,
+                    rn: Register::X3,
+                    rm: Operand::Register(Register::X2),
+                    width: crate::ir::RegisterWidth::X64,
+                },
+            ];
+
+            let config =
+                EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
+            assert_eq!(
+                check_equivalence_with_config(&bfxil, &expanded, &config),
+                EquivalenceResult::Equivalent,
+                "BFXIL equivalence failed for lsb={lsb}, width={width}"
+            );
+        }
+
+        for (lsb, width) in [(8, 8), (0, 1), (60, 4), (0, 64)] {
+            assert_bfxil_equivalent_to_lsr_mask_clear_or(lsb, width);
+        }
     }
 
     /// SMT proves `UBFIZ rd,rn,#lsb,#width` ≡
     /// `AND tmp,rn,#low_mask; LSL rd,tmp,#lsb`.
     #[test]
     fn test_ubfiz_equivalent_to_and_lsl() {
-        let lsb = 4i64;
-        let width = 8u8;
-        let low_mask = (1i64 << width) - 1;
+        fn assert_ubfiz_equivalent_to_and_lsl(lsb: u8, width: u8) {
+            let lsb = lsb as i64;
+            let low_mask = low_bit_mask(width);
 
-        let ubfiz = vec![Instruction::Ubfiz {
-            rd: Register::X0,
-            rn: Register::X1,
-            lsb: lsb as u8,
-            width,
-        }];
-
-        let and_lsl = vec![
-            Instruction::And {
-                rd: Register::X2,
-                rn: Register::X1,
-                rm: Operand::Immediate(low_mask),
-                width: crate::ir::RegisterWidth::X64,
-            },
-            Instruction::Lsl {
+            let ubfiz = vec![Instruction::Ubfiz {
                 rd: Register::X0,
-                rn: Register::X2,
-                shift: Operand::Immediate(lsb),
-            },
-        ];
+                rn: Register::X1,
+                lsb: lsb as u8,
+                width,
+            }];
 
-        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
-        assert_eq!(
-            check_equivalence_with_config(&ubfiz, &and_lsl, &config),
-            EquivalenceResult::Equivalent
-        );
+            let and_lsl = vec![
+                Instruction::And {
+                    rd: Register::X2,
+                    rn: Register::X1,
+                    rm: Operand::Immediate(low_mask),
+                    width: crate::ir::RegisterWidth::X64,
+                },
+                Instruction::Lsl {
+                    rd: Register::X0,
+                    rn: Register::X2,
+                    shift: Operand::Immediate(lsb),
+                },
+            ];
+
+            let config =
+                EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
+            assert_eq!(
+                check_equivalence_with_config(&ubfiz, &and_lsl, &config),
+                EquivalenceResult::Equivalent,
+                "UBFIZ equivalence failed for lsb={lsb}, width={width}"
+            );
+        }
+
+        for (lsb, width) in [(4, 8), (0, 1), (60, 4), (0, 64)] {
+            assert_ubfiz_equivalent_to_and_lsl(lsb, width);
+        }
     }
 
     /// SMT proves `SBFIZ rd,rn,#lsb,#width` ≡
     /// `LSL tmp,rn,#(64-width); ASR tmp,tmp,#(64-width); LSL rd,tmp,#lsb`.
     #[test]
     fn test_sbfiz_equivalent_to_lsl_asr_lsl() {
-        let lsb = 4i64;
-        let width = 8u8;
-        let sign_extend_shift = 64i64 - width as i64;
+        fn assert_sbfiz_equivalent_to_lsl_asr_lsl(lsb: u8, width: u8) {
+            let lsb = lsb as i64;
+            let sign_extend_shift = 64i64 - width as i64;
 
-        let sbfiz = vec![Instruction::Sbfiz {
-            rd: Register::X0,
-            rn: Register::X1,
-            lsb: lsb as u8,
-            width,
-        }];
-
-        let lsl_asr_lsl = vec![
-            Instruction::Lsl {
-                rd: Register::X2,
-                rn: Register::X1,
-                shift: Operand::Immediate(sign_extend_shift),
-            },
-            Instruction::Asr {
-                rd: Register::X2,
-                rn: Register::X2,
-                shift: Operand::Immediate(sign_extend_shift),
-            },
-            Instruction::Lsl {
+            let sbfiz = vec![Instruction::Sbfiz {
                 rd: Register::X0,
-                rn: Register::X2,
-                shift: Operand::Immediate(lsb),
-            },
-        ];
+                rn: Register::X1,
+                lsb: lsb as u8,
+                width,
+            }];
 
-        let config = EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
-        assert_eq!(
-            check_equivalence_with_config(&sbfiz, &lsl_asr_lsl, &config),
-            EquivalenceResult::Equivalent
-        );
+            let lsl_asr_lsl = vec![
+                Instruction::Lsl {
+                    rd: Register::X2,
+                    rn: Register::X1,
+                    shift: Operand::Immediate(sign_extend_shift),
+                },
+                Instruction::Asr {
+                    rd: Register::X2,
+                    rn: Register::X2,
+                    shift: Operand::Immediate(sign_extend_shift),
+                },
+                Instruction::Lsl {
+                    rd: Register::X0,
+                    rn: Register::X2,
+                    shift: Operand::Immediate(lsb),
+                },
+            ];
+
+            let config =
+                EquivalenceConfig::with_live_out(LiveOut::from_registers(vec![Register::X0]));
+            assert_eq!(
+                check_equivalence_with_config(&sbfiz, &lsl_asr_lsl, &config),
+                EquivalenceResult::Equivalent,
+                "SBFIZ equivalence failed for lsb={lsb}, width={width}"
+            );
+        }
+
+        for (lsb, width) in [(4, 8), (0, 1), (60, 4), (0, 64)] {
+            assert_sbfiz_equivalent_to_lsl_asr_lsl(lsb, width);
+        }
     }
 
     /// Issue #241 regression: AArch64 variable LSL consumes only the low 6

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Strengthen the AArch64 SMT equivalence tests for SBFX, BFXIL, UBFIZ, and SBFIZ so each alias now proves the existing representative case plus low-boundary, high-boundary, and full-register width cases. Also applies a minimal clippy cleanup in SMT bitvector calls required for the local warning-deny gate.\n\nCloses #431\n\n**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**