### PR TITLE
x86: fix MovImm CodeSize cost to match assembler encoding (#225)

### DIFF
--- a/src/assembler/x86.rs
+++ b/src/assembler/x86.rs
@@ -102,10 +102,11 @@ fn encode_64(ops: &mut dynasmrt::x64::Assembler, instr: &X86Instruction) -> Resu
         }
         X86Instruction::MovImm { rd, imm } => {
             let rd = reg_index(*rd)?;
-            // Prefer the imm32 sign-extended encoding (5 bytes including
-            // REX) when the immediate fits — Capstone shows this as
-            // canonical "mov rax, 0x...". Fall back to MOVABS (10 bytes)
-            // for the rare full 64-bit immediate case.
+            // Prefer the imm32 sign-extended encoding (`REX.W C7 /0 id`,
+            // 7 bytes) when the immediate fits — Capstone shows this as
+            // canonical "mov rax, 0x...". Fall back to MOVABS
+            // (`REX.W B8+rd io`, 10 bytes) for the full 64-bit immediate
+            // case. The CodeSize cost model mirrors these lengths (issue #225).
             if let Ok(i32_imm) = i32::try_from(*imm) {
                 dynasm!(ops ; .arch x64 ; mov Rq(rd), i32_imm);
             } else {
@@ -827,6 +828,54 @@ mod tests {
             }])
             .expect_err("x86-32 mov imm requires imm32");
         assert!(err.contains("does not fit in 32 bits"));
+    }
+
+    #[test]
+    fn movimm_code_size_is_upper_bound_on_assembled_length() {
+        // Cross-layer guard (issue #225): the CodeSize cost model must never
+        // underestimate the assembler's real MovImm encoding, or length-based
+        // search pruning becomes unsound. Assemble boundary immediates and
+        // assert cost >= actual bytes for both modes.
+        use crate::semantics::cost::CostMetric;
+        use crate::semantics::cost_x86::instruction_cost;
+
+        let mut a64 = X86Assembler::new_64();
+        for imm in [
+            0i64,
+            1,
+            -1,
+            i32::MAX as i64,
+            i32::MIN as i64,
+            i64::MAX,
+            i64::MIN,
+        ] {
+            let instr = X86Instruction::MovImm {
+                rd: X86Register::RAX,
+                imm,
+            };
+            let bytes = a64.assemble_instructions(&[instr]).unwrap();
+            let cost = instruction_cost(&instr, &CostMetric::CodeSize, 64);
+            assert!(
+                cost >= bytes.len() as u64,
+                "x64 MovImm cost {cost} < assembled {} for imm {imm}",
+                bytes.len()
+            );
+        }
+
+        let mut a32 = X86Assembler::new_32();
+        for imm in [0i64, 1, -1, i32::MAX as i64, i32::MIN as i64] {
+            let instr = X86Instruction::MovImm {
+                rd: X86Register::RAX,
+                imm,
+            };
+            let bytes = a32.assemble_instructions(&[instr]).unwrap();
+            let cost = instruction_cost(&instr, &CostMetric::CodeSize, 32);
+            assert!(
+                cost >= bytes.len() as u64,
+                "x86-32 MovImm cost {cost} < assembled {} for imm {imm}",
+                bytes.len()
+            );
+        }
     }
 
     // --- CMOV encoding round-trips through Capstone ---

