### PR TITLE
ci: add manual release workflow with version bump and artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,12 +80,15 @@ jobs:
 
       - name: Bump version
         id: bump
+        env:
+          BUMP: ${{ inputs.bump }}
+          VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          if [ -n "${{ inputs.version }}" ]; then
-            NEW_VERSION="$(scripts/bump-version.sh "${{ inputs.version }}")"
+          if [ -n "$VERSION" ]; then
+            NEW_VERSION="$(scripts/bump-version.sh "$VERSION")"
           else
-            NEW_VERSION="$(scripts/bump-version.sh "${{ inputs.bump }}")"
+            NEW_VERSION="$(scripts/bump-version.sh "$BUMP")"
           fi
           echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
           echo "tag=v${NEW_VERSION}" >> "$GITHUB_OUTPUT"
@@ -98,19 +101,22 @@ jobs:
         run: ./ci_check.sh
 
       - name: Commit + tag
+        env:
+          TAG: ${{ steps.bump.outputs.tag }}
         run: |
           git add Cargo.toml Cargo.lock
-          git commit -m "chore(release): ${{ steps.bump.outputs.tag }}"
-          git tag -a "${{ steps.bump.outputs.tag }}" -m "Release ${{ steps.bump.outputs.tag }}"
+          git commit -m "chore(release): ${TAG}"
+          git tag -a "${TAG}" -m "Release ${TAG}"
 
       - name: Build release binary
         run: cargo build --release --locked
 
       - name: Collect release artifacts
         id: artifacts
+        env:
+          TAG: ${{ steps.bump.outputs.tag }}
         run: |
           set -euo pipefail
-          TAG="${{ steps.bump.outputs.tag }}"
           STAGE="s11-${TAG}-${TARGET}"
           mkdir -p "release-upload/${STAGE}"
           cp target/release/s11 "release-upload/${STAGE}/"
@@ -121,28 +127,34 @@ jobs:
           ls -la release-upload
 
       - name: Push version bump + tag
+        env:
+          TAG: ${{ steps.bump.outputs.tag }}
         run: |
           git push origin "HEAD:${GITHUB_REF_NAME}"
-          git push origin "${{ steps.bump.outputs.tag }}"
+          git push origin "${TAG}"
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.bump.outputs.tag }}
+          DRAFT: ${{ inputs.draft }}
+          PRERELEASE: ${{ inputs.prerelease }}
         run: |
           set -euo pipefail
