### PR TITLE
test(x86): require SMT-backed enumerative verification

### DIFF
--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -1865,6 +1865,8 @@ mod tests {
                 rs: X86Register::RBX,
             }])
         );
+        assert!(result.statistics.smt_queries > 0);
+        assert!(result.statistics.smt_equivalent > 0);
     }
 
     #[test]
@@ -1904,5 +1906,7 @@ mod tests {
                 rs: X86Register::RBX,
             }])
         );
+        assert!(result.statistics.smt_queries > 0);
+        assert!(result.statistics.smt_equivalent > 0);
     }
 }

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -1280,6 +1280,76 @@ mod tests {
         assert!(metrics.smt_formula_bytes.is_none());
     }
 
+    fn assert_x86_register_output_smt_only_refutation<I>()
+    where
+        I: EquivalenceBackend<Instruction = X86Instruction, Register = X86Register>,
+    {
+        let target = vec![X86Instruction::AddReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RCX,
+        }];
+        let candidate = vec![
+            X86Instruction::AddReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RDX,
+            },
+            X86Instruction::SubImm {
+                rd: X86Register::RAX,
+                imm: 1,
+            },
+        ];
+        let live_out = X86LiveOut::from_registers(vec![X86Register::RAX]);
+
+        let fast_cfg = EquivalenceConfigFor::<I>::fast_only().live_out(live_out.clone());
+        let (fast_result, fast_metrics) =
+            check_equivalence_for_metrics::<I>(&target, &candidate, &fast_cfg);
+        assert_eq!(fast_result, EquivalenceResult::Equivalent);
+        assert!(!fast_metrics.smt_called);
+
+        let cfg = EquivalenceConfigFor::<I>::default().live_out(live_out);
+        let (result, metrics) = check_equivalence_for_metrics::<I>(&target, &candidate, &cfg);
+        assert_eq!(result, EquivalenceResult::NotEquivalent);
+        assert!(metrics.smt_called);
+    }
+
+    #[test]
+    fn x86_register_output_smt_only_refutation() {
+        assert_x86_register_output_smt_only_refutation::<crate::isa::X86_64>();
+        assert_x86_register_output_smt_only_refutation::<crate::isa::X86_32>();
+    }
+
+    fn assert_x86_eflags_smt_only_refutation<I>()
+    where
+        I: EquivalenceBackend<Instruction = X86Instruction, Register = X86Register>,
+    {
+        let target = vec![X86Instruction::CmpReg {
+            rn: X86Register::RCX,
+            rs: X86Register::RDX,
+        }];
+        let candidate = vec![X86Instruction::CmpReg {
+            rn: X86Register::RSI,
+            rs: X86Register::RDI,
+        }];
+        let live_out = X86LiveOut::empty().with_flags(true);
+
+        let fast_cfg = EquivalenceConfigFor::<I>::fast_only().live_out(live_out.clone());
+        let (fast_result, fast_metrics) =
+            check_equivalence_for_metrics::<I>(&target, &candidate, &fast_cfg);
+        assert_eq!(fast_result, EquivalenceResult::Equivalent);
+        assert!(!fast_metrics.smt_called);
+
+        let cfg = EquivalenceConfigFor::<I>::default().live_out(live_out);
+        let (result, metrics) = check_equivalence_for_metrics::<I>(&target, &candidate, &cfg);
+        assert_eq!(result, EquivalenceResult::NotEquivalent);
+        assert!(metrics.smt_called);
+    }
+
+    #[test]
+    fn x86_eflags_smt_only_refutation() {
+        assert_x86_eflags_smt_only_refutation::<crate::isa::X86_64>();
+        assert_x86_eflags_smt_only_refutation::<crate::isa::X86_32>();
+    }
+
     #[test]
     fn x86_non_fast_equivalent_result_still_invokes_smt() {
         let seq_mov = vec![X86Instruction::MovImm {

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -1303,6 +1303,10 @@ mod tests {
         let fast_cfg = EquivalenceConfigFor::<I>::fast_only().live_out(live_out.clone());
         let (fast_result, fast_metrics) =
             check_equivalence_for_metrics::<I>(&target, &candidate, &fast_cfg);
+        // The fast path seeds register i with `seed + i` for every seed
+        // (RAX=0, RCX=1, RDX=2), so target RAX = seed + (seed+1) = 2*seed+1 and
+        // candidate RAX = (seed + (seed+2)) - 1 = 2*seed+1 on every concrete
+        // trial. The pair is equal by construction here; only SMT can refute it.
         assert_eq!(fast_result, EquivalenceResult::Equivalent);
         assert!(!fast_metrics.smt_called);
 
@@ -1335,6 +1339,10 @@ mod tests {
         let fast_cfg = EquivalenceConfigFor::<I>::fast_only().live_out(live_out.clone());
         let (fast_result, fast_metrics) =
             check_equivalence_for_metrics::<I>(&target, &candidate, &fast_cfg);
+        // The fast path seeds register i with `seed + i` for every seed
+        // (RCX=1, RDX=2, RSI=6, RDI=7), so both compares compute -1 (RCX-RDX
+        // and RSI-RDI) and produce identical flags on every concrete trial.
+        // The pair is flag-equivalent by construction here; only SMT refutes it.
         assert_eq!(fast_result, EquivalenceResult::Equivalent);
         assert!(!fast_metrics.smt_called);
 


### PR DESCRIPTION
Summary:
- Add x86-64 and x86-32 SMT-only refutation coverage for register live-outs and EFLAGS live-outs.
- Assert x86 enumerative rewrites record SMT queries and SMT-equivalent candidates before acceptance.

Closes #82

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**