### PR TITLE
x86: add TEST (reg/imm) flag-setting instruction (#624)

### DIFF
--- a/docs/capability.md
+++ b/docs/capability.md
@@ -97,12 +97,14 @@ with width-parameterised SMT equivalence.
 
 Rewritable straight-line mnemonic families:
 
-- `mov`, `add`, `sub`, `and`, `or`, `xor`, `cmp`
+- `mov`, `add`, `sub`, `and`, `or`, `xor`, `cmp`, `test`
 - Conditional moves: `cmov<cond>`
 
 The data-movement/arithmetic/logical/comparison families have register and
-immediate forms where the x86 IR models them. `cmov<cond>` has register
-operands and reads EFLAGS without modifying them.
+immediate forms where the x86 IR models them. `cmp` and `test` are
+flag-setting: each discards its result and writes only EFLAGS (`cmp` from a
+subtraction, `test` from a bitwise AND that clears CF/OF). `cmov<cond>` has
+register operands and reads EFLAGS without modifying them.
 
 The x86 IR does not yet carry operand width. To avoid rewriting partial-width
 operations as full-width operations, the binary optimization path currently

--- a/src/assembler/x86.rs
+++ b/src/assembler/x86.rs
@@ -187,6 +187,18 @@ fn encode_64(ops: &mut dynasmrt::x64::Assembler, instr: &X86Instruction) -> Resu
             dynasm!(ops ; .arch x64 ; cmp Rq(rn), imm);
             Ok(())
         }
+        X86Instruction::TestReg { rn, rs } => {
+            let rn = reg_index(*rn)?;
+            let rs = reg_index(*rs)?;
+            dynasm!(ops ; .arch x64 ; test Rq(rn), Rq(rs));
+            Ok(())
+        }
+        X86Instruction::TestImm { rn, imm } => {
+            let rn = reg_index(*rn)?;
+            let imm = signed_imm_i32(*imm)?;
+            dynasm!(ops ; .arch x64 ; test Rq(rn), imm);
+            Ok(())
+        }
         X86Instruction::Cmov { rd, rs, cond } => {
             let rd = reg_index(*rd)?;
             let rs = reg_index(*rs)?;
@@ -339,6 +351,18 @@ fn encode_32(ops: &mut dynasmrt::x86::Assembler, instr: &X86Instruction) -> Resu
             let rn = reg_index_32(*rn)?;
             let imm = imm32_bitpattern_i32(*imm)?;
             dynasm!(ops ; .arch x86 ; cmp Rd(rn), imm);
+            Ok(())
+        }
+        X86Instruction::TestReg { rn, rs } => {
+            let rn = reg_index_32(*rn)?;
+            let rs = reg_index_32(*rs)?;
+            dynasm!(ops ; .arch x86 ; test Rd(rn), Rd(rs));
+            Ok(())
+        }
+        X86Instruction::TestImm { rn, imm } => {
+            let rn = reg_index_32(*rn)?;
+            let imm = imm32_bitpattern_i32(*imm)?;
+            dynasm!(ops ; .arch x86 ; test Rd(rn), imm);
             Ok(())
         }
         X86Instruction::Cmov { rd, rs, cond } => {
@@ -636,6 +660,46 @@ mod tests {
             },
             "cmp",
             &["rax", "7"],
+        );
+    }
+
+    #[test]
+    fn test_variants_x86_64() {
+        check_x86_64(
+            X86Instruction::TestReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            "test",
+            &["rax", "rbx"],
+        );
+        check_x86_64(
+            X86Instruction::TestImm {
+                rn: X86Register::RAX,
+                imm: 5,
+            },
+            "test",
+            &["rax", "5"],
+        );
+    }
+
+    #[test]
+    fn test_variants_x86_32() {
+        check_x86_32(
+            X86Instruction::TestReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            "test",
+            &["eax", "ebx"],
+        );
+        check_x86_32(
+            X86Instruction::TestImm {
+                rn: X86Register::RAX,
+                imm: 5,
+            },
+            "test",
+            &["eax", "5"],
         );
     }
 

--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -306,6 +306,13 @@ pub enum X86Instruction {
     CmpReg { rn: X86Register, rs: X86Register },
     /// `cmp rn, imm` — `rn - imm` discarding the result; sets EFLAGS.
     CmpImm { rn: X86Register, imm: i64 },
+    /// `test rn, rs` — `rn & rs` discarding the result; clears CF/OF, sets
+    /// SF/ZF/PF (AF undefined). Non-destructive sibling of `and`, just as
+    /// `cmp` is the non-destructive sibling of `sub`.
+    TestReg { rn: X86Register, rs: X86Register },
+    /// `test rn, imm` — `rn & imm` discarding the result; clears CF/OF, sets
+    /// SF/ZF/PF (AF undefined).
+    TestImm { rn: X86Register, imm: i64 },
     /// `cmovCC rd, rs` — conditional move. Reads EFLAGS;
     /// when `cond` holds, writes `rd = rs`; otherwise `rd` is unchanged.
     /// Does not modify EFLAGS.
@@ -337,8 +344,11 @@ impl X86Instruction {
             | X86Instruction::XorReg { rd, .. }
             | X86Instruction::XorImm { rd, .. }
             | X86Instruction::Cmov { rd, .. } => Some(*rd),
+            // CMP and TEST discard their result; only EFLAGS is written.
             X86Instruction::CmpReg { .. }
             | X86Instruction::CmpImm { .. }
+            | X86Instruction::TestReg { .. }
+            | X86Instruction::TestImm { .. }
             | X86Instruction::Jcc { .. } => None,
         }
     }
@@ -352,6 +362,7 @@ impl X86Instruction {
             X86Instruction::OrReg { .. } | X86Instruction::OrImm { .. } => "or",
             X86Instruction::XorReg { .. } | X86Instruction::XorImm { .. } => "xor",
             X86Instruction::CmpReg { .. } | X86Instruction::CmpImm { .. } => "cmp",
+            X86Instruction::TestReg { .. } | X86Instruction::TestImm { .. } => "test",
             X86Instruction::Cmov { cond, .. } => cond.cmov_mnemonic(),
             X86Instruction::Jcc { cond } => cond.jcc_mnemonic(),
         }
