### PR TITLE
test(x86): cover high-register stochastic and symbolic rewrites

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2304,6 +2304,19 @@ mod cli_helper_tests {
         }
     }
 
+    fn r10_zeroing_target() -> [X86Instruction; 2] {
+        let zero_r10 = X86Instruction::XorReg {
+            rd: X86Register::R10,
+            rs: X86Register::R10,
+        };
+        [zero_r10, zero_r10]
+    }
+
+    fn assert_single_r10_rewrite(optimized: &[X86Instruction]) {
+        assert_eq!(optimized.len(), 1);
+        assert_eq!(optimized[0].destination(), Some(X86Register::R10));
+    }
+
     fn build_minimal_elf64(text_bytes: &[u8], text_vaddr: u64, machine: u16) -> Vec<u8> {
         let elf_header_size = 64usize;
         let shentsize = 64usize;
@@ -3231,6 +3244,46 @@ mod cli_helper_tests {
         .expect("two identical R10/-1 writes must collapse to one");
         assert_eq!(optimized.len(), 1);
         assert_eq!(optimized[0].destination(), Some(X86Register::R10));
+    }
+
+    /// Regression (issue #458): stochastic search must consume the
+    /// target-derived x86 register pool end-to-end, not just expose it in the
+    /// config. R10 is outside `default_x86_registers()`, so a successful
+    /// rewrite proves the search backend can synthesize high-register
+    /// candidates.
+    #[test]
+    fn x86_stochastic_finds_rewrite_for_r10_only_target() {
+        let mut opts = options_for(Algorithm::Stochastic);
+        opts.timeout = None;
+        opts.solver_timeout = Duration::from_secs(30);
+        opts.cost_metric = CostMetric::InstructionCount;
+        opts.iterations = 50_000;
+        opts.seed = Some(7);
+
+        let target = r10_zeroing_target();
+        let optimized = run_x86_stochastic(&target, 64, &opts)
+            .expect("two identical R10 zeroing writes must collapse to one");
+
+        assert_single_r10_rewrite(&optimized);
+    }
+
+    /// Regression (issue #458): symbolic search must also use the
+    /// target-derived x86 register pool when synthesizing candidates. This
+    /// closes the end-to-end gap left by config-only coverage for high x86-64
+    /// registers.
+    #[test]
+    fn x86_symbolic_finds_rewrite_for_r10_only_target() {
+        let mut opts = options_for(Algorithm::Symbolic);
+        opts.timeout = None;
+        opts.solver_timeout = Duration::from_secs(30);
+        opts.search_mode = SearchMode::Linear;
+        opts.cost_metric = CostMetric::InstructionCount;
+
+        let target = r10_zeroing_target();
+        let optimized = run_x86_symbolic(&target, 64, &opts)
+            .expect("two identical R10 zeroing writes must collapse to one");
+
+        assert_single_r10_rewrite(&optimized);
     }
 
     #[test]

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- Add x86-64 helper regressions proving stochastic and symbolic search can collapse an R10-only target end to end.
- Reuse a shared R10 zeroing fixture and assert the optimized sequence is a one-instruction rewrite that writes R10.
- Remove existing clippy needless-borrow warnings in SMT bitvector code so the required local clippy gate passes.

Operational note:
- Attempted `gh pr create --base main --head sym/s11/458-add-end-to-end-x86-stochastic-symbolic-regression-test-for-r10r15-only-targets ...`, but GitHub GraphQL quota was exhausted. Opened this PR through the local `gh api` REST fallback instead.

Validation:
- cargo fmt --all
- cargo clippy --all -- -D warnings
- ./build_tests.sh
- cargo test --all
- ./ci_check.sh
- scripts/full_test.sh was requested by the autonomous contract, but this repository has no scripts/full_test.sh path.

Closes #458

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**