### PR TITLE
feat(aarch64): generate w32 logical shifted operands

### DIFF
--- a/docs/capability.md
+++ b/docs/capability.md
@@ -47,6 +47,8 @@ Rewritable straight-line mnemonics accepted by the parser and Capstone bridge:
   `bics`, `orn`, `eon`
   - Logical-immediate forms for `and`, `ands`, `orr`, `eor`, and `tst`
     support both 64-bit `X` registers and 32-bit `W` registers.
+    Non-flag-setting `and`, `orr`, and `eor` also support 32-bit `W`
+    register and shifted-register forms.
     Capstone `mov Wd|WSP, #imm` bitmask aliases are accepted for the
     `orr Wd|WSP, wzr, #imm` form.
 - Shifts and rotate: `lsl`, `lsr`, `asr`, `ror`

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -121,6 +121,33 @@ macro_rules! emit_shifted_reg_3op_logical {
     }};
 }
 
+macro_rules! emit_shifted_reg_3op_logical_w {
+    ($ops:expr, $mnem:ident, $rd:expr, $rn:expr, $rm:expr, $kind:expr, $amt:expr) => {{
+        let rd_n: u8 = $rd;
+        let rn_n: u8 = $rn;
+        let rm_n: u8 = $rm;
+        let amt_n: u32 = ($amt) as u32;
+        match $kind {
+            ShiftKind::Lsl => {
+                dynasm!($ops ; .arch aarch64 ; $mnem W(rd_n), W(rn_n), W(rm_n), LSL amt_n);
+                Ok(())
+            }
+            ShiftKind::Lsr => {
+                dynasm!($ops ; .arch aarch64 ; $mnem W(rd_n), W(rn_n), W(rm_n), LSR amt_n);
+                Ok(())
+            }
+            ShiftKind::Asr => {
+                dynasm!($ops ; .arch aarch64 ; $mnem W(rd_n), W(rn_n), W(rm_n), ASR amt_n);
+                Ok(())
+            }
+            ShiftKind::Ror => {
+                dynasm!($ops ; .arch aarch64 ; $mnem W(rd_n), W(rn_n), W(rm_n), ROR amt_n);
+                Ok(())
+            }
+        }
+    }};
+}
+
 /// 2-operand arithmetic shifted-register form (Cmp/Cmn) — no ROR.
 macro_rules! emit_shifted_reg_2op_arith {
     ($ops:expr, $mnem:ident, $rn:expr, $rm:expr, $kind:expr, $amt:expr) => {{
@@ -897,15 +924,22 @@ impl AArch64Assembler {
 
                 match rm {
                     Operand::Register(rm_reg) => {
-                        if *width != RegisterWidth::X64 {
-                            return Err("AND with W registers supports immediate operands only; register and shifted-register forms require X registers".to_string());
-                        }
                         let rd_reg = register_to_dynasm(*rd)?;
                         let rm_reg_num = register_to_dynasm(*rm_reg)?;
-                        dynasm!(ops
-                            ; .arch aarch64
-                            ; and X(rd_reg), X(rn_reg), X(rm_reg_num)
-                        );
+                        match width {
+                            RegisterWidth::X64 => {
+                                dynasm!(ops
+                                    ; .arch aarch64
+                                    ; and X(rd_reg), X(rn_reg), X(rm_reg_num)
+                                );
+                            }
+                            RegisterWidth::W32 => {
+                                dynasm!(ops
+                                    ; .arch aarch64
+                                    ; and W(rd_reg), W(rn_reg), W(rm_reg_num)
+                                );
+                            }
+                        }
                         Ok(())
                     }
                     Operand::Immediate(imm) => {
@@ -937,14 +971,16 @@ impl AArch64Assembler {
                         Ok(())
                     }
                     Operand::ShiftedRegister { reg, kind, amount } => {
-                        if *width != RegisterWidth::X64 {
-                            return Err("AND with W registers supports immediate operands only; register and shifted-register forms require X registers".to_string());
-                        }
                         let rd_reg = register_to_dynasm(*rd)?;
                         let rm_reg_num = register_to_dynasm(*reg)?;
-                        emit_shifted_reg_3op_logical!(
-                            ops, and, rd_reg, rn_reg, rm_reg_num, kind, *amount
-                        )
+                        match width {
+                            RegisterWidth::X64 => emit_shifted_reg_3op_logical!(
+                                ops, and, rd_reg, rn_reg, rm_reg_num, kind, *amount
+                            ),
+                            RegisterWidth::W32 => emit_shifted_reg_3op_logical_w!(
+                                ops, and, rd_reg, rn_reg, rm_reg_num, kind, *amount
+                            ),
+                        }
                     }
                     Operand::ExtendedRegister { .. } => {
                         Err("ExtendedRegister encoding not yet implemented".to_string())
@@ -956,15 +992,22 @@ impl AArch64Assembler {
 
                 match rm {
                     Operand::Register(rm_reg) => {
-                        if *width != RegisterWidth::X64 {
-                            return Err("ORR with W registers supports immediate operands only; register and shifted-register forms require X registers".to_string());
-                        }
                         let rd_reg = register_to_dynasm(*rd)?;
                         let rm_reg_num = register_to_dynasm(*rm_reg)?;
-                        dynasm!(ops
-                            ; .arch aarch64
-                            ; orr X(rd_reg), X(rn_reg), X(rm_reg_num)
-                        );
+                        match width {
+                            RegisterWidth::X64 => {
+                                dynasm!(ops
+                                    ; .arch aarch64
+                                    ; orr X(rd_reg), X(rn_reg), X(rm_reg_num)
+                                );
+                            }
+                            RegisterWidth::W32 => {
+                                dynasm!(ops
+                                    ; .arch aarch64
+                                    ; orr W(rd_reg), W(rn_reg), W(rm_reg_num)
+                                );
+                            }
+                        }
                         Ok(())
                     }
                     Operand::Immediate(imm) => {
@@ -995,14 +1038,16 @@ impl AArch64Assembler {
                         Ok(())
                     }
                     Operand::ShiftedRegister { reg, kind, amount } => {
-                        if *width != RegisterWidth::X64 {
-                            return Err("ORR with W registers supports immediate operands only; register and shifted-register forms require X registers".to_string());
-                        }
                         let rd_reg = register_to_dynasm(*rd)?;
                         let rm_reg_num = register_to_dynasm(*reg)?;
-                        emit_shifted_reg_3op_logical!(
-                            ops, orr, rd_reg, rn_reg, rm_reg_num, kind, *amount
-                        )
+                        match width {
+                            RegisterWidth::X64 => emit_shifted_reg_3op_logical!(
+                                ops, orr, rd_reg, rn_reg, rm_reg_num, kind, *amount
+                            ),
+                            RegisterWidth::W32 => emit_shifted_reg_3op_logical_w!(
+                                ops, orr, rd_reg, rn_reg, rm_reg_num, kind, *amount
+                            ),
+                        }
                     }
                     Operand::ExtendedRegister { .. } => {
                         Err("ExtendedRegister encoding not yet implemented".to_string())
@@ -1014,15 +1059,22 @@ impl AArch64Assembler {
 
                 match rm {
                     Operand::Register(rm_reg) => {
-                        if *width != RegisterWidth::X64 {
-                            return Err("EOR with W registers supports immediate operands only; register and shifted-register forms require X registers".to_string());
-                        }
                         let rd_reg = register_to_dynasm(*rd)?;
                         let rm_reg_num = register_to_dynasm(*rm_reg)?;
-                        dynasm!(ops
-                            ; .arch aarch64
-                            ; eor X(rd_reg), X(rn_reg), X(rm_reg_num)
-                        );
+                        match width {
+                            RegisterWidth::X64 => {
+                                dynasm!(ops
+                                    ; .arch aarch64
+                                    ; eor X(rd_reg), X(rn_reg), X(rm_reg_num)
+                                );
+                            }
+                            RegisterWidth::W32 => {
+                                dynasm!(ops
+                                    ; .arch aarch64
+                                    ; eor W(rd_reg), W(rn_reg), W(rm_reg_num)
+                                );
+                            }
+                        }
                         Ok(())
                     }
                     Operand::Immediate(imm) => {
@@ -1053,14 +1105,16 @@ impl AArch64Assembler {
                         Ok(())
                     }
                     Operand::ShiftedRegister { reg, kind, amount } => {
-                        if *width != RegisterWidth::X64 {
-                            return Err("EOR with W registers supports immediate operands only; register and shifted-register forms require X registers".to_string());
-                        }
                         let rd_reg = register_to_dynasm(*rd)?;
                         let rm_reg_num = register_to_dynasm(*reg)?;
-                        emit_shifted_reg_3op_logical!(
-                            ops, eor, rd_reg, rn_reg, rm_reg_num, kind, *amount
-                        )
+                        match width {
+                            RegisterWidth::X64 => emit_shifted_reg_3op_logical!(
+                                ops, eor, rd_reg, rn_reg, rm_reg_num, kind, *amount
+                            ),
+                            RegisterWidth::W32 => emit_shifted_reg_3op_logical_w!(
+                                ops, eor, rd_reg, rn_reg, rm_reg_num, kind, *amount
+                            ),
+                        }
                     }
                     Operand::ExtendedRegister { .. } => {
                         Err("ExtendedRegister encoding not yet implemented".to_string())
@@ -2818,6 +2872,58 @@ mod tests {
             let bytes = assembler
                 .assemble_instructions(&[instr], 0)
                 .expect("W32 logical immediate should encode");
+            disassemble_and_verify(&bytes, mnemonic, &operands);
+        }
+    }
+
+    #[test]
+    fn test_w32_logical_register_and_shifted_register_roundtrip() {
+        let cases: Vec<(Instruction, &str, Vec<&str>)> = vec![
+            (
+                Instruction::And {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::Register(Register::X2),
+                    width: RegisterWidth::W32,
+                },
+                "and",
+                vec!["w0", "w1", "w2"],
+            ),
+            (
+                Instruction::Orr {
+                    rd: Register::X3,
+                    rn: Register::X4,
+                    rm: Operand::ShiftedRegister {
+                        reg: Register::X5,
+                        kind: ShiftKind::Lsl,
+                        amount: 31,
+                    },
+                    width: RegisterWidth::W32,
+                },
+                "orr",
+                vec!["w3", "w4", "w5", "lsl #31"],
+            ),
+            (
+                Instruction::Eor {
+                    rd: Register::X6,
+                    rn: Register::X7,
+                    rm: Operand::ShiftedRegister {
+                        reg: Register::X8,
+                        kind: ShiftKind::Ror,
+                        amount: 7,
+                    },
+                    width: RegisterWidth::W32,
+                },
+                "eor",
+                vec!["w6", "w7", "w8", "ror #7"],
+            ),
+        ];
+
+        for (instr, mnemonic, operands) in cases {
+            let mut assembler = AArch64Assembler::new();
+            let bytes = assembler
+                .assemble_instructions(&[instr], 0)
+                .expect("W32 logical register or shifted-register form should encode");
             disassemble_and_verify(&bytes, mnemonic, &operands);
         }
     }

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -843,12 +843,7 @@ impl Instruction {
             Instruction::And { rd, rn, rm, width }
             | Instruction::Orr { rd, rn, rm, width }
             | Instruction::Eor { rd, rn, rm, width } => match rm {
-                Operand::Register(reg) => {
-                    *width == RegisterWidth::X64
-                        && is_x_or_xzr(*rd)
-                        && is_x_or_xzr(*rn)
-                        && is_x_or_xzr(*reg)
-                }
+                Operand::Register(reg) => is_x_or_xzr(*rd) && is_x_or_xzr(*rn) && is_x_or_xzr(*reg),
                 // rd in the Xn|SP slot (SP allowed, XZR forbidden); rn in the
                 // plain Xn slot (XZR allowed via reg 31, SP forbidden).
                 Operand::Immediate(imm) => match width {
@@ -860,8 +855,11 @@ impl Instruction {
                     }
                 },
                 Operand::ShiftedRegister { reg, amount, .. } => {
-                    *width == RegisterWidth::X64
-                        && *amount <= 63
+                    let max_amount = match width {
+                        RegisterWidth::X64 => 63,
+                        RegisterWidth::W32 => 31,
+                    };
+                    *amount <= max_amount
                         && is_x_or_xzr(*reg)
                         && is_x_or_xzr(*rd)
                         && is_x_or_xzr(*rn)
@@ -1486,21 +1484,21 @@ impl fmt::Display for Instruction {
                 "and {}, {}, {}",
                 width.register_name(*rd),
                 width.register_name(*rn),
-                rm
+                rm.display_with_width(*width)
             ),
             Instruction::Orr { rd, rn, rm, width } => write!(
                 f,
                 "orr {}, {}, {}",
                 width.register_name(*rd),
                 width.register_name(*rn),
-                rm
+                rm.display_with_width(*width)
             ),
             Instruction::Eor { rd, rn, rm, width } => write!(
                 f,
                 "eor {}, {}, {}",
                 width.register_name(*rd),
                 width.register_name(*rn),
-                rm
+                rm.display_with_width(*width)
             ),
             Instruction::Lsl { rd, rn, shift } => write!(f, "lsl {}, {}, {}", rd, rn, shift),
             Instruction::Lsr { rd, rn, shift } => write!(f, "lsr {}, {}, {}", rd, rn, shift),
@@ -2939,6 +2937,118 @@ mod tests {
                 "TST with {:?} must be encodable",
                 kind
             );
+        }
+    }
+
+    #[test]
+    fn test_is_encodable_w32_logical_register_and_shifted_register_forms() {
+        for instr in [
+            Instruction::And {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Register(Register::X2),
+                width: RegisterWidth::W32,
+            },
+            Instruction::Orr {
+                rd: Register::X3,
+                rn: Register::X4,
+                rm: Operand::Register(Register::XZR),
+                width: RegisterWidth::W32,
+            },
+            Instruction::Eor {
+                rd: Register::XZR,
+                rn: Register::X7,
+                rm: Operand::Register(Register::X8),
+                width: RegisterWidth::W32,
+            },
+        ] {
+            assert!(instr.is_encodable_aarch64(), "{instr} must be encodable");
+        }
+
+        for kind in [
+            ShiftKind::Lsl,
+            ShiftKind::Lsr,
+            ShiftKind::Asr,
+            ShiftKind::Ror,
+        ] {
+            for instr in [
+                Instruction::And {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::ShiftedRegister {
+                        reg: Register::X2,
+                        kind,
+                        amount: 31,
+                    },
+                    width: RegisterWidth::W32,
+                },
+                Instruction::Orr {
+                    rd: Register::X3,
+                    rn: Register::X4,
+                    rm: Operand::ShiftedRegister {
+                        reg: Register::X5,
+                        kind,
+                        amount: 31,
+                    },
+                    width: RegisterWidth::W32,
+                },
+                Instruction::Eor {
+                    rd: Register::X6,
+                    rn: Register::X7,
+                    rm: Operand::ShiftedRegister {
+                        reg: Register::X8,
+                        kind,
+                        amount: 31,
+                    },
+                    width: RegisterWidth::W32,
+                },
+            ] {
+                assert!(instr.is_encodable_aarch64(), "{instr} must be encodable");
+            }
+        }
+    }
+
+    #[test]
+    fn test_is_encodable_w32_logical_shifted_register_rejects_amount_32_and_sp() {
+        assert!(
+            !Instruction::And {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::ShiftedRegister {
+                    reg: Register::X2,
+                    kind: ShiftKind::Lsl,
+                    amount: 32,
+                },
+                width: RegisterWidth::W32,
+            }
+            .is_encodable_aarch64()
+        );
+
+        for instr in [
+            Instruction::And {
+                rd: Register::SP,
+                rn: Register::X1,
+                rm: Operand::Register(Register::X2),
+                width: RegisterWidth::W32,
+            },
+            Instruction::Orr {
+                rd: Register::X0,
+                rn: Register::SP,
+                rm: Operand::Register(Register::X2),
+                width: RegisterWidth::W32,
+            },
+            Instruction::Eor {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::ShiftedRegister {
+                    reg: Register::SP,
+                    kind: ShiftKind::Ror,
+                    amount: 7,
+                },
+                width: RegisterWidth::W32,
+            },
+        ] {
+            assert!(!instr.is_encodable_aarch64(), "{instr} must be rejected");
         }
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1288,68 +1288,41 @@ fn parse_sub(operands: &[&str]) -> Result<Instruction, String> {
 
 /// Parse AND instruction
 fn parse_and(operands: &[&str]) -> Result<Instruction, String> {
-    if operands.len() == 3 {
-        let (rd, rn, width) = parse_same_width_registers("and", operands)?;
-        let rm = match width {
-            RegisterWidth::W32 => Operand::Immediate(parse_immediate(operands[2])?),
-            RegisterWidth::X64 => parse_operand(operands[2])?,
-        };
-        return Ok(Instruction::And { rd, rn, rm, width });
+    if operands.len() != 3 && operands.len() != 4 {
+        return Err(format!(
+            "and requires 3 or 4 operands, got {}",
+            operands.len()
+        ));
     }
-
-    let rm = parse_rm_3op("and", operands)?;
-    let rd = parse_register(operands[0])?;
-    let rn = parse_register(operands[1])?;
-    Ok(Instruction::And {
-        rd,
-        rn,
-        rm,
-        width: RegisterWidth::X64,
-    })
+    let (rd, rn, width) = parse_same_width_registers("and", operands)?;
+    let rm = parse_rm_3op_with_width("and", operands, width)?;
+    Ok(Instruction::And { rd, rn, rm, width })
 }
 
 /// Parse ORR instruction
 fn parse_orr(operands: &[&str]) -> Result<Instruction, String> {
-    if operands.len() == 3 {
-        let (rd, rn, width) = parse_same_width_registers("orr", operands)?;
-        let rm = match width {
-            RegisterWidth::W32 => Operand::Immediate(parse_immediate(operands[2])?),
-            RegisterWidth::X64 => parse_operand(operands[2])?,
-        };
-        return Ok(Instruction::Orr { rd, rn, rm, width });
+    if operands.len() != 3 && operands.len() != 4 {
+        return Err(format!(
+            "orr requires 3 or 4 operands, got {}",
+            operands.len()
+        ));
     }
-
-    let rm = parse_rm_3op("orr", operands)?;
-    let rd = parse_register(operands[0])?;
-    let rn = parse_register(operands[1])?;
-    Ok(Instruction::Orr {
-        rd,
-        rn,
-        rm,
-        width: RegisterWidth::X64,
-    })
+    let (rd, rn, width) = parse_same_width_registers("orr", operands)?;
+    let rm = parse_rm_3op_with_width("orr", operands, width)?;
+    Ok(Instruction::Orr { rd, rn, rm, width })
 }
 
 /// Parse EOR instruction
 fn parse_eor(operands: &[&str]) -> Result<Instruction, String> {
-    if operands.len() == 3 {
-        let (rd, rn, width) = parse_same_width_registers("eor", operands)?;
-        let rm = match width {
-            RegisterWidth::W32 => Operand::Immediate(parse_immediate(operands[2])?),
-            RegisterWidth::X64 => parse_operand(operands[2])?,
-        };
-        return Ok(Instruction::Eor { rd, rn, rm, width });
+    if operands.len() != 3 && operands.len() != 4 {
+        return Err(format!(
+            "eor requires 3 or 4 operands, got {}",
+            operands.len()
+        ));
     }
-
-    let rm = parse_rm_3op("eor", operands)?;
-    let rd = parse_register(operands[0])?;
-    let rn = parse_register(operands[1])?;
-    Ok(Instruction::Eor {
-        rd,
-        rn,
-        rm,
-        width: RegisterWidth::X64,
-    })
+    let (rd, rn, width) = parse_same_width_registers("eor", operands)?;
+    let rm = parse_rm_3op_with_width("eor", operands, width)?;
+    Ok(Instruction::Eor { rd, rn, rm, width })
 }
 
 /// Parse LSL instruction
@@ -2618,6 +2591,18 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_w_logical_register_and_shifted_register_roundtrip() {
+        for text in [
+            "and w0, w1, w2",
+            "orr w3, w4, w5, lsl #31",
+            "eor w6, w7, w8, ror #7",
+        ] {
+            let instr = parse_one(text);
+            assert_eq!(format!("{}", instr), text);
+        }
+    }
+
+    #[test]
     fn test_parse_mov_w_logical_immediate_aliases() {
         let instr = parse_one("mov w0, #0xff");
         assert_eq!(
@@ -2651,7 +2636,9 @@ mod tests {
             "ands wsp, w1, #255",
             "tst wsp, #255",
             "and w0, x1, #255",
-            "and w0, w1, w2",
+            "and w0, w1, w2, lsl #32",
+            "orr w0, w1, x2",
+            "eor w0, w1, x2, lsl #1",
             "mov wzr, #0xff",
             "mov w0, #5",
         ] {

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -230,7 +230,7 @@ impl Mutator {
                 match choice {
                     0 => *rd = self.random_register(rng),
                     1 => *rn = self.random_register(rng),
-                    _ => *rm = self.random_logical_operand(rng, *width, true),
+                    _ => *rm = self.random_logical_operand(rng, *width, true, true),
                 }
             }
             Instruction::Lsl { rd, rn, shift }
@@ -289,7 +289,7 @@ impl Mutator {
                 if rng.random_bool(0.5) {
                     *rn = self.random_register(rng);
                 } else {
-                    *rm = self.random_logical_operand(rng, *width, true);
+                    *rm = self.random_logical_operand(rng, *width, true, false);
                 }
             }
             // CCMP / CCMN: rn (register), rm (operand), nzcv (0..=15), cond.
@@ -409,7 +409,7 @@ impl Mutator {
                 match choice {
                     0 => *rd = self.random_register(rng),
                     1 => *rn = self.random_register(rng),
-                    _ => *rm = self.random_logical_operand(rng, *width, false),
+                    _ => *rm = self.random_logical_operand(rng, *width, false, false),
                 }
             }
             // CSET / CSETM: only rd and cond can change; cond from the 14
@@ -1185,11 +1185,11 @@ impl Mutator {
         rng: &mut R,
         width: RegisterWidth,
         allow_shifted: bool,
+        allow_w32_register_or_shifted: bool,
     ) -> Operand {
-        // W32-always-immediate policy: W32 logical operands are sampled as
-        // bitmask immediates only (no register/shifted operands), unlike the
-        // X64 path below which also samples registers and shifted registers.
-        if width == RegisterWidth::W32 {
+        // W32 flag-setting logical forms still sample bitmask immediates only.
+        // Non-flag-setting AND/ORR/EOR opt into the W32 register/shifted space.
+        if width == RegisterWidth::W32 && !allow_w32_register_or_shifted {
             return Operand::Immediate(self.random_logical_immediate(rng, width));
         }
 
@@ -1197,7 +1197,7 @@ impl Mutator {
             && rng.random_bool(SHIFTED_REGISTER_OPERAND_PROBABILITY)
             && !self.registers.is_empty()
         {
-            self.random_shifted_register(rng, true, RegisterWidth::X64)
+            self.random_shifted_register(rng, true, width)
         } else if rng.random_bool(0.5) {
             Operand::Register(self.random_register(rng))
         } else {
@@ -1226,10 +1226,9 @@ impl Mutator {
             Operand::ExtendedRegister { reg, .. } if width == RegisterWidth::X64 => {
                 Operand::Register(reg)
             }
-            // W32-always-immediate policy (see `random_logical_operand`): the
-            // X64 arms above preserve register/shifted/extended forms, so this
-            // catch-all only ever sees W32 operands. They are deliberately
-            // resampled as bitmask immediates rather than kept as registers.
+            // Opcode bridges keep W32 logical operands in the historical
+            // immediate-only space; W32 register/shifted sampling is limited
+            // to direct AND/ORR/EOR operand mutation.
             Operand::Register(_)
             | Operand::ShiftedRegister { .. }
             | Operand::ExtendedRegister { .. } => {
@@ -1705,6 +1704,81 @@ mod tests {
             assert!(
                 saw_immediate,
                 "{name} operand mutation never sampled a logical immediate"
+            );
+        }
+    }
+
+    #[test]
+    fn mutate_operand_can_produce_w32_logical_shifted_registers() {
+        let mutator = default_mutator();
+        let starts = [
+            (
+                "AND W32",
+                Instruction::And {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::Immediate(0xff),
+                    width: RegisterWidth::W32,
+                },
+            ),
+            (
+                "ORR W32",
+                Instruction::Orr {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::Immediate(0xff),
+                    width: RegisterWidth::W32,
+                },
+            ),
+            (
+                "EOR W32",
+                Instruction::Eor {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::Immediate(0xff),
+                    width: RegisterWidth::W32,
+                },
+            ),
+        ];
+
+        for (idx, (name, start)) in starts.into_iter().enumerate() {
+            let mut rng = StdRng::seed_from_u64(0x4730 + idx as u64);
+            let mut saw_shifted = false;
+            let mut saw_ror = false;
+
+            for _ in 0..20_000 {
+                let mut seq = vec![start];
+                mutator.mutate_operand(&mut rng, &mut seq);
+                assert!(
+                    seq[0].is_encodable_aarch64(),
+                    "{name} operand mutation produced non-encodable {}",
+                    seq[0]
+                );
+
+                let rm = match seq[0] {
+                    Instruction::And { rm, .. }
+                    | Instruction::Orr { rm, .. }
+                    | Instruction::Eor { rm, .. } => rm,
+                    other => panic!("mutate_operand changed {name} opcode: {other:?}"),
+                };
+
+                if let Operand::ShiftedRegister { kind, amount, .. } = rm {
+                    saw_shifted = true;
+                    saw_ror |= kind == crate::ir::ShiftKind::Ror;
+                    assert!(
+                        amount <= 31,
+                        "{name} W32 shifted-register proposal used amount {amount}"
+                    );
+                }
+            }
+
+            assert!(
+                saw_shifted,
+                "{name} operand mutation never sampled a shifted-register rm"
+            );
+            assert!(
+                saw_ror,
+                "{name} operand mutation never sampled a ROR shifted-register rm"
             );
         }
     }
@@ -2200,6 +2274,40 @@ mod tests {
             } = seq[0]
             {
                 panic!("W32 TST mutation must not emit shifted-register operands");
+            }
+        }
+    }
+
+    #[test]
+    fn mutate_operand_keeps_w32_flag_logicals_immediate_only() {
+        let mutator = default_mutator();
+        let starts = [
+            Instruction::Tst {
+                rn: Register::X1,
+                rm: Operand::Immediate(0xff),
+                width: RegisterWidth::W32,
+            },
+            Instruction::Ands {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Immediate(0xff),
+                width: RegisterWidth::W32,
+            },
+        ];
+
+        for (idx, start) in starts.into_iter().enumerate() {
+            let mut rng = StdRng::seed_from_u64(0x4735 + idx as u64);
+            for _ in 0..5_000 {
+                let mut seq = vec![start];
+                mutator.mutate_operand(&mut rng, &mut seq);
+                let rm = match seq[0] {
+                    Instruction::Tst { rm, .. } | Instruction::Ands { rm, .. } => rm,
+                    other => panic!("mutate_operand changed W32 flag logical opcode: {other:?}"),
+                };
+                assert!(
+                    matches!(rm, Operand::Immediate(_)),
+                    "W32 flag logical mutation must stay immediate-only, got {seq:?}"
+                );
             }
         }
     }

--- a/src/semantics/concrete.rs
+++ b/src/semantics/concrete.rs
@@ -71,7 +71,10 @@ fn eval_logical_operand(
     operand: &Operand,
     width: RegisterWidth,
 ) -> u64 {
-    eval_operand(state, operand).as_u64() & mask_for_register_width(width)
+    match width {
+        RegisterWidth::W32 => eval_w_operand(state, operand),
+        RegisterWidth::X64 => eval_operand(state, operand).as_u64(),
+    }
 }
 
 fn logical_flags(result: u64, width: RegisterWidth) -> ConditionFlags {
@@ -1162,6 +1165,65 @@ mod tests {
         };
         let new_state = apply_instruction_concrete(state, &instr);
         assert_eq!(new_state.get_register(Register::X0).as_u64(), 0xFFFF_0000);
+    }
+
+    #[test]
+    fn test_w32_logical_shifted_registers_use_low_32_bits_before_shifting() {
+        for (instr, pre_values, expected) in [
+            (
+                Instruction::And {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::ShiftedRegister {
+                        reg: Register::X2,
+                        kind: ShiftKind::Lsr,
+                        amount: 1,
+                    },
+                    width: RegisterWidth::W32,
+                },
+                vec![
+                    (Register::X1, 0xFFFF_FFFF),
+                    (Register::X2, 0x0000_0001_0000_0000),
+                ],
+                0,
+            ),
+            (
+                Instruction::Orr {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::ShiftedRegister {
+                        reg: Register::X2,
+                        kind: ShiftKind::Asr,
+                        amount: 31,
+                    },
+                    width: RegisterWidth::W32,
+                },
+                vec![(Register::X1, 0), (Register::X2, 0x0000_0001_8000_0000)],
+                0xFFFF_FFFF,
+            ),
+            (
+                Instruction::Eor {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::ShiftedRegister {
+                        reg: Register::X2,
+                        kind: ShiftKind::Ror,
+                        amount: 1,
+                    },
+                    width: RegisterWidth::W32,
+                },
+                vec![(Register::X1, 0), (Register::X2, 0x0000_0001_0000_0000)],
+                0,
+            ),
+        ] {
+            let state = state_with(pre_values);
+            let new_state = apply_instruction_concrete(state, &instr);
+            assert_eq!(
+                new_state.get_register(Register::X0).as_u64(),
+                expected,
+                "{instr} must use W-register source semantics"
+            );
+        }
     }
 
     #[test]

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -74,10 +74,9 @@ fn register_logical_value(state: &MachineState, reg: Register, width: RegisterWi
 }
 
 fn eval_logical_operand(state: &MachineState, operand: &Operand, width: RegisterWidth) -> BV {
-    let value = state.eval_operand(operand);
     match width {
-        RegisterWidth::W32 => value.extract(31, 0),
-        RegisterWidth::X64 => value,
+        RegisterWidth::W32 => eval_w_operand(state, operand),
+        RegisterWidth::X64 => state.eval_operand(operand),
     }
 }
 
@@ -2694,6 +2693,56 @@ mod tests {
             ),
         ] {
             assert_concrete_smt_parity(&instr, &[(Register::X1, pre)], Register::X0);
+        }
+    }
+
+    #[test]
+    fn test_w32_logical_shifted_register_concrete_smt_parity() {
+        for (instr, pre_values) in [
+            (
+                Instruction::And {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::ShiftedRegister {
+                        reg: Register::X2,
+                        kind: crate::ir::ShiftKind::Lsr,
+                        amount: 1,
+                    },
+                    width: RegisterWidth::W32,
+                },
+                vec![
+                    (Register::X1, 0xFFFF_FFFF),
+                    (Register::X2, 0x0000_0001_0000_0000),
+                ],
+            ),
+            (
+                Instruction::Orr {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::ShiftedRegister {
+                        reg: Register::X2,
+                        kind: crate::ir::ShiftKind::Asr,
+                        amount: 31,
+                    },
+                    width: RegisterWidth::W32,
+                },
+                vec![(Register::X1, 0), (Register::X2, 0x0000_0001_8000_0000)],
+            ),
+            (
+                Instruction::Eor {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm: Operand::ShiftedRegister {
+                        reg: Register::X2,
+                        kind: crate::ir::ShiftKind::Ror,
+                        amount: 1,
+                    },
+                    width: RegisterWidth::W32,
+                },
+                vec![(Register::X1, 0), (Register::X2, 0x0000_0001_0000_0000)],
+            ),
+        ] {
+            assert_concrete_smt_parity(&instr, &pre_values, Register::X0);
         }
     }
 

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -482,8 +482,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -493,7 +493,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -886,14 +886,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -901,20 +901,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {

--- a/tests/integration/docs_capability.rs
+++ b/tests/integration/docs_capability.rs
@@ -71,6 +71,12 @@ fn docs_capability_documents_w_logical_immediates() {
     );
     assert!(
         matrix.contains(
+            "non-flag-setting `and`, `orr`, and `eor` also support 32-bit `w` register and shifted-register forms"
+        ),
+        "docs/capability.md must document W-register logical shifted-register support"
+    );
+    assert!(
+        matrix.contains(
             "capstone `mov wd|wsp, #imm` bitmask aliases are accepted for the `orr wd|wsp, wzr, #imm` form"
         ),
         "docs/capability.md must document Capstone MOV aliases for W logical-immediate ORR"


### PR DESCRIPTION
Summary:
- accept, display, encode, assemble, and verify W32 AND/ORR/EOR register and shifted-register forms
- update concrete and SMT W32 shifted logical operand semantics to shift low 32 bits first
- let stochastic operand mutation sample W32 logical shifted-register forms while keeping W32 TST/ANDS immediate-only
- document the expanded AArch64 capability

Closes #473

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**