### PR TITLE
docs: split X86_SUPPORTED_MNEMONICS into rewritable + fixed-terminator constants (#341)

### DIFF
--- a/src/docs_support.rs
+++ b/src/docs_support.rs
@@ -18,14 +18,7 @@ pub const AARCH64_FIXED_TERMINATORS: &[&str] = &[
     "b", "b.<cond>", "bl", "br", "ret", "cbz", "cbnz", "tbz", "tbnz",
 ];
 
-pub const X86_SUPPORTED_MNEMONICS: &[&str] = &[
-    "mov",
-    "add",
-    "sub",
-    "and",
-    "or",
-    "xor",
-    "cmp",
-    "cmov<cond>",
-    "j<cond>",
-];
+pub const X86_REWRITABLE_MNEMONICS: &[&str] =
+    &["mov", "add", "sub", "and", "or", "xor", "cmp", "cmov<cond>"];
+
+pub const X86_FIXED_TERMINATORS: &[&str] = &["j<cond>"];

--- a/tests/integration/docs_capability.rs
+++ b/tests/integration/docs_capability.rs
@@ -2,7 +2,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use s11::docs_support::{
-    AARCH64_FIXED_TERMINATORS, AARCH64_REWRITABLE_MNEMONICS, X86_SUPPORTED_MNEMONICS,
+    AARCH64_FIXED_TERMINATORS, AARCH64_REWRITABLE_MNEMONICS, X86_FIXED_TERMINATORS,
+    X86_REWRITABLE_MNEMONICS,
 };
 
 fn repo_file(relative: &str) -> PathBuf {
@@ -302,10 +303,16 @@ fn x86_support_is_visible_in_public_docs() {
         !matrix.contains("parallel x86 pipeline"),
         "docs/capability.md must not describe x86 as a parallel pipeline"
     );
-    for mnemonic in X86_SUPPORTED_MNEMONICS {
+    for mnemonic in X86_REWRITABLE_MNEMONICS {
         assert!(
             matrix.contains(&format!("`{mnemonic}`")),
-            "docs/capability.md must list x86 mnemonic `{mnemonic}`"
+            "docs/capability.md must list x86 rewritable mnemonic `{mnemonic}`"
+        );
+    }
+    for terminator in X86_FIXED_TERMINATORS {
+        assert!(
+            matrix.contains(&format!("`{terminator}`")),
+            "docs/capability.md must list x86 fixed terminator `{terminator}`"
         );
     }
 


### PR DESCRIPTION
Closes #341.

`X86_SUPPORTED_MNEMONICS` mixed rewritable mnemonics with the fixed `j<cond>` terminator. This mirrors the AArch64 split:
- `X86_REWRITABLE_MNEMONICS` = `mov, add, sub, and, or, xor, cmp, cmov<cond>`
- `X86_FIXED_TERMINATORS` = `j<cond>` (new)

`x86_support_is_visible_in_public_docs` now iterates both constants separately, matching how `docs_capability_lists_every_checked_in_aarch64_mnemonic` chains `AARCH64_REWRITABLE_MNEMONICS` + `AARCH64_FIXED_TERMINATORS`.

`./ci_check.sh` + `RUSTFLAGS="-D warnings" cargo build` pass locally.