### PR TITLE
fix(x86): prefilter stochastic immediate pools

### DIFF
--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -531,6 +531,20 @@ fn x86_imm32_bitpattern_ok(imm: i64) -> bool {
     x86_signed_imm32_ok(imm) || u32::try_from(imm).is_ok()
 }
 
+fn x86_mov_imm_ok(mode: crate::assembler::x86::X86Mode, imm: i64) -> bool {
+    match mode {
+        crate::assembler::x86::X86Mode::Mode64 => true,
+        crate::assembler::x86::X86Mode::Mode32 => x86_imm32_bitpattern_ok(imm),
+    }
+}
+
+fn x86_non_mov_imm_ok(mode: crate::assembler::x86::X86Mode, imm: i64) -> bool {
+    match mode {
+        crate::assembler::x86::X86Mode::Mode64 => x86_signed_imm32_ok(imm),
+        crate::assembler::x86::X86Mode::Mode32 => x86_imm32_bitpattern_ok(imm),
+    }
+}
+
 impl crate::isa::traits::FlagsAnalysis<X86Instruction> for X86_64 {
     fn modifies_flags(instr: &X86Instruction) -> bool {
         x86_modifies_flags(instr)
@@ -724,9 +738,10 @@ impl crate::isa::traits::Assembler<X86Instruction> for X86_32 {
     }
 }
 
-/// x86 mutator for stochastic search. Carries a filtered register pool
-/// (Mode32 excludes R8-R15 once at construction), an immediate pool and
-/// the four operator weights borrowed from the AArch64 `Mutator`.
+/// x86 mutator for stochastic search. Carries filtered register and
+/// immediate pools (Mode32 excludes R8-R15 once at construction, and
+/// immediates are split by MOV vs non-MOV encodability) plus the four
+/// operator weights borrowed from the AArch64 `Mutator`.
 ///
 /// **Destructive-form invariant** (`src/isa/x86.rs:150-158`): every
 /// non-MOV variant has `rd` in `source_registers()`. Mutating any
@@ -739,15 +754,18 @@ impl crate::isa::traits::Assembler<X86Instruction> for X86_32 {
 #[derive(Debug, Clone)]
 pub struct X86Mutator {
     registers: Vec<X86Register>,
-    immediates: Vec<i64>,
+    mov_immediates: Vec<i64>,
+    non_mov_immediates: Vec<i64>,
+    mode: crate::assembler::x86::X86Mode,
     weights: crate::search::config::MutationWeights,
 }
 
 impl X86Mutator {
-    /// Construct a mutator. `mode` is consumed here to filter extended
-    /// registers (Mode32 excludes R8-R15) once at construction; it is
-    /// not retained as a field. Downstream mutation therefore cannot
-    /// reintroduce extended registers.
+    /// Construct a mutator. `mode` filters extended registers (Mode32
+    /// excludes R8-R15) and immediate pools once at construction, then
+    /// remains available for opcode-bridge immediate validation.
+    /// Downstream mutation therefore cannot reintroduce extended
+    /// registers or immediates that the target opcode class cannot encode.
     pub fn new(
         registers: Vec<X86Register>,
         immediates: Vec<i64>,
@@ -761,9 +779,20 @@ impl X86Mutator {
                     || matches!(r.index(), Some(i) if i < 8)
             })
             .collect();
+        let mov_immediates = immediates
+            .iter()
+            .copied()
+            .filter(|&imm| x86_mov_imm_ok(mode, imm))
+            .collect();
+        let non_mov_immediates = immediates
+            .into_iter()
+            .filter(|&imm| x86_non_mov_imm_ok(mode, imm))
+            .collect();
         Self {
             registers,
-            immediates,
+            mov_immediates,
+            non_mov_immediates,
+            mode,
             weights,
         }
     }
@@ -776,11 +805,35 @@ impl X86Mutator {
         }
     }
 
-    fn pick_immediate<R: rand::RngExt>(&self, rng: &mut R) -> i64 {
-        if self.immediates.is_empty() {
+    fn pick_mov_immediate<R: rand::RngExt>(&self, rng: &mut R) -> i64 {
+        if self.mov_immediates.is_empty() {
             0
         } else {
-            self.immediates[rng.random_range(0..self.immediates.len())]
+            self.mov_immediates[rng.random_range(0..self.mov_immediates.len())]
+        }
+    }
+
+    fn pick_non_mov_immediate<R: rand::RngExt>(&self, rng: &mut R) -> i64 {
+        if self.non_mov_immediates.is_empty() {
+            0
+        } else {
+            self.non_mov_immediates[rng.random_range(0..self.non_mov_immediates.len())]
+        }
+    }
+
+    fn keep_or_pick_mov_immediate<R: rand::RngExt>(&self, rng: &mut R, imm: i64) -> i64 {
+        if x86_mov_imm_ok(self.mode, imm) {
+            imm
+        } else {
+            self.pick_mov_immediate(rng)
+        }
+    }
+
+    fn keep_or_pick_non_mov_immediate<R: rand::RngExt>(&self, rng: &mut R, imm: i64) -> i64 {
+        if x86_non_mov_imm_ok(self.mode, imm) {
+            imm
+        } else {
+            self.pick_non_mov_immediate(rng)
         }
     }
 
@@ -789,23 +842,43 @@ impl X86Mutator {
         let opcode = rng.random_range(0..u32::from(X86_REWRITABLE_OPCODE_COUNT));
         let rd = self.pick_register(rng)?;
         let rs = self.pick_register(rng)?;
-        let imm = self.pick_immediate(rng);
         let cond = X86Condition::ALL[rng.random_range(0..X86Condition::ALL.len())];
         Some(match opcode {
             0 => X86Instruction::MovReg { rd, rs },
-            1 => X86Instruction::MovImm { rd, imm },
+            1 => X86Instruction::MovImm {
+                rd,
+                imm: self.pick_mov_immediate(rng),
+            },
             2 => X86Instruction::AddReg { rd, rs },
-            3 => X86Instruction::AddImm { rd, imm },
+            3 => X86Instruction::AddImm {
+                rd,
+                imm: self.pick_non_mov_immediate(rng),
+            },
             4 => X86Instruction::SubReg { rd, rs },
-            5 => X86Instruction::SubImm { rd, imm },
+            5 => X86Instruction::SubImm {
+                rd,
+                imm: self.pick_non_mov_immediate(rng),
+            },
             6 => X86Instruction::AndReg { rd, rs },
-            7 => X86Instruction::AndImm { rd, imm },
+            7 => X86Instruction::AndImm {
+                rd,
+                imm: self.pick_non_mov_immediate(rng),
+            },
             8 => X86Instruction::OrReg { rd, rs },
-            9 => X86Instruction::OrImm { rd, imm },
+            9 => X86Instruction::OrImm {
+                rd,
+                imm: self.pick_non_mov_immediate(rng),
+            },
             10 => X86Instruction::XorReg { rd, rs },
-            11 => X86Instruction::XorImm { rd, imm },
+            11 => X86Instruction::XorImm {
+                rd,
+                imm: self.pick_non_mov_immediate(rng),
+            },
             12 => X86Instruction::CmpReg { rn: rd, rs },
-            13 => X86Instruction::CmpImm { rn: rd, imm },
+            13 => X86Instruction::CmpImm {
+                rn: rd,
+                imm: self.pick_non_mov_immediate(rng),
+            },
             _ => X86Instruction::Cmov { rd, rs, cond },
         })
     }
@@ -817,13 +890,13 @@ impl X86Mutator {
         let idx = rng.random_range(0..sequence.len());
         if self.registers.is_empty() {
             match &mut sequence[idx] {
-                X86Instruction::MovImm { imm, .. }
-                | X86Instruction::AddImm { imm, .. }
+                X86Instruction::MovImm { imm, .. } => *imm = self.pick_mov_immediate(rng),
+                X86Instruction::AddImm { imm, .. }
                 | X86Instruction::SubImm { imm, .. }
                 | X86Instruction::AndImm { imm, .. }
                 | X86Instruction::OrImm { imm, .. }
                 | X86Instruction::XorImm { imm, .. }
-                | X86Instruction::CmpImm { imm, .. } => *imm = self.pick_immediate(rng),
+                | X86Instruction::CmpImm { imm, .. } => *imm = self.pick_non_mov_immediate(rng),
                 X86Instruction::MovReg { .. }
                 | X86Instruction::AddReg { .. }
                 | X86Instruction::SubReg { .. }
@@ -848,7 +921,7 @@ impl X86Mutator {
                 if rng.random_bool(0.5) {
                     *rd = self.pick_register(rng).expect("register pool is non-empty");
                 } else {
-                    *imm = self.pick_immediate(rng);
+                    *imm = self.pick_mov_immediate(rng);
                 }
             }
             X86Instruction::AddReg { rd, rs }
@@ -870,7 +943,7 @@ impl X86Mutator {
                 if rng.random_bool(0.5) {
                     *rd = self.pick_register(rng).expect("register pool is non-empty");
                 } else {
-                    *imm = self.pick_immediate(rng);
+                    *imm = self.pick_non_mov_immediate(rng);
                 }
             }
             X86Instruction::CmpReg { rn, rs } => {
@@ -884,7 +957,7 @@ impl X86Mutator {
                 if rng.random_bool(0.5) {
                     *rn = self.pick_register(rng).expect("register pool is non-empty");
                 } else {
-                    *imm = self.pick_immediate(rng);
+                    *imm = self.pick_non_mov_immediate(rng);
                 }
             }
             X86Instruction::Cmov { rd, rs, .. } => {
@@ -939,16 +1012,34 @@ impl X86Mutator {
             | X86Instruction::AndImm { rd, imm }
             | X86Instruction::OrImm { rd, imm }
             | X86Instruction::XorImm { rd, imm } => match rng.random_range(0..6u32) {
-                0 => X86Instruction::MovImm { rd, imm },
-                1 => X86Instruction::AddImm { rd, imm },
-                2 => X86Instruction::SubImm { rd, imm },
-                3 => X86Instruction::AndImm { rd, imm },
-                4 => X86Instruction::OrImm { rd, imm },
-                _ => X86Instruction::XorImm { rd, imm },
+                0 => X86Instruction::MovImm {
+                    rd,
+                    imm: self.keep_or_pick_mov_immediate(rng, imm),
+                },
+                1 => X86Instruction::AddImm {
+                    rd,
+                    imm: self.keep_or_pick_non_mov_immediate(rng, imm),
+                },
+                2 => X86Instruction::SubImm {
+                    rd,
+                    imm: self.keep_or_pick_non_mov_immediate(rng, imm),
+                },
+                3 => X86Instruction::AndImm {
+                    rd,
+                    imm: self.keep_or_pick_non_mov_immediate(rng, imm),
+                },
+                4 => X86Instruction::OrImm {
+                    rd,
+                    imm: self.keep_or_pick_non_mov_immediate(rng, imm),
+                },
+                _ => X86Instruction::XorImm {
+                    rd,
+                    imm: self.keep_or_pick_non_mov_immediate(rng, imm),
+                },
             },
             X86Instruction::CmpReg { rn, .. } => X86Instruction::CmpImm {
                 rn,
-                imm: self.pick_immediate(rng),
+                imm: self.pick_non_mov_immediate(rng),
             },
             X86Instruction::CmpImm { rn, .. } => match self.pick_register(rng) {
                 Some(rs) => X86Instruction::CmpReg { rn, rs },
@@ -2084,7 +2175,7 @@ mod tests {
         let mutator = X86Mutator::new(
             vec![X86Register::RBX],
             // Unused by CmpImm → CmpReg (which calls pick_register, not
-            // pick_immediate); a value absent from the target makes that clear.
+            // an immediate picker); a value absent from the target makes that clear.
             vec![0],
             MutationWeights {
                 operand: 0.0,
@@ -2226,6 +2317,283 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn x86_mutator_mode32_filters_immediate_pool_to_encodable_bitpatterns() {
+        use crate::isa::traits::{Assembler, ISAMutator};
+        use crate::search::config::MutationWeights;
+        use rand::SeedableRng;
+        use rand_chacha::ChaCha8Rng;
+        use std::collections::BTreeSet;
+
+        let mutator = X86Mutator::new(
+            Vec::new(),
+            vec![
+                i64::from(i32::MIN) - 1,
+                i64::from(i32::MIN),
+                i64::from(i32::MAX),
+                i64::from(u32::MAX),
+                i64::from(u32::MAX) + 1,
+                i64::MAX,
+            ],
+            MutationWeights {
+                operand: 1.0,
+                opcode: 0.0,
+                swap: 0.0,
+                instruction: 0.0,
+            },
+            crate::assembler::x86::X86Mode::Mode32,
+        );
+        let mut rng = ChaCha8Rng::seed_from_u64(500);
+        let mut seq = vec![X86Instruction::AddImm {
+            rd: X86Register::RAX,
+            imm: 0,
+        }];
+        let mut seen = BTreeSet::new();
+
+        for _ in 0..1000 {
+            seq = mutator.mutate(&mut rng, &seq);
+            let [X86Instruction::AddImm { rd, imm }] = seq.as_slice() else {
+                panic!("operand-only mutation changed instruction shape: {seq:?}");
+            };
+            let instr = X86Instruction::AddImm { rd: *rd, imm: *imm };
+            assert!(
+                <X86_32 as Assembler<X86Instruction>>::can_assemble(&X86_32, &instr),
+                "Mode32 mutator emitted unencodable immediate {imm}"
+            );
+            seen.insert(*imm);
+        }
+
+        assert!(seen.contains(&i64::from(i32::MIN)));
+        assert!(seen.contains(&i64::from(i32::MAX)));
+        assert!(seen.contains(&i64::from(u32::MAX)));
+    }
+
+    #[test]
+    fn x86_mutator_mode64_splits_movabs_from_non_mov_immediate_pool() {
+        use crate::isa::traits::{Assembler, ISAMutator};
+        use crate::search::config::MutationWeights;
+        use rand::SeedableRng;
+        use rand_chacha::ChaCha8Rng;
+        use std::collections::BTreeSet;
+
+        let mutator = X86Mutator::new(
+            Vec::new(),
+            vec![
+                i64::MAX,
+                i64::from(i32::MIN),
+                i64::from(i32::MAX),
+                i64::from(i32::MAX) + 1,
+            ],
+            MutationWeights {
+                operand: 1.0,
+                opcode: 0.0,
+                swap: 0.0,
+                instruction: 0.0,
+            },
+            crate::assembler::x86::X86Mode::Mode64,
+        );
+
+        let mut mov_rng = ChaCha8Rng::seed_from_u64(501);
+        let mut mov_seq = vec![X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: 0,
+        }];
+        let mut saw_movabs = false;
+        for _ in 0..1000 {
+            mov_seq = mutator.mutate(&mut mov_rng, &mov_seq);
+            let [X86Instruction::MovImm { imm, .. }] = mov_seq.as_slice() else {
+                panic!("operand-only mutation changed MOV shape: {mov_seq:?}");
+            };
+            saw_movabs |= *imm == i64::MAX;
+        }
+        assert!(saw_movabs, "Mode64 MOV immediate pool lost MOVABS values");
+
+        let non_mov_forms: [ImmForm; 6] = [
+            ("add", |imm| X86Instruction::AddImm {
+                rd: X86Register::RAX,
+                imm,
+            }),
+            ("sub", |imm| X86Instruction::SubImm {
+                rd: X86Register::RAX,
+                imm,
+            }),
+            ("and", |imm| X86Instruction::AndImm {
+                rd: X86Register::RAX,
+                imm,
+            }),
+            ("or", |imm| X86Instruction::OrImm {
+                rd: X86Register::RAX,
+                imm,
+            }),
+            ("xor", |imm| X86Instruction::XorImm {
+                rd: X86Register::RAX,
+                imm,
+            }),
+            ("cmp", |imm| X86Instruction::CmpImm {
+                rn: X86Register::RAX,
+                imm,
+            }),
+        ];
+
+        for (name, form) in non_mov_forms {
+            let mut rng = ChaCha8Rng::seed_from_u64(502);
+            let mut seq = vec![form(0)];
+            let mut seen = BTreeSet::new();
+            for _ in 0..1000 {
+                seq = mutator.mutate(&mut rng, &seq);
+                let [instr] = seq.as_slice() else {
+                    panic!("operand-only mutation changed {name} sequence length: {seq:?}");
+                };
+                assert!(
+                    <X86_64 as Assembler<X86Instruction>>::can_assemble(&X86_64, instr),
+                    "Mode64 mutator emitted unencodable {name} immediate: {instr:?}"
+                );
+                let imm = match instr {
+                    X86Instruction::AddImm { imm, .. }
+                    | X86Instruction::SubImm { imm, .. }
+                    | X86Instruction::AndImm { imm, .. }
+                    | X86Instruction::OrImm { imm, .. }
+                    | X86Instruction::XorImm { imm, .. }
+                    | X86Instruction::CmpImm { imm, .. } => *imm,
+                    other => panic!("operand-only mutation changed {name} shape: {other:?}"),
+                };
+                seen.insert(imm);
+            }
+            assert!(seen.contains(&i64::from(i32::MIN)), "{name} lost i32::MIN");
+            assert!(seen.contains(&i64::from(i32::MAX)), "{name} lost i32::MAX");
+        }
+    }
+
+    #[test]
+    fn x86_mutator_mode64_operand_and_instruction_mutations_keep_non_mov_immediates_encodable() {
+        use crate::isa::traits::{Assembler, ISAMutator};
+        use crate::search::config::MutationWeights;
+        use rand::SeedableRng;
+        use rand_chacha::ChaCha8Rng;
+
+        let mutator = X86Mutator::new(
+            vec![X86Register::RAX, X86Register::RBX],
+            vec![i64::MAX, 17, i64::from(i32::MAX) + 1],
+            MutationWeights {
+                operand: 0.5,
+                opcode: 0.0,
+                swap: 0.0,
+                instruction: 0.5,
+            },
+            crate::assembler::x86::X86Mode::Mode64,
+        );
+        let mut rng = ChaCha8Rng::seed_from_u64(503);
+        let mut seq = vec![
+            X86Instruction::MovImm {
+                rd: X86Register::RAX,
+                imm: 0,
+            },
+            X86Instruction::AddImm {
+                rd: X86Register::RAX,
+                imm: 0,
+            },
+            X86Instruction::CmpImm {
+                rn: X86Register::RAX,
+                imm: 0,
+            },
+        ];
+        let mut saw_movabs = false;
+        let mut saw_non_mov_immediate = false;
+
+        for _ in 0..5000 {
+            seq = mutator.mutate(&mut rng, &seq);
+            for instr in &seq {
+                match instr {
+                    X86Instruction::MovImm { imm, .. } => {
+                        saw_movabs |= *imm == i64::MAX;
+                    }
+                    X86Instruction::AddImm { .. }
+                    | X86Instruction::SubImm { .. }
+                    | X86Instruction::AndImm { .. }
+                    | X86Instruction::OrImm { .. }
+                    | X86Instruction::XorImm { .. }
+                    | X86Instruction::CmpImm { .. } => {
+                        saw_non_mov_immediate = true;
+                        assert!(
+                            <X86_64 as Assembler<X86Instruction>>::can_assemble(&X86_64, instr),
+                            "Mode64 mutation emitted unencodable non-MOV immediate: {instr:?}"
+                        );
+                    }
+                    X86Instruction::MovReg { .. }
+                    | X86Instruction::AddReg { .. }
+                    | X86Instruction::SubReg { .. }
+                    | X86Instruction::AndReg { .. }
+                    | X86Instruction::OrReg { .. }
+                    | X86Instruction::XorReg { .. }
+                    | X86Instruction::CmpReg { .. }
+                    | X86Instruction::Cmov { .. }
+                    | X86Instruction::Jcc { .. } => {}
+                }
+            }
+        }
+
+        assert!(saw_movabs, "Mode64 MOV mutation never drew i64::MAX");
+        assert!(
+            saw_non_mov_immediate,
+            "test never observed a non-MOV immediate mutation"
+        );
+    }
+
+    #[test]
+    fn x86_mutator_mode64_opcode_mutation_replaces_movabs_immediate_for_non_mov_forms() {
+        use crate::isa::traits::{Assembler, ISAMutator};
+        use crate::search::config::MutationWeights;
+        use rand::SeedableRng;
+        use rand_chacha::ChaCha8Rng;
+
+        let mutator = X86Mutator::new(
+            vec![X86Register::RAX],
+            vec![7],
+            MutationWeights {
+                operand: 0.0,
+                opcode: 1.0,
+                swap: 0.0,
+                instruction: 0.0,
+            },
+            crate::assembler::x86::X86Mode::Mode64,
+        );
+        let target = vec![X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: i64::MAX,
+        }];
+        let mut rng = ChaCha8Rng::seed_from_u64(504);
+        let mut saw_non_mov_bridge = false;
+
+        for _ in 0..100 {
+            let mutated = mutator.mutate(&mut rng, &target);
+            let [instr] = mutated.as_slice() else {
+                panic!("opcode-only mutation changed sequence length: {mutated:?}");
+            };
+            match instr {
+                X86Instruction::MovImm { imm, .. } => {
+                    assert_eq!(*imm, i64::MAX, "MOVABS immediate should stay valid for MOV");
+                }
+                X86Instruction::AddImm { .. }
+                | X86Instruction::SubImm { .. }
+                | X86Instruction::AndImm { .. }
+                | X86Instruction::OrImm { .. }
+                | X86Instruction::XorImm { .. } => {
+                    saw_non_mov_bridge = true;
+                    assert!(
+                        <X86_64 as Assembler<X86Instruction>>::can_assemble(&X86_64, instr),
+                        "opcode mutation carried a MOVABS immediate into {instr:?}"
+                    );
+                }
+                other => panic!("unexpected opcode mutation from MOV immediate: {other:?}"),
+            }
+        }
+
+        assert!(
+            saw_non_mov_bridge,
+            "test never observed MOV immediate bridge to a non-MOV form"
+        );
     }
 
     #[test]

--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -886,49 +886,37 @@ impl X86Mutator {
             return None;
         }
         // Rewritable variants only: 7 reg-reg + 7 reg-imm + CMOVcc.
-        // Immediates are drawn from the encodability-split pools (MOV vs
-        // non-MOV) rather than the shared free helper, which only takes a
-        // single immediate pool.
+        // The RNG draw order/count MUST stay in lock-step with the shared
+        // free helper `generate_random_rewritable_x86_instruction`
+        // (opcode → rd → rs → imm → cond, all four drawn unconditionally)
+        // so callers that interleave the two stay deterministic. The only
+        // #593 behaviour change is *which* prefiltered pool the single imm
+        // draw indexes: opcode 1 (MOV) uses the MOVABS-capable `mov`
+        // pool, every other imm form uses the non-MOV pool.
         let opcode = rng.random_range(0..u32::from(X86_REWRITABLE_OPCODE_COUNT));
         let rd = self.pick_register(rng)?;
         let rs = self.pick_register(rng)?;
+        let imm = if opcode == 1 {
+            self.pick_mov_immediate(rng)
+        } else {
+            self.pick_non_mov_immediate(rng)
+        };
         let cond = X86Condition::ALL[rng.random_range(0..X86Condition::ALL.len())];
         Some(match opcode {
             0 => X86Instruction::MovReg { rd, rs },
-            1 => X86Instruction::MovImm {
-                rd,
-                imm: self.pick_mov_immediate(rng),
-            },
+            1 => X86Instruction::MovImm { rd, imm },
             2 => X86Instruction::AddReg { rd, rs },
-            3 => X86Instruction::AddImm {
-                rd,
-                imm: self.pick_non_mov_immediate(rng),
-            },
+            3 => X86Instruction::AddImm { rd, imm },
             4 => X86Instruction::SubReg { rd, rs },
-            5 => X86Instruction::SubImm {
-                rd,
-                imm: self.pick_non_mov_immediate(rng),
-            },
+            5 => X86Instruction::SubImm { rd, imm },
             6 => X86Instruction::AndReg { rd, rs },
-            7 => X86Instruction::AndImm {
-                rd,
-                imm: self.pick_non_mov_immediate(rng),
-            },
+            7 => X86Instruction::AndImm { rd, imm },
             8 => X86Instruction::OrReg { rd, rs },
-            9 => X86Instruction::OrImm {
-                rd,
-                imm: self.pick_non_mov_immediate(rng),
-            },
+            9 => X86Instruction::OrImm { rd, imm },
             10 => X86Instruction::XorReg { rd, rs },
-            11 => X86Instruction::XorImm {
-                rd,
-                imm: self.pick_non_mov_immediate(rng),
-            },
+            11 => X86Instruction::XorImm { rd, imm },
             12 => X86Instruction::CmpReg { rn: rd, rs },
-            13 => X86Instruction::CmpImm {
-                rn: rd,
-                imm: self.pick_non_mov_immediate(rng),
-            },
+            13 => X86Instruction::CmpImm { rn: rd, imm },
             _ => X86Instruction::Cmov { rd, rs, cond },
         })
     }

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary
- Split X86Mutator immediates into MOV and non-MOV pools so Mode64 keeps MOVABS values while non-MOV forms draw only signed imm32 values.
- Filter Mode32 immediates to canonical 32-bit bit patterns at mutator construction.
- Validate carried immediates during opcode mutation and fall back to filtered pools when changing opcode class.
- Remove pre-existing needless SMT temporary borrows so the local clippy gate passes.

Tests
- cargo test x86_mutator --lib
- cargo test x86_generic_encodability_rejects_out_of_range_immediates --lib
- cargo test x86_64_can_assemble_rejects_non_mov_immediates_outside_imm32 --lib
- cargo test x86_32_can_assemble_rejects_extended_registers_and_out_of_range_immediates --lib
- cargo test x86_stochastic --lib
- cargo clippy --all -- -D warnings
- cargo test --all
- ./ci_check.sh

Note: scripts/full_test.sh is not present in this repository; ./ci_check.sh is the documented local CI mirror.

Closes #500

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**