-          args=(--generate-notes --title "${{ steps.bump.outputs.tag }}")
-          if [ "${{ inputs.draft }}" = "true" ]; then args+=(--draft); fi
-          if [ "${{ inputs.prerelease }}" = "true" ]; then args+=(--prerelease); fi
-          gh release create "${{ steps.bump.outputs.tag }}" \
+          args=(--generate-notes --title "${TAG}")
+          if [ "$DRAFT" = "true" ]; then args+=(--draft); fi
+          if [ "$PRERELEASE" = "true" ]; then args+=(--prerelease); fi
+          gh release create "${TAG}" \
             "${args[@]}" \
             ./release-upload/*
 
       - name: Open next dev cycle
         if: ${{ inputs.draft != true && inputs.prerelease != true }}
+        env:
+          VERSION: ${{ steps.bump.outputs.version }}
         run: |
           set -euo pipefail
-          BASE="${{ steps.bump.outputs.version }}"
-          BASE="${BASE%%-*}"
+          BASE="${VERSION%%-*}"
           IFS='.' read -r MA MI PA <<< "$BASE"
           NEXT="${MA}.${MI}.$((PA + 1))-dev"
           scripts/bump-version.sh "$NEXT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,162 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Semver bump (ignored if explicit `version` is set)'
+        type: choice
+        required: true
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+      version:
+        description: 'Explicit version (e.g. 1.2.3). Overrides `bump` if set.'
+        type: string
+        required: false
+        default: ''
+      draft:
+        description: 'Publish release as draft'
+        type: boolean
+        required: false
+        default: false
+      prerelease:
+        description: 'Mark release as pre-release'
+        type: boolean
+        required: false
+        default: false
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+  TARGET: x86_64-unknown-linux-gnu
+
+jobs:
+  release:
+    name: Bump version and build Linux artifacts
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: Checkout (full history for tagging)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate branch
+        run: |
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "Release must be run from 'main' (got ${GITHUB_REF_NAME})." >&2
+            exit 1
+          fi
+
+      - name: Install system build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libcapstone-dev gcc-aarch64-linux-gnu z3 libz3-dev
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh \
+            | sudo bash -s -- --to /usr/local/bin
+
+      - name: Setup Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --profile minimal --default-toolchain stable --component rustfmt
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Configure git author
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Bump version
+        id: bump
+        run: |
+          set -euo pipefail
+          if [ -n "${{ inputs.version }}" ]; then
+            NEW_VERSION="$(scripts/bump-version.sh "${{ inputs.version }}")"
+          else
+            NEW_VERSION="$(scripts/bump-version.sh "${{ inputs.bump }}")"
+          fi
+          echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Bumped to v${NEW_VERSION}"
+
+      - name: Verify tree (fmt + build + tests)
+        # ci_check.sh runs: cargo fmt --check, debug build, build_tests.sh,
+        # cargo test, and test_all.sh. It also refreshes Cargo.lock with the
+        # bumped version so the commit below stays in sync.
+        run: ./ci_check.sh
+
+      - name: Commit + tag
+        run: |
+          git add Cargo.toml Cargo.lock
+          git commit -m "chore(release): ${{ steps.bump.outputs.tag }}"
+          git tag -a "${{ steps.bump.outputs.tag }}" -m "Release ${{ steps.bump.outputs.tag }}"
+
+      - name: Build release binary
+        run: cargo build --release --locked
+
+      - name: Collect release artifacts
+        id: artifacts
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.bump.outputs.tag }}"
+          STAGE="s11-${TAG}-${TARGET}"
+          mkdir -p "release-upload/${STAGE}"
+          cp target/release/s11 "release-upload/${STAGE}/"
+          cp README.md LICENSE "release-upload/${STAGE}/"
+          tar -C release-upload -czf "release-upload/${STAGE}.tar.gz" "${STAGE}"
+          rm -rf "release-upload/${STAGE}"
+          (cd release-upload && sha256sum ./* > SHA256SUMS.txt)
+          ls -la release-upload
+
+      - name: Push version bump + tag
+        run: |
+          git push origin "HEAD:${GITHUB_REF_NAME}"
+          git push origin "${{ steps.bump.outputs.tag }}"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          args=(--generate-notes --title "${{ steps.bump.outputs.tag }}")
+          if [ "${{ inputs.draft }}" = "true" ]; then args+=(--draft); fi
+          if [ "${{ inputs.prerelease }}" = "true" ]; then args+=(--prerelease); fi
+          gh release create "${{ steps.bump.outputs.tag }}" \
+            "${args[@]}" \
+            ./release-upload/*
+
+      - name: Open next dev cycle
+        if: ${{ inputs.draft != true && inputs.prerelease != true }}
+        run: |
+          set -euo pipefail
+          BASE="${{ steps.bump.outputs.version }}"
+          BASE="${BASE%%-*}"
+          IFS='.' read -r MA MI PA <<< "$BASE"
+          NEXT="${MA}.${MI}.$((PA + 1))-dev"
+          scripts/bump-version.sh "$NEXT"
+          # Sync the s11 entry in Cargo.lock to the new manifest version.
+          cargo update --workspace
+          git add Cargo.toml Cargo.lock
+          git commit -m "chore: open ${NEXT} dev cycle"
+          git push origin "HEAD:${GITHUB_REF_NAME}"
+
+      - name: Upload build artifacts (for debugging / reruns)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-artifacts-${{ steps.bump.outputs.tag }}
+          path: release-upload/
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,70 @@
+# Releasing s11
+
+Releases are cut by the [`Release`](../.github/workflows/release.yml) GitHub
+Actions workflow. It is **manually triggered** (`workflow_dispatch`) and must be
+run from `main`. The workflow bumps the version, verifies the tree, builds a
+Linux release binary, tags the commit, and publishes a GitHub Release with
+auto-generated notes.
+
+## Cutting a release
+
+1. Make sure `main` is green and contains everything you want to ship.
+2. Go to **Actions → Release → Run workflow** (or `gh workflow run release.yml`).
+3. Choose the inputs:
+
+   | Input        | Default | Meaning                                                              |
+   | ------------ | ------- | -------------------------------------------------------------------- |
+   | `bump`       | `patch` | Semver increment: `patch`, `minor`, or `major`.                      |
+   | `version`    | `''`    | Explicit version (e.g. `1.2.3`). Overrides `bump` when set.          |
+   | `draft`      | `false` | Publish the GitHub Release as a draft.                               |
+   | `prerelease` | `false` | Mark the GitHub Release as a pre-release.                            |
+
+4. Run it. On success you get:
+   - a `chore(release): vX.Y.Z` commit and an annotated `vX.Y.Z` tag on `main`,
+   - a GitHub Release `vX.Y.Z` with generated notes and the build artifacts,
+   - a follow-up `chore: open X.Y.(Z+1)-dev dev cycle` commit (skipped for
+     draft / pre-release runs).
+
+## What the workflow does
+
+1. **Validate branch** — refuses to run anywhere but `main`.
+2. **Install deps** — `libcapstone-dev`, `z3` + `libz3-dev`,
+   `gcc-aarch64-linux-gnu`, `just`, and a stable Rust toolchain (mirrors CI).
+3. **Bump version** — [`scripts/bump-version.sh`](../scripts/bump-version.sh)
+   rewrites the `[package]` version in `Cargo.toml`.
+4. **Verify** — runs [`ci_check.sh`](../ci_check.sh) (fmt check, build,
+   `build_tests.sh`, `cargo test`, `test_all.sh`). This also refreshes
+   `Cargo.lock` with the new version.
+5. **Commit + tag** — commits `Cargo.toml` + `Cargo.lock` and creates an
+   annotated tag.
+6. **Build + package** — `cargo build --release --locked`, then tars the
+   `s11` binary with `README.md` and `LICENSE` into
+   `s11-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz` and writes `SHA256SUMS.txt`.
+7. **Push + publish** — pushes the bump and tag, then
+   `gh release create --generate-notes` attaches the artifacts.
+8. **Open next dev cycle** — bumps to `X.Y.(Z+1)-dev` and pushes.
+
+## Artifacts and runtime dependencies
+
+The release tarball contains a dynamically linked `x86_64-unknown-linux-gnu`
+binary. It links against the system **Z3** and **Capstone** libraries (the
+project builds against `libz3-dev` / `libcapstone-dev`), so the target machine
+must have `libz3` and `libcapstone` installed to run it. Verify a download with:
+
+```sh
+sha256sum --check SHA256SUMS.txt
+```
+
+## Cutting a version locally (without the workflow)
+
+`scripts/bump-version.sh` is standalone and reusable:
+
+```sh
+scripts/bump-version.sh patch     # 0.1.0 -> 0.1.1
+scripts/bump-version.sh minor     # 0.1.0 -> 0.2.0
+scripts/bump-version.sh 1.0.0-rc.1  # explicit version
+```
+
+It prints the new version to stdout and edits only the `[package]` version line.
+Prefer the workflow for real releases so tagging, verification, and note
+generation stay consistent.

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Bump the [package] version in Cargo.toml.
+#
+# Usage:
+#   scripts/bump-version.sh <patch|minor|major>     # semver increment
+#   scripts/bump-version.sh <X.Y.Z[-suffix]>        # set an explicit version
+#
+# The new version is printed to stdout (and nothing else), so it can be
+# captured directly:  NEW="$(scripts/bump-version.sh patch)"
+# All human-facing logging goes to stderr.
+#
+# Only the first `version = "..."` line (the [package] version) is rewritten;
+# dependency version specifiers are inline tables and are left untouched.
+set -euo pipefail
+
+MANIFEST="${MANIFEST:-Cargo.toml}"
+
+log() { echo "$@" >&2; }
+
+if [ "$#" -ne 1 ]; then
+  log "usage: $0 <patch|minor|major|X.Y.Z[-suffix]>"
+  exit 2
+fi
+
+if [ ! -f "$MANIFEST" ]; then
+  log "error: $MANIFEST not found (run from the repository root)"
+  exit 1
+fi
+
+current="$(grep -m1 -E '^version = "' "$MANIFEST" | sed -E 's/^version = "([^"]+)".*/\1/')"
+if [ -z "$current" ]; then
+  log "error: could not find a [package] version in $MANIFEST"
+  exit 1
+fi
+
+case "$1" in
+  patch | minor | major)
+    base="${current%%-*}" # drop any pre-release / build suffix
+    IFS='.' read -r major minor patch <<EOF
+$base
+EOF
+    if ! [[ "$major" =~ ^[0-9]+$ && "$minor" =~ ^[0-9]+$ && "$patch" =~ ^[0-9]+$ ]]; then
+      log "error: current version '$current' is not a plain X.Y.Z; pass an explicit version"
+      exit 1
+    fi
+    case "$1" in
+      patch) patch=$((patch + 1)) ;;
+      minor)
+        minor=$((minor + 1))
+        patch=0
+        ;;
+      major)
+        major=$((major + 1))
+        minor=0
+        patch=0
+        ;;
+    esac
+    new="${major}.${minor}.${patch}"
+    ;;
+  [0-9]*)
+    new="$1"
+    ;;
+  *)
+    log "error: unknown bump '$1' (expected patch|minor|major or an explicit X.Y.Z)"
+    exit 2
+    ;;
+esac
+
+# Rewrite only the first `version = "..."` line.
+sed -i -E '0,/^version = "[^"]+"/s//version = "'"$new"'"/' "$MANIFEST"
+
+log "bumped $current -> $new"
+echo "$new"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -59,6 +59,10 @@ EOF
     ;;
   [0-9]*)
     new="$1"
