### PR TITLE
refactor(tests): use tempfile tempdirs in opt tests

### DIFF
--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {

--- a/tests/integration/opt_test.rs
+++ b/tests/integration/opt_test.rs
@@ -452,21 +452,18 @@ fn test_opt_rejects_unsupported_instruction_window() {
 /// Helper for memory-op integration tests: assert that `s11 opt` on the
 /// given single-instruction window succeeds.
 ///
-/// Each test copies the source ELF to a unique tmp path
-/// (`std::env::temp_dir` joined with the supplied `fixture_tag`) so
-/// concurrent `cargo test` runs don't collide on the
-/// `<input>_optimized` artifact the binary always writes alongside its
-/// input. The artifact is cleaned up before the test returns.
-fn assert_opt_succeeds_on_window(source_elf: &Path, fixture_tag: &str, start_addr: u64) {
+/// Each test copies the source ELF to a unique tempdir so concurrent
+/// `cargo test` runs don't collide on the `<input>_optimized` artifact
+/// the binary always writes alongside its input. The tempdir is cleaned
+/// up automatically when the helper returns or panics.
+fn assert_opt_succeeds_on_window(source_elf: &Path, start_addr: u64) {
     let binary = get_binary_path();
     let end_addr = start_addr + 4;
 
-    let tmp_dir = std::env::temp_dir().join(format!("s11_opt_{fixture_tag}"));
-    let _ = fs::remove_dir_all(&tmp_dir);
-    fs::create_dir_all(&tmp_dir).expect("create temp fixture dir");
-    let test_elf = tmp_dir.join("loops_debug");
+    let tmp_dir = tempfile::tempdir().expect("create temp fixture dir");
+    let test_elf = tmp_dir.path().join("loops_debug");
     fs::copy(source_elf, &test_elf).expect("copy ELF fixture to tmp");
-    let optimized_path = tmp_dir.join("loops_debug_optimized");
+    let optimized_path = tmp_dir.path().join("loops_debug_optimized");
 
     let output = Command::new(&binary)
         .arg("opt")
@@ -479,7 +476,6 @@ fn assert_opt_succeeds_on_window(source_elf: &Path, fixture_tag: &str, start_add
         .expect("Failed to execute s11");
 
     if !output.status.success() {
-        let _ = fs::remove_dir_all(&tmp_dir);
         panic!(
             "opt failed on memory-op window 0x{start_addr:x}.\nstdout: {}\nstderr: {}",
             String::from_utf8_lossy(&output.stdout),
@@ -490,7 +486,6 @@ fn assert_opt_succeeds_on_window(source_elf: &Path, fixture_tag: &str, start_add
     let stdout = String::from_utf8_lossy(&output.stdout);
     let ok = stdout.contains("Optimization completed successfully");
     let optimized_exists = optimized_path.exists();
-    let _ = fs::remove_dir_all(&tmp_dir);
 
     assert!(
         ok,
@@ -518,7 +513,7 @@ fn test_opt_accepts_stp_writeback_window() {
         &[0xff, 0xff, 0xff, 0xff],
         "stp x29, x30, [sp, #-16]!",
     );
-    assert_opt_succeeds_on_window(&source_elf, "stp_writeback", start_addr);
+    assert_opt_succeeds_on_window(&source_elf, start_addr);
 }
 
 #[test]
@@ -536,7 +531,7 @@ fn test_opt_accepts_ldp_postindex_window() {
         &[0xff, 0xff, 0xff, 0xff],
         "ldp x29, x30, [sp], #16",
     );
-    assert_opt_succeeds_on_window(&source_elf, "ldp_postindex", start_addr);
+    assert_opt_succeeds_on_window(&source_elf, start_addr);
 }
 
 #[test]
@@ -558,7 +553,7 @@ fn test_opt_accepts_ldr_positive_offset_window() {
         &[0x00, 0x00, 0xc0, 0xff],
         "ldr xN, [xM{, #imm}]",
     );
-    assert_opt_succeeds_on_window(&source_elf, "ldr_offset", start_addr);
+    assert_opt_succeeds_on_window(&source_elf, start_addr);
 }
 
 #[test]


### PR DESCRIPTION
Summary:
- Align the opt integration helper with `tempfile::tempdir()` RAII cleanup.
- Remove deterministic fixture tags and manual temp-dir cleanup from the opt memory-window tests.
- Remove current-toolchain clippy warnings in SMT bitvector code so the required quality gate stays green.

Closes #512

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**