### PR TITLE
refactor(search): share x86 base search config builder

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1747,9 +1747,14 @@ fn build_x86_enumerative_search_config(
     width: u32,
     options: &OptimizationOptions,
 ) -> SearchConfig {
+    // Enumerative verification reads `config.symbolic.solver_timeout`, so the
+    // CLI --solver-timeout must be attached here even though the stochastic
+    // fields stay out of the enumerative config.
+    let symbolic_config = SymbolicConfig::default().with_timeout(options.solver_timeout);
     build_x86_base_search_config(target, width, options)
         .with_immediates(x86_enumerative_immediates_from_target(target))
         .with_cores(options.cores)
+        .with_symbolic(symbolic_config)
 }
 
 /// Run x86 enumerative search and return the optimized sequence if any.
@@ -3379,10 +3384,9 @@ mod cli_helper_tests {
         assert_eq!(config.stochastic.beta, default_stochastic.beta);
         assert_eq!(config.stochastic.iterations, default_stochastic.iterations);
         assert_eq!(config.stochastic.seed, default_stochastic.seed);
-        assert_eq!(
-            config.symbolic.solver_timeout,
-            SymbolicConfig::default().solver_timeout
-        );
+        // The enumerative path keeps stochastic fields out but still honors the
+        // CLI --solver-timeout for its SMT verification queries.
+        assert_eq!(config.symbolic.solver_timeout, Duration::from_millis(37));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -919,6 +919,20 @@ fn build_hybrid_search_config(
         .with_timeout_option(options.timeout)
 }
 
+fn build_x86_base_search_config(
+    target: &[isa::x86::X86Instruction],
+    width: u32,
+    options: &OptimizationOptions,
+) -> SearchConfig {
+    SearchConfig::default()
+        .with_cost_metric(options.cost_metric)
+        .with_timeout_option(options.timeout)
+        .with_verbose(options.verbose)
+        .with_x86_registers(x86_registers_from_target(target))
+        .with_immediates(isa::x86::default_x86_immediates())
+        .with_x86_width(width)
+}
+
 fn build_x86_stochastic_search_config(
     target: &[isa::x86::X86Instruction],
     width: u32,
@@ -931,15 +945,9 @@ fn build_x86_stochastic_search_config(
 
     let symbolic_config = SymbolicConfig::default().with_timeout(options.solver_timeout);
 
-    SearchConfig::default()
+    build_x86_base_search_config(target, width, options)
         .with_stochastic(stochastic_config)
         .with_symbolic(symbolic_config)
-        .with_cost_metric(options.cost_metric)
-        .with_timeout_option(options.timeout)
-        .with_verbose(options.verbose)
-        .with_x86_registers(x86_registers_from_target(target))
-        .with_immediates(isa::x86::default_x86_immediates())
-        .with_x86_width(width)
 }
 
 fn build_x86_symbolic_search_config(
@@ -951,14 +959,7 @@ fn build_x86_symbolic_search_config(
         .with_search_mode(options.search_mode)
         .with_timeout(options.solver_timeout);
 
-    SearchConfig::default()
-        .with_symbolic(symbolic_config)
-        .with_cost_metric(options.cost_metric)
-        .with_timeout_option(options.timeout)
-        .with_verbose(options.verbose)
-        .with_x86_registers(x86_registers_from_target(target))
-        .with_immediates(isa::x86::default_x86_immediates())
-        .with_x86_width(width)
+    build_x86_base_search_config(target, width, options).with_symbolic(symbolic_config)
 }
 
 /// Run optimization using the selected algorithm.
@@ -1738,14 +1739,15 @@ fn x86_enumerative_immediates_from_target(target: &[isa::x86::X86Instruction]) -
 
 /// Build the search config for the x86 *enumerative* path. Like stochastic and
 /// symbolic search, enumerative search draws candidates from the target's own
-/// registers; it additionally derives immediates from the target and honours
-/// --cores now that the trait-backed search is rayon-parallel.
+/// registers via the shared x86 base; it additionally derives immediates from
+/// the target and honours --cores now that the trait-backed search is
+/// rayon-parallel.
 fn build_x86_enumerative_search_config(
     target: &[isa::x86::X86Instruction],
     width: u32,
     options: &OptimizationOptions,
 ) -> SearchConfig {
-    build_x86_stochastic_search_config(target, width, options)
+    build_x86_base_search_config(target, width, options)
         .with_immediates(x86_enumerative_immediates_from_target(target))
         .with_cores(options.cores)
 }
@@ -3329,6 +3331,57 @@ mod cli_helper_tests {
         assert!(
             config.available_immediates.contains(&-1),
             "immediate pool must include -1"
+        );
+    }
+
+    #[test]
+    fn build_x86_enumerative_search_config_does_not_inherit_stochastic_options() {
+        let mut opts = options_for(Algorithm::Enumerative);
+        opts.timeout = Some(Duration::from_millis(31));
+        opts.solver_timeout = Duration::from_millis(37);
+        opts.beta = 7.25;
+        opts.iterations = 987;
+        opts.seed = Some(123);
+        opts.cost_metric = CostMetric::Latency;
+        opts.verbose = true;
+        opts.cores = Some(4);
+
+        let target = vec![
+            X86Instruction::MovImm {
+                rd: X86Register::R11,
+                imm: -5,
+            },
+            X86Instruction::AddReg {
+                rd: X86Register::R12,
+                rs: X86Register::R11,
+            },
+            X86Instruction::CmpImm {
+                rn: X86Register::R10,
+                imm: 3,
+            },
+        ];
+        let config = build_x86_enumerative_search_config(&target, 32, &opts);
+
+        assert_eq!(
+            config.x86_available_registers,
+            vec![X86Register::R11, X86Register::R12]
+        );
+        assert!(config.available_immediates.contains(&-5));
+        assert!(config.available_immediates.contains(&3));
+        assert_eq!(config.cores, Some(4));
+        assert_eq!(config.cost_metric, CostMetric::Latency);
+        assert_eq!(config.timeout, Some(Duration::from_millis(31)));
+        assert!(config.verbose);
+        assert_eq!(config.x86_width, 32);
+        assert_eq!(config.x86_mode, assembler::x86::X86Mode::Mode32);
+
+        let default_stochastic = StochasticConfig::default();
+        assert_eq!(config.stochastic.beta, default_stochastic.beta);
+        assert_eq!(config.stochastic.iterations, default_stochastic.iterations);
+        assert_eq!(config.stochastic.seed, default_stochastic.seed);
+        assert_eq!(
+            config.symbolic.solver_timeout,
+            SymbolicConfig::default().solver_timeout
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3669,7 +3669,7 @@ mod cli_helper_tests {
         assert_eq!(config.timeout, Some(Duration::from_millis(31)));
         assert!(config.verbose);
         assert_eq!(config.x86_width, 32);
-        assert_eq!(config.x86_mode, assembler::x86::X86Mode::Mode32);
+        assert_eq!(config.x86_mode(), assembler::x86::X86Mode::Mode32);
 
         let default_stochastic = StochasticConfig::default();
         assert_eq!(config.stochastic.beta, default_stochastic.beta);

--- a/src/main.rs
+++ b/src/main.rs
@@ -3677,7 +3677,10 @@ mod cli_helper_tests {
         assert_eq!(config.stochastic.seed, default_stochastic.seed);
         // The enumerative path keeps stochastic fields out but still honors the
         // CLI --solver-timeout for its SMT verification queries.
-        assert_eq!(config.symbolic.solver_timeout, Duration::from_millis(37));
+        assert_eq!(
+            config.symbolic.solver_timeout,
+            Some(Duration::from_millis(37))
+        );
     }
 
     #[test]

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
## Summary
- add a shared x86 base SearchConfig builder for common register, immediate, timeout, cost, verbosity, and width setup
- stop the x86 enumerative builder from inheriting stochastic-only beta/iterations/seed values
- include a mechanical clippy cleanup required to keep the local lint gate green on the current toolchain

Closes #457

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**