### PR TITLE
test(parser): pin W-form bitfield rejection

### DIFF
--- a/docs/capability.md
+++ b/docs/capability.md
@@ -57,7 +57,10 @@ Rewritable straight-line mnemonics accepted by the parser and Capstone bridge:
 - Single-source bit manipulation: `clz`, `cls`, `rbit`, `rev`, `rev32`,
   `rev16`
 - Standalone extend aliases: `uxtb`, `uxth`, `sxtb`, `sxth`, `sxtw`
-- Bit-field aliases: `ubfx`, `sbfx`, `bfi`, `bfxil`, `ubfiz`, `sbfiz`
+- Bit-field aliases are 64-bit `X`-form only: `ubfx`, `sbfx`, `bfi`,
+  `bfxil`, `ubfiz`, `sbfiz`. W-form bitfield aliases remain unsupported by
+  design for now because the current IR has no width on these instruction
+  variants.
 - Memory loads and stores (issue #68, [ADR-0007](adr/0007-memory-model.md);
   byte-addressed Z3-array memory model with sound full aliasing, whole-memory
   live-out auto-derived): `ldr`, `ldrb`, `ldrh`, `ldrsb`, `ldrsh`, `ldrsw`,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3061,6 +3061,30 @@ mod tests {
     }
 
     #[test]
+    fn parse_bfm_like_rejects_w_form_registers() {
+        for mnemonic in ["ubfx", "sbfx", "bfi", "bfxil", "ubfiz", "sbfiz"] {
+            let line = format!("{mnemonic} w0, w1, #5, #10");
+            assert!(
+                parse_line(&line).is_err(),
+                "{line} must remain unsupported until bitfield IR tracks width"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_bfm_like_rejects_mixed_w_x_registers() {
+        for mnemonic in ["ubfx", "sbfx", "bfi", "bfxil", "ubfiz", "sbfiz"] {
+            for operands in ["x0, w1", "w0, x1"] {
+                let line = format!("{mnemonic} {operands}, #5, #10");
+                assert!(
+                    parse_line(&line).is_err(),
+                    "{line} must not erase operand width into X-form IR"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn parse_line_covers_all_core_mnemonics() {
         let cases = [
             ("sub x0, x1, #3", "sub x0, x1, #3"),

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {

--- a/tests/integration/docs_capability.rs
+++ b/tests/integration/docs_capability.rs
@@ -127,6 +127,19 @@ fn docs_capability_documents_w_mov_add_sub_forms() {
 }
 
 #[test]
+fn docs_capability_documents_bitfield_alias_width_scope() {
+    let matrix = normalized_doc("docs/capability.md");
+    assert!(
+        matrix.contains("bit-field aliases are 64-bit `x`-form only"),
+        "docs/capability.md must document X-form-only bitfield alias support"
+    );
+    assert!(
+        matrix.contains("w-form bitfield aliases remain unsupported"),
+        "docs/capability.md must document unsupported W-form bitfield aliases"
+    );
+}
+
+#[test]
 fn enumerative_candidate_growth_visible_in_public_docs() {
     for doc in ["README.md", "TUTORIAL.md", "docs/capability.md"] {
         let body = normalized_doc(doc);


### PR DESCRIPTION
## Summary
- Document AArch64 bitfield aliases as 64-bit X-form only in the capability matrix.
- Add parser regressions that reject W-form and mixed W/X bitfield alias operands until the IR tracks width explicitly.
- Remove current SMT needless-borrow Clippy warnings so the required clippy gate stays green.

Closes #435

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**

## Validation
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `./build_tests.sh`
- `cargo test --all`
- `scripts/full_test.sh` is not present in this repository
- `./ci_check.sh`