### PR TITLE
test(search): isolate length-two cost counter

### DIFF
--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -645,7 +645,22 @@ mod tests {
     use crate::isa::{ISA, ISAMutator, InstructionType, OperandType, RegisterType, U64};
     use crate::search::config::SymbolicConfig;
 
-    static LENGTH_TWO_COST_CALLS: AtomicU64 = AtomicU64::new(0);
+    std::thread_local! {
+        static LENGTH_TWO_COST_CALLS: std::cell::Cell<u64> =
+            const { std::cell::Cell::new(0) };
+    }
+
+    fn reset_length_two_cost_calls() {
+        LENGTH_TWO_COST_CALLS.with(|calls| calls.set(0));
+    }
+
+    fn increment_length_two_cost_calls() {
+        LENGTH_TWO_COST_CALLS.with(|calls| calls.set(calls.get() + 1));
+    }
+
+    fn length_two_cost_calls() -> u64 {
+        LENGTH_TWO_COST_CALLS.with(|calls| calls.get())
+    }
 
     impl EnumerativeBackend<crate::isa::RiscV64> for crate::isa::RiscV64 {
         type LiveOut = ();
@@ -669,7 +684,7 @@ mod tests {
             _seq: &[crate::isa::riscv::RiscVInstruction],
             _config: &SearchConfig,
         ) -> u64 {
-            LENGTH_TWO_COST_CALLS.fetch_add(1, Ordering::Relaxed);
+            increment_length_two_cost_calls();
             std::thread::sleep(std::time::Duration::from_millis(10));
             1
         }
@@ -682,6 +697,26 @@ mod tests {
         ) -> (EquivalenceResult, EquivalenceMetrics) {
             panic!("cost-pruned timeout regression must not verify candidates")
         }
+    }
+
+    #[test]
+    fn length_two_cost_counter_is_thread_local() {
+        use crate::isa::RiscV64;
+
+        let config = SearchConfig::default();
+        reset_length_two_cost_calls();
+
+        std::thread::spawn(move || {
+            <RiscV64 as EnumerativeBackend<RiscV64>>::sequence_cost(&[], &config);
+        })
+        .join()
+        .expect("cost counter probe thread should finish");
+
+        assert_eq!(
+            length_two_cost_calls(),
+            0,
+            "cost calls from another test thread must not affect this test thread"
+        );
     }
 
     static CACHE_PROBE_TEST_LOCK: TestMutex<()> = TestMutex::new(());
@@ -1585,14 +1620,14 @@ mod tests {
         let live_out = ();
         let config = SearchConfig::default().with_timeout(std::time::Duration::from_millis(5));
         let shared = SharedState::<RiscV64>::new(0);
-        LENGTH_TWO_COST_CALLS.store(0, Ordering::Relaxed);
 
         let pool = rayon::ThreadPoolBuilder::new()
             .num_threads(1)
             .build()
             .expect("private rayon pool");
-        let start = std::time::Instant::now();
-        pool.install(|| {
+        let cost_calls = pool.install(|| {
+            reset_length_two_cost_calls();
+            let start = std::time::Instant::now();
             run_length_two::<RiscV64>(
                 &target,
                 &live_out,
@@ -1601,13 +1636,17 @@ mod tests {
                 None,
                 &shared,
                 start,
-            )
+            );
+            length_two_cost_calls()
         });
 
-        let cost_calls = LENGTH_TWO_COST_CALLS.load(Ordering::Relaxed);
         assert!(
             shared.stop.load(Ordering::Relaxed),
             "timeout should set shared stop inside the inner length-two loop"
+        );
+        assert!(
+            cost_calls > 0,
+            "expected to observe cost calls from the worker running length-two search"
         );
         assert!(
             cost_calls < all_instructions.len() as u64,

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- Replace the length-two mock cost counter with thread-local Cell helpers and add a cross-thread isolation regression.
- Read/reset the timeout test counter inside the private Rayon worker and assert at least one observed cost call.
- Remove current clippy needless-borrow warnings in SMT helpers so the local gate is green.

Verification:
- cargo test length_two_cost_counter_is_thread_local
- cargo test length_two_search_honors_timeout_inside_inner_loop
- cargo test search::enumerative::search::tests
- cargo clippy --all -- -D warnings
- ./build_tests.sh
- cargo test --all
- ./ci_check.sh

Closes #463

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**