### PR TITLE
test(equiv): cover memory window without fast-only warning

### DIFF
--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {

--- a/tests/integration/equiv_test.rs
+++ b/tests/integration/equiv_test.rs
@@ -7,24 +7,32 @@ fn get_binary_path() -> std::path::PathBuf {
     std::path::PathBuf::from(env!("CARGO_BIN_EXE_s11"))
 }
 
-fn run_equiv_fast_only(seq1_text: &str, seq2_text: &str) -> Output {
+fn run_equiv(seq1_text: &str, seq2_text: &str, fast_only: bool) -> Output {
     let dir = tempfile::tempdir().expect("create temp dir for equiv fixtures");
     let seq1 = dir.path().join("seq1.s");
     let seq2 = dir.path().join("seq2.s");
     std::fs::write(&seq1, seq1_text).expect("write first sequence");
     std::fs::write(&seq2, seq2_text).expect("write second sequence");
 
-    Command::new(get_binary_path())
-        .arg("equiv")
-        .arg(&seq1)
-        .arg(&seq2)
-        .arg("--fast-only")
+    let mut command = Command::new(get_binary_path());
+    command.arg("equiv").arg(&seq1).arg(&seq2);
+    if fast_only {
+        command.arg("--fast-only");
+    }
+    command
         .arg("--live-out")
         .arg("x0")
         .arg("--timeout")
-        .arg("5")
-        .output()
-        .expect("execute s11 equiv")
+        .arg("5");
+    command.output().expect("execute s11 equiv")
+}
+
+fn run_equiv_fast_only(seq1_text: &str, seq2_text: &str) -> Output {
+    run_equiv(seq1_text, seq2_text, true)
+}
+
+fn run_equiv_without_fast_only(seq1_text: &str, seq2_text: &str) -> Output {
+    run_equiv(seq1_text, seq2_text, false)
 }
 
 #[test]
@@ -49,6 +57,31 @@ fn equiv_fast_only_memory_window_warns_when_overridden() {
         stderr.matches(FAST_ONLY_MEMORY_WARNING).count(),
         1,
         "stderr should contain the ADR-0007 fast-only override warning exactly once, stderr:\n{}",
+        stderr
+    );
+}
+
+#[test]
+fn equiv_memory_window_without_fast_only_does_not_warn() {
+    let output = run_equiv_without_fast_only("ldr x0, [x1]\n", "ldr x0, [x1]\n");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "s11 equiv should succeed, status: {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        stdout,
+        stderr
+    );
+    assert!(
+        stdout.contains("EQUIVALENT"),
+        "stdout should report equivalence, stdout:\n{}",
+        stdout
+    );
+    assert!(
+        !stderr.contains(FAST_ONLY_MEMORY_WARNING),
+        "stderr should not contain the memory fast-only override warning, stderr:\n{}",
         stderr
     );
 }


### PR DESCRIPTION
Summary:
- Add an integration regression for a memory-bearing AArch64 equiv window without --fast-only, asserting no ADR-0007 override warning is emitted.
- Share the equiv test helper across fast-only and normal CLI invocations.
- Remove existing needless SMT AST borrows so the required local clippy gate is warning-clean.

Tests:
- cargo test --test integration_tests equiv_memory_window_without_fast_only_does_not_warn -- --nocapture
- cargo test --test integration_tests equiv_test -- --nocapture
- cargo fmt --all
- cargo clippy --all -- -D warnings
- ./build_tests.sh
- cargo test --all
- ./ci_check.sh

Closes #507

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**