### PR TITLE
x86: add INC and DEC single-operand instructions (CF-preserving) (#626)

### DIFF
--- a/docs/capability.md
+++ b/docs/capability.md
@@ -98,7 +98,7 @@ with width-parameterised SMT equivalence.
 Rewritable straight-line mnemonic families:
 
 - `mov`, `add`, `sub`, `and`, `or`, `xor`, `cmp`, `test`
-- Single-operand: `neg`, `not`
+- Single-operand: `neg`, `not`, `inc`, `dec`
 - Conditional moves: `cmov<cond>`
 
 The data-movement/arithmetic/logical/comparison families have register and
@@ -107,7 +107,10 @@ flag-setting: each discards its result and writes only EFLAGS (`cmp` from a
 subtraction, `test` from a bitwise AND that clears CF/OF). `neg` and `not`
 are single-operand: `neg` computes `rd = -rd` and sets EFLAGS as if from
 `0 - rd` (CF = rd != 0), whereas `not` computes `rd = !rd` and leaves EFLAGS
-unchanged (like `mov`). `cmov<cond>` has register operands and reads EFLAGS
+unchanged (like `mov`). `inc` (`rd = rd + 1`) and `dec` (`rd = rd - 1`) are
+also single-operand and set OF/SF/ZF/PF as the corresponding `add`/`sub` by 1
+would, but — unlike `add`/`sub` — they preserve CF (the incoming carry flows
+through unchanged). `cmov<cond>` has register operands and reads EFLAGS
 without modifying them.
 
 The x86 IR does not yet carry operand width. To avoid rewriting partial-width

--- a/src/assembler/x86.rs
+++ b/src/assembler/x86.rs
@@ -209,6 +209,16 @@ fn encode_64(ops: &mut dynasmrt::x64::Assembler, instr: &X86Instruction) -> Resu
             dynasm!(ops ; .arch x64 ; not Rq(rd));
             Ok(())
         }
+        X86Instruction::Inc { rd } => {
+            let rd = reg_index(*rd)?;
+            dynasm!(ops ; .arch x64 ; inc Rq(rd));
+            Ok(())
+        }
+        X86Instruction::Dec { rd } => {
+            let rd = reg_index(*rd)?;
+            dynasm!(ops ; .arch x64 ; dec Rq(rd));
+            Ok(())
+        }
         X86Instruction::Cmov { rd, rs, cond } => {
             let rd = reg_index(*rd)?;
             let rs = reg_index(*rs)?;
@@ -383,6 +393,16 @@ fn encode_32(ops: &mut dynasmrt::x86::Assembler, instr: &X86Instruction) -> Resu
         X86Instruction::Not { rd } => {
             let rd = reg_index_32(*rd)?;
             dynasm!(ops ; .arch x86 ; not Rd(rd));
+            Ok(())
+        }
+        X86Instruction::Inc { rd } => {
+            let rd = reg_index_32(*rd)?;
+            dynasm!(ops ; .arch x86 ; inc Rd(rd));
+            Ok(())
+        }
+        X86Instruction::Dec { rd } => {
+            let rd = reg_index_32(*rd)?;
+            dynasm!(ops ; .arch x86 ; dec Rd(rd));
             Ok(())
         }
         X86Instruction::Cmov { rd, rs, cond } => {
@@ -755,6 +775,42 @@ mod tests {
                 rd: X86Register::RBX,
             },
             "not",
+            &["ebx"],
+        );
+    }
+
+    #[test]
+    fn inc_dec_variants_x86_64() {
+        check_x86_64(
+            X86Instruction::Inc {
+                rd: X86Register::RAX,
+            },
+            "inc",
+            &["rax"],
+        );
+        check_x86_64(
+            X86Instruction::Dec {
+                rd: X86Register::RBX,
+            },
+            "dec",
+            &["rbx"],
+        );
+    }
+
+    #[test]
+    fn inc_dec_variants_x86_32() {
+        check_x86_32(
+            X86Instruction::Inc {
+                rd: X86Register::RAX,
+            },
+            "inc",
+            &["eax"],
+        );
+        check_x86_32(
+            X86Instruction::Dec {
+                rd: X86Register::RBX,
+            },
+            "dec",
             &["ebx"],
         );
     }

--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -320,6 +320,14 @@ pub enum X86Instruction {
     /// `not rd` — `rd = !rd` (bitwise complement). Single-operand; reads and
     /// writes `rd`. Affects NO flags — EFLAGS is left unchanged, like `mov`.
     Not { rd: X86Register },
+    /// `inc rd` — `rd = rd + 1`. Single-operand; reads and writes `rd`. Sets
+    /// OF/SF/ZF/PF as for `rd + 1` but, unlike `add`, leaves CF UNCHANGED
+    /// (carry-in flows through to carry-out): the prior CF is preserved.
+    Inc { rd: X86Register },
+    /// `dec rd` — `rd = rd - 1`. Single-operand; reads and writes `rd`. Sets
+    /// OF/SF/ZF/PF as for `rd - 1` but, unlike `sub`, leaves CF UNCHANGED:
+    /// the prior CF is preserved.
+    Dec { rd: X86Register },
     /// `cmovCC rd, rs` — conditional move. Reads EFLAGS;
     /// when `cond` holds, writes `rd = rs`; otherwise `rd` is unchanged.
     /// Does not modify EFLAGS.
@@ -352,6 +360,8 @@ impl X86Instruction {
             | X86Instruction::XorImm { rd, .. }
             | X86Instruction::Neg { rd }
             | X86Instruction::Not { rd }
+            | X86Instruction::Inc { rd }
+            | X86Instruction::Dec { rd }
             | X86Instruction::Cmov { rd, .. } => Some(*rd),
             // CMP and TEST discard their result; only EFLAGS is written.
             X86Instruction::CmpReg { .. }
@@ -374,6 +384,8 @@ impl X86Instruction {
             X86Instruction::TestReg { .. } | X86Instruction::TestImm { .. } => "test",
             X86Instruction::Neg { .. } => "neg",
             X86Instruction::Not { .. } => "not",
+            X86Instruction::Inc { .. } => "inc",
+            X86Instruction::Dec { .. } => "dec",
             X86Instruction::Cmov { cond, .. } => cond.cmov_mnemonic(),
             X86Instruction::Jcc { cond } => cond.jcc_mnemonic(),
         }
@@ -405,8 +417,12 @@ impl X86Instruction {
             // writes no register — mirrors CMP.
             X86Instruction::TestReg { rn, rs } => vec![*rn, *rs],
             X86Instruction::TestImm { rn, .. } => vec![*rn],
-            // NEG / NOT are single-operand: each reads its own destination.
-            X86Instruction::Neg { rd } | X86Instruction::Not { rd } => vec![*rd],
+            // NEG / NOT / INC / DEC are single-operand: each reads its own
+            // destination.
+            X86Instruction::Neg { rd }
+            | X86Instruction::Not { rd }
+            | X86Instruction::Inc { rd }
+            | X86Instruction::Dec { rd } => vec![*rd],
             // Cmov reads both rd (kept on false branch) and rs.
             X86Instruction::Cmov { rd, rs, .. } => vec![*rd, *rs],
             X86Instruction::Jcc { .. } => vec![],
@@ -453,11 +469,13 @@ impl InstructionType for X86Instruction {
             X86Instruction::TestImm { .. } => 15,
             X86Instruction::Neg { .. } => 16,
             X86Instruction::Not { .. } => 17,
-            // Cmov MUST stay the last rewritable opcode (COUNT - 1 == 18):
+            X86Instruction::Inc { .. } => 18,
+            X86Instruction::Dec { .. } => 19,
+            // Cmov MUST stay the last rewritable opcode (COUNT - 1 == 20):
             // the CMOV distinct-register draw at both generation sites is
             // gated on `opcode == X86_REWRITABLE_OPCODE_COUNT - 1`.
-            X86Instruction::Cmov { .. } => 18,
-            X86Instruction::Jcc { .. } => 19,
+            X86Instruction::Cmov { .. } => 20,
+            X86Instruction::Jcc { .. } => 21,
         }
     }
 
@@ -505,7 +523,10 @@ impl fmt::Display for X86Instruction {
                 write!(f, "{} {}, {}", mn, rn, imm)
             }
             // Single-operand: render just the destination register.
-            X86Instruction::Neg { rd } | X86Instruction::Not { rd } => write!(f, "{} {}", mn, rd),
+            X86Instruction::Neg { rd }
+            | X86Instruction::Not { rd }
+            | X86Instruction::Inc { rd }
+            | X86Instruction::Dec { rd } => write!(f, "{} {}", mn, rd),
             X86Instruction::Cmov { rd, rs, .. } => write!(f, "{} {}, {}", mn, rd, rs),
             // Target is opaque to the IR; render with a placeholder.
             X86Instruction::Jcc { .. } => write!(f, "{} <target>", mn),
@@ -791,6 +812,8 @@ impl crate::isa::traits::Assembler<X86Instruction> for X86_64 {
             | X86Instruction::TestReg { .. }
             | X86Instruction::Neg { .. }
             | X86Instruction::Not { .. }
+            | X86Instruction::Inc { .. }
+            | X86Instruction::Dec { .. }
             | X86Instruction::Cmov { .. }
             | X86Instruction::Jcc { .. } => true,
         }
@@ -828,7 +851,10 @@ impl crate::isa::traits::Assembler<X86Instruction> for X86_32 {
             X86Instruction::CmpImm { rn, imm } | X86Instruction::TestImm { rn, imm } => {
                 reg_ok_32(*rn) && x86_imm32_bitpattern_ok(*imm)
             }
-            X86Instruction::Neg { rd } | X86Instruction::Not { rd } => reg_ok_32(*rd),
+            X86Instruction::Neg { rd }
+            | X86Instruction::Not { rd }
+            | X86Instruction::Inc { rd }
+            | X86Instruction::Dec { rd } => reg_ok_32(*rd),
             X86Instruction::Cmov { rd, rs, .. } => reg_ok_32(*rd) && reg_ok_32(*rs),
             X86Instruction::Jcc { .. } => true,
         }
@@ -1015,6 +1041,8 @@ impl X86Mutator {
                 | X86Instruction::TestReg { .. }
                 | X86Instruction::Neg { .. }
                 | X86Instruction::Not { .. }
+                | X86Instruction::Inc { .. }
+                | X86Instruction::Dec { .. }
                 | X86Instruction::Jcc { .. } => {}
                 X86Instruction::Cmov { cond, .. } => *cond = self.pick_condition(rng),
             }
@@ -1071,8 +1099,11 @@ impl X86Mutator {
                     *imm = self.pick_non_mov_immediate(rng);
                 }
             }
-            // NEG / NOT have a single register operand; mutate it.
-            X86Instruction::Neg { rd } | X86Instruction::Not { rd } => {
+            // NEG / NOT / INC / DEC have a single register operand; mutate it.
+            X86Instruction::Neg { rd }
+            | X86Instruction::Not { rd }
+            | X86Instruction::Inc { rd }
+            | X86Instruction::Dec { rd } => {
                 *rd = self.pick_register(rng).expect("register pool is non-empty");
             }
             X86Instruction::Cmov { rd, rs, cond } => {
@@ -1172,11 +1203,20 @@ impl X86Mutator {
                 Some(rs) => X86Instruction::TestReg { rn, rs },
                 None => current,
             },
-            // NEG and NOT share the single-operand (rd-only) shape, so the
-            // opcode-bridge mutation flips between them — always a real
-            // change, like CMP ↔ TEST.
-            X86Instruction::Neg { rd } => X86Instruction::Not { rd },
-            X86Instruction::Not { rd } => X86Instruction::Neg { rd },
+            // NEG / NOT / INC / DEC share the single-operand (rd-only) shape,
+            // so the opcode-bridge mutation swaps among the four. Like the
+            // reg-reg / reg-imm groups (and unlike the guaranteed-change
+            // CMP↔TEST pair), the draw range includes the current variant, so
+            // it may produce an identity mutation.
+            X86Instruction::Neg { rd }
+            | X86Instruction::Not { rd }
+            | X86Instruction::Inc { rd }
+            | X86Instruction::Dec { rd } => match rng.random_range(0..4u32) {
+                0 => X86Instruction::Neg { rd },
+                1 => X86Instruction::Not { rd },
+                2 => X86Instruction::Inc { rd },
+                _ => X86Instruction::Dec { rd },
+            },
             // Cmov has a unique shape (rd, rs, cond) with no opcode-shape
             // siblings; keep it unchanged in the opcode-bridge mutator.
             X86Instruction::Cmov { .. } => current,
@@ -1251,17 +1291,19 @@ impl crate::isa::traits::ISAMutator<X86Instruction> for X86Mutator {
 #[derive(Clone, Copy, Debug, Default)]
 pub struct X86InstructionGenerator;
 
-// One entry per rewritable opcode family: 8 reg-reg + 8 reg-imm + NEG + NOT
-// + CMOVcc. CMOVcc counts as a single family here even though `generate_all`
-// expands it across all 16 `X86Condition::ALL` variants per register pair.
+// One entry per rewritable opcode family: 6 reg-reg + 6 reg-imm + CMP + TEST
+// (each reg/imm) + NEG + NOT + INC + DEC + CMOVcc. CMOVcc counts as a single
+// family here even though `generate_all` expands it across all 16
+// `X86Condition::ALL` variants per register pair.
 //
-// CMOV MUST remain the LAST opcode (index COUNT - 1 == 18): both
+// CMOV MUST remain the LAST opcode (index COUNT - 1 == 20): both
 // `X86Mutator::random_instruction` and
 // `generate_random_rewritable_x86_instruction` gate the extra distinct-source
 // CMOV draw on `opcode == X86_REWRITABLE_OPCODE_COUNT - 1`. New flag-only
-// families (CMP, TEST) and single-operand families (NEG, NOT) are inserted
-// before CMOV in `build_x86_instruction_by_opcode` to preserve that invariant.
-const X86_REWRITABLE_OPCODE_COUNT: u8 = 19;
+// families (CMP, TEST) and single-operand families (NEG, NOT, INC, DEC) are
+// inserted before CMOV in `build_x86_instruction_by_opcode` to preserve that
+// invariant.
+const X86_REWRITABLE_OPCODE_COUNT: u8 = 21;
 
 fn has_distinct_register_pair(registers: &[X86Register]) -> bool {
     let Some(first) = registers.first() else {
@@ -1276,7 +1318,7 @@ fn has_distinct_register_pair(registers: &[X86Register]) -> bool {
 /// `X86Mutator::random_instruction` and
 /// `generate_random_rewritable_x86_instruction` both delegate here so the two
 /// dispatch tables cannot drift (see issue #348). Operand drawing and RNG draw
-/// order stay at the call sites; the CMOV slot (opcode 18, the last index)
+/// order stay at the call sites; the CMOV slot (opcode 20, the last index)
 /// consumes the `rs` the caller resolved via `pick_register_except` so
 /// `rs != rd`.
 ///
@@ -1306,13 +1348,15 @@ pub(crate) fn build_x86_instruction_by_opcode(
         13 => X86Instruction::CmpImm { rn: rd, imm },
         14 => X86Instruction::TestReg { rn: rd, rs },
         15 => X86Instruction::TestImm { rn: rd, imm },
-        // NEG / NOT are single-operand: they consume only `rd` (rs/imm/cond
-        // are ignored).
+        // NEG / NOT / INC / DEC are single-operand: they consume only `rd`
+        // (rs/imm/cond are ignored).
         16 => X86Instruction::Neg { rd },
         17 => X86Instruction::Not { rd },
-        // Cmov stays last (index 18 == X86_REWRITABLE_OPCODE_COUNT - 1) so the
+        18 => X86Instruction::Inc { rd },
+        19 => X86Instruction::Dec { rd },
+        // Cmov stays last (index 20 == X86_REWRITABLE_OPCODE_COUNT - 1) so the
         // CMOV distinct-register draw at the two generation sites stays correct.
-        18 => X86Instruction::Cmov { rd, rs, cond },
+        20 => X86Instruction::Cmov { rd, rs, cond },
         _ => unreachable!("opcode out of range"),
     }
 }
@@ -1428,10 +1472,12 @@ impl InstructionGenerator<X86Instruction> for X86InstructionGenerator {
                 out.push(X86Instruction::TestImm { rn: rd, imm });
             }
         }
-        // Single-operand variants (NEG, NOT): one per register.
+        // Single-operand variants (NEG, NOT, INC, DEC): one per register.
         for &rd in registers {
             out.push(X86Instruction::Neg { rd });
             out.push(X86Instruction::Not { rd });
+            out.push(X86Instruction::Inc { rd });
+            out.push(X86Instruction::Dec { rd });
         }
         // CMOVcc is rewritable and reads flags, so enumerate every
         // condition for each non-identical register pair. Jcc remains
@@ -1522,9 +1568,11 @@ fn with_destination(instr: X86Instruction, new_rd: X86Register) -> X86Instructio
         X86Instruction::CmpImm { imm, .. } => X86Instruction::CmpImm { rn: new_rd, imm },
         X86Instruction::TestReg { rs, .. } => X86Instruction::TestReg { rn: new_rd, rs },
         X86Instruction::TestImm { imm, .. } => X86Instruction::TestImm { rn: new_rd, imm },
-        // NEG / NOT have only a destination register; redirect it.
+        // NEG / NOT / INC / DEC have only a destination register; redirect it.
         X86Instruction::Neg { .. } => X86Instruction::Neg { rd: new_rd },
         X86Instruction::Not { .. } => X86Instruction::Not { rd: new_rd },
+        X86Instruction::Inc { .. } => X86Instruction::Inc { rd: new_rd },
+        X86Instruction::Dec { .. } => X86Instruction::Dec { rd: new_rd },
         X86Instruction::Cmov { rd, rs, cond } => X86Instruction::Cmov {
             rd: if new_rd == rs { rd } else { new_rd },
             rs,
@@ -1553,9 +1601,12 @@ fn with_sources(instr: X86Instruction, new_rs: X86Register, new_imm: i64) -> X86
         X86Instruction::CmpImm { rn, .. } => X86Instruction::CmpImm { rn, imm: new_imm },
         X86Instruction::TestReg { rn, .. } => X86Instruction::TestReg { rn, rs: new_rs },
         X86Instruction::TestImm { rn, .. } => X86Instruction::TestImm { rn, imm: new_imm },
-        // NEG / NOT have no source operand to vary; carry through unchanged.
+        // NEG / NOT / INC / DEC have no source operand to vary; carry through
+        // unchanged.
         X86Instruction::Neg { rd } => X86Instruction::Neg { rd },
         X86Instruction::Not { rd } => X86Instruction::Not { rd },
+        X86Instruction::Inc { rd } => X86Instruction::Inc { rd },
+        X86Instruction::Dec { rd } => X86Instruction::Dec { rd },
         // Cmov's `rs` is mutated; `cond` and `rd` carry through unchanged.
         X86Instruction::Cmov { rd, rs, cond } => X86Instruction::Cmov {
             rd,
@@ -1608,9 +1659,9 @@ mod tests {
 
         let n = regs.len();
         let m = imms.len();
-        // 8 reg-reg families + 8 reg-imm families + 2 single-operand families
-        // (NEG, NOT) + CMOVcc over distinct pairs.
-        let expected_len = 8 * n * n + 8 * n * m + 2 * n + n * (n - 1) * X86Condition::ALL.len();
+        // 8 reg-reg families + 8 reg-imm families + 4 single-operand families
+        // (NEG, NOT, INC, DEC) + CMOVcc over distinct pairs.
+        let expected_len = 8 * n * n + 8 * n * m + 4 * n + n * (n - 1) * X86Condition::ALL.len();
         assert_eq!(
             all.len(),
             expected_len,
@@ -1794,6 +1845,8 @@ mod tests {
                 | X86Instruction::TestReg { .. }
                 | X86Instruction::Neg { .. }
                 | X86Instruction::Not { .. }
+                | X86Instruction::Inc { .. }
+                | X86Instruction::Dec { .. }
                 | X86Instruction::Cmov { .. }
                 | X86Instruction::Jcc { .. } => {}
             }
@@ -2903,6 +2956,8 @@ mod tests {
                 | X86Instruction::TestReg { .. }
                 | X86Instruction::Neg { .. }
                 | X86Instruction::Not { .. }
+                | X86Instruction::Inc { .. }
+                | X86Instruction::Dec { .. }
                 | X86Instruction::Cmov { .. }
                 | X86Instruction::Jcc { .. } => {}
             }
@@ -2978,8 +3033,10 @@ mod tests {
             (15, X86Instruction::TestImm { rn: rd, imm }),
             (16, X86Instruction::Neg { rd }),
             (17, X86Instruction::Not { rd }),
-            // Cmov stays last at COUNT - 1 == 18.
-            (18, X86Instruction::Cmov { rd, rs, cond }),
+            (18, X86Instruction::Inc { rd }),
+            (19, X86Instruction::Dec { rd }),
+            // Cmov stays last at COUNT - 1 == 20.
+            (20, X86Instruction::Cmov { rd, rs, cond }),
         ];
 
         for (opcode, want) in expected {
@@ -3011,7 +3068,9 @@ mod tests {
             (15, "test"),
             (16, "neg"),
             (17, "not"),
-            (18, "cmove"),
+            (18, "inc"),
+            (19, "dec"),
+            (20, "cmove"),
         ];
         for (opcode, mnem) in mnemonics {
             assert_eq!(
@@ -3469,6 +3528,8 @@ mod tests {
                     | X86Instruction::TestReg { .. }
                     | X86Instruction::Neg { .. }
                     | X86Instruction::Not { .. }
+                    | X86Instruction::Inc { .. }
+                    | X86Instruction::Dec { .. }
                     | X86Instruction::Cmov { .. }
                     | X86Instruction::Jcc { .. } => {}
                 }

--- a/src/parser/x86.rs
+++ b/src/parser/x86.rs
@@ -363,12 +363,12 @@ fn x86_ir_from_mnemonic_impl(
         return Ok(Some(X86Instruction::Jcc { cond }));
     }
 
-    // NEG / NOT are the only SINGLE-operand families. They expect exactly
-    // one register operand: a comma in the operand string (e.g. the
+    // NEG / NOT / INC / DEC are the SINGLE-operand families. They expect
+    // exactly one register operand: a comma in the operand string (e.g. the
     // two-operand `neg rax, rbx`) is rejected as an unsupported shape via
     // `Ok(None)`, the same way an unknown mnemonic is. Handled here, ahead
     // of the two-operand families below which hard-require `parts.len() == 2`.
-    if matches!(mnemonic.as_str(), "neg" | "not") {
+    if matches!(mnemonic.as_str(), "neg" | "not" | "inc" | "dec") {
         let parts: Vec<&str> = op_str.split(',').map(|s| s.trim()).collect();
         if parts.len() != 1 {
             return Ok(None);
@@ -376,7 +376,9 @@ fn x86_ir_from_mnemonic_impl(
         let rd = parse_x86_register_with_mode(parts[0], mode)?;
         return Ok(Some(match mnemonic.as_str() {
             "neg" => X86Instruction::Neg { rd },
-            _ => X86Instruction::Not { rd },
+            "not" => X86Instruction::Not { rd },
+            "inc" => X86Instruction::Inc { rd },
+            _ => X86Instruction::Dec { rd },
         }));
     }
 
@@ -452,8 +454,8 @@ fn x86_ir_from_mnemonic_impl(
 /// Recognised lines: empty, comments (`;`, `//`, `#`), labels
 /// (`name:`), directives (`.foo`), and instructions whose mnemonic is
 /// one of the supported families (mov, add, sub, and, or, xor, cmp,
-/// test, the single-operand neg/not, plus the conditional cmovCC and
-/// jCC variants). Anything else is a parse error.
+/// test, the single-operand neg/not/inc/dec, plus the conditional cmovCC
+/// and jCC variants). Anything else is a parse error.
 pub fn parse_x86_assembly_string(
     content: &str,
     source_name: String,
@@ -881,6 +883,67 @@ mod tests {
         // rbx` is an unsupported shape and surfaces as Ok(None), not a Neg.
         assert!(x86_ir_from_mnemonic("neg", "rax, rbx").unwrap().is_none());
         assert!(x86_ir_from_mnemonic("not", "rax, rbx").unwrap().is_none());
+    }
+
+    #[test]
+    fn inc_dec_parse_single_operand_and_round_trip_display() {
+        // `inc rax` / `dec rax` parse to the single-operand variants and
+        // their Display output round-trips back to the same IR.
+        let inc = x86_ir_from_mnemonic("inc", "rax").unwrap().unwrap();
+        assert_eq!(
+            inc,
+            X86Instruction::Inc {
+                rd: X86Register::RAX
+            }
+        );
+        assert_eq!(inc.to_string(), "inc rax");
+
+        let dec = x86_ir_from_mnemonic("dec", "rax").unwrap().unwrap();
+        assert_eq!(
+            dec,
+            X86Instruction::Dec {
+                rd: X86Register::RAX
+            }
+        );
+        assert_eq!(dec.to_string(), "dec rax");
+
+        for instr in [inc, dec] {
+            let text = instr.to_string();
+            let (mnemonic, ops) = text.split_once(char::is_whitespace).unwrap();
+            assert_eq!(
+                x86_ir_from_mnemonic(mnemonic, ops).unwrap().unwrap(),
+                instr,
+                "round-trip failed for {text}"
+            );
+        }
+    }
+
+    #[test]
+    fn inc_dec_with_two_operands_is_rejected() {
+        // The single-operand families must reject a second operand: `inc rax,
+        // rbx` is an unsupported shape and surfaces as Ok(None), not an Inc.
+        assert!(x86_ir_from_mnemonic("inc", "rax, rbx").unwrap().is_none());
+        assert!(x86_ir_from_mnemonic("dec", "rax, rbx").unwrap().is_none());
+    }
+
+    #[test]
+    fn inc_dec_round_trip_through_mode_aware_binary_path() {
+        assert_eq!(
+            x86_ir_from_mnemonic_for_mode("inc", "rax", X86ParseMode::Mode64)
+                .unwrap()
+                .unwrap(),
+            X86Instruction::Inc {
+                rd: X86Register::RAX
+            }
+        );
+        assert_eq!(
+            x86_ir_from_mnemonic_for_mode("dec", "eax", X86ParseMode::Mode32)
+                .unwrap()
+                .unwrap(),
+            X86Instruction::Dec {
+                rd: X86Register::RAX
+            }
+        );
     }
 
     #[test]

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -1028,12 +1028,12 @@ mod tests {
         let mut search: StochasticSearch<X86_64> = StochasticSearch::new();
         let config = SearchConfig::default()
             .with_stochastic(
-                // Seed retuned from 7 to 1 when NEG/NOT raised the rewritable
-                // opcode count to 19, shifting the seeded mutation trajectory
-                // so seed 7 no longer reached `mov rax, rbx` within 500 iters.
+                // Seed retuned from 1 to 2 when INC/DEC raised the rewritable
+                // opcode count to 21, shifting the seeded mutation trajectory
+                // so seed 1 no longer reached `mov rax, rbx` within 500 iters.
                 StochasticConfig::default()
                     .with_iterations(500)
-                    .with_seed(1),
+                    .with_seed(2),
             )
             .with_x86_registers(vec![X86Register::RAX, X86Register::RBX, X86Register::RCX])
             .with_immediates(vec![0, 1]);

--- a/src/semantics/concrete_x86.rs
+++ b/src/semantics/concrete_x86.rs
@@ -43,6 +43,8 @@ pub fn apply_instruction_concrete_x86(
         X86Instruction::TestImm { rn, imm } => apply_test_imm(&mut state, *rn, *imm),
         X86Instruction::Neg { rd } => apply_neg(&mut state, *rd),
         X86Instruction::Not { rd } => apply_not(&mut state, *rd),
+        X86Instruction::Inc { rd } => apply_inc(&mut state, *rd),
+        X86Instruction::Dec { rd } => apply_dec(&mut state, *rd),
         X86Instruction::Cmov { rd, rs, cond } => {
             if state.get_flags().evaluate(*cond) {
                 let v = state.get_register(*rs);
@@ -113,6 +115,33 @@ fn apply_neg(state: &mut X86ConcreteMachineState, rd: crate::isa::x86::X86Regist
 fn apply_not(state: &mut X86ConcreteMachineState, rd: crate::isa::x86::X86Register) {
     let old = state.get_register(rd).as_u64();
     state.set_register(rd, ConcreteValue::new(!old));
+}
+
+// INC computes `rd = rd + 1`. It sets OF/SF/ZF/PF exactly as `add rd, 1` would,
+// but — the load-bearing subtlety — it leaves CF UNCHANGED (the incoming carry
+// flows through untouched). We capture the prior CF FIRST, compute the ADD flag
+// path for `rd + 1`, then override CF back to the captured value.
+fn apply_inc(state: &mut X86ConcreteMachineState, rd: crate::isa::x86::X86Register) {
+    let prev_cf = state.get_flags().cf;
+    let old = state.get_register(rd).as_u64();
+    let result = old.wrapping_add(1);
+    state.set_register(rd, ConcreteValue::new(result));
+    let mut flags = Eflags::from_add(old, 1, result, state.width());
+    flags.cf = prev_cf;
+    state.set_flags(flags);
+}
+
+// DEC computes `rd = rd - 1`. Like INC it sets OF/SF/ZF/PF as `sub rd, 1` would
+// while leaving CF UNCHANGED. Capture the prior CF first, derive flags from the
+// SUB path for `rd - 1`, then restore CF.
+fn apply_dec(state: &mut X86ConcreteMachineState, rd: crate::isa::x86::X86Register) {
+    let prev_cf = state.get_flags().cf;
+    let old = state.get_register(rd).as_u64();
+    let result = old.wrapping_sub(1);
+    state.set_register(rd, ConcreteValue::new(result));
+    let mut flags = Eflags::from_sub(old, 1, result, state.width());
+    flags.cf = prev_cf;
+    state.set_flags(flags);
 }
 
 #[derive(Clone, Copy)]
@@ -382,6 +411,97 @@ mod tests {
             flags_before,
             "NOT must leave EFLAGS unchanged"
         );
+    }
+
+    #[test]
+    fn inc_adds_one_and_sets_zf_sf_pf_of() {
+        // INC 0xFF -> 0x100: result nonzero, ZF clear, SF clear, no signed
+        // overflow.
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(0xFF));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::Inc {
+                rd: X86Register::RAX,
+            },
+        );
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 0x100);
+        let flags = after.get_flags();
+        assert!(!flags.zf);
+        assert!(!flags.sf);
+        assert!(!flags.of);
+
+        // INC of -1 (all ones) wraps to 0: ZF set.
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(u64::MAX));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::Inc {
+                rd: X86Register::RAX,
+            },
+        );
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 0);
+        assert!(after.get_flags().zf, "INC of -1 wraps to 0 -> ZF set");
+    }
+
+    #[test]
+    fn dec_subtracts_one_and_sets_zf_sf() {
+        // DEC 1 -> 0: ZF set.
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(1));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::Dec {
+                rd: X86Register::RAX,
+            },
+        );
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 0);
+        assert!(after.get_flags().zf, "dec 1 -> 0 -> ZF set");
+
+        // DEC 0 -> -1 (all ones): SF set, ZF clear.
+        let state = X86ConcreteMachineState::new_zeroed(64);
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::Dec {
+                rd: X86Register::RAX,
+            },
+        );
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), u64::MAX);
+        let flags = after.get_flags();
+        assert!(flags.sf, "dec 0 -> -1 -> SF set");
+        assert!(!flags.zf);
+    }
+
+    // The load-bearing INC/DEC subtlety: CF is preserved across the operation,
+    // unlike ADD/SUB which derive CF from the arithmetic. We assert this in
+    // both directions (CF=1 stays 1, CF=0 stays 0) for both INC and DEC.
+    #[test]
+    fn inc_dec_preserve_carry_flag() {
+        for instr in [
+            X86Instruction::Inc {
+                rd: X86Register::RAX,
+            },
+            X86Instruction::Dec {
+                rd: X86Register::RAX,
+            },
+        ] {
+            for cf_in in [true, false] {
+                let mut state = X86ConcreteMachineState::new_zeroed(64);
+                // Use a value where ADD/SUB by 1 would *change* CF if it were
+                // derived (e.g. u64::MAX: add 1 carries; sub 1 from 0 borrows),
+                // so a preserved CF is genuinely distinguishable.
+                state.set_register(X86Register::RAX, ConcreteValue::new(u64::MAX));
+                let mut flags = state.get_flags();
+                flags.cf = cf_in;
+                state.set_flags(flags);
+                let after = apply_instruction_concrete_x86(state, &instr);
+                assert_eq!(
+                    after.get_flags().cf,
+                    cf_in,
+                    "{instr:?} must preserve CF (incoming CF = {cf_in})"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/semantics/cost_x86.rs
+++ b/src/semantics/cost_x86.rs
@@ -58,7 +58,10 @@ fn instruction_code_size(instr: &X86Instruction, width: u32) -> u64 {
         | X86Instruction::TestReg { .. }
         // NEG / NOT are single-operand `F7 /3` / `F7 /2` = 2 bytes (+REX.W).
         | X86Instruction::Neg { .. }
-        | X86Instruction::Not { .. } => 2 + rex,
+        | X86Instruction::Not { .. }
+        // INC / DEC are single-operand `FF /0` / `FF /1` = 2 bytes (+REX.W).
+        | X86Instruction::Inc { .. }
+        | X86Instruction::Dec { .. } => 2 + rex,
         X86Instruction::AddImm { .. }
         | X86Instruction::SubImm { .. }
         | X86Instruction::AndImm { .. }

--- a/src/semantics/smt_x86.rs
+++ b/src/semantics/smt_x86.rs
@@ -371,6 +371,34 @@ pub fn apply_instruction(
             let result = state.get_register(*rd).bvnot();
             state.set_register(*rd, result);
         }
+        // INC computes `rd = rd + 1` and sets OF/SF/ZF/PF exactly as `add rd, 1`
+        // would, but — the load-bearing subtlety — leaves CF UNCHANGED (the
+        // incoming carry flows through). Capture the prior CF BV FIRST, compute
+        // the ADD flag path for `rd + 1`, then override CF back to the captured
+        // BV so it equals the incoming CF.
+        X86Instruction::Inc { rd } => {
+            let prev_cf = state.get_flags().cf.clone();
+            let old = state.get_register(*rd).clone();
+            let one = BV::from_u64(1, state.width());
+            let result = old.bvadd(&one);
+            let mut flags = compute_eflags_add(&old, &one, state.width());
+            flags.cf = prev_cf;
+            state.set_register(*rd, result);
+            state.set_flags(flags);
+        }
+        // DEC computes `rd = rd - 1`. Like INC it sets OF/SF/ZF/PF as `sub rd, 1`
+        // would while leaving CF UNCHANGED. Capture the prior CF BV first, derive
+        // flags from the SUB path for `rd - 1`, then restore CF.
+        X86Instruction::Dec { rd } => {
+            let prev_cf = state.get_flags().cf.clone();
+            let old = state.get_register(*rd).clone();
+            let one = BV::from_u64(1, state.width());
+            let result = old.bvsub(&one);
+            let mut flags = compute_eflags_sub(&old, &one, state.width());
+            flags.cf = prev_cf;
+            state.set_register(*rd, result);
+            state.set_flags(flags);
+        }
         X86Instruction::Cmov { rd, rs, cond } => {
             let pred = x86_condition_to_smt(*cond, state.get_flags());
             let rs_val = state.get_register(*rs).clone();
@@ -724,6 +752,150 @@ mod tests {
             SatResult::Unsat,
             "NOT must leave every EFLAGS bit unchanged"
         );
+    }
+
+    // --- symbolic INC / DEC ---
+
+    // The KEY INC theorem: `inc rd` and `add rd, 1` AGREE on the result and on
+    // OF/SF/ZF/PF, and differ EXACTLY in CF — `inc` leaves CF equal to the
+    // incoming CF, while `add rd, 1` derives CF from the addition (so it can
+    // differ from the incoming CF). We prove all three claims over one shared
+    // symbolic state (same incoming rax AND same incoming CF).
+    #[test]
+    fn inc_matches_add_one_except_cf_which_inc_preserves() {
+        let prefix = "shared";
+        let s_inc = MachineStateX86::new_symbolic(prefix, 64);
+        let s_add = MachineStateX86::new_symbolic(prefix, 64);
+        // Both share the same symbolic incoming CF (identical const name).
+        let incoming_cf = s_inc.get_flags().cf.clone();
+
+        let after_inc = apply_instruction(
+            s_inc,
+            &X86Instruction::Inc {
+                rd: X86Register::RAX,
+            },
+        );
+        let after_add = apply_instruction(
+            s_add,
+            &X86Instruction::AddImm {
+                rd: X86Register::RAX,
+                imm: 1,
+            },
+        );
+
+        let inc_flags = after_inc.get_flags();
+        let add_flags = after_add.get_flags();
+
+        // (1) result and OF/SF/ZF/PF agree: negation is unsat.
+        {
+            let solver = Solver::new();
+            solver.assert(z3::ast::Bool::or(&[
+                &after_inc
+                    .get_register(X86Register::RAX)
+                    .eq(after_add.get_register(X86Register::RAX))
+                    .not(),
+                &inc_flags.of.eq(add_flags.of).not(),
+                &inc_flags.sf.eq(add_flags.sf).not(),
+                &inc_flags.zf.eq(add_flags.zf).not(),
+                &inc_flags.pf.eq(add_flags.pf).not(),
+            ]));
+            assert_eq!(
+                solver.check(),
+                SatResult::Unsat,
+                "INC and ADD-1 must agree on result and OF/SF/ZF/PF"
+            );
+        }
+
+        // (2) INC's CF equals the incoming CF: negation is unsat.
+        {
+            let solver = Solver::new();
+            solver.assert(inc_flags.cf.eq(&incoming_cf).not());
+            assert_eq!(
+                solver.check(),
+                SatResult::Unsat,
+                "INC must leave CF == the incoming CF"
+            );
+        }
+
+        // (3) ADD-1's CF is NOT pinned to the incoming CF: there exists a model
+        // where they differ (e.g. rax = u64::MAX makes ADD carry to CF=1 while
+        // the incoming CF can be 0). A SAT result proves INC genuinely diverges
+        // from ADD-1 on CF.
+        {
+            let solver = Solver::new();
+            solver.assert(add_flags.cf.eq(&incoming_cf).not());
+            assert_eq!(
+                solver.check(),
+                SatResult::Sat,
+                "ADD-1's CF must be able to differ from the incoming CF"
+            );
+        }
+    }
+
+    // The DEC sibling theorem: `dec rd` and `sub rd, 1` agree on result and
+    // OF/SF/ZF/PF, but DEC preserves CF while SUB-1 derives it.
+    #[test]
+    fn dec_matches_sub_one_except_cf_which_dec_preserves() {
+        let prefix = "shared";
+        let s_dec = MachineStateX86::new_symbolic(prefix, 64);
+        let s_sub = MachineStateX86::new_symbolic(prefix, 64);
+        let incoming_cf = s_dec.get_flags().cf.clone();
+
+        let after_dec = apply_instruction(
+            s_dec,
+            &X86Instruction::Dec {
+                rd: X86Register::RAX,
+            },
+        );
+        let after_sub = apply_instruction(
+            s_sub,
+            &X86Instruction::SubImm {
+                rd: X86Register::RAX,
+                imm: 1,
+            },
+        );
+
+        let dec_flags = after_dec.get_flags();
+        let sub_flags = after_sub.get_flags();
+
+        {
+            let solver = Solver::new();
+            solver.assert(z3::ast::Bool::or(&[
+                &after_dec
+                    .get_register(X86Register::RAX)
+                    .eq(after_sub.get_register(X86Register::RAX))
+                    .not(),
+                &dec_flags.of.eq(sub_flags.of).not(),
+                &dec_flags.sf.eq(sub_flags.sf).not(),
+                &dec_flags.zf.eq(sub_flags.zf).not(),
+                &dec_flags.pf.eq(sub_flags.pf).not(),
+            ]));
+            assert_eq!(
+                solver.check(),
+                SatResult::Unsat,
+                "DEC and SUB-1 must agree on result and OF/SF/ZF/PF"
+            );
+        }
+
+        {
+            let solver = Solver::new();
+            solver.assert(dec_flags.cf.eq(&incoming_cf).not());
+            assert_eq!(
+                solver.check(),
+                SatResult::Unsat,
+                "DEC must leave CF == the incoming CF"
+            );
+        }
+
+        {
+            let solver = Solver::new();
+            solver.assert(sub_flags.cf.eq(&incoming_cf).not());
+            assert_eq!(
+                solver.check(),
+                SatResult::Sat,
+                "SUB-1's CF must be able to differ from the incoming CF"
+            );
+        }
     }
 
     // --- symbolic CMOV ---


### PR DESCRIPTION
Closes #626.

Adds `Inc { rd }` / `Dec { rd }`. The load-bearing subtlety: INC/DEC update OF/SF/ZF/PF like `rd ± 1` but **leave CF unchanged** (unlike ADD/SUB).

**CF preservation** (both paths read the prior CF first, then override): SMT — `let prev_cf = state.get_flags().cf.clone();` → `compute_eflags_add/sub(&old, &one, width)` → `flags.cf = prev_cf;`. Concrete — same with `Eflags::from_add/sub` then `flags.cf = prev_cf;`.

**Key SMT theorem** `inc_matches_add_one_except_cf_which_inc_preserves` (+ `dec_…`): over one shared symbolic state with a symbolic incoming CF, proves (1) `inc`/`add rd,1` agree on result + OF/SF/ZF/PF, (2) `inc`'s CF == the incoming CF, and (3) `add rd,1`'s CF is *not* pinned to the incoming CF (SAT) — i.e. INC diverges from ADD-1 *only* on CF. Concrete `inc_dec_preserve_carry_flag` covers both CF=0/1 at `rd=u64::MAX`.

**CMOV invariant**: inserted at opcodes 18/19 before CMOV → `…16 Neg,17 Not,18 Inc,19 Dec,20 Cmov`; `X86_REWRITABLE_OPCODE_COUNT` 19→21; Cmov stays last (20 = COUNT−1). Parity + `opcode_dispatch_is_consistent` green.

Single-operand parser branch extended to inc/dec (rejects 2-operand forms). Wired through isa/parser/concrete/SMT/assembler/cost/docs. Stochastic end-to-end seed retuned 1→2 (documented; assertion unchanged — same trajectory shift as #625) and the `generate_all` single-operand count formula updated for the 4 single-operand variants.

(I deliberately did **not** add INC/DEC to the concrete↔SMT parity harness: it starts from a zeroed concrete CF but an unconstrained symbolic CF, so a CF-preserving op would spuriously fail its CF-equality assertion; CF preservation is proven by the dedicated tests above instead.)

`./ci_check.sh` + `RUSTFLAGS="-D warnings" cargo build` pass; clippy adds no new lints in changed files; 1346 lib tests green.