### PR TITLE
test(aarch64): guard non-enumerated opcode ids

### DIFF
--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -1827,6 +1827,7 @@ fn mutate_shift_operand<R: RngExt>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ir::types::{AccessWidth, AddressOperand, IndexMode, LabelId};
     use rand::SeedableRng;
     use rand_chacha::ChaCha8Rng;
     use std::collections::BTreeSet;
@@ -2134,6 +2135,92 @@ mod tests {
         ]
     }
 
+    fn non_enumerated_instruction_families() -> Vec<Instruction> {
+        let target = LabelId(0x1000);
+        let addr = AddressOperand::Imm {
+            base: Register::X1,
+            offset: 0,
+            mode: IndexMode::Offset,
+        };
+
+        vec![
+            Instruction::B { target },
+            Instruction::BCond {
+                target,
+                cond: Condition::EQ,
+            },
+            Instruction::Ret { rn: Register::X30 },
+            Instruction::Cbz {
+                rn: Register::X0,
+                target,
+            },
+            Instruction::Cbnz {
+                rn: Register::X0,
+                target,
+            },
+            Instruction::Tbz {
+                rt: Register::X0,
+                bit: 3,
+                target,
+            },
+            Instruction::Tbnz {
+                rt: Register::X0,
+                bit: 3,
+                target,
+            },
+            Instruction::Bl { target },
+            Instruction::Br { rn: Register::X16 },
+            Instruction::Ldr {
+                rt: Register::X0,
+                addr,
+                width: AccessWidth::Extended,
+            },
+            Instruction::Ldrs {
+                rt: Register::X0,
+                addr,
+                width: AccessWidth::Word,
+            },
+            Instruction::Str {
+                rt: Register::X0,
+                addr,
+                width: AccessWidth::Extended,
+            },
+            Instruction::Ldp {
+                rt1: Register::X0,
+                rt2: Register::X2,
+                addr,
+                width: AccessWidth::Extended,
+                signed: false,
+            },
+            Instruction::Stp {
+                rt1: Register::X0,
+                rt2: Register::X2,
+                addr,
+                width: AccessWidth::Extended,
+            },
+            Instruction::Adc {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Register::X2,
+            },
+            Instruction::Adcs {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Register::X2,
+            },
+            Instruction::Sbc {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Register::X2,
+            },
+            Instruction::Sbcs {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Register::X2,
+            },
+        ]
+    }
+
     #[test]
     fn test_aarch64_isa_metadata() {
         let isa = AArch64;
@@ -2410,6 +2497,23 @@ mod tests {
             .collect();
         assert_eq!(seen.len(), all_instruction_families().len());
         assert_eq!(seen.len(), generator.opcode_count() as usize);
+    }
+
+    #[test]
+    fn non_enumerated_instruction_families_stay_above_opcode_count() {
+        let generator = AArch64InstructionGenerator;
+        let opcode_count = generator.opcode_count();
+
+        for instr in non_enumerated_instruction_families() {
+            let id = instr.opcode_id();
+            assert!(
+                id >= opcode_count,
+                "non-enumerated opcode {} has id {} below opcode_count {}",
+                instr,
+                id,
+                opcode_count
+            );
+        }
     }
 
     #[test]

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -1977,7 +1977,7 @@ fn mutate_shift_operand<R: RngExt>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ir::types::{AccessWidth, AddressOperand, IndexMode, LabelId};
+    use crate::ir::types::{AccessWidth, AddressOperand, IndexMode, LabelId, PairAccessWidth};
     use rand::SeedableRng;
     use rand_chacha::ChaCha8Rng;
     use std::collections::{BTreeMap, BTreeSet};
@@ -2345,14 +2345,14 @@ mod tests {
                 rt1: Register::X0,
                 rt2: Register::X2,
                 addr,
-                width: AccessWidth::Extended,
+                width: PairAccessWidth::Extended,
                 signed: false,
             },
             Instruction::Stp {
                 rt1: Register::X0,
                 rt2: Register::X2,
                 addr,
-                width: AccessWidth::Extended,
+                width: PairAccessWidth::Extended,
             },
             Instruction::Adc {
                 rd: Register::X0,

--- a/src/semantics/smt.rs
+++ b/src/semantics/smt.rs
@@ -483,8 +483,8 @@ pub fn compute_flags_add(lhs: &BV, rhs: &BV, width: u32) -> Nzcv {
 pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let sum = lhs
         .zero_ext(1)
-        .bvadd(&rhs.zero_ext(1))
-        .bvadd(&carry.zero_ext(width));
+        .bvadd(rhs.zero_ext(1))
+        .bvadd(carry.zero_ext(width));
     let result = sum.extract(width - 1, 0);
     let zero = BV::from_u64(0, width);
     let msb = width - 1;
@@ -494,7 +494,7 @@ pub fn compute_flags_adc(lhs: &BV, rhs: &BV, carry: &BV, width: u32) -> Nzcv {
     let lhs_sign = lhs.extract(msb, msb);
     let rhs_sign = rhs.extract(msb, msb);
     let res_sign = result.extract(msb, msb);
-    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(&bv_one());
+    let signs_match = lhs_sign.bvxor(&rhs_sign).bvxor(bv_one());
     let signs_flip = lhs_sign.bvxor(&res_sign);
     let v = signs_match.bvand(&signs_flip);
     (n, z, c, v)
@@ -887,14 +887,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Adcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_adc(&lhs, &rhs, &carry, width);
-            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(&carry.zero_ext(width - 1)));
+            state.set_register(*rd, lhs.bvadd(&rhs).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         // Subtract with carry: rd = rn + NOT(rm) + C.
@@ -902,20 +902,14 @@ pub fn apply_instruction(mut state: MachineState, instruction: &Instruction) -> 
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
         }
         Instruction::Sbcs { rd, rn, rm } => {
             let lhs = state.get_register(*rn).clone();
             let rhs = state.get_register(*rm).clone();
             let carry = state.get_flags().2.clone();
             let (n, z, c, v) = compute_flags_sbc(&lhs, &rhs, &carry, width);
-            state.set_register(
-                *rd,
-                lhs.bvadd(&rhs.bvnot()).bvadd(&carry.zero_ext(width - 1)),
-            );
+            state.set_register(*rd, lhs.bvadd(rhs.bvnot()).bvadd(carry.zero_ext(width - 1)));
             state.set_flags(n, z, c, v);
         }
         Instruction::Ands {


### PR DESCRIPTION
Add a regression guard that keeps branch, memory, and carry opcode family IDs at or above AArch64 opcode_count(), preserving the generated-family boundary from both sides.

Also includes a small Clippy cleanup in SMT bit-vector code so the warnings-denied lint gate passes locally.

Closes #508

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**