### PR TITLE
refactor(search): hoist shifted-register SP guard

### DIFF
--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -137,11 +137,11 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
             //   Add/Sub: LSL/LSR/ASR (no ROR)
             //   And/Orr/Eor: LSL/LSR/ASR/ROR
             // AArch64 shifted-register encodings cannot use SP in rd/rn/rm, so
-            // pre-filter those tuples instead of allocating candidates that the
-            // later encodability pass will discard.
+            // hoist the rd/rn filter while keeping rm filtered per tuple.
             use crate::ir::ShiftKind;
+            let shifted_register_allows_rd_rn = rd != Register::SP && rn != Register::SP;
             for &rm in registers {
-                if rd != Register::SP && rn != Register::SP && rm != Register::SP {
+                if shifted_register_allows_rd_rn && rm != Register::SP {
                     for &amount in SHIFTED_OP_AMOUNTS {
                         for kind in [ShiftKind::Lsl, ShiftKind::Lsr, ShiftKind::Asr] {
                             let sr = Operand::ShiftedRegister {
@@ -2641,6 +2641,37 @@ mod tests {
             )
         });
         assert!(has_uxtb, "enumeration missing ADD with UXTB extended-reg");
+    }
+
+    #[test]
+    fn enumerate_extended_register_add_sub_allows_sp_rd_rn() {
+        let regs = vec![Register::SP, Register::X0];
+        let imms = vec![];
+        let candidates = generate_all_instructions(&regs, &imms);
+        let extended_x0_uxtb = Operand::ExtendedRegister {
+            reg: Register::X0,
+            kind: crate::ir::ExtendKind::Uxtb,
+            shift: 0,
+        };
+
+        for expected in [
+            Instruction::Add {
+                rd: Register::SP,
+                rn: Register::SP,
+                rm: extended_x0_uxtb,
+            },
+            Instruction::Sub {
+                rd: Register::SP,
+                rn: Register::SP,
+                rm: extended_x0_uxtb,
+            },
+        ] {
+            assert!(
+                candidates.contains(&expected),
+                "enumeration missing SP-bearing extended-register candidate: {}",
+                expected
+            );
+        }
     }
 
     #[test]

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
## Summary
- Hoist the shifted-register rd/rn SP predicate out of the rm loop while keeping the per-rm SP filter.
- Add a regression test proving extended-register ADD/SUB candidates still allow SP in rd/rn.
- Apply mechanical Clippy borrow cleanup in SMT code because the required local zero-warning gate failed on the current toolchain before that cleanup.

## Tests
- cargo test search::candidate::tests (includes mutation-red check against the unsafe hoist shape)
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test --all (rerun after ./build_tests.sh populated binaries)
- ./ci_check.sh

Note: scripts/full_test.sh is not present in this repo; ./ci_check.sh runs the repo's test_all.sh.

Closes #439

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**