### PR TITLE
ci: gate library unit tests; stop swallowing integration failures (#599)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,8 @@ jobs:
     - name: Build
       run: cargo build --verbose
 
-    - name: Run unit tests only
-      run: cargo test --bins --verbose
+    - name: Run unit tests (lib + bins)
+      run: cargo test --lib --bins --verbose
       
     - name: Check s11 binary exists
       run: |
@@ -60,7 +60,7 @@ jobs:
     - name: Run integration tests with debug output
       run: |
         export RUST_BACKTRACE=1
-        cargo test --test integration_tests -- --nocapture || true
+        cargo test --test integration_tests -- --nocapture
         
     - name: Run all tests
       run: ./test_all.sh


### PR DESCRIPTION
Fixes #599.

## Background — concern #1 was already fixed by #511
Issue #599 reported two things: a failing library test, **and** a CI gap that hid it. The issue was filed against `57116ff` (the commit *before* PR #511 merged). On current `main` (`8a6fd96`, = #511):

- `cargo test --lib -- --exact search::candidate::tests::generate_random_instruction_clamps_arith_compare_immediates_to_imm12` → **passes**
- full library suite → **1214 passed, 0 failed**
- the `coverage` check on `8a6fd96` → **success** (the chronic redness is gone)

#511's fix was a legitimate RNG-vector recalibration, not a mask over a generator regression: the generator correctly clamps compare/arith immediates to imm12 (`.rem_euclid(0x1000)`, `src/search/candidate.rs:1121`), and it had gained a 3-way `shape` selector (register/immediate/shifted, `candidate.rs:1100`), so the test's fixed RNG vector needed the added `shape: 1=immediate` word (`candidate.rs:2417`). **No `candidate.rs` change is needed here.**

## What this PR delivers — concern #2 (the CI masking gap)
The gating `test` job (`.github/workflows/test.yml`) had two masking holes:

1. **`cargo test --bins`** ran only binary-target tests, skipping the library crate's `--lib` unit tests — so the broken library test passed the gating job and only the non-gating `coverage` job caught it.
2. **`cargo test --test integration_tests ... || true`** swallowed integration-test failures.

This PR:
- changes the unit-test step to **`cargo test --lib --bins --verbose`** (library tests now gate). `--lib --bins` runs only `src/lib.rs` + `src/main.rs` unit tests — it does **not** pull in the `integration_tests` target, which needs the cross-compiled `binaries/` built by a later step, so the existing step ordering is preserved.
- drops the **`|| true`** from the integration step so integration failures fail the job.

## Verification
`./ci_check.sh` (builds `binaries/`, then runs the full suite) is green locally:
- library: **1214 passed / 0 failed** · binaries: 69 passed · integration: **42 passed / 0 failed** · doctests: 1 ignored
- ✓ formatting ✓ build ✓ test-binary build ✓ tests

The integration suite passing (42/0) confirms removing `|| true` will not turn the gate red.