### PR TITLE
fix(release): add fallback artifact tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,7 +168,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: linux-artifacts-${{ steps.bump.outputs.tag }}
+          name: linux-artifacts-${{ steps.bump.outputs.tag || 'unknown' }}
           path: release-upload/
           if-no-files-found: warn
           retention-days: 14


### PR DESCRIPTION
Summary:
- Fall back to `unknown` when the release bump step does not produce a tag before debug artifact upload.
- Preserve successful release artifact names when `steps.bump.outputs.tag` is set.

Verification:
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `./build_tests.sh`
- `cargo test --all`
- `./ci_check.sh`

Closes #605

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**