--- a/src/semantics/cost_x86.rs
+++ b/src/semantics/cost_x86.rs
@@ -31,16 +31,24 @@ fn instruction_latency(_instr: &X86Instruction) -> u64 {
 ///   = 3 bytes.
 /// - Register-immediate (32-bit imm): opcode + ModR/M + 4-byte imm
 ///   = 6 bytes plus REX for x86-64 = 7 bytes.
-/// - MOV reg, imm32: opcode + ModR/M + 4-byte imm = 6 bytes (x86-32)
-///   or 7 bytes (x86-64 with REX.W); for full 64-bit immediates the
-///   MOV reg, imm64 encoding takes 10 bytes — we use 7 as an upper
-///   bound for small/sign-extendable immediates and document the
-///   approximation.
+/// - MOV reg, imm is immediate-dependent (see `MovImm` arm): x86-32 uses the
+///   5-byte `B8+rd id`; x86-64 uses the 7-byte `REX.W C7 /0 id` when the
+///   immediate fits in i32, else the 10-byte `REX.W B8+rd io` movabs. These
+///   match the assembler exactly (a flat cost previously underestimated
+///   movabs, which is unsound for length-based pruning).
 fn instruction_code_size(instr: &X86Instruction, width: u32) -> u64 {
     let rex = if width == 64 { 1 } else { 0 };
     match instr {
         X86Instruction::MovReg { .. } => 2 + rex,
-        X86Instruction::MovImm { .. } => 5 + rex,
+        // See the module doc-comment: immediate-dependent to stay a valid
+        // upper bound on the assembler's MovImm encoding (issue #225).
+        X86Instruction::MovImm { imm, .. } => {
+            if width == 64 {
+                if i32::try_from(*imm).is_ok() { 7 } else { 10 }
+            } else {
+                5
+            }
+        }
         X86Instruction::AddReg { .. }
         | X86Instruction::SubReg { .. }
         | X86Instruction::AndReg { .. }
@@ -149,6 +157,32 @@ mod tests {
         assert_eq!(sequence_cost(&seq, &CostMetric::CodeSize, 64), 6);
         // 2 + 2 = 4 bytes on x86-32.
         assert_eq!(sequence_cost(&seq, &CostMetric::CodeSize, 32), 4);
+    }
+
+    #[test]
+    fn mov_imm_code_size_is_immediate_dependent() {
+        let zero = X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: 0,
+        };
+        let small = X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: i32::MAX as i64,
+        };
+        let big = X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: i64::MAX,
+        };
+        // x86-64: imm fitting i32 -> 7-byte `REX.W C7 /0 id`; full 64-bit imm
+        // -> 10-byte `REX.W B8+rd io` movabs. (The old flat `5 + rex` = 6
+        // underestimated both, breaking length-pruning soundness.)
+        assert_eq!(instruction_cost(&zero, &CostMetric::CodeSize, 64), 7);
+        assert_eq!(instruction_cost(&small, &CostMetric::CodeSize, 64), 7);
+        assert_eq!(instruction_cost(&big, &CostMetric::CodeSize, 64), 10);
+        // x86-32: `B8+rd id` is 5 bytes (no REX; the assembler rejects
+        // immediates that do not fit imm32 rather than emitting movabs).
+        assert_eq!(instruction_cost(&zero, &CostMetric::CodeSize, 32), 5);
+        assert_eq!(instruction_cost(&small, &CostMetric::CodeSize, 32), 5);
     }
 
     // --- CMOV / Jcc cost ---


### PR DESCRIPTION
Closes #225.

The audit confirmed half of #225 (the `can_assemble` immediate-range check) was already fixed; this PR closes the remaining `CodeSize` half.

`instruction_code_size` returned a flat `5 + rex` for every `MovImm`, but the assembler emits different lengths depending on the immediate (verified by measuring `assemble_instructions(...).len()`):

| case | encoding | bytes |
|---|---|---|
| x86-64, imm fits i32 | `REX.W C7 /0 id` | **7** |
| x86-64, full 64-bit imm | `REX.W B8+rd io` (movabs) | **10** |
| x86-32, imm32 | `B8+rd id` | **5** |

The old flat cost (6 on x86-64) **underestimated** both the imm32 form (7) and movabs (10). Since `CodeSize` feeds length-based pruning in enumerative/symbolic search, an underestimate is unsound (it can prune a candidate that is actually longer than believed).

**Changes**
- `cost_x86.rs`: `MovImm` arm is now immediate-dependent, matching the assembler exactly; module doc-comment updated.
- `assembler/x86.rs`: corrected the misleading "5 bytes including REX" comment (it is 7); added `movimm_code_size_is_upper_bound_on_assembled_length` — a cross-layer regression test that assembles boundary immediates and asserts `cost >= bytes.len()` for both modes (this would have caught the original bug).

**TDD**: `mov_imm_code_size_is_immediate_dependent` (red against the flat cost) pins 7/10/5; the cross-layer test pins the soundness invariant. `./ci_check.sh` + `RUSTFLAGS="-D warnings" cargo build` pass locally.