### PR TITLE
test(search): assert shifted-register prefilter count

### DIFF
--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -2235,9 +2235,11 @@ mod tests {
             }
         }
 
-        assert!(
-            shifted_count > 0,
-            "enumeration must retain valid shifted-register candidates"
+        // 2 non-SP choices for each of rd/rn/rm, with 162 shifted-register
+        // binary candidates per tuple from the current AArch64 candidate matrix.
+        assert_eq!(
+            shifted_count, 1296,
+            "enumeration must retain the expected shifted-register candidate count"
         );
     }
 

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- Strengthen the SP-prefilter regression test to assert the exact shifted-register binary candidate count of 1296.
- Keep the count formula visible in the test so future candidate-matrix changes fail loudly.
- Remove existing needless SMT temporary borrows so the required clippy gate passes under the current toolchain.

Tests:
- cargo test test_generate_all_instructions_shifted_register_prefilters_sp
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test --all (after ./build_tests.sh generated required integration fixtures)
- ./ci_check.sh

Note: scripts/full_test.sh from the autonomous prompt is not present in this s11 workspace; this repo uses ./ci_check.sh and test_all.sh instead.

Closes #436

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**