+    if ! [[ "$new" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?(\+[0-9A-Za-z.]+)?$ ]]; then
+      log "error: '$new' is not a valid version (expected X.Y.Z, optionally -prerelease and/or +build)"
+      exit 2
+    fi
     ;;
   *)
     log "error: unknown bump '$1' (expected patch|minor|major or an explicit X.Y.Z)"
@@ -66,8 +70,10 @@ EOF
     ;;
 esac
 
-# Rewrite only the first `version = "..."` line.
-sed -i -E '0,/^version = "[^"]+"/s//version = "'"$new"'"/' "$MANIFEST"
+# Rewrite only the first `version = "..."` line. `$new` is validated above
+# (no `/`), and the substitution uses `|` as its delimiter so the replacement
+# text can never be mistaken for the end of the s command.
+sed -i -E "0,/^version = \"[^\"]+\"/s|^version = \"[^\"]+\"|version = \"${new}\"|" "$MANIFEST"
 
 log "bumped $current -> $new"
 echo "$new"


### PR DESCRIPTION
Adds a release process for s11 modeled on the one in [`pmatos/pewpew`](https://github.com/pmatos/pewpew/blob/main/.github/workflows/release.yml), adapted from Node/Electron to Rust/Cargo.

## What's added

- **`.github/workflows/release.yml`** — a manually-dispatched (`workflow_dispatch`) Release workflow:
  - Inputs: `bump` (patch/minor/major), explicit `version`, `draft`, `prerelease`.
  - `concurrency: release`, `permissions: contents: write`.
  - Validates it's run from `main`; installs the same build deps as CI (`libcapstone-dev`, `z3`/`libz3-dev`, `gcc-aarch64-linux-gnu`, `just`, stable Rust + rustfmt).
  - Bumps the version, runs **`ci_check.sh`** as the verify gate (which also re-syncs `Cargo.lock`), commits + tags.
  - Builds `cargo build --release --locked`, packages `s11` + `README.md` + `LICENSE` into `s11-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz` with `SHA256SUMS.txt`.
  - Pushes the bump + tag, publishes a GitHub Release with `gh release create --generate-notes`, then opens the next `X.Y.(Z+1)-dev` cycle (skipped for draft/pre-release).

- **`scripts/bump-version.sh`** — the `npm version` equivalent for Cargo. Self-contained bash; bumps the `[package]` version in `Cargo.toml` (patch/minor/major or explicit), edits only the package version line (dependency specifiers untouched), prints the new version to stdout. Reusable for local releases.

- **`docs/RELEASING.md`** — how to trigger the workflow, input reference, what each step does, the local-bump escape hatch, and the runtime-dependency caveat.

## Notes / decisions

- **Verify gate reuse:** the workflow runs the repo's own `ci_check.sh` rather than re-listing steps, so the release gate stays identical to local CI.
- **Artifact portability:** the binary is dynamically linked against system **libz3**/**libcapstone**, so targets need those installed (documented in `RELEASING.md`). Static-linking Z3 is a possible follow-up if a self-contained artifact is wanted.
- **Releases from `main`:** the workflow pushes the release commit + dev-cycle commit directly to `main`, matching pewpew.

## Validation

- `release.yml` parses as valid YAML (14 steps, all inputs).
- `bump-version.sh`: `bash -n` clean; patch/minor/major/explicit/prerelease all verified against a temp `Cargo.toml`; bad input rejected; dependency lines untouched.