@@ -379,6 +390,10 @@ impl X86Instruction {
             | X86Instruction::XorImm { rd, .. } => vec![*rd],
             X86Instruction::CmpReg { rn, rs } => vec![*rn, *rs],
             X86Instruction::CmpImm { rn, .. } => vec![*rn],
+            // TEST reads both operands (or just rn for the immediate form) and
+            // writes no register — mirrors CMP.
+            X86Instruction::TestReg { rn, rs } => vec![*rn, *rs],
+            X86Instruction::TestImm { rn, .. } => vec![*rn],
             // Cmov reads both rd (kept on false branch) and rs.
             X86Instruction::Cmov { rd, rs, .. } => vec![*rd, *rs],
             X86Instruction::Jcc { .. } => vec![],
@@ -421,8 +436,13 @@ impl InstructionType for X86Instruction {
             X86Instruction::XorImm { .. } => 11,
             X86Instruction::CmpReg { .. } => 12,
             X86Instruction::CmpImm { .. } => 13,
-            X86Instruction::Cmov { .. } => 14,
-            X86Instruction::Jcc { .. } => 15,
+            X86Instruction::TestReg { .. } => 14,
+            X86Instruction::TestImm { .. } => 15,
+            // Cmov MUST stay the last rewritable opcode (COUNT - 1 == 16):
+            // the CMOV distinct-register draw at both generation sites is
+            // gated on `opcode == X86_REWRITABLE_OPCODE_COUNT - 1`.
+            X86Instruction::Cmov { .. } => 16,
+            X86Instruction::Jcc { .. } => 17,
         }
     }
 
@@ -461,8 +481,12 @@ impl fmt::Display for X86Instruction {
             | X86Instruction::AndImm { rd, imm }
             | X86Instruction::OrImm { rd, imm }
             | X86Instruction::XorImm { rd, imm } => write!(f, "{} {}, {}", mn, rd, imm),
-            X86Instruction::CmpReg { rn, rs } => write!(f, "{} {}, {}", mn, rn, rs),
-            X86Instruction::CmpImm { rn, imm } => write!(f, "{} {}, {}", mn, rn, imm),
+            X86Instruction::CmpReg { rn, rs } | X86Instruction::TestReg { rn, rs } => {
+                write!(f, "{} {}, {}", mn, rn, rs)
+            }
+            X86Instruction::CmpImm { rn, imm } | X86Instruction::TestImm { rn, imm } => {
+                write!(f, "{} {}, {}", mn, rn, imm)
+            }
             X86Instruction::Cmov { rd, rs, .. } => write!(f, "{} {}, {}", mn, rd, rs),
             // Target is opaque to the IR; render with a placeholder.
             X86Instruction::Jcc { .. } => write!(f, "{} <target>", mn),
@@ -734,7 +758,8 @@ impl crate::isa::traits::Assembler<X86Instruction> for X86_64 {
             | X86Instruction::AndImm { imm, .. }
             | X86Instruction::OrImm { imm, .. }
             | X86Instruction::XorImm { imm, .. }
-            | X86Instruction::CmpImm { imm, .. } => x86_signed_imm32_ok(*imm),
+            | X86Instruction::CmpImm { imm, .. }
+            | X86Instruction::TestImm { imm, .. } => x86_signed_imm32_ok(*imm),
             X86Instruction::MovReg { .. }
             | X86Instruction::MovImm { .. }
             | X86Instruction::AddReg { .. }
@@ -743,6 +768,7 @@ impl crate::isa::traits::Assembler<X86Instruction> for X86_64 {
             | X86Instruction::OrReg { .. }
             | X86Instruction::XorReg { .. }
             | X86Instruction::CmpReg { .. }
+            | X86Instruction::TestReg { .. }
             | X86Instruction::Cmov { .. }
             | X86Instruction::Jcc { .. } => true,
         }
@@ -774,8 +800,12 @@ impl crate::isa::traits::Assembler<X86Instruction> for X86_32 {
             | X86Instruction::AndImm { rd, imm }
             | X86Instruction::OrImm { rd, imm }
             | X86Instruction::XorImm { rd, imm } => reg_ok_32(*rd) && x86_imm32_bitpattern_ok(*imm),
-            X86Instruction::CmpReg { rn, rs } => reg_ok_32(*rn) && reg_ok_32(*rs),
-            X86Instruction::CmpImm { rn, imm } => reg_ok_32(*rn) && x86_imm32_bitpattern_ok(*imm),
+            X86Instruction::CmpReg { rn, rs } | X86Instruction::TestReg { rn, rs } => {
+                reg_ok_32(*rn) && reg_ok_32(*rs)
+            }
+            X86Instruction::CmpImm { rn, imm } | X86Instruction::TestImm { rn, imm } => {
+                reg_ok_32(*rn) && x86_imm32_bitpattern_ok(*imm)
+            }
             X86Instruction::Cmov { rd, rs, .. } => reg_ok_32(*rd) && reg_ok_32(*rs),
             X86Instruction::Jcc { .. } => true,
         }
@@ -950,7 +980,8 @@ impl X86Mutator {
                 | X86Instruction::AndImm { imm, .. }
                 | X86Instruction::OrImm { imm, .. }
                 | X86Instruction::XorImm { imm, .. }
-                | X86Instruction::CmpImm { imm, .. } => *imm = self.pick_non_mov_immediate(rng),
+                | X86Instruction::CmpImm { imm, .. }
+                | X86Instruction::TestImm { imm, .. } => *imm = self.pick_non_mov_immediate(rng),
                 X86Instruction::MovReg { .. }
                 | X86Instruction::AddReg { .. }
                 | X86Instruction::SubReg { .. }
@@ -958,6 +989,7 @@ impl X86Mutator {
                 | X86Instruction::OrReg { .. }
                 | X86Instruction::XorReg { .. }
                 | X86Instruction::CmpReg { .. }
+                | X86Instruction::TestReg { .. }
                 | X86Instruction::Jcc { .. } => {}
                 X86Instruction::Cmov { cond, .. } => *cond = self.pick_condition(rng),
             }
@@ -1000,14 +1032,14 @@ impl X86Mutator {
                     *imm = self.pick_non_mov_immediate(rng);
                 }
             }
-            X86Instruction::CmpReg { rn, rs } => {
+            X86Instruction::CmpReg { rn, rs } | X86Instruction::TestReg { rn, rs } => {
                 if rng.random_bool(0.5) {
                     *rn = self.pick_register(rng).expect("register pool is non-empty");
                 } else {
                     *rs = self.pick_register(rng).expect("register pool is non-empty");
                 }
             }
-            X86Instruction::CmpImm { rn, imm } => {
+            X86Instruction::CmpImm { rn, imm } | X86Instruction::TestImm { rn, imm } => {
                 if rng.random_bool(0.5) {
                     *rn = self.pick_register(rng).expect("register pool is non-empty");
                 } else {
@@ -1101,6 +1133,16 @@ impl X86Mutator {
                 Some(rs) => X86Instruction::CmpReg { rn, rs },
                 None => current,
             },
+            // TEST mirrors CMP: the opcode-bridge mutation always flips
+            // between its register and immediate forms.
+            X86Instruction::TestReg { rn, .. } => X86Instruction::TestImm {
+                rn,
+                imm: self.pick_non_mov_immediate(rng),
+            },
+            X86Instruction::TestImm { rn, .. } => match self.pick_register(rng) {
+                Some(rs) => X86Instruction::TestReg { rn, rs },
+                None => current,
+            },
             // Cmov has a unique shape (rd, rs, cond) with no opcode-shape
             // siblings; keep it unchanged in the opcode-bridge mutator.
             X86Instruction::Cmov { .. } => current,
@@ -1175,10 +1217,17 @@ impl crate::isa::traits::ISAMutator<X86Instruction> for X86Mutator {
 #[derive(Clone, Copy, Debug, Default)]
 pub struct X86InstructionGenerator;
 
-// One entry per rewritable opcode family: 7 reg-reg + 7 reg-imm + CMOVcc.
+// One entry per rewritable opcode family: 8 reg-reg + 8 reg-imm + CMOVcc.
 // CMOVcc counts as a single family here even though `generate_all` expands
 // it across all 16 `X86Condition::ALL` variants per register pair.
-const X86_REWRITABLE_OPCODE_COUNT: u8 = 15;
+//
+// CMOV MUST remain the LAST opcode (index COUNT - 1 == 16): both
+// `X86Mutator::random_instruction` and
+// `generate_random_rewritable_x86_instruction` gate the extra distinct-source
+// CMOV draw on `opcode == X86_REWRITABLE_OPCODE_COUNT - 1`. New flag-only
+// families (CMP, TEST) are inserted before CMOV in
+// `build_x86_instruction_by_opcode` to preserve that invariant.
+const X86_REWRITABLE_OPCODE_COUNT: u8 = 17;
 
 fn has_distinct_register_pair(registers: &[X86Register]) -> bool {
     let Some(first) = registers.first() else {
@@ -1193,8 +1242,9 @@ fn has_distinct_register_pair(registers: &[X86Register]) -> bool {
 /// `X86Mutator::random_instruction` and
 /// `generate_random_rewritable_x86_instruction` both delegate here so the two
 /// dispatch tables cannot drift (see issue #348). Operand drawing and RNG draw
-/// order stay at the call sites; the CMOV slot (opcode 14) consumes the `rs`
-/// the caller resolved via `pick_register_except` so `rs != rd`.
+/// order stay at the call sites; the CMOV slot (opcode 16, the last index)
+/// consumes the `rs` the caller resolved via `pick_register_except` so
+/// `rs != rd`.
 ///
 /// Keep this in lock-step with `X86_REWRITABLE_OPCODE_COUNT` and the
 /// `opcode_dispatch_is_consistent` test, which pins the full mapping.
@@ -1220,7 +1270,11 @@ pub(crate) fn build_x86_instruction_by_opcode(
         11 => X86Instruction::XorImm { rd, imm },
         12 => X86Instruction::CmpReg { rn: rd, rs },
         13 => X86Instruction::CmpImm { rn: rd, imm },
-        14 => X86Instruction::Cmov { rd, rs, cond },
+        14 => X86Instruction::TestReg { rn: rd, rs },
+        15 => X86Instruction::TestImm { rn: rd, imm },
+        // Cmov stays last (index 16 == X86_REWRITABLE_OPCODE_COUNT - 1) so the
+        // CMOV distinct-register draw at the two generation sites stays correct.
+        16 => X86Instruction::Cmov { rd, rs, cond },
         _ => unreachable!("opcode out of range"),
     }
 }
@@ -1310,7 +1364,7 @@ pub fn default_x86_immediates() -> Vec<i64> {
 impl InstructionGenerator<X86Instruction> for X86InstructionGenerator {
     fn generate_all(&self, registers: &[X86Register], immediates: &[i64]) -> Vec<X86Instruction> {
         let mut out = Vec::new();
-        // Register-register variants (7 data mnemonics).
+        // Register-register variants (8 data mnemonics).
         for &rd in registers {
             for &rs in registers {
                 out.push(X86Instruction::MovReg { rd, rs });
@@ -1320,9 +1374,10 @@ impl InstructionGenerator<X86Instruction> for X86InstructionGenerator {
                 out.push(X86Instruction::OrReg { rd, rs });
                 out.push(X86Instruction::XorReg { rd, rs });
                 out.push(X86Instruction::CmpReg { rn: rd, rs });
+                out.push(X86Instruction::TestReg { rn: rd, rs });
             }
         }
-        // Register-immediate variants (7 data mnemonics).
+        // Register-immediate variants (8 data mnemonics).
         for &rd in registers {
             for &imm in immediates {
                 out.push(X86Instruction::MovImm { rd, imm });
@@ -1332,6 +1387,7 @@ impl InstructionGenerator<X86Instruction> for X86InstructionGenerator {
                 out.push(X86Instruction::OrImm { rd, imm });
                 out.push(X86Instruction::XorImm { rd, imm });
                 out.push(X86Instruction::CmpImm { rn: rd, imm });
+                out.push(X86Instruction::TestImm { rn: rd, imm });
             }
         }
         // CMOVcc is rewritable and reads flags, so enumerate every
@@ -1418,9 +1474,11 @@ fn with_destination(instr: X86Instruction, new_rd: X86Register) -> X86Instructio
         X86Instruction::OrImm { imm, .. } => X86Instruction::OrImm { rd: new_rd, imm },
         X86Instruction::XorReg { rs, .. } => X86Instruction::XorReg { rd: new_rd, rs },
         X86Instruction::XorImm { imm, .. } => X86Instruction::XorImm { rd: new_rd, imm },
-        // CMP variants have rn instead of rd; mutate rn for symmetry.
+        // CMP / TEST variants have rn instead of rd; mutate rn for symmetry.
         X86Instruction::CmpReg { rs, .. } => X86Instruction::CmpReg { rn: new_rd, rs },
         X86Instruction::CmpImm { imm, .. } => X86Instruction::CmpImm { rn: new_rd, imm },
+        X86Instruction::TestReg { rs, .. } => X86Instruction::TestReg { rn: new_rd, rs },
+        X86Instruction::TestImm { imm, .. } => X86Instruction::TestImm { rn: new_rd, imm },
         X86Instruction::Cmov { rd, rs, cond } => X86Instruction::Cmov {
             rd: if new_rd == rs { rd } else { new_rd },
             rs,
@@ -1447,6 +1505,8 @@ fn with_sources(instr: X86Instruction, new_rs: X86Register, new_imm: i64) -> X86
         X86Instruction::XorImm { rd, .. } => X86Instruction::XorImm { rd, imm: new_imm },
         X86Instruction::CmpReg { rn, .. } => X86Instruction::CmpReg { rn, rs: new_rs },
         X86Instruction::CmpImm { rn, .. } => X86Instruction::CmpImm { rn, imm: new_imm },
+        X86Instruction::TestReg { rn, .. } => X86Instruction::TestReg { rn, rs: new_rs },
+        X86Instruction::TestImm { rn, .. } => X86Instruction::TestImm { rn, imm: new_imm },
         // Cmov's `rs` is mutated; `cond` and `rd` carry through unchanged.
         X86Instruction::Cmov { rd, rs, cond } => X86Instruction::Cmov {
             rd,
@@ -1499,7 +1559,8 @@ mod tests {
 
         let n = regs.len();
         let m = imms.len();
-        let expected_len = 7 * n * n + 7 * n * m + n * (n - 1) * X86Condition::ALL.len();
+        // 8 reg-reg families + 8 reg-imm families + CMOVcc over distinct pairs.
+        let expected_len = 8 * n * n + 8 * n * m + n * (n - 1) * X86Condition::ALL.len();
         assert_eq!(
             all.len(),
             expected_len,
@@ -1669,7 +1730,8 @@ mod tests {
                 | X86Instruction::AndImm { imm, .. }
                 | X86Instruction::OrImm { imm, .. }
                 | X86Instruction::XorImm { imm, .. }
-                | X86Instruction::CmpImm { imm, .. } => {
+                | X86Instruction::CmpImm { imm, .. }
+                | X86Instruction::TestImm { imm, .. } => {
                     assert!(imms.contains(&imm), "immediate {} outside pool", imm);
                 }
                 X86Instruction::MovReg { .. }
@@ -1679,6 +1741,7 @@ mod tests {
                 | X86Instruction::OrReg { .. }
                 | X86Instruction::XorReg { .. }
                 | X86Instruction::CmpReg { .. }
+                | X86Instruction::TestReg { .. }
                 | X86Instruction::Cmov { .. }
                 | X86Instruction::Jcc { .. } => {}
             }
@@ -1996,6 +2059,8 @@ mod tests {
             X86Instruction::XorImm { rd, imm: 0 },
             X86Instruction::CmpReg { rn: rd, rs },
             X86Instruction::CmpImm { rn: rd, imm: 0 },
+            X86Instruction::TestReg { rn: rd, rs },
+            X86Instruction::TestImm { rn: rd, imm: 0 },
             X86Instruction::Cmov {
                 rd,
                 rs,
@@ -2003,8 +2068,8 @@ mod tests {
             },
         ];
 
-        // Rewritable non-terminator variants: 14 data forms + CMOVcc.
-        assert_eq!(variants.len(), 15);
+        // Rewritable non-terminator variants: 16 data forms + CMOVcc.
+        assert_eq!(variants.len(), 17);
         let ids: Vec<u8> = variants
             .iter()
             .map(<X86Instruction as InstructionType>::opcode_id)
@@ -2063,6 +2128,8 @@ mod tests {
             (X86Instruction::XorImm { rd, imm: 1 }, "xor rax, 1"),
             (X86Instruction::CmpReg { rn: rd, rs }, "cmp rax, rbx"),
             (X86Instruction::CmpImm { rn: rd, imm: 7 }, "cmp rax, 7"),
+            (X86Instruction::TestReg { rn: rd, rs }, "test rax, rbx"),
+            (X86Instruction::TestImm { rn: rd, imm: 5 }, "test rax, 5"),
         ];
         for (instr, expected) in cases {
             assert_eq!(format!("{}", instr), *expected);
@@ -2088,6 +2155,8 @@ mod tests {
             (X86Instruction::XorImm { rd, imm: 0 }, "xor"),
             (X86Instruction::CmpReg { rn: rd, rs }, "cmp"),
             (X86Instruction::CmpImm { rn: rd, imm: 0 }, "cmp"),
+            (X86Instruction::TestReg { rn: rd, rs }, "test"),
+            (X86Instruction::TestImm { rn: rd, imm: 0 }, "test"),
         ];
         for (instr, expected) in cases {
             assert_eq!(instr.mnemonic(), *expected);
@@ -2185,6 +2254,15 @@ mod tests {
             X86Instruction::CmpImm { rn: rd, imm: 0 }.source_registers(),
             vec![rd]
         );
+        // TEST mirrors CMP: reads both registers (or just rn), writes none.
+        assert_eq!(
+            X86Instruction::TestReg { rn: rd, rs }.source_registers(),
+            vec![rd, rs]
+        );
+        assert_eq!(
+            X86Instruction::TestImm { rn: rd, imm: 0 }.source_registers(),
+            vec![rd]
+        );
     }
 
     #[test]
@@ -2205,9 +2283,11 @@ mod tests {
             (X86Instruction::OrImm { rd, imm: 0 }, Some(rd)),
             (X86Instruction::XorReg { rd, rs }, Some(rd)),
             (X86Instruction::XorImm { rd, imm: 0 }, Some(rd)),
-            // CMP variants never write a register.
+            // CMP and TEST variants never write a register.
             (X86Instruction::CmpReg { rn: rd, rs }, None),
             (X86Instruction::CmpImm { rn: rd, imm: 0 }, None),
+            (X86Instruction::TestReg { rn: rd, rs }, None),
+            (X86Instruction::TestImm { rn: rd, imm: 0 }, None),
         ];
         for (instr, want) in cases {
             assert_eq!(
@@ -2743,7 +2823,8 @@ mod tests {
                 | X86Instruction::AndImm { imm, .. }
                 | X86Instruction::OrImm { imm, .. }
                 | X86Instruction::XorImm { imm, .. }
-                | X86Instruction::CmpImm { imm, .. } => {
+                | X86Instruction::CmpImm { imm, .. }
+                | X86Instruction::TestImm { imm, .. } => {
                     saw_immediate_form = true;
                     assert_eq!(imm, 0);
                 }
@@ -2754,6 +2835,7 @@ mod tests {
                 | X86Instruction::OrReg { .. }
                 | X86Instruction::XorReg { .. }
                 | X86Instruction::CmpReg { .. }
+                | X86Instruction::TestReg { .. }
                 | X86Instruction::Cmov { .. }
                 | X86Instruction::Jcc { .. } => {}
             }
@@ -2825,7 +2907,10 @@ mod tests {
             (11, X86Instruction::XorImm { rd, imm }),
             (12, X86Instruction::CmpReg { rn: rd, rs }),
             (13, X86Instruction::CmpImm { rn: rd, imm }),
-            (14, X86Instruction::Cmov { rd, rs, cond }),
+            (14, X86Instruction::TestReg { rn: rd, rs }),
+            (15, X86Instruction::TestImm { rn: rd, imm }),
+            // Cmov stays last at COUNT - 1 == 16.
+            (16, X86Instruction::Cmov { rd, rs, cond }),
         ];
 
         for (opcode, want) in expected {
@@ -2853,7 +2938,9 @@ mod tests {
             (11, "xor"),
             (12, "cmp"),
             (13, "cmp"),
-            (14, "cmove"),
+            (14, "test"),
+            (15, "test"),
+            (16, "cmove"),
         ];
         for (opcode, mnem) in mnemonics {
             assert_eq!(
@@ -3293,7 +3380,8 @@ mod tests {
                     | X86Instruction::AndImm { .. }
                     | X86Instruction::OrImm { .. }
                     | X86Instruction::XorImm { .. }
-                    | X86Instruction::CmpImm { .. } => {
+                    | X86Instruction::CmpImm { .. }
+                    | X86Instruction::TestImm { .. } => {
                         saw_non_mov_immediate = true;
                         assert!(
                             <X86_64 as Assembler<X86Instruction>>::can_assemble(&X86_64, instr),
@@ -3307,6 +3395,7 @@ mod tests {
                     | X86Instruction::OrReg { .. }
                     | X86Instruction::XorReg { .. }
                     | X86Instruction::CmpReg { .. }
+                    | X86Instruction::TestReg { .. }
                     | X86Instruction::Cmov { .. }
                     | X86Instruction::Jcc { .. } => {}
                 }

--- a/src/parser/x86.rs
+++ b/src/parser/x86.rs
@@ -369,7 +369,7 @@ fn x86_ir_from_mnemonic_impl(
     // immediate parse error.
     if !matches!(
         mnemonic.as_str(),
-        "mov" | "movabs" | "add" | "sub" | "and" | "or" | "xor" | "cmp"
+        "mov" | "movabs" | "add" | "sub" | "and" | "or" | "xor" | "cmp" | "test"
     ) {
         return Ok(None);
     }
@@ -420,6 +420,10 @@ fn x86_ir_from_mnemonic_impl(
             |rn, rs| X86Instruction::CmpReg { rn, rs },
             |rn, imm| X86Instruction::CmpImm { rn, imm },
         ),
+        "test" => make(
+            |rn, rs| X86Instruction::TestReg { rn, rs },
+            |rn, imm| X86Instruction::TestImm { rn, imm },
+        ),
         _ => Ok(None),
     }
 }
@@ -430,8 +434,8 @@ fn x86_ir_from_mnemonic_impl(
 ///
 /// Recognised lines: empty, comments (`;`, `//`, `#`), labels
 /// (`name:`), directives (`.foo`), and instructions whose mnemonic is
-/// one of the nine supported families (mov, add, sub, and, or, xor,
-/// cmp plus the conditional cmovCC and jCC variants). Anything else is
+/// one of the supported families (mov, add, sub, and, or, xor, cmp,
+/// test plus the conditional cmovCC and jCC variants). Anything else is
 /// a parse error.
 pub fn parse_x86_assembly_string(
     content: &str,
@@ -637,6 +641,22 @@ mod tests {
                 },
             ),
             (
+                "test",
+                "rax, rbx",
+                X86Instruction::TestReg {
+                    rn: X86Register::RAX,
+                    rs: X86Register::RBX,
+                },
+            ),
+            (
+                "test",
+                "rax, 5",
+                X86Instruction::TestImm {
+                    rn: X86Register::RAX,
+                    imm: 5,
+                },
+            ),
+            (
                 "cmove",
                 "rax, rbx",
                 X86Instruction::Cmov {
@@ -741,6 +761,67 @@ mod tests {
         assert!(
             err.contains("not encodable in x86-32"),
             "unexpected error for r8d: {err}"
+        );
+    }
+
+    #[test]
+    fn test_mnemonic_parses_reg_and_imm_forms_and_round_trips_display() {
+        // `test rax, rbx` and `test rax, 5` parse to TestReg/TestImm, and the
+        // Display output round-trips back through the parser to the same IR.
+        let reg = x86_ir_from_mnemonic("test", "rax, rbx").unwrap().unwrap();
+        assert_eq!(
+            reg,
+            X86Instruction::TestReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX,
+            }
+        );
+        assert_eq!(reg.to_string(), "test rax, rbx");
+
+        let imm = x86_ir_from_mnemonic("test", "rax, 5").unwrap().unwrap();
+        assert_eq!(
+            imm,
+            X86Instruction::TestImm {
+                rn: X86Register::RAX,
+                imm: 5,
+            }
+        );
+        assert_eq!(imm.to_string(), "test rax, 5");
+
+        // Display → parse round-trip for both forms.
+        for instr in [reg, imm] {
+            let text = instr.to_string();
+            let mut parts = text.splitn(2, char::is_whitespace);
+            let mnemonic = parts.next().unwrap();
+            let ops = parts.next().unwrap();
+            assert_eq!(
+                x86_ir_from_mnemonic(mnemonic, ops).unwrap().unwrap(),
+                instr,
+                "round-trip failed for {text}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_mnemonic_round_trips_through_mode_aware_binary_path() {
+        // The Capstone/binary path (mode-aware) must also accept `test`.
+        assert_eq!(
+            x86_ir_from_mnemonic_for_mode("test", "rax, rbx", X86ParseMode::Mode64)
+                .unwrap()
+                .unwrap(),
+            X86Instruction::TestReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX,
+            }
+        );
+        assert_eq!(
+            x86_ir_from_mnemonic_for_mode("test", "eax, 5", X86ParseMode::Mode32)
+                .unwrap()
+                .unwrap(),
+            X86Instruction::TestImm {
+                rn: X86Register::RAX,
+                imm: 5,
+            }
         );
     }
 

--- a/src/semantics/concrete_x86.rs
+++ b/src/semantics/concrete_x86.rs
@@ -39,6 +39,8 @@ pub fn apply_instruction_concrete_x86(
         X86Instruction::XorImm { rd, imm } => apply_binop_imm(&mut state, *rd, *imm, Binop::Xor),
         X86Instruction::CmpReg { rn, rs } => apply_cmp_reg(&mut state, *rn, *rs),
         X86Instruction::CmpImm { rn, imm } => apply_cmp_imm(&mut state, *rn, *imm),
+        X86Instruction::TestReg { rn, rs } => apply_test_reg(&mut state, *rn, *rs),
+        X86Instruction::TestImm { rn, imm } => apply_test_imm(&mut state, *rn, *imm),
         X86Instruction::Cmov { rd, rs, cond } => {
             if state.get_flags().evaluate(*cond) {
                 let v = state.get_register(*rs);
@@ -70,6 +72,27 @@ fn apply_cmp_imm(state: &mut X86ConcreteMachineState, rn: crate::isa::x86::X86Re
     let rhs = imm as u64;
     let result = lhs.wrapping_sub(rhs);
     state.set_flags(Eflags::from_sub(lhs, rhs, result, state.width()));
+}
+
+// TEST is the non-destructive sibling of AND: it computes `rn & rhs`, sets
+// flags from the result via the logical path (CF=OF=0, SF/ZF/PF from result),
+// and writes no register — just as CMP discards a SUB result.
+fn apply_test_reg(
+    state: &mut X86ConcreteMachineState,
+    rn: crate::isa::x86::X86Register,
+    rs: crate::isa::x86::X86Register,
+) {
+    let lhs = state.get_register(rn).as_u64();
+    let rhs = state.get_register(rs).as_u64();
+    let result = lhs & rhs;
+    state.set_flags(Eflags::from_logical(result, state.width()));
+}
+
+fn apply_test_imm(state: &mut X86ConcreteMachineState, rn: crate::isa::x86::X86Register, imm: i64) {
+    let lhs = state.get_register(rn).as_u64();
+    let rhs = imm as u64;
+    let result = lhs & rhs;
+    state.set_flags(Eflags::from_logical(result, state.width()));
 }
 
 #[derive(Clone, Copy)]
@@ -194,6 +217,82 @@ mod tests {
         // Operand registers must be unchanged.
         assert_eq!(after.get_register(X86Register::RAX).as_u64(), 5);
         assert_eq!(after.get_register(X86Register::RBX).as_u64(), 5);
+    }
+
+    #[test]
+    fn testreg_zero_result_sets_zf_clears_cf_of_without_writing_register() {
+        // rax & rbx == 0 -> ZF set; TEST writes no register and always
+        // clears CF/OF (logical-flag semantics).
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(0xf0));
+        state.set_register(X86Register::RBX, ConcreteValue::new(0x0f));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::TestReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+        );
+        let flags = after.get_flags();
+        assert!(flags.zf, "0xf0 & 0x0f == 0 -> ZF set");
+        assert!(!flags.cf, "TEST always clears CF");
+        assert!(!flags.of, "TEST always clears OF");
+        assert!(!flags.sf);
+        // Operands are untouched.
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 0xf0);
+        assert_eq!(after.get_register(X86Register::RBX).as_u64(), 0x0f);
+    }
+
+    #[test]
+    fn testreg_nonzero_result_clears_zf_keeps_cf_of_clear() {
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(0xff));
+        state.set_register(X86Register::RBX, ConcreteValue::new(0x0f));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::TestReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+        );
+        let flags = after.get_flags();
+        assert!(!flags.zf, "0xff & 0x0f == 0x0f != 0 -> ZF clear");
+        assert!(!flags.cf);
+        assert!(!flags.of);
+    }
+
+    #[test]
+    fn testimm_masks_and_sets_flags_without_writing_register() {
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(0x80));
+        // 0x80 & 0x80 = 0x80 (top bit of low byte set) -> nonzero.
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::TestImm {
+                rn: X86Register::RAX,
+                imm: 0x80,
+            },
+        );
+        let flags = after.get_flags();
+        assert!(!flags.zf);
+        assert!(!flags.cf);
+        assert!(!flags.of);
+        // rn untouched.
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 0x80);
+
+        // 0x80 & 0x7f == 0 -> ZF set.
+        let mut state2 = X86ConcreteMachineState::new_zeroed(64);
+        state2.set_register(X86Register::RAX, ConcreteValue::new(0x80));
+        let after2 = apply_instruction_concrete_x86(
+            state2,
+            &X86Instruction::TestImm {
+                rn: X86Register::RAX,
+                imm: 0x7f,
+            },
+        );
+        assert!(after2.get_flags().zf);
+        assert!(!after2.get_flags().cf);
+        assert!(!after2.get_flags().of);
     }
 
     #[test]

--- a/src/semantics/cost_x86.rs
+++ b/src/semantics/cost_x86.rs
@@ -54,13 +54,15 @@ fn instruction_code_size(instr: &X86Instruction, width: u32) -> u64 {
         | X86Instruction::AndReg { .. }
         | X86Instruction::OrReg { .. }
         | X86Instruction::XorReg { .. }
-        | X86Instruction::CmpReg { .. } => 2 + rex,
+        | X86Instruction::CmpReg { .. }
+        | X86Instruction::TestReg { .. } => 2 + rex,
         X86Instruction::AddImm { .. }
         | X86Instruction::SubImm { .. }
         | X86Instruction::AndImm { .. }
         | X86Instruction::OrImm { .. }
         | X86Instruction::XorImm { .. }
-        | X86Instruction::CmpImm { .. } => 6 + rex,
+        | X86Instruction::CmpImm { .. }
+        | X86Instruction::TestImm { .. } => 6 + rex,
         // CMOV is `0F 4x ModR/M` = 3 bytes plus REX.W on 64-bit.
         X86Instruction::Cmov { .. } => 3 + rex,
         // Short-form Jcc is `7x rel8` = 2 bytes (no REX). Long-form
@@ -139,6 +141,25 @@ mod tests {
         };
         assert_eq!(instruction_cost(&rr, &CostMetric::CodeSize, 32), 2);
         assert_eq!(instruction_cost(&ri, &CostMetric::CodeSize, 32), 6);
+    }
+
+    #[test]
+    fn test_code_size_and_latency_mirror_cmp() {
+        let reg = X86Instruction::TestReg {
+            rn: X86Register::RAX,
+            rs: X86Register::RBX,
+        };
+        let imm = X86Instruction::TestImm {
+            rn: X86Register::RAX,
+            imm: 5,
+        };
+        // Same sizes as CMP: reg-reg 2(+rex), reg-imm 6(+rex); latency 1.
+        assert_eq!(instruction_cost(&reg, &CostMetric::CodeSize, 64), 3);
+        assert_eq!(instruction_cost(&reg, &CostMetric::CodeSize, 32), 2);
+        assert_eq!(instruction_cost(&imm, &CostMetric::CodeSize, 64), 7);
+        assert_eq!(instruction_cost(&imm, &CostMetric::CodeSize, 32), 6);
+        assert_eq!(instruction_cost(&reg, &CostMetric::Latency, 64), 1);
+        assert_eq!(instruction_cost(&imm, &CostMetric::Latency, 64), 1);
     }
 
     #[test]

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -981,16 +981,21 @@ where
     use crate::semantics::concrete_x86::apply_instruction_concrete_x86;
     use crate::semantics::state::X86ConcreteMachineState;
 
-    // Detect any CMP in either sequence — that's the trigger to also
-    // compare EFLAGS even if the caller didn't declare flags live.
-    let cmp_present = seq1.iter().chain(seq2.iter()).any(|i| {
+    // Detect any flags-only instruction (CMP or TEST) in either sequence —
+    // that's the trigger to also compare EFLAGS even if the caller didn't
+    // declare flags live. Both discard their result and exist solely for
+    // their EFLAGS effect, so a rewrite that drops or alters them must be
+    // caught on the flags even when no register is live-out.
+    let flags_only_present = seq1.iter().chain(seq2.iter()).any(|i| {
         matches!(
             i,
             crate::isa::x86::X86Instruction::CmpReg { .. }
                 | crate::isa::x86::X86Instruction::CmpImm { .. }
+                | crate::isa::x86::X86Instruction::TestReg { .. }
+                | crate::isa::x86::X86Instruction::TestImm { .. }
         )
     });
-    let flags_must_match = cmp_present || config.live_out.flags_live();
+    let flags_must_match = flags_only_present || config.live_out.flags_live();
 
     // Deterministic seed sequence: the first four are hand-picked
     // boundary cases (zero, one, an asymmetric bit pattern, all-ones);

--- a/src/semantics/smt_x86.rs
+++ b/src/semantics/smt_x86.rs
@@ -336,6 +336,23 @@ pub fn apply_instruction(
             let flags = compute_eflags_sub(&lhs, &rhs, state.width());
             state.set_flags(flags);
         }
+        // TEST sets EFLAGS from `rn & rhs` (the AND/logical path: CF=OF=0,
+        // SF/ZF/PF from the result) without writing a register — the
+        // non-destructive sibling of AND, mirroring how CMP is to SUB.
+        X86Instruction::TestReg { rn, rs } => {
+            let lhs = state.get_register(*rn).clone();
+            let rhs = state.get_register(*rs).clone();
+            let result = lhs.bvand(&rhs);
+            let flags = compute_eflags_logical(&result, state.width());
+            state.set_flags(flags);
+        }
+        X86Instruction::TestImm { rn, imm } => {
+            let lhs = state.get_register(*rn).clone();
+            let rhs = state.imm_bv(*imm);
+            let result = lhs.bvand(&rhs);
+            let flags = compute_eflags_logical(&result, state.width());
+            state.set_flags(flags);
+        }
         X86Instruction::Cmov { rd, rs, cond } => {
             let pred = x86_condition_to_smt(*cond, state.get_flags());
             let rs_val = state.get_register(*rs).clone();
@@ -522,6 +539,74 @@ mod tests {
             solver.check(),
             SatResult::Unsat,
             "CF after CMP must equal (rax <u rbx)"
+        );
+    }
+
+    // --- symbolic TEST ---
+
+    #[test]
+    fn test_does_not_change_register_state() {
+        // TEST discards its result, so no register may change symbolically.
+        let s0 = MachineStateX86::new_symbolic("s", 64);
+        let rax_before = s0.get_register(X86Register::RAX).clone();
+        let s1 = apply_instruction(
+            s0,
+            &X86Instruction::TestReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+        );
+        let solver = Solver::new();
+        solver.assert(s1.get_register(X86Register::RAX).eq(&rax_before).not());
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "TEST must leave RAX symbolically unchanged"
+        );
+    }
+
+    #[test]
+    fn test_rax_rax_equivalent_to_cmp_rax_zero_on_zf_sf_and_clears_cf_of() {
+        // The key correctness theorem for TEST. Both `test rax, rax` (computing
+        // `rax & rax == rax`) and `cmp rax, 0` (computing `rax - 0 == rax`)
+        // observe the value `rax`, so they must agree on the result-derived
+        // flags. We run both over states built with the SAME symbolic prefix,
+        // so both derive from one shared `rax` constant, then assert (by
+        // unsat-of-negation):
+        //   * ZF agrees  — both are 1 iff rax == 0,
+        //   * SF agrees  — both equal the top (sign) bit of rax, and
+        //   * CF and OF are constant-zero after TEST (logical semantics).
+        let after_test = apply_instruction(
+            MachineStateX86::new_symbolic("shared", 64),
+            &X86Instruction::TestReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RAX,
+            },
+        );
+        let after_cmp = apply_instruction(
+            MachineStateX86::new_symbolic("shared", 64),
+            &X86Instruction::CmpImm {
+                rn: X86Register::RAX,
+                imm: 0,
+            },
+        );
+
+        let test_flags = after_test.get_flags();
+        let cmp_flags = after_cmp.get_flags();
+        let zero1 = BV::from_u64(0, 1);
+
+        // ZF and SF must match the CMP-with-zero baseline; CF/OF are zero.
+        let solver = Solver::new();
+        solver.assert(z3::ast::Bool::or(&[
+            &test_flags.zf.eq(cmp_flags.zf).not(),
+            &test_flags.sf.eq(cmp_flags.sf).not(),
+            &test_flags.cf.eq(&zero1).not(),
+            &test_flags.of.eq(&zero1).not(),
+        ]));
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "TEST rax,rax must agree with CMP rax,0 on ZF/SF and clear CF/OF"
         );
     }
 
@@ -803,6 +888,17 @@ mod tests {
     #[test]
     fn parity_cmp_reg() {
         let instr = X86Instruction::CmpReg {
+            rn: X86Register::RAX,
+            rs: X86Register::RBX,
+        };
+        for &(a, b) in PARITY_SAMPLES {
+            assert_x86_concrete_smt_parity(&instr, a, b);
+        }
+    }
+
+    #[test]
+    fn parity_test_reg() {
+        let instr = X86Instruction::TestReg {
             rn: X86Register::RAX,
             rs: X86Register::RBX,
         };


### PR DESCRIPTION
Closes #624.

Adds the x86 `TEST` instruction (reg,reg and reg,imm) end to end. `TEST rn, rs` computes `rn & rhs`, sets SF/ZF/PF from the result, clears CF and OF, and discards the result (no destination) — the non-destructive sibling of `CMP`, mirroring how `CMP` relates to `SUB`.

**Wired through every layer**: `X86Instruction` enum + `destination`/`mnemonic`/`source_registers`/`opcode_id`/`has_side_effects`/`Display`; `build_x86_instruction_by_opcode`; parser allow-list + dispatch; concrete interpreter; SMT lowering (`bvand` + logical flags, CF=OF=0, no register write); assembler `encode_64`/`encode_32` (dynasm `test`); cost model; and `docs/capability.md`.

**CMOV invariant preserved**: TEST is inserted at opcodes 14/15 *before* CMOV, and `X86_REWRITABLE_OPCODE_COUNT` is bumped 15→17, so CMOV stays the last opcode (16 = COUNT−1) — the distinct-register draw gated on `opcode == COUNT-1` remains correct. The cross-stream parity test and `opcode_dispatch_is_consistent` pass unchanged/updated.

**Key SMT theorem**: `test_rax_rax_equivalent_to_cmp_rax_zero_on_zf_sf_and_clears_cf_of` proves `test rax, rax` agrees with `cmp rax, 0` on ZF/SF and that TEST forces CF=OF=0. Plus `test_does_not_change_register_state`, parser round-trip, concrete, and assembler Capstone round-trip tests.

`./ci_check.sh` + `RUSTFLAGS="-D warnings" cargo build` pass; all 1323 lib tests green.