### PR TITLE
docs(adr): document x86 immediate constraint duplication

### DIFF
--- a/docs/adr/0004-isa-trait-collapse.md
+++ b/docs/adr/0004-isa-trait-collapse.md
@@ -3,6 +3,12 @@
 Status: Accepted
 Date: 2026-05-16
 
+## Amendment (2026-06-19): x86 immediate encodability stays duplicated across the prefilter and assembler
+
+The x86 `Assembler::can_assemble` implementations in `src/isa/x86.rs` intentionally duplicate the assembler-side immediate constraints from `src/assembler/x86.rs`. The prefilter helpers `x86_signed_imm32_ok` and `x86_imm32_bitpattern_ok` keep generic search helpers such as `src/search/candidate.rs::is_sequence_encodable_for` from sending obviously unencodable candidates into the heavier dynasm path. The assembler helpers `signed_imm_i32` and `imm32_bitpattern_i32` remain the final encoding authority and own the emitted error text.
+
+This is an accepted cost of the trait/assembler boundary, not a request to collapse the helper pairs into shared code. Future x86 immediate-encoding changes must update both sides: the ISA prefilter should stay conservative, and the assembler should stay authoritative. In particular, x86-64 non-`MOV` immediate forms are limited to signed imm32 encodings, x86-64 `MovImm` may still use `movabs` for full-width immediates, and x86-32 immediate forms accept canonical 32-bit bit patterns while continuing to reject R8-R15 register operands.
+
 ## Context
 
 Issue #77 called for collapsing the parallel AArch64, x86 and RISC-V pipelines onto the existing trait surface in `src/isa/traits.rs`. At planning time the `ISA` / `InstructionType` / `OperandType` / `RegisterType` / `InstructionGenerator` traits had impls on every backend, but four others — `ConcreteExecutor`, `SymbolicExecutor`, `CostModel`, `Assembler` — had **no implementations** and were bypassed by free functions in `src/semantics/{concrete,smt,cost,equivalence}.rs` and their `_x86` siblings, plus `src/assembler/{mod,x86}.rs`. The search layer (`src/search/`), the validation layer (`src/validation/`), and the CLI in `src/main.rs` referenced `crate::ir::Instruction` directly, with a duplicated x86 pipeline (`optimize_elf_binary_x86`, `convert_to_x86_ir`, etc.) sitting beside the AArch64 path. RISC-V was rejected even though `src/isa/riscv.rs` implemented the existing trait surface.

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- Add an ADR-0004 amendment documenting the deliberate x86 immediate-constraint duplication between the ISA prefilter and dynasm assembler.
- Note that future x86 immediate encoding changes must update both helper pairs while keeping the prefilter conservative and the assembler authoritative.
- Include a small clippy cleanup in SMT code required by the explicit local `cargo clippy --all -- -D warnings` gate.

Verification:
- `rg -n "x86_signed_imm32_ok|x86_imm32_bitpattern_ok|signed_imm_i32|imm32_bitpattern_i32|is_sequence_encodable_for|Assembler::can_assemble" docs/adr/0004-isa-trait-collapse.md src/isa/x86.rs src/assembler/x86.rs src/search/candidate.rs`
- `git diff --check`
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `./build_tests.sh`
- `cargo test --all`
- `./ci_check.sh`

Closes #501

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**