### PR TITLE
tests: add end-to-end x86-64 opt integration test (known shortening) (#91)

### DIFF
--- a/build_tests.sh
+++ b/build_tests.sh
@@ -35,6 +35,19 @@ if command -v gcc >/dev/null && [ "$(gcc -dumpmachine | head -c 6)" = "x86_64" ]
         gcc -g -O0 -o "binaries/x86_64/${base_name}_debug" "$test_file"
         gcc -O2     -o "binaries/x86_64/${base_name}_opt"   "$test_file"
     done
+
+    # Hand-written register-only x86 assembly fixtures (tests/x86_asm/*.s).
+    # gcc compiles the tests/*.c sources to memory-operand-heavy code the
+    # x86 opt path does not model; these fixtures stay inside the supported
+    # register/immediate subset and encode a known deterministic shortening
+    # for the end-to-end opt integration tests. `-no-pie -nostdlib` gives a
+    # fixed-address ELF so window addresses are stable across rebuilds.
+    for asm_file in tests/x86_asm/*.s; do
+        [ -e "$asm_file" ] || continue
+        base_name=$(basename "$asm_file" .s)
+        echo "Assembling x86-64 fixture $base_name..."
+        gcc -no-pie -nostdlib -o "binaries/x86_64/${base_name}" "$asm_file"
+    done
 else
     echo "Skipping x86-64 (no x86_64 host gcc)."
 fi

--- a/tests/integration/opt_test.rs
+++ b/tests/integration/opt_test.rs
@@ -940,6 +940,130 @@ fn test_opt_x86_stochastic_is_no_longer_rejected_at_cli() {
     let _ = fs::remove_file(optimized_path);
 }
 
+/// Scan every executable section of `path` for the first occurrence of the
+/// raw byte sequence `needle`, returning its virtual address. Used by the x86
+/// end-to-end opt test to locate a known instruction window by its exact
+/// encoding so the test survives toolchain layout drift.
+fn x86_find_byte_sequence(path: &Path, needle: &[u8]) -> u64 {
+    let data = std::fs::read(path).expect("read test ELF");
+    let elf =
+        elf::ElfBytes::<elf::endian::AnyEndian>::minimal_parse(&data).expect("parse test ELF");
+    let section_headers = elf.section_headers().expect("read section headers");
+
+    for section in section_headers.iter() {
+        if section.sh_flags & elf::abi::SHF_EXECINSTR as u64 == 0 {
+            continue;
+        }
+        let start = section.sh_offset as usize;
+        let size = section.sh_size as usize;
+        if size < needle.len() {
+            continue;
+        }
+        let bytes = &data[start..start + size];
+        if let Some(off) = bytes.windows(needle.len()).position(|w| w == needle) {
+            return section.sh_addr + off as u64;
+        }
+    }
+
+    panic!("byte sequence {needle:02x?} not found in any executable section of {path:?}");
+}
+
+/// End-to-end x86-64 opt test (issue #91): run the `s11 opt` CLI on a real
+/// x86-64 ELF and assert a *known* one-instruction shortening is found and
+/// reported.
+///
+/// The `binaries/x86_64/dup_mov_imm` fixture (assembled from
+/// `tests/x86_asm/dup_mov_imm.s` by `build_tests.sh`) contains two identical
+/// `mov rax, 5` instructions. Only RAX is live-out and neither MOV touches
+/// EFLAGS, so the enumerative (deterministic) search collapses the redundant
+/// pair to a single `mov rax, 5`. The window is located by its exact encoding
+/// (`48 c7 c0 05 00 00 00` twice) so the assertion is stable across rebuilds.
+///
+/// Mirrors `test_opt_basic_functionality` (AArch64) but pins the *result*: the
+/// opt path must report "Optimized to 1 instructions" and complete, not merely
+/// run. If the fixture is absent (e.g. no host x86-64 gcc), the test skips
+/// rather than failing, matching the other x86 opt tests here.
+#[test]
+fn test_opt_x86_64_known_shortening() {
+    let binary = get_binary_path();
+    let source_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("binaries")
+        .join("x86_64")
+        .join("dup_mov_imm");
+    if !source_elf.exists() {
+        eprintln!(
+            "Skipping x86-64 known-shortening opt test: {:?} not present (run build_tests.sh)",
+            source_elf
+        );
+        return;
+    }
+
+    // `mov rax, 5` == 48 c7 c0 05 00 00 00; find the first of the redundant
+    // pair and take a 14-byte (two-instruction) window over both.
+    let mov_rax_5: [u8; 7] = [0x48, 0xc7, 0xc0, 0x05, 0x00, 0x00, 0x00];
+    let pair: Vec<u8> = mov_rax_5.iter().chain(mov_rax_5.iter()).copied().collect();
+    let start_addr = x86_find_byte_sequence(&source_elf, &pair);
+    let end_addr = start_addr + pair.len() as u64;
+
+    // Copy to a unique tempdir so concurrent `cargo test` runs don't collide
+    // on the `<input>_optimized` artifact the binary always writes.
+    let tmp_dir = tempfile::tempdir().expect("create temp fixture dir");
+    let test_elf = tmp_dir.path().join("dup_mov_imm");
+    fs::copy(&source_elf, &test_elf).expect("copy x86-64 fixture to tmp");
+    let optimized_path = tmp_dir.path().join("dup_mov_imm_optimized");
+
+    let output = Command::new(&binary)
+        .arg("opt")
+        .arg(&test_elf)
+        .arg("--arch")
+        .arg("x86-64")
+        .arg("--algorithm")
+        .arg("enumerative")
+        .arg("--timeout")
+        .arg("30")
+        .arg("--start-addr")
+        .arg(format!("0x{start_addr:x}"))
+        .arg("--end-addr")
+        .arg(format!("0x{end_addr:x}"))
+        .output()
+        .expect("Failed to execute s11");
+
+    assert!(
+        output.status.success(),
+        "x86-64 opt should succeed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Detected: X86_64"),
+        "should run the x86-64 opt path; stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("Disassembled 2 instructions"),
+        "should disassemble the two-instruction window; stdout: {stdout}"
+    );
+    // The known shortening: 2 instructions collapse to 1.
+    assert!(
+        stdout.contains("Optimized to 1 instructions"),
+        "x86-64 opt must find the one-instruction shortening; stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("Created optimized binary"),
+        "should write the optimized binary; stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("Optimization completed successfully"),
+        "should complete the optimization; stdout: {stdout}"
+    );
+    assert!(
+        optimized_path.exists(),
+        "optimized binary should be created at {:?}",
+        optimized_path,
+    );
+}
+
 #[test]
 fn test_opt_x86_symbolic_is_no_longer_rejected_at_cli() {
     // Companion to the stochastic regression test: symbolic must

--- a/tests/x86_asm/README.md
+++ b/tests/x86_asm/README.md
@@ -1,0 +1,15 @@
+# x86 assembly fixtures
+
+Hand-written x86 assembly fixtures for end-to-end `s11 opt` integration
+tests. Unlike the `tests/*.c` sources (which gcc compiles to memory-operand
+heavy code the x86 opt path does not model), these fixtures are restricted to
+the register-only / register-immediate instruction subset the x86 optimizer
+supports, and they encode a *known* deterministic shortening.
+
+`build_tests.sh` assembles each `.s` here into `binaries/x86_64/<name>` with
+host gcc (`-no-pie -nostdlib`), giving a fixed-address ELF whose window
+addresses are stable across rebuilds.
+
+- `dup_mov_imm.s` — two identical `mov rax, 5` instructions. The enumerative
+  search collapses the redundant pair to a single `mov rax, 5` (a one
+  instruction shortening), exercised by `test_opt_x86_64_known_shortening`.

--- a/tests/x86_asm/dup_mov_imm.s
+++ b/tests/x86_asm/dup_mov_imm.s
@@ -1,0 +1,18 @@
+// Known one-instruction shortening fixture for the x86-64 opt path.
+//
+// Two identical `mov rax, 5` instructions are semantically equivalent to a
+// single `mov rax, 5` (only RAX is live-out; neither MOV touches EFLAGS), so
+// the enumerative search deterministically rewrites the 2-instruction window
+// to 1 instruction. The trailing NOPs pad the function so the window never
+// abuts the section end. Register/immediate only — the x86 IR models no
+// memory operands.
+.intel_syntax noprefix
+.text
+.globl _start
+_start:
+    mov rax, 5
+    mov rax, 5
+    nop
+    nop
+    nop
+    nop


### PR DESCRIPTION
Closes #91.

Adds an end-to-end test that runs the `s11 opt` CLI on an x86-64 ELF and asserts a *known* one-instruction shortening is found and reported.

**Fixture**: new hand-written register-only assembly fixture `tests/x86_asm/dup_mov_imm.s`, assembled by `build_tests.sh` (`gcc -no-pie -nostdlib`, fixed-address ELF) into `binaries/x86_64/dup_mov_imm`. The existing gcc-compiled `tests/*.c` fixtures are unusable because the x86 opt path models no memory operands (their `mov [rbp-…]` code is rejected); and a single-instruction zero-idiom can't be exercised (enumerative search only searches lengths `1..target.len()`, so `target.len() >= 2` is required). The fixture is two identical `mov rax, 5` (`48 c7 c0 05 00 00 00` ×2); only RAX is live-out and MOV touches no flags, so the deterministic enumerative search collapses the pair to one `mov rax, 5`.

**Test** `test_opt_x86_64_known_shortening` locates the window by scanning the executable section for the exact 14-byte encoding (robust to layout drift), runs `--algorithm enumerative` (deterministic), and asserts `Detected: X86_64`, `Disassembled 2 instructions`, `Optimized to 1 instructions`, `Created optimized binary`, `Optimization completed successfully`, plus that the `_optimized` artifact is written. Skips gracefully if the fixture is absent (matching the sibling x86 opt tests); CI's `test.yml`/`coverage.yml` run `build_tests.sh` first, and the runners have host x86-64 gcc.

Verified deterministic (test 3×, raw CLI 5×: 40 candidates, 1 SMT query, 1 improvement). `./ci_check.sh` + `RUSTFLAGS="-D warnings" cargo build` pass.