### PR TITLE
test(parser): cover XZR/WZR standalone extend round trips

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3412,6 +3412,62 @@ mod tests {
     }
 
     #[test]
+    fn parse_standalone_extend_round_trips_zero_registers() {
+        // Issue #428: keep zero-register spellings stable
+        // across Display -> parse_line -> Display for standalone extends.
+        let cases = [
+            (
+                Instruction::Uxtb {
+                    rd: Register::XZR,
+                    rn: Register::XZR,
+                },
+                "uxtb wzr, wzr",
+            ),
+            (
+                Instruction::Uxth {
+                    rd: Register::XZR,
+                    rn: Register::XZR,
+                },
+                "uxth wzr, wzr",
+            ),
+            (
+                Instruction::Sxtb {
+                    rd: Register::XZR,
+                    rn: Register::XZR,
+                },
+                "sxtb xzr, wzr",
+            ),
+            (
+                Instruction::Sxth {
+                    rd: Register::XZR,
+                    rn: Register::XZR,
+                },
+                "sxth xzr, wzr",
+            ),
+            (
+                Instruction::Sxtw {
+                    rd: Register::XZR,
+                    rn: Register::XZR,
+                },
+                "sxtw xzr, wzr",
+            ),
+        ];
+
+        for (expected, expected_text) in cases {
+            assert_eq!(expected.to_string(), expected_text);
+
+            let parsed = match parse_line(expected_text)
+                .unwrap_or_else(|e| panic!("{expected_text}: {e}"))
+            {
+                LineResult::Instruction(instr) => instr,
+                LineResult::Skip => panic!("unexpected skip for {expected_text}"),
+            };
+            assert_eq!(parsed, expected, "parse mismatch for {expected_text}");
+            assert_eq!(parsed.to_string(), expected_text);
+        }
+    }
+
+    #[test]
     fn parse_sxt_rejects_w_destination() {
         // Issue #60 follow-up (Codex P1 on the rebased branch): `sxtb w0, w1`
         // is the 32-bit-Wd-write form architecturally — distinct from the

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- Add parser/display round-trip coverage for XZR/WZR operands on SXTB, SXTH, SXTW, UXTB, and UXTH.
- Keep SP/WSP out of the round-trip table because standalone extend SP operands remain intentionally unencodable and parse_line rejects unencodable IR.
- Remove existing needless SMT bitvector borrows so the required clippy gate is green.

Verification:
- cargo fmt --all
- cargo clippy --all -- -D warnings
- ./build_tests.sh
- cargo test --all
- ./ci_check.sh

Closes #428

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**