### PR TITLE
docs(search): clarify SMT query counter semantics

### DIFF
--- a/src/search/result.rs
+++ b/src/search/result.rs
@@ -129,7 +129,8 @@ pub struct SearchStatistics {
     pub candidates_evaluated: u64,
     /// Number of candidates that passed fast (concrete) validation
     pub candidates_passed_fast: u64,
-    /// Number of SMT queries made
+    /// Number of SMT solver queries that reached Z3 `solver.check()`.
+    /// Fast-path refutations and other pre-SMT exits are not counted.
     pub smt_queries: u64,
     /// Cumulative wall-clock time spent inside Z3 `solver.check()` calls,
     /// aggregated across every SMT-reaching candidate during the search.

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -241,8 +241,6 @@ where
             self.statistics.candidates_passed_fast += 1;
 
             if proposal_cost < best_cost {
-                self.statistics.smt_queries += 1;
-
                 let (verdict, metrics) = <I as StochasticBackend<I>>::check_equivalence(
                     target,
                     &proposal,
@@ -251,6 +249,9 @@ where
                     smt_timeout,
                 );
                 self.statistics.smt_elapsed += metrics.smt_elapsed;
+                if metrics.smt_called {
+                    self.statistics.smt_queries += 1;
+                }
                 if let EquivalenceResult::Equivalent = verdict {
                     self.statistics.smt_equivalent += 1;
                     self.statistics.improvements_found += 1;
@@ -339,6 +340,8 @@ mod tests {
     use crate::search::config::{StochasticConfig, SymbolicConfig};
     use crate::semantics::cost::CostMetric;
     use crate::semantics::live_out::LiveOut;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering as AtomicOrdering};
+    use std::sync::{Mutex as TestMutex, MutexGuard};
 
     fn mov_add_sequence() -> Vec<Instruction> {
         vec![
@@ -526,6 +529,23 @@ mod tests {
             const { std::cell::Cell::new(None) };
     }
 
+    const TIMEOUT_PROBE_NOT_EQUIVALENT: usize = 0;
+    const TIMEOUT_PROBE_EQUIVALENT: usize = 1;
+
+    static TIMEOUT_PROBE_TEST_LOCK: TestMutex<()> = TestMutex::new(());
+    static TIMEOUT_PROBE_VERDICT: AtomicUsize = AtomicUsize::new(TIMEOUT_PROBE_EQUIVALENT);
+    static TIMEOUT_PROBE_SMT_CALLED: AtomicBool = AtomicBool::new(true);
+
+    fn set_timeout_probe_result(verdict: usize, smt_called: bool) -> MutexGuard<'static, ()> {
+        let guard = TIMEOUT_PROBE_TEST_LOCK
+            .lock()
+            .expect("timeout probe test lock poisoned");
+        TIMEOUT_PROBE_VERDICT.store(verdict, AtomicOrdering::SeqCst);
+        TIMEOUT_PROBE_SMT_CALLED.store(smt_called, AtomicOrdering::SeqCst);
+        RECORDED_SMT_TIMEOUT_MS.with(|recorded| recorded.set(None));
+        guard
+    }
+
     impl StochasticBackend<TimeoutProbeIsa> for TimeoutProbeIsa {
         type State = ();
         type LiveOut = ();
@@ -582,9 +602,16 @@ mod tests {
             timeout: Duration,
         ) -> (EquivalenceResult, crate::semantics::EquivalenceMetrics) {
             RECORDED_SMT_TIMEOUT_MS.with(|recorded| recorded.set(Some(timeout.as_millis() as u64)));
+            let metrics = crate::semantics::EquivalenceMetrics {
+                smt_called: TIMEOUT_PROBE_SMT_CALLED.load(AtomicOrdering::SeqCst),
+                ..crate::semantics::EquivalenceMetrics::default()
+            };
             (
-                EquivalenceResult::Equivalent,
-                crate::semantics::EquivalenceMetrics::default(),
+                match TIMEOUT_PROBE_VERDICT.load(AtomicOrdering::SeqCst) {
+                    TIMEOUT_PROBE_EQUIVALENT => EquivalenceResult::Equivalent,
+                    _ => EquivalenceResult::NotEquivalent,
+                },
+                metrics,
             )
         }
 
@@ -603,9 +630,12 @@ mod tests {
         }
     }
 
-    fn run_timeout_probe_search(symbolic_config: SymbolicConfig) -> Option<u64> {
-        RECORDED_SMT_TIMEOUT_MS.with(|recorded| recorded.set(None));
-
+    fn run_timeout_probe_search_with(
+        symbolic_config: SymbolicConfig,
+        verdict: usize,
+        smt_called: bool,
+    ) -> (SearchStatistics, Option<u64>) {
+        let _guard = set_timeout_probe_result(verdict, smt_called);
         let mut search: StochasticSearch<TimeoutProbeIsa> = StochasticSearch::new();
         let config = SearchConfig::default()
             .with_stochastic(
@@ -617,9 +647,19 @@ mod tests {
             .with_symbolic(symbolic_config);
         let target = [TimeoutProbeInstruction(1), TimeoutProbeInstruction(2)];
         let result = search.search(&target, &(), &config);
-        assert_eq!(result.statistics.smt_queries, 1);
+        let statistics = result.statistics;
 
-        RECORDED_SMT_TIMEOUT_MS.with(|recorded| recorded.get())
+        (
+            statistics,
+            RECORDED_SMT_TIMEOUT_MS.with(|recorded| recorded.get()),
+        )
+    }
+
+    fn run_timeout_probe_search(symbolic_config: SymbolicConfig) -> Option<u64> {
+        let (statistics, recorded_timeout) =
+            run_timeout_probe_search_with(symbolic_config, TIMEOUT_PROBE_EQUIVALENT, true);
+        assert_eq!(statistics.smt_queries, 1);
+        recorded_timeout
     }
 
     #[test]
@@ -641,6 +681,20 @@ mod tests {
         let recorded_timeout = run_timeout_probe_search(symbolic_config);
 
         assert_eq!(recorded_timeout, Some(5000));
+    }
+
+    #[test]
+    fn stochastic_search_does_not_count_pre_smt_refutation_as_smt_query() {
+        let (statistics, recorded_timeout) = run_timeout_probe_search_with(
+            SymbolicConfig::default().with_timeout(Duration::from_millis(17)),
+            TIMEOUT_PROBE_NOT_EQUIVALENT,
+            false,
+        );
+
+        assert_eq!(recorded_timeout, Some(17));
+        assert_eq!(statistics.candidates_passed_fast, 1);
+        assert_eq!(statistics.smt_queries, 0);
+        assert_eq!(statistics.smt_equivalent, 0);
     }
 
     #[test]

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Summary:
- Clarify that SearchStatistics::smt_queries counts real Z3 solver.check() calls, not fast-path or pre-SMT refutations.
- Remove current clippy needless-borrow warnings in SMT helpers so the required local gate passes with warnings denied.

Closes #504

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**