### PR TITLE
test(search): harden run_length_two inner timeout regression

### DIFF
--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -1237,116 +1237,116 @@ mod tests {
             .with_timeout_option(None)
     }
 
-    #[derive(Clone)]
-    struct InnerTimeoutIsa;
-
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-    struct InnerTimeoutInstruction(u8);
-
-    impl std::fmt::Display for InnerTimeoutInstruction {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "probe{}", self.0)
-        }
-    }
-
-    impl InstructionType for InnerTimeoutInstruction {
-        type Register = Register;
-        type Operand = Operand;
-
-        fn destination(&self) -> Option<Self::Register> {
-            Some(Register::X0)
-        }
-
-        fn source_registers(&self) -> Vec<Self::Register> {
-            Vec::new()
-        }
-
-        fn opcode_id(&self) -> u8 {
-            self.0
-        }
-
-        fn mnemonic(&self) -> &'static str {
-            "probe"
-        }
-    }
-
-    struct InnerTimeoutMutator;
-
-    impl ISAMutator<InnerTimeoutInstruction> for InnerTimeoutMutator {
-        fn mutate<R: rand::RngExt>(
-            &self,
-            _rng: &mut R,
-            sequence: &[InnerTimeoutInstruction],
-        ) -> Vec<InnerTimeoutInstruction> {
-            sequence.to_vec()
-        }
-    }
-
-    impl ISA for InnerTimeoutIsa {
-        type Register = Register;
-        type Operand = Operand;
-        type Instruction = InnerTimeoutInstruction;
-        type Width = U64;
-        type Flags = ();
-        type Mutator = InnerTimeoutMutator;
-
-        fn name(&self) -> &'static str {
-            "InnerTimeout"
-        }
-
-        fn register_count(&self) -> usize {
-            1
-        }
-
-        fn instruction_size(&self) -> Option<usize> {
-            Some(1)
-        }
-
-        fn general_registers(&self) -> Vec<Self::Register> {
-            vec![Register::X0]
-        }
-
-        fn zero_register(&self) -> Option<Self::Register> {
-            Some(Register::XZR)
-        }
-    }
-
-    static INNER_TIMEOUT_COST_CALLS: AtomicUsize = AtomicUsize::new(0);
-
-    impl EnumerativeBackend<InnerTimeoutIsa> for InnerTimeoutIsa {
-        type LiveOut = ();
-
-        fn registers_from_config(_config: &SearchConfig) -> Vec<Register> {
-            vec![Register::X0]
-        }
-
-        fn immediates_from_config(_config: &SearchConfig) -> Vec<i64> {
-            vec![0]
-        }
-
-        fn enumerate_all(_regs: &[Register], _imms: &[i64]) -> Vec<InnerTimeoutInstruction> {
-            vec![InnerTimeoutInstruction(0), InnerTimeoutInstruction(1)]
-        }
-
-        fn sequence_cost(_seq: &[InnerTimeoutInstruction], _config: &SearchConfig) -> u64 {
-            INNER_TIMEOUT_COST_CALLS.fetch_add(1, Ordering::Relaxed);
-            std::thread::sleep(std::time::Duration::from_millis(50));
-            1
-        }
-
-        fn check_equivalence(
-            _target: &[InnerTimeoutInstruction],
-            _candidate: &[InnerTimeoutInstruction],
-            _live_out: &Self::LiveOut,
-            _smt_timeout: Duration,
-        ) -> (EquivalenceResult, EquivalenceMetrics) {
-            panic!("cost pruning should prevent equivalence checks")
-        }
-    }
-
     #[test]
     fn run_length_two_sets_stop_when_inner_deadline_expires() {
-        INNER_TIMEOUT_COST_CALLS.store(0, Ordering::Relaxed);
+        #[derive(Clone)]
+        struct InnerTimeoutIsa;
+
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+        struct InnerTimeoutInstruction(u8);
+
+        impl fmt::Display for InnerTimeoutInstruction {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "probe{}", self.0)
+            }
+        }
+
+        impl InstructionType for InnerTimeoutInstruction {
+            type Register = Register;
+            type Operand = Operand;
+
+            fn destination(&self) -> Option<Self::Register> {
+                Some(Register::X0)
+            }
+
+            fn source_registers(&self) -> Vec<Self::Register> {
+                Vec::new()
+            }
+
+            fn opcode_id(&self) -> u8 {
+                self.0
+            }
+
+            fn mnemonic(&self) -> &'static str {
+                "probe"
+            }
+        }
+
+        struct InnerTimeoutMutator;
+
+        impl ISAMutator<InnerTimeoutInstruction> for InnerTimeoutMutator {
+            fn mutate<R: rand::RngExt>(
+                &self,
+                _rng: &mut R,
+                sequence: &[InnerTimeoutInstruction],
+            ) -> Vec<InnerTimeoutInstruction> {
+                sequence.to_vec()
+            }
+        }
+
+        impl ISA for InnerTimeoutIsa {
+            type Register = Register;
+            type Operand = Operand;
+            type Instruction = InnerTimeoutInstruction;
+            type Width = U64;
+            type Flags = ();
+            type Mutator = InnerTimeoutMutator;
+
+            fn name(&self) -> &'static str {
+                "InnerTimeout"
+            }
+
+            fn register_count(&self) -> usize {
+                1
+            }
+
+            fn instruction_size(&self) -> Option<usize> {
+                Some(1)
+            }
+
+            fn general_registers(&self) -> Vec<Self::Register> {
+                vec![Register::X0]
+            }
+
+            fn zero_register(&self) -> Option<Self::Register> {
+                Some(Register::XZR)
+            }
+        }
+
+        static COST_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+        impl EnumerativeBackend<InnerTimeoutIsa> for InnerTimeoutIsa {
+            type LiveOut = ();
+
+            fn registers_from_config(_config: &SearchConfig) -> Vec<Register> {
+                vec![Register::X0]
+            }
+
+            fn immediates_from_config(_config: &SearchConfig) -> Vec<i64> {
+                vec![0]
+            }
+
+            fn enumerate_all(_regs: &[Register], _imms: &[i64]) -> Vec<InnerTimeoutInstruction> {
+                vec![InnerTimeoutInstruction(0), InnerTimeoutInstruction(1)]
+            }
+
+            fn sequence_cost(_seq: &[InnerTimeoutInstruction], _config: &SearchConfig) -> u64 {
+                COST_CALLS.fetch_add(1, Ordering::Relaxed);
+                std::thread::sleep(std::time::Duration::from_millis(50));
+                1
+            }
+
+            fn check_equivalence(
+                _target: &[InnerTimeoutInstruction],
+                _candidate: &[InnerTimeoutInstruction],
+                _live_out: &Self::LiveOut,
+                _smt_timeout: Duration,
+            ) -> (EquivalenceResult, EquivalenceMetrics) {
+                panic!("cost pruning should prevent equivalence checks")
+            }
+        }
+
+        COST_CALLS.store(0, Ordering::Relaxed);
 
         let config = SearchConfig::default().with_timeout(std::time::Duration::from_millis(25));
         let target = vec![InnerTimeoutInstruction(9), InnerTimeoutInstruction(8)];
@@ -1377,7 +1377,7 @@ mod tests {
             "inner loop should set stop after the timeout expires"
         );
         assert_eq!(
-            INNER_TIMEOUT_COST_CALLS.load(Ordering::Relaxed),
+            COST_CALLS.load(Ordering::Relaxed),
             1,
             "timeout should be checked before evaluating the second inner candidate"
         );

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- Localize the `run_length_two_sets_stop_when_inner_deadline_expires` fake ISA/backend and cost counter to the single regression test that owns it.
- Preserve the existing 25 ms timeout / 50 ms sleep margin because no flake was observed.
- Remove existing clippy `needless_borrows_for_generic_args` warnings in `src/semantics/smt.rs` so the mandated local clippy gate passes.

Validation:
- `cargo test run_length_two_sets_stop_when_inner_deadline_expires`
- `cargo test length_two_search_honors_timeout_inside_inner_loop`
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `./build_tests.sh`
- `cargo test --all`
- `./ci_check.sh`

Note: `scripts/full_test.sh` referenced by the run prompt does not exist in this s11 checkout; the repository-provided full preflight is `./ci_check.sh`, which also ran `test_all.sh`.

Closes #454

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**
