### PR TITLE
search: drop vestigial SearchConfig x86_width/x86_mode and width(config) threading (#372)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1075,12 +1075,12 @@ fn build_hybrid_search_config(
 
 /// Shared base `SearchConfig` for the x86 stochastic/symbolic/enumerative
 /// builders. Sets the fields they configure identically — cost metric, overall
-/// and SMT solver timeouts, verbosity, the target-derived register pool, the
-/// default immediate pool, and operand width — so each builder only layers on
-/// its algorithm-specific pieces.
+/// and SMT solver timeouts, verbosity, the target-derived register pool, and the
+/// default immediate pool — so each builder only layers on its
+/// algorithm-specific pieces. Operand width is architectural (owned by the ISA
+/// marker), not a config field.
 fn build_x86_base_search_config(
     target: &[isa::x86::X86Instruction],
-    width: u32,
     options: &OptimizationOptions,
 ) -> SearchConfig {
     SearchConfig::default()
@@ -1090,12 +1090,10 @@ fn build_x86_base_search_config(
         .with_verbose(options.verbose)
         .with_x86_registers(x86_registers_from_target(target))
         .with_immediates(isa::x86::default_x86_immediates())
-        .with_x86_width(width)
 }
 
 fn build_x86_stochastic_search_config(
     target: &[isa::x86::X86Instruction],
-    width: u32,
     options: &OptimizationOptions,
 ) -> SearchConfig {
     let stochastic_config = StochasticConfig::default()
@@ -1103,12 +1101,11 @@ fn build_x86_stochastic_search_config(
         .with_iterations(options.iterations)
         .with_seed_option(options.seed);
 
-    build_x86_base_search_config(target, width, options).with_stochastic(stochastic_config)
+    build_x86_base_search_config(target, options).with_stochastic(stochastic_config)
 }
 
 fn build_x86_symbolic_search_config(
     target: &[isa::x86::X86Instruction],
-    width: u32,
     options: &OptimizationOptions,
     // Binary-patching guard: direct IR callers can allow same-count CodeSize
     // search, but the ELF frontend disables it when Capstone exposed
@@ -1117,7 +1114,7 @@ fn build_x86_symbolic_search_config(
 ) -> SearchConfig {
     let symbolic_config = SymbolicConfig::default().with_search_mode(options.search_mode);
 
-    build_x86_base_search_config(target, width, options)
+    build_x86_base_search_config(target, options)
         .with_symbolic(symbolic_config)
         .with_x86_same_count_code_size_allowed(same_count_code_size_allowed)
 }
@@ -2040,10 +2037,9 @@ fn x86_live_out_for_optimization(
 /// solver timeout (`--solver-timeout`) wiring.
 fn build_x86_enumerative_search_config(
     target: &[isa::x86::X86Instruction],
-    width: u32,
     options: &OptimizationOptions,
 ) -> SearchConfig {
-    build_x86_stochastic_search_config(target, width, options)
+    build_x86_stochastic_search_config(target, options)
         .with_immediates(x86_enumerative_immediates_from_target(target))
         .with_cores(options.cores)
 }
@@ -2057,7 +2053,7 @@ fn run_x86_enumerative(
 ) -> Option<Vec<isa::x86::X86Instruction>> {
     use search::SearchAlgorithm;
 
-    let config = build_x86_enumerative_search_config(target, width, options);
+    let config = build_x86_enumerative_search_config(target, options);
     let live_out = x86_live_out_for_optimization(target, downstream_flags_live);
 
     let (optimized, statistics) = if width == 32 {
@@ -2099,7 +2095,7 @@ fn run_x86_stochastic(
     use search::SearchAlgorithm;
     use search::stochastic::StochasticSearch;
 
-    let config = build_x86_stochastic_search_config(target, width, options);
+    let config = build_x86_stochastic_search_config(target, options);
     if config.x86_available_registers.is_empty() {
         return None;
     }
@@ -2146,8 +2142,7 @@ fn run_x86_symbolic(
     use search::SearchAlgorithm;
     use search::symbolic::SymbolicSearch;
 
-    let config =
-        build_x86_symbolic_search_config(target, width, options, same_count_code_size_allowed);
+    let config = build_x86_symbolic_search_config(target, options, same_count_code_size_allowed);
     let live_out = x86_live_out_for_optimization(target, downstream_flags_live);
 
     let (optimized, statistics) = if width == 32 {
@@ -4020,7 +4015,7 @@ mod cli_helper_tests {
                 imm: 1,
             },
         ];
-        let config = build_x86_enumerative_search_config(&target, 64, &opts);
+        let config = build_x86_enumerative_search_config(&target, &opts);
         assert_eq!(config.x86_available_registers, vec![X86Register::RBX]);
         assert!(
             !config.x86_available_registers.contains(&X86Register::RAX),
@@ -4199,7 +4194,7 @@ mod cli_helper_tests {
                 imm: 1,
             },
         ];
-        let config = build_x86_enumerative_search_config(&target, 64, &opts);
+        let config = build_x86_enumerative_search_config(&target, &opts);
         assert_eq!(config.cores, Some(3), "--cores must be threaded through");
         assert_eq!(config.solver_timeout, Some(Duration::from_millis(37)));
         assert!(
@@ -4247,7 +4242,7 @@ mod cli_helper_tests {
                 imm: 3,
             },
         ];
-        let config = build_x86_enumerative_search_config(&target, 32, &opts);
+        let config = build_x86_enumerative_search_config(&target, &opts);
 
         assert_eq!(
             config.x86_available_registers,
@@ -4261,8 +4256,6 @@ mod cli_helper_tests {
         assert_eq!(config.cost_metric, CostMetric::Latency);
         assert_eq!(config.timeout, Some(Duration::from_millis(31)));
         assert!(config.verbose);
-        assert_eq!(config.x86_width, 32);
-        assert_eq!(config.x86_mode(), assembler::x86::X86Mode::Mode32);
 
         // The enumerative builder reuses the stochastic builder, so the
         // stochastic fields are populated from the CLI options. They are inert
@@ -4412,7 +4405,7 @@ mod cli_helper_tests {
                 rs: X86Register::RSP,
             },
         ];
-        let config = build_x86_stochastic_search_config(&target, 32, &opts);
+        let config = build_x86_stochastic_search_config(&target, &opts);
 
         assert_eq!(config.solver_timeout, Some(Duration::from_millis(19)));
         assert_eq!(config.stochastic.beta, 3.5);
@@ -4453,7 +4446,6 @@ mod cli_helper_tests {
                         rs: X86Register::RBP,
                     },
                 ],
-                64,
                 &opts,
             )
             .x86_available_registers
@@ -4464,8 +4456,6 @@ mod cli_helper_tests {
             config.available_immediates,
             isa::x86::default_x86_immediates()
         );
-        assert_eq!(config.x86_width, 32);
-        assert_eq!(config.x86_mode(), assembler::x86::X86Mode::Mode32);
     }
 
     #[test]
@@ -4499,7 +4489,7 @@ mod cli_helper_tests {
                 imm: 0,
             },
         ];
-        let config = build_x86_symbolic_search_config(&target, 64, &opts, true);
+        let config = build_x86_symbolic_search_config(&target, &opts, true);
 
         assert_eq!(config.x86_available_registers, vec![X86Register::R12]);
         assert!(
@@ -4531,7 +4521,6 @@ mod cli_helper_tests {
                         rs: X86Register::RBP,
                     },
                 ],
-                64,
                 &opts,
                 true,
             )
@@ -4548,11 +4537,9 @@ mod cli_helper_tests {
             config.available_immediates,
             isa::x86::default_x86_immediates()
         );
-        assert_eq!(config.x86_width, 64);
-        assert_eq!(config.x86_mode(), assembler::x86::X86Mode::Mode64);
         assert!(config.x86_same_count_code_size_allowed);
         assert!(
-            !build_x86_symbolic_search_config(&target, 64, &opts, false)
+            !build_x86_symbolic_search_config(&target, &opts, false)
                 .x86_same_count_code_size_allowed
         );
     }

--- a/src/search/config.rs
+++ b/src/search/config.rs
@@ -338,8 +338,6 @@ pub struct SearchConfig {
     /// x86 symbolic / LLM backends. Defaults to the same 8 GPRs the
     /// AArch64 pool ships at the same cardinality.
     pub x86_available_registers: Vec<crate::isa::x86::X86Register>,
-    /// x86 operand width: 64 for x86-64, 32 for x86-32.
-    pub x86_width: u32,
     /// Whether x86 symbolic code-size search may consider same-instruction-count
     /// candidates. Direct IR callers default to true; the ELF frontend can
     /// disable this when source operands used partial-register aliases that the
@@ -382,7 +380,6 @@ impl Default for SearchConfig {
                 0, 1, 2, 3, 4, 5, 7, 8, 10, 15, 16, 31, 32, 63, 64, 100, 255, 256, 1000, 4095,
             ],
             x86_available_registers: crate::isa::x86::default_x86_registers(),
-            x86_width: 64,
             x86_same_count_code_size_allowed: true,
             stochastic: StochasticConfig::default(),
             symbolic: SymbolicConfig::default(),
@@ -484,28 +481,6 @@ impl SearchConfig {
     pub fn with_stop_flag(mut self, flag: Arc<AtomicBool>) -> Self {
         self.stop_flag = Some(flag);
         self
-    }
-
-    /// Set the x86 operand width (32 or 64).
-    pub fn with_x86_width(mut self, width: u32) -> Self {
-        // Only 32 and 64 are valid x86 widths. Other values currently
-        // fall back to Mode64 through `x86_mode()`, which is a misuse trap.
-        debug_assert!(
-            width == 32 || width == 64,
-            "with_x86_width: only 32 or 64 are valid; got {}",
-            width
-        );
-        self.x86_width = width;
-        self
-    }
-
-    /// Return the x86 assembler mode derived from `x86_width`.
-    pub fn x86_mode(&self) -> crate::assembler::x86::X86Mode {
-        if self.x86_width == 32 {
-            crate::assembler::x86::X86Mode::Mode32
-        } else {
-            crate::assembler::x86::X86Mode::Mode64
-        }
     }
 
     pub fn with_x86_same_count_code_size_allowed(mut self, allowed: bool) -> Self {
@@ -622,22 +597,6 @@ mod tests {
 
         let unset = SearchConfig::default().with_solver_timeout_option(None);
         assert_eq!(unset.solver_timeout, None);
-    }
-
-    #[test]
-    fn search_config_derives_x86_mode_from_width() {
-        assert_eq!(
-            SearchConfig::default().x86_mode(),
-            crate::assembler::x86::X86Mode::Mode64
-        );
-        assert_eq!(
-            SearchConfig::default().with_x86_width(32).x86_mode(),
-            crate::assembler::x86::X86Mode::Mode32
-        );
-        assert_eq!(
-            SearchConfig::default().with_x86_width(64).x86_mode(),
-            crate::assembler::x86::X86Mode::Mode64
-        );
     }
 
     #[test]

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -2579,7 +2579,6 @@ mod tests {
             .with_x86_registers(vec![X86Register::RAX, X86Register::RBX])
             .with_immediates(vec![0])
             .with_cost_metric(CostMetric::CodeSize)
-            .with_x86_width(64)
             // No wall-clock deadline: the length-1 search over a tiny pool is
             // bounded and terminates on its own. A finite timeout here is
             // nondeterministic under coverage instrumentation (the slow
@@ -2623,7 +2622,6 @@ mod tests {
             .with_x86_registers(vec![X86Register::RAX, X86Register::RBX, X86Register::R8])
             .with_immediates(vec![0])
             .with_cost_metric(CostMetric::CodeSize)
-            .with_x86_width(32)
             // See the x86-64 sibling test: a bounded length-1 search needs no
             // wall-clock deadline, and a finite one flakes under coverage.
             .with_timeout_option(None);

--- a/src/search/stochastic/backend.rs
+++ b/src/search/stochastic/backend.rs
@@ -103,10 +103,9 @@ pub trait StochasticBackend<I: ISA>: Sized {
     }
 
     /// Width parameter for cost + state masking. Architecture markers own
-    /// this width so a mismatched config cannot silently change semantics.
-    /// `config` is retained only for API symmetry; implementations are
-    /// expected to return an architectural constant and must not read it.
-    fn width(config: &SearchConfig) -> u32;
+    /// this width so a mismatched config cannot silently change semantics;
+    /// implementations return an architectural constant.
+    fn width() -> u32;
 }
 
 // ---- AArch64 backend ----
@@ -225,7 +224,7 @@ impl StochasticBackend<crate::isa::AArch64> for crate::isa::AArch64 {
         crate::search::candidate::generate_random_sequence(rng, len, regs, imms)
     }
 
-    fn width(_config: &SearchConfig) -> u32 {
+    fn width() -> u32 {
         64
     }
 }
@@ -374,7 +373,7 @@ impl StochasticBackend<crate::isa::X86_64> for crate::isa::X86_64 {
             .copied()
     }
 
-    fn width(_config: &SearchConfig) -> u32 {
+    fn width() -> u32 {
         64
     }
 }
@@ -465,7 +464,7 @@ impl StochasticBackend<crate::isa::X86_32> for crate::isa::X86_32 {
             .copied()
     }
 
-    fn width(_config: &SearchConfig) -> u32 {
+    fn width() -> u32 {
         crate::isa::X86_32.register_width()
     }
 }
@@ -574,21 +573,19 @@ mod tests {
     }
 
     #[test]
-    fn x86_32_stochastic_width_is_architectural_even_with_default_config() {
-        let config = SearchConfig::default();
-        assert_eq!(config.x86_width, 64);
-
+    fn stochastic_width_is_architectural() {
+        // Width is owned by the ISA marker, not configuration: each backend
+        // returns its architectural constant from the no-arg `width()`.
         assert_eq!(
-            <crate::isa::X86_32 as StochasticBackend<crate::isa::X86_32>>::width(&config),
+            <crate::isa::X86_32 as StochasticBackend<crate::isa::X86_32>>::width(),
             32
         );
-
-        // X86_64 was already correct; this cross-check guards against a
-        // future regression and is not part of the x86-32 bug being fixed.
         assert_eq!(
-            <crate::isa::X86_64 as StochasticBackend<crate::isa::X86_64>>::width(
-                &SearchConfig::default().with_x86_width(32),
-            ),
+            <crate::isa::X86_64 as StochasticBackend<crate::isa::X86_64>>::width(),
+            64
+        );
+        assert_eq!(
+            <crate::isa::AArch64 as StochasticBackend<crate::isa::AArch64>>::width(),
             64
         );
     }

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -79,7 +79,7 @@ where
     ) -> Self::Result {
         self.reset();
         let start_time = Instant::now();
-        let width = <I as StochasticBackend<I>>::width(config);
+        let width = <I as StochasticBackend<I>>::width();
 
         let original_cost =
             <I as StochasticBackend<I>>::sequence_cost(target, &config.cost_metric, width);
@@ -642,7 +642,7 @@ mod tests {
             vec![TimeoutProbeInstruction(1); len]
         }
 
-        fn width(_config: &SearchConfig) -> u32 {
+        fn width() -> u32 {
             64
         }
     }
@@ -1033,8 +1033,7 @@ mod tests {
                     .with_seed(7),
             )
             .with_x86_registers(vec![X86Register::RAX, X86Register::RBX, X86Register::RCX])
-            .with_immediates(vec![0, 1])
-            .with_x86_width(64);
+            .with_immediates(vec![0, 1]);
 
         let live_out = X86LiveOut::from_registers(vec![X86Register::RAX]).with_flags(false);
 
@@ -1086,8 +1085,7 @@ mod tests {
             )
             // Mode32 restricts to the low-8 GPRs.
             .with_x86_registers(vec![X86Register::RAX, X86Register::RBX, X86Register::RCX])
-            .with_immediates(vec![0, 1])
-            .with_x86_width(32);
+            .with_immediates(vec![0, 1]);
 
         let live_out = X86LiveOut::from_registers(vec![X86Register::RAX]).with_flags(false);
         let target = vec![

--- a/src/search/symbolic/backend.rs
+++ b/src/search/symbolic/backend.rs
@@ -64,10 +64,9 @@ pub trait SymbolicBackend<I: ISA>: Sized {
     ) -> (EquivalenceResult, EquivalenceMetrics);
 
     /// Width parameter for cost + state masking. Architecture markers own
-    /// this width so a mismatched config cannot silently change semantics.
-    /// `config` is retained only for API symmetry; implementations are
-    /// expected to return an architectural constant and must not read it.
-    fn width(config: &SearchConfig) -> u32;
+    /// this width so a mismatched config cannot silently change semantics;
+    /// implementations return an architectural constant.
+    fn width() -> u32;
 }
 
 // ---- AArch64 backend ----
@@ -116,7 +115,7 @@ impl SymbolicBackend<crate::isa::AArch64> for crate::isa::AArch64 {
         crate::semantics::equivalence::check_equivalence_with_config_metrics(target, proposal, &cfg)
     }
 
-    fn width(_config: &SearchConfig) -> u32 {
+    fn width() -> u32 {
         64
     }
 }
@@ -185,7 +184,7 @@ impl SymbolicBackend<crate::isa::X86_64> for crate::isa::X86_64 {
         )
     }
 
-    fn width(_config: &SearchConfig) -> u32 {
+    fn width() -> u32 {
         64
     }
 }
@@ -263,7 +262,7 @@ impl SymbolicBackend<crate::isa::X86_32> for crate::isa::X86_32 {
         )
     }
 
-    fn width(_config: &SearchConfig) -> u32 {
+    fn width() -> u32 {
         crate::isa::X86_32.register_width()
     }
 }
@@ -315,21 +314,19 @@ mod tests {
     }
 
     #[test]
-    fn x86_32_symbolic_width_is_architectural_even_with_default_config() {
-        let config = SearchConfig::default();
-        assert_eq!(config.x86_width, 64);
-
+    fn symbolic_width_is_architectural() {
+        // Width is owned by the ISA marker, not configuration: each backend
+        // returns its architectural constant from the no-arg `width()`.
         assert_eq!(
-            <crate::isa::X86_32 as SymbolicBackend<crate::isa::X86_32>>::width(&config),
+            <crate::isa::X86_32 as SymbolicBackend<crate::isa::X86_32>>::width(),
             32
         );
-
-        // X86_64 was already correct; this cross-check guards against a
-        // future regression and is not part of the x86-32 bug being fixed.
         assert_eq!(
-            <crate::isa::X86_64 as SymbolicBackend<crate::isa::X86_64>>::width(
-                &SearchConfig::default().with_x86_width(32),
-            ),
+            <crate::isa::X86_64 as SymbolicBackend<crate::isa::X86_64>>::width(),
+            64
+        );
+        assert_eq!(
+            <crate::isa::AArch64 as SymbolicBackend<crate::isa::AArch64>>::width(),
             64
         );
     }

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -93,7 +93,7 @@ where
     ) -> Option<Vec<I::Instruction>> {
         let regs = <I as SymbolicBackend<I>>::registers_from_config(config);
         let imms = <I as SymbolicBackend<I>>::immediates_from_config(config);
-        let width = <I as SymbolicBackend<I>>::width(config);
+        let width = <I as SymbolicBackend<I>>::width();
         let all_instructions = <I as SymbolicBackend<I>>::enumerate_all(&regs, &imms);
 
         let original_cost =
@@ -153,7 +153,7 @@ where
         best_cost: &mut u64,
         start_time: Instant,
     ) -> Option<Vec<I::Instruction>> {
-        let width = <I as SymbolicBackend<I>>::width(config);
+        let width = <I as SymbolicBackend<I>>::width();
         let mut best_at_length: Option<Vec<I::Instruction>> = None;
         // If the target ends in a terminator (x86 Jcc, AArch64 branch),
         // candidate proposals must end in the same terminator for the
@@ -332,7 +332,7 @@ where
         config: &SearchConfig,
     ) -> bool {
         let timeout = config.solver_timeout.unwrap_or(Duration::from_secs(5));
-        let width = <I as SymbolicBackend<I>>::width(config);
+        let width = <I as SymbolicBackend<I>>::width();
 
         let (verdict, metrics) = <I as SymbolicBackend<I>>::check_equivalence(
             target, candidate, live_out, width, timeout,
@@ -389,7 +389,7 @@ where
     ) -> Self::Result {
         self.reset();
         let start_time = Instant::now();
-        let width = <I as SymbolicBackend<I>>::width(config);
+        let width = <I as SymbolicBackend<I>>::width();
 
         let original_cost =
             <I as SymbolicBackend<I>>::sequence_cost(target, &config.cost_metric, width);
@@ -676,7 +676,7 @@ mod tests {
             (EquivalenceResult::NotEquivalent, metrics)
         }
 
-        fn width(_config: &SearchConfig) -> u32 {
+        fn width() -> u32 {
             64
         }
     }
@@ -1462,7 +1462,6 @@ mod tests {
         let config = SearchConfig::default()
             .with_x86_registers(vec![X86Register::RAX, X86Register::RBX])
             .with_immediates(vec![0])
-            .with_x86_width(64)
             .with_timeout_option(Some(Duration::from_secs(30)));
 
         let live_out = X86LiveOut::from_registers(vec![X86Register::RAX]).with_flags(false);
@@ -1504,7 +1503,6 @@ mod tests {
         let config = SearchConfig::default()
             .with_x86_registers(vec![X86Register::RAX])
             .with_immediates(vec![0])
-            .with_x86_width(64)
             .with_cost_metric(CostMetric::CodeSize)
             .with_timeout_option(Some(Duration::from_secs(5)));
 
@@ -1535,7 +1533,6 @@ mod tests {
         let config = SearchConfig::default()
             .with_x86_registers(vec![X86Register::RAX])
             .with_immediates(vec![0])
-            .with_x86_width(64)
             .with_x86_same_count_code_size_allowed(false)
             .with_cost_metric(CostMetric::CodeSize)
             .with_timeout_option(Some(Duration::from_secs(5)));
@@ -1566,7 +1563,6 @@ mod tests {
         let config = SearchConfig::default()
             .with_x86_registers(vec![X86Register::RAX])
             .with_immediates(vec![0])
-            .with_x86_width(64)
             .with_cost_metric(CostMetric::InstructionCount)
             .with_timeout_option(Some(Duration::from_secs(5)));
 
@@ -1594,7 +1590,6 @@ mod tests {
         let config = SearchConfig::default()
             .with_x86_registers(vec![X86Register::RAX])
             .with_immediates(vec![0])
-            .with_x86_width(64)
             .with_cost_metric(CostMetric::CodeSize);
         let target = vec![
             X86Instruction::MovImm {
@@ -1623,7 +1618,6 @@ mod tests {
         let config = SearchConfig::default()
             .with_x86_registers(vec![X86Register::RAX])
             .with_immediates(vec![0])
-            .with_x86_width(64)
             .with_x86_same_count_code_size_allowed(false)
             .with_cost_metric(CostMetric::CodeSize)
             .with_timeout_option(Some(Duration::from_secs(5)));
@@ -1662,7 +1656,6 @@ mod tests {
         let config = SearchConfig::default()
             .with_x86_registers(vec![X86Register::RAX, X86Register::RBX])
             .with_immediates(vec![0])
-            .with_x86_width(32)
             .with_timeout_option(Some(Duration::from_secs(5)));
 
         let live_out = X86LiveOut::from_registers(vec![X86Register::RAX]).with_flags(false);
@@ -1692,7 +1685,6 @@ mod tests {
         let config = SearchConfig::default()
             .with_x86_registers(vec![X86Register::RAX])
             .with_immediates(vec![0])
-            .with_x86_width(32)
             .with_cost_metric(CostMetric::CodeSize)
             .with_timeout_option(Some(Duration::from_secs(5)));
 


### PR DESCRIPTION
Closes #372.

After x86 width became architectural (each backend hardcodes its width by ISA marker), three things were dead:
- `SearchConfig::x86_width` — write-only (set via `with_x86_width`, read only by `x86_mode()`).
- `SearchConfig::x86_mode()` — called only in tests; production `X86Mode` selection is independent (backends pick `Mode64`/`Mode32` directly).
- The `config: &SearchConfig` parameter on the backend `width()` trait method — ignored by all 6 impls (each returns an architectural constant).

**Changes** (7 files, +55/−127):
- `config.rs`: removed `x86_width` field + `Default` entry + `with_x86_width` setter + `x86_mode()` accessor + the now-moot derived-mode test.
- `stochastic/backend.rs` + `symbolic/backend.rs`: `fn width(config: &SearchConfig) -> u32` → `fn width() -> u32`; updated all impls; invariant tests rewritten to the no-arg signature (`{stochastic,symbolic}_width_is_architectural` assert X86_32→32, X86_64→64, AArch64→64).
- `mcmc.rs` / `synthesis.rs` / `enumerative/search.rs`: updated `::width()` call sites + test impls; dropped dead `.with_x86_width()` fixtures.
- `main.rs`: dropped the now-unused `width` param from the `build_x86_*_search_config` helpers (the `width` arg on `run_x86_{enumerative,stochastic,symbolic}` is kept — still live for backend selection).

`./ci_check.sh` + `RUSTFLAGS="-D warnings" cargo build` pass; 1309 lib tests green.