### PR TITLE
x86: add SHL/SAL/SHR/SAR immediate-count shifts (#628)

### DIFF
--- a/docs/capability.md
+++ b/docs/capability.md
@@ -99,6 +99,7 @@ Rewritable straight-line mnemonic families:
 
 - `mov`, `add`, `sub`, `and`, `or`, `xor`, `cmp`, `test`
 - Single-operand: `neg`, `not`, `inc`, `dec`
+- Immediate-count shifts: `shl`/`sal`, `shr`, `sar`
 - Conditional moves: `cmov<cond>`
 
 The data-movement/arithmetic/logical/comparison families have register and
@@ -110,8 +111,16 @@ are single-operand: `neg` computes `rd = -rd` and sets EFLAGS as if from
 unchanged (like `mov`). `inc` (`rd = rd + 1`) and `dec` (`rd = rd - 1`) are
 also single-operand and set OF/SF/ZF/PF as the corresponding `add`/`sub` by 1
 would, but — unlike `add`/`sub` — they preserve CF (the incoming carry flows
-through unchanged). `cmov<cond>` has register operands and reads EFLAGS
-without modifying them.
+through unchanged). `shl`/`sal`, `shr`, and `sar` are immediate-count shifts:
+the count is a compile-time constant masked to `width-1` (the CL-register-count
+form is not yet modelled). A masked count of 0 leaves the register and ALL
+flags unchanged; for a nonzero count SF/ZF/PF come from the result and CF is the
+last bit shifted out. OF is architecturally defined only for a count of 1 and
+is UNDEFINED for larger counts; the model uses the count-1 OF formula for every
+nonzero count as a deterministic, internally-consistent value, so downstream
+code must not rely on OF after a count > 1 shift. `sal` assembles identically to
+`shl` and parses to the same IR. `cmov<cond>` has register operands and reads
+EFLAGS without modifying them.
 
 The x86 IR does not yet carry operand width. To avoid rewriting partial-width
 operations as full-width operations, the binary optimization path currently

--- a/src/assembler/x86.rs
+++ b/src/assembler/x86.rs
@@ -219,6 +219,24 @@ fn encode_64(ops: &mut dynasmrt::x64::Assembler, instr: &X86Instruction) -> Resu
             dynasm!(ops ; .arch x64 ; dec Rq(rd));
             Ok(())
         }
+        X86Instruction::Shl { rd, imm } => {
+            let rd = reg_index(*rd)?;
+            let count = shift_count_imm8(*imm)?;
+            dynasm!(ops ; .arch x64 ; shl Rq(rd), BYTE count);
+            Ok(())
+        }
+        X86Instruction::Shr { rd, imm } => {
+            let rd = reg_index(*rd)?;
+            let count = shift_count_imm8(*imm)?;
+            dynasm!(ops ; .arch x64 ; shr Rq(rd), BYTE count);
+            Ok(())
+        }
+        X86Instruction::Sar { rd, imm } => {
+            let rd = reg_index(*rd)?;
+            let count = shift_count_imm8(*imm)?;
+            dynasm!(ops ; .arch x64 ; sar Rq(rd), BYTE count);
+            Ok(())
+        }
         X86Instruction::Cmov { rd, rs, cond } => {
             let rd = reg_index(*rd)?;
             let rs = reg_index(*rs)?;
@@ -275,6 +293,16 @@ fn encode_64(ops: &mut dynasmrt::x64::Assembler, instr: &X86Instruction) -> Resu
 /// sign-extended 32-bit immediate.
 fn signed_imm_i32(imm: i64) -> Result<i32, String> {
     i32::try_from(imm).map_err(|_| format!("immediate {} does not fit in 32 bits", imm))
+}
+
+/// A shift count encodes as `imm8`. Accept `0..=255` and emit it as the raw
+/// byte (dynasm takes the shift count as an `i8`); reject anything that does
+/// not fit a single byte. `can_assemble` performs the same check up front, so
+/// this is a defensive backstop.
+fn shift_count_imm8(imm: i64) -> Result<i8, String> {
+    u8::try_from(imm)
+        .map(|byte| byte as i8)
+        .map_err(|_| format!("shift count {} does not fit in imm8", imm))
 }
 
 /// Like [`signed_imm_i32`] but also accepts canonical 32-bit bit patterns.
@@ -403,6 +431,24 @@ fn encode_32(ops: &mut dynasmrt::x86::Assembler, instr: &X86Instruction) -> Resu
         X86Instruction::Dec { rd } => {
             let rd = reg_index_32(*rd)?;
             dynasm!(ops ; .arch x86 ; dec Rd(rd));
+            Ok(())
+        }
+        X86Instruction::Shl { rd, imm } => {
+            let rd = reg_index_32(*rd)?;
+            let count = shift_count_imm8(*imm)?;
+            dynasm!(ops ; .arch x86 ; shl Rd(rd), BYTE count);
+            Ok(())
+        }
+        X86Instruction::Shr { rd, imm } => {
+            let rd = reg_index_32(*rd)?;
+            let count = shift_count_imm8(*imm)?;
+            dynasm!(ops ; .arch x86 ; shr Rd(rd), BYTE count);
+            Ok(())
+        }
+        X86Instruction::Sar { rd, imm } => {
+            let rd = reg_index_32(*rd)?;
+            let count = shift_count_imm8(*imm)?;
+            dynasm!(ops ; .arch x86 ; sar Rd(rd), BYTE count);
             Ok(())
         }
         X86Instruction::Cmov { rd, rs, cond } => {
@@ -812,6 +858,69 @@ mod tests {
             },
             "dec",
             &["ebx"],
+        );
+    }
+
+    #[test]
+    fn shift_variants_x86_64() {
+        check_x86_64(
+            X86Instruction::Shl {
+                rd: X86Register::RAX,
+                imm: 1,
+            },
+            "shl",
+            &["rax", "1"],
+        );
+        check_x86_64(
+            X86Instruction::Shr {
+                rd: X86Register::RBX,
+                imm: 3,
+            },
+            "shr",
+            &["rbx", "3"],
+        );
+        check_x86_64(
+            X86Instruction::Sar {
+                rd: X86Register::RCX,
+                imm: 7,
+            },
+            "sar",
+            &["rcx", "7"],
+        );
+    }
+
+    #[test]
+    fn shift_variants_x86_32() {
+        check_x86_32(
+            X86Instruction::Shl {
+                rd: X86Register::RAX,
+                imm: 2,
+            },
+            "shl",
+            &["eax", "2"],
+        );
+        check_x86_32(
+            X86Instruction::Sar {
+                rd: X86Register::RBX,
+                imm: 4,
+            },
+            "sar",
+            &["ebx", "4"],
+        );
+    }
+
+    // SAL and SHL assemble to identical bytes; Capstone disassembles the
+    // encoding as `shl`. The IR has no Sal variant (the parser folds `sal`
+    // into `Shl`), so we assert the `Shl` encoding round-trips as `shl`.
+    #[test]
+    fn shl_encoding_disassembles_as_shl_not_sal() {
+        check_x86_64(
+            X86Instruction::Shl {
+                rd: X86Register::RDX,
+                imm: 5,
+            },
+            "shl",
+            &["rdx", "5"],
         );
     }
 

--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -328,6 +328,26 @@ pub enum X86Instruction {
     /// OF/SF/ZF/PF as for `rd - 1` but, unlike `sub`, leaves CF UNCHANGED:
     /// the prior CF is preserved.
     Dec { rd: X86Register },
+    /// `shl rd, imm` (a.k.a. `sal`) — logical/arithmetic left shift by a
+    /// compile-time COUNT. Reads and writes `rd`. `imm` is the shift count;
+    /// x86 masks it to `width-1` (5 bits at width 32, 6 bits at width 64). A
+    /// masked count of 0 leaves `rd` and ALL flags unchanged; otherwise
+    /// SF/ZF/PF come from the result, CF is the last bit shifted out (original
+    /// bit `width - eff`), and OF (architecturally defined only for count 1) is
+    /// `MSB(result) XOR CF`. The CL-register-count form is not modelled.
+    Shl { rd: X86Register, imm: i64 },
+    /// `shr rd, imm` — logical (unsigned) right shift by a compile-time COUNT.
+    /// Reads and writes `rd`. `imm` is masked like `shl`. Masked count 0 leaves
+    /// `rd` and ALL flags unchanged; otherwise SF/ZF/PF from the result, CF =
+    /// original bit `eff - 1`, OF (count 1 only) = MSB of the original `rd`. The
+    /// CL-register-count form is not modelled.
+    Shr { rd: X86Register, imm: i64 },
+    /// `sar rd, imm` — arithmetic (signed) right shift by a compile-time COUNT.
+    /// Reads and writes `rd`. `imm` is masked like `shl`. Masked count 0 leaves
+    /// `rd` and ALL flags unchanged; otherwise SF/ZF/PF from the result, CF =
+    /// original bit `eff - 1`, OF (count 1 only) = 0. The CL-register-count form
+    /// is not modelled.
+    Sar { rd: X86Register, imm: i64 },
     /// `cmovCC rd, rs` — conditional move. Reads EFLAGS;
     /// when `cond` holds, writes `rd = rs`; otherwise `rd` is unchanged.
     /// Does not modify EFLAGS.
@@ -362,6 +382,9 @@ impl X86Instruction {
             | X86Instruction::Not { rd }
             | X86Instruction::Inc { rd }
             | X86Instruction::Dec { rd }
+            | X86Instruction::Shl { rd, .. }
+            | X86Instruction::Shr { rd, .. }
+            | X86Instruction::Sar { rd, .. }
             | X86Instruction::Cmov { rd, .. } => Some(*rd),
             // CMP and TEST discard their result; only EFLAGS is written.
             X86Instruction::CmpReg { .. }
@@ -386,6 +409,9 @@ impl X86Instruction {
             X86Instruction::Not { .. } => "not",
             X86Instruction::Inc { .. } => "inc",
             X86Instruction::Dec { .. } => "dec",
+            X86Instruction::Shl { .. } => "shl",
+            X86Instruction::Shr { .. } => "shr",
+            X86Instruction::Sar { .. } => "sar",
             X86Instruction::Cmov { cond, .. } => cond.cmov_mnemonic(),
             X86Instruction::Jcc { cond } => cond.jcc_mnemonic(),
         }
@@ -410,7 +436,11 @@ impl X86Instruction {
             | X86Instruction::SubImm { rd, .. }
             | X86Instruction::AndImm { rd, .. }
             | X86Instruction::OrImm { rd, .. }
-            | X86Instruction::XorImm { rd, .. } => vec![*rd],
+            | X86Instruction::XorImm { rd, .. }
+            // SHL / SHR / SAR read and write rd; the count is an immediate.
+            | X86Instruction::Shl { rd, .. }
+            | X86Instruction::Shr { rd, .. }
+            | X86Instruction::Sar { rd, .. } => vec![*rd],
             X86Instruction::CmpReg { rn, rs } => vec![*rn, *rs],
             X86Instruction::CmpImm { rn, .. } => vec![*rn],
             // TEST reads both operands (or just rn for the immediate form) and
@@ -471,11 +501,14 @@ impl InstructionType for X86Instruction {
             X86Instruction::Not { .. } => 17,
             X86Instruction::Inc { .. } => 18,
             X86Instruction::Dec { .. } => 19,
-            // Cmov MUST stay the last rewritable opcode (COUNT - 1 == 20):
+            X86Instruction::Shl { .. } => 20,
+            X86Instruction::Shr { .. } => 21,
+            X86Instruction::Sar { .. } => 22,
+            // Cmov MUST stay the last rewritable opcode (COUNT - 1 == 23):
             // the CMOV distinct-register draw at both generation sites is
             // gated on `opcode == X86_REWRITABLE_OPCODE_COUNT - 1`.
-            X86Instruction::Cmov { .. } => 20,
-            X86Instruction::Jcc { .. } => 21,
+            X86Instruction::Cmov { .. } => 23,
+            X86Instruction::Jcc { .. } => 24,
         }
     }
 
@@ -515,7 +548,11 @@ impl fmt::Display for X86Instruction {
             | X86Instruction::SubImm { rd, imm }
             | X86Instruction::AndImm { rd, imm }
             | X86Instruction::OrImm { rd, imm }
-            | X86Instruction::XorImm { rd, imm } => write!(f, "{} {}, {}", mn, rd, imm),
+            | X86Instruction::XorImm { rd, imm }
+            // SHL / SHR / SAR render `mnemonic rd, count`.
+            | X86Instruction::Shl { rd, imm }
+            | X86Instruction::Shr { rd, imm }
+            | X86Instruction::Sar { rd, imm } => write!(f, "{} {}, {}", mn, rd, imm),
             X86Instruction::CmpReg { rn, rs } | X86Instruction::TestReg { rn, rs } => {
                 write!(f, "{} {}, {}", mn, rn, rs)
             }
@@ -634,6 +671,14 @@ pub fn x86_reads_flags(instr: &X86Instruction) -> bool {
 
 fn x86_signed_imm32_ok(imm: i64) -> bool {
     i32::try_from(imm).is_ok()
+}
+
+/// A shift count encodes as `imm8`, so it must fit `0..=255`. x86 masks the
+/// count to the operand width at execution time, but the *encoding* still
+/// only carries a single byte, so any negative or >255 count is unencodable
+/// and must be rejected before the search proposes it.
+fn x86_shift_count_imm8_ok(imm: i64) -> bool {
+    u8::try_from(imm).is_ok()
 }
 
 fn x86_imm32_bitpattern_ok(imm: i64) -> bool {
@@ -801,6 +846,12 @@ impl crate::isa::traits::Assembler<X86Instruction> for X86_64 {
             | X86Instruction::XorImm { imm, .. }
             | X86Instruction::CmpImm { imm, .. }
             | X86Instruction::TestImm { imm, .. } => x86_signed_imm32_ok(*imm),
+            // SHL / SHR / SAR encode their count as imm8: reject any count that
+            // does not fit a single byte so the search never proposes an
+            // unencodable shift.
+            X86Instruction::Shl { imm, .. }
+            | X86Instruction::Shr { imm, .. }
+            | X86Instruction::Sar { imm, .. } => x86_shift_count_imm8_ok(*imm),
             X86Instruction::MovReg { .. }
             | X86Instruction::MovImm { .. }
             | X86Instruction::AddReg { .. }
@@ -851,6 +902,10 @@ impl crate::isa::traits::Assembler<X86Instruction> for X86_32 {
             X86Instruction::CmpImm { rn, imm } | X86Instruction::TestImm { rn, imm } => {
                 reg_ok_32(*rn) && x86_imm32_bitpattern_ok(*imm)
             }
+            // SHL / SHR / SAR: legal 32-bit register plus an imm8 count.
+            X86Instruction::Shl { rd, imm }
+            | X86Instruction::Shr { rd, imm }
+            | X86Instruction::Sar { rd, imm } => reg_ok_32(*rd) && x86_shift_count_imm8_ok(*imm),
             X86Instruction::Neg { rd }
             | X86Instruction::Not { rd }
             | X86Instruction::Inc { rd }
@@ -879,6 +934,10 @@ pub struct X86Mutator {
     registers: Vec<X86Register>,
     mov_immediates: Vec<i64>,
     non_mov_immediates: Vec<i64>,
+    // Shift counts encode as imm8 (`0..=255`), a stricter range than the
+    // arithmetic/logical immediates, so they are filtered into their own pool
+    // at construction. See `x86_shift_count_imm8_ok`.
+    shift_counts: Vec<i64>,
     mode: crate::assembler::x86::X86Mode,
     weights: crate::search::config::MutationWeights,
 }
@@ -907,6 +966,11 @@ impl X86Mutator {
             .copied()
             .filter(|&imm| x86_mov_imm_ok(mode, imm))
             .collect();
+        let shift_counts = immediates
+            .iter()
+            .copied()
+            .filter(|&imm| x86_shift_count_imm8_ok(imm))
+            .collect();
         let non_mov_immediates = immediates
             .into_iter()
             .filter(|&imm| x86_non_mov_imm_ok(mode, imm))
@@ -915,6 +979,7 @@ impl X86Mutator {
             registers,
             mov_immediates,
             non_mov_immediates,
+            shift_counts,
             mode,
             weights,
         }
@@ -957,6 +1022,25 @@ impl X86Mutator {
             imm
         } else {
             self.pick_non_mov_immediate(rng)
+        }
+    }
+
+    /// Draw a shift count from the imm8-encodable pool. Falls back to 1 (the
+    /// canonical single-bit shift) when the pool holds no encodable count, so
+    /// a drawn shift is always assemblable.
+    fn pick_shift_count<R: rand::RngExt>(&self, rng: &mut R) -> i64 {
+        if self.shift_counts.is_empty() {
+            1
+        } else {
+            self.shift_counts[rng.random_range(0..self.shift_counts.len())]
+        }
+    }
+
+    fn keep_or_pick_shift_count<R: rand::RngExt>(&self, rng: &mut R, imm: i64) -> i64 {
+        if x86_shift_count_imm8_ok(imm) {
+            imm
+        } else {
+            self.pick_shift_count(rng)
         }
     }
 
@@ -1031,6 +1115,11 @@ impl X86Mutator {
                 | X86Instruction::XorImm { imm, .. }
                 | X86Instruction::CmpImm { imm, .. }
                 | X86Instruction::TestImm { imm, .. } => *imm = self.pick_non_mov_immediate(rng),
+                // SHL / SHR / SAR carry a shift count; mutate it from the
+                // imm8-encodable pool even with no register pool.
+                X86Instruction::Shl { imm, .. }
+                | X86Instruction::Shr { imm, .. }
+                | X86Instruction::Sar { imm, .. } => *imm = self.pick_shift_count(rng),
                 X86Instruction::MovReg { .. }
                 | X86Instruction::AddReg { .. }
                 | X86Instruction::SubReg { .. }
@@ -1097,6 +1186,17 @@ impl X86Mutator {
                     *rn = self.pick_register(rng).expect("register pool is non-empty");
                 } else {
                     *imm = self.pick_non_mov_immediate(rng);
+                }
+            }
+            // SHL / SHR / SAR mutate either the destination register or the
+            // imm8 shift count.
+            X86Instruction::Shl { rd, imm }
+            | X86Instruction::Shr { rd, imm }
+            | X86Instruction::Sar { rd, imm } => {
+                if rng.random_bool(0.5) {
+                    *rd = self.pick_register(rng).expect("register pool is non-empty");
+                } else {
+                    *imm = self.pick_shift_count(rng);
                 }
             }
             // NEG / NOT / INC / DEC have a single register operand; mutate it.
@@ -1217,6 +1317,21 @@ impl X86Mutator {
                 2 => X86Instruction::Inc { rd },
                 _ => X86Instruction::Dec { rd },
             },
+            // SHL / SHR / SAR share the reg-plus-count shape, so the
+            // opcode-bridge mutation swaps among the three, carrying the
+            // current count through (re-drawing it only if it became
+            // unencodable). Like the reg-reg / reg-imm groups, the draw range
+            // includes the current variant, so it may be an identity mutation.
+            X86Instruction::Shl { rd, imm }
+            | X86Instruction::Shr { rd, imm }
+            | X86Instruction::Sar { rd, imm } => {
+                let imm = self.keep_or_pick_shift_count(rng, imm);
+                match rng.random_range(0..3u32) {
+                    0 => X86Instruction::Shl { rd, imm },
+                    1 => X86Instruction::Shr { rd, imm },
+                    _ => X86Instruction::Sar { rd, imm },
+                }
+            }
             // Cmov has a unique shape (rd, rs, cond) with no opcode-shape
             // siblings; keep it unchanged in the opcode-bridge mutator.
             X86Instruction::Cmov { .. } => current,
@@ -1292,18 +1407,18 @@ impl crate::isa::traits::ISAMutator<X86Instruction> for X86Mutator {
 pub struct X86InstructionGenerator;
 
 // One entry per rewritable opcode family: 6 reg-reg + 6 reg-imm + CMP + TEST
-// (each reg/imm) + NEG + NOT + INC + DEC + CMOVcc. CMOVcc counts as a single
-// family here even though `generate_all` expands it across all 16
-// `X86Condition::ALL` variants per register pair.
+// (each reg/imm) + NEG + NOT + INC + DEC + SHL + SHR + SAR + CMOVcc. CMOVcc
+// counts as a single family here even though `generate_all` expands it across
+// all 16 `X86Condition::ALL` variants per register pair.
 //
-// CMOV MUST remain the LAST opcode (index COUNT - 1 == 20): both
+// CMOV MUST remain the LAST opcode (index COUNT - 1 == 23): both
 // `X86Mutator::random_instruction` and
 // `generate_random_rewritable_x86_instruction` gate the extra distinct-source
 // CMOV draw on `opcode == X86_REWRITABLE_OPCODE_COUNT - 1`. New flag-only
-// families (CMP, TEST) and single-operand families (NEG, NOT, INC, DEC) are
-// inserted before CMOV in `build_x86_instruction_by_opcode` to preserve that
-// invariant.
-const X86_REWRITABLE_OPCODE_COUNT: u8 = 21;
+// families (CMP, TEST), single-operand families (NEG, NOT, INC, DEC), and the
+// immediate-count shift families (SHL, SHR, SAR) are inserted before CMOV in
+// `build_x86_instruction_by_opcode` to preserve that invariant.
+const X86_REWRITABLE_OPCODE_COUNT: u8 = 24;
 
 fn has_distinct_register_pair(registers: &[X86Register]) -> bool {
     let Some(first) = registers.first() else {
@@ -1318,7 +1433,7 @@ fn has_distinct_register_pair(registers: &[X86Register]) -> bool {
 /// `X86Mutator::random_instruction` and
 /// `generate_random_rewritable_x86_instruction` both delegate here so the two
 /// dispatch tables cannot drift (see issue #348). Operand drawing and RNG draw
-/// order stay at the call sites; the CMOV slot (opcode 20, the last index)
+/// order stay at the call sites; the CMOV slot (opcode 23, the last index)
 /// consumes the `rs` the caller resolved via `pick_register_except` so
 /// `rs != rd`.
 ///
@@ -1354,9 +1469,16 @@ pub(crate) fn build_x86_instruction_by_opcode(
         17 => X86Instruction::Not { rd },
         18 => X86Instruction::Inc { rd },
         19 => X86Instruction::Dec { rd },
-        // Cmov stays last (index 20 == X86_REWRITABLE_OPCODE_COUNT - 1) so the
+        // SHL / SHR / SAR consume `rd` plus the shared `imm` shift count. The
+        // count is only checked for imm8-encodability at `can_assemble` time,
+        // so no extra RNG draw is introduced here — the two dispatch sites stay
+        // in lock-step on the shared `imm`.
+        20 => X86Instruction::Shl { rd, imm },
+        21 => X86Instruction::Shr { rd, imm },
+        22 => X86Instruction::Sar { rd, imm },
+        // Cmov stays last (index 23 == X86_REWRITABLE_OPCODE_COUNT - 1) so the
         // CMOV distinct-register draw at the two generation sites stays correct.
-        20 => X86Instruction::Cmov { rd, rs, cond },
+        23 => X86Instruction::Cmov { rd, rs, cond },
         _ => unreachable!("opcode out of range"),
     }
 }
@@ -1479,6 +1601,20 @@ impl InstructionGenerator<X86Instruction> for X86InstructionGenerator {
             out.push(X86Instruction::Inc { rd });
             out.push(X86Instruction::Dec { rd });
         }
+        // Immediate-count shifts (SHL, SHR, SAR): one per (register, count).
+        // The count encodes as imm8, so only imm8-encodable immediates yield a
+        // candidate; larger pool entries are skipped here rather than emitted
+        // and later rejected by `can_assemble`.
+        for &rd in registers {
+            for &imm in immediates {
+                if !x86_shift_count_imm8_ok(imm) {
+                    continue;
+                }
+                out.push(X86Instruction::Shl { rd, imm });
+                out.push(X86Instruction::Shr { rd, imm });
+                out.push(X86Instruction::Sar { rd, imm });
+            }
+        }
         // CMOVcc is rewritable and reads flags, so enumerate every
         // condition for each non-identical register pair. Jcc remains
         // excluded.
@@ -1573,6 +1709,10 @@ fn with_destination(instr: X86Instruction, new_rd: X86Register) -> X86Instructio
         X86Instruction::Not { .. } => X86Instruction::Not { rd: new_rd },
         X86Instruction::Inc { .. } => X86Instruction::Inc { rd: new_rd },
         X86Instruction::Dec { .. } => X86Instruction::Dec { rd: new_rd },
+        // SHL / SHR / SAR redirect the destination, carrying the count.
+        X86Instruction::Shl { imm, .. } => X86Instruction::Shl { rd: new_rd, imm },
+        X86Instruction::Shr { imm, .. } => X86Instruction::Shr { rd: new_rd, imm },
+        X86Instruction::Sar { imm, .. } => X86Instruction::Sar { rd: new_rd, imm },
         X86Instruction::Cmov { rd, rs, cond } => X86Instruction::Cmov {
             rd: if new_rd == rs { rd } else { new_rd },
             rs,
@@ -1607,6 +1747,33 @@ fn with_sources(instr: X86Instruction, new_rs: X86Register, new_imm: i64) -> X86
         X86Instruction::Not { rd } => X86Instruction::Not { rd },
         X86Instruction::Inc { rd } => X86Instruction::Inc { rd },
         X86Instruction::Dec { rd } => X86Instruction::Dec { rd },
+        // SHL / SHR / SAR vary the shift count via `new_imm`, but only when it
+        // is imm8-encodable; otherwise keep the existing count so the result
+        // stays assemblable.
+        X86Instruction::Shl { rd, imm } => X86Instruction::Shl {
+            rd,
+            imm: if x86_shift_count_imm8_ok(new_imm) {
+                new_imm
+            } else {
+                imm
+            },
+        },
+        X86Instruction::Shr { rd, imm } => X86Instruction::Shr {
+            rd,
+            imm: if x86_shift_count_imm8_ok(new_imm) {
+                new_imm
+            } else {
+                imm
+            },
+        },
+        X86Instruction::Sar { rd, imm } => X86Instruction::Sar {
+            rd,
+            imm: if x86_shift_count_imm8_ok(new_imm) {
+                new_imm
+            } else {
+                imm
+            },
+        },
         // Cmov's `rs` is mutated; `cond` and `rd` carry through unchanged.
         X86Instruction::Cmov { rd, rs, cond } => X86Instruction::Cmov {
             rd,
@@ -1659,13 +1826,20 @@ mod tests {
 
         let n = regs.len();
         let m = imms.len();
+        // Shifts only enumerate over imm8-encodable counts (e.g. -1 is dropped).
+        let shift_m = imms
+            .iter()
+            .filter(|&&imm| u8::try_from(imm).is_ok())
+            .count();
         // 8 reg-reg families + 8 reg-imm families + 4 single-operand families
-        // (NEG, NOT, INC, DEC) + CMOVcc over distinct pairs.
-        let expected_len = 8 * n * n + 8 * n * m + 4 * n + n * (n - 1) * X86Condition::ALL.len();
+        // (NEG, NOT, INC, DEC) + 3 shift families (SHL, SHR, SAR over imm8
+        // counts) + CMOVcc over distinct pairs.
+        let expected_len =
+            8 * n * n + 8 * n * m + 4 * n + 3 * n * shift_m + n * (n - 1) * X86Condition::ALL.len();
         assert_eq!(
             all.len(),
             expected_len,
-            "generate_all should only prune CMOV self-pairs from the full pool"
+            "generate_all should only prune CMOV self-pairs and non-imm8 shift counts from the full pool"
         );
 
         // For each opcode_id, at least one variant must appear.
@@ -1832,7 +2006,13 @@ mod tests {
                 | X86Instruction::OrImm { imm, .. }
                 | X86Instruction::XorImm { imm, .. }
                 | X86Instruction::CmpImm { imm, .. }
-                | X86Instruction::TestImm { imm, .. } => {
+                | X86Instruction::TestImm { imm, .. }
+                // Shifts draw their count from the same shared `imm` slot in
+                // `generate_random_rewritable_x86_instruction`, so it is in the
+                // pool too.
+                | X86Instruction::Shl { imm, .. }
+                | X86Instruction::Shr { imm, .. }
+                | X86Instruction::Sar { imm, .. } => {
                     assert!(imms.contains(&imm), "immediate {} outside pool", imm);
                 }
                 X86Instruction::MovReg { .. }
@@ -2942,7 +3122,11 @@ mod tests {
                 | X86Instruction::OrImm { imm, .. }
                 | X86Instruction::XorImm { imm, .. }
                 | X86Instruction::CmpImm { imm, .. }
-                | X86Instruction::TestImm { imm, .. } => {
+                | X86Instruction::TestImm { imm, .. }
+                // Shifts carry the same shared `imm` draw (0 for an empty pool).
+                | X86Instruction::Shl { imm, .. }
+                | X86Instruction::Shr { imm, .. }
+                | X86Instruction::Sar { imm, .. } => {
                     saw_immediate_form = true;
                     assert_eq!(imm, 0);
                 }
@@ -3035,8 +3219,11 @@ mod tests {
             (17, X86Instruction::Not { rd }),
             (18, X86Instruction::Inc { rd }),
             (19, X86Instruction::Dec { rd }),
-            // Cmov stays last at COUNT - 1 == 20.
-            (20, X86Instruction::Cmov { rd, rs, cond }),
+            (20, X86Instruction::Shl { rd, imm }),
+            (21, X86Instruction::Shr { rd, imm }),
+            (22, X86Instruction::Sar { rd, imm }),
+            // Cmov stays last at COUNT - 1 == 23.
+            (23, X86Instruction::Cmov { rd, rs, cond }),
         ];
 
         for (opcode, want) in expected {
@@ -3070,7 +3257,10 @@ mod tests {
             (17, "not"),
             (18, "inc"),
             (19, "dec"),
-            (20, "cmove"),
+            (20, "shl"),
+            (21, "shr"),
+            (22, "sar"),
+            (23, "cmove"),
         ];
         for (opcode, mnem) in mnemonics {
             assert_eq!(
@@ -3511,7 +3701,12 @@ mod tests {
                     | X86Instruction::OrImm { .. }
                     | X86Instruction::XorImm { .. }
                     | X86Instruction::CmpImm { .. }
-                    | X86Instruction::TestImm { .. } => {
+                    | X86Instruction::TestImm { .. }
+                    // Shifts carry an imm8 count; the same encodability
+                    // invariant applies — `can_assemble` must accept them.
+                    | X86Instruction::Shl { .. }
+                    | X86Instruction::Shr { .. }
+                    | X86Instruction::Sar { .. } => {
                         saw_non_mov_immediate = true;
                         assert!(
                             <X86_64 as Assembler<X86Instruction>>::can_assemble(&X86_64, instr),

--- a/src/parser/x86.rs
+++ b/src/parser/x86.rs
@@ -388,7 +388,19 @@ fn x86_ir_from_mnemonic_impl(
     // immediate parse error.
     if !matches!(
         mnemonic.as_str(),
-        "mov" | "movabs" | "add" | "sub" | "and" | "or" | "xor" | "cmp" | "test"
+        "mov"
+            | "movabs"
+            | "add"
+            | "sub"
+            | "and"
+            | "or"
+            | "xor"
+            | "cmp"
+            | "test"
+            | "shl"
+            | "sal"
+            | "shr"
+            | "sar"
     ) {
         return Ok(None);
     }
@@ -443,6 +455,18 @@ fn x86_ir_from_mnemonic_impl(
             |rn, rs| X86Instruction::TestReg { rn, rs },
             |rn, imm| X86Instruction::TestImm { rn, imm },
         ),
+        // SHL/SAL, SHR, SAR take a register plus an immediate COUNT. `sal`
+        // assembles identically to `shl`, so it parses to `Shl`. Only the
+        // immediate-count form is modelled — the register (CL) count form is
+        // deferred and surfaces as `Ok(None)` (an unsupported shape).
+        "shl" | "sal" | "shr" | "sar" => match src_op {
+            X86Operand::Immediate(imm) => Ok(Some(match mnemonic.as_str() {
+                "shl" | "sal" => X86Instruction::Shl { rd, imm },
+                "shr" => X86Instruction::Shr { rd, imm },
+                _ => X86Instruction::Sar { rd, imm },
+            })),
+            X86Operand::Register(_) => Ok(None),
+        },
         _ => Ok(None),
     }
 }
@@ -454,8 +478,9 @@ fn x86_ir_from_mnemonic_impl(
 /// Recognised lines: empty, comments (`;`, `//`, `#`), labels
 /// (`name:`), directives (`.foo`), and instructions whose mnemonic is
 /// one of the supported families (mov, add, sub, and, or, xor, cmp,
-/// test, the single-operand neg/not/inc/dec, plus the conditional cmovCC
-/// and jCC variants). Anything else is a parse error.
+/// test, the single-operand neg/not/inc/dec, the immediate-count shifts
+/// shl/sal/shr/sar, plus the conditional cmovCC and jCC variants). Anything
+/// else is a parse error.
 pub fn parse_x86_assembly_string(
     content: &str,
     source_name: String,
@@ -947,6 +972,94 @@ mod tests {
     }
 
     #[test]
+    fn shift_parse_register_plus_count_and_round_trip_display() {
+        // shl / shr / sar parse to the immediate-count variants and Display
+        // round-trips back to the same IR.
+        let shl = x86_ir_from_mnemonic("shl", "rax, 1").unwrap().unwrap();
+        assert_eq!(
+            shl,
+            X86Instruction::Shl {
+                rd: X86Register::RAX,
+                imm: 1
+            }
+        );
+        assert_eq!(shl.to_string(), "shl rax, 1");
+
+        let shr = x86_ir_from_mnemonic("shr", "rbx, 3").unwrap().unwrap();
+        assert_eq!(
+            shr,
+            X86Instruction::Shr {
+                rd: X86Register::RBX,
+                imm: 3
+            }
+        );
+
+        let sar = x86_ir_from_mnemonic("sar", "rcx, 7").unwrap().unwrap();
+        assert_eq!(
+            sar,
+            X86Instruction::Sar {
+                rd: X86Register::RCX,
+                imm: 7
+            }
+        );
+
+        for instr in [shl, shr, sar] {
+            let text = instr.to_string();
+            let (mnemonic, ops) = text.split_once(char::is_whitespace).unwrap();
+            assert_eq!(
+                x86_ir_from_mnemonic(mnemonic, ops).unwrap().unwrap(),
+                instr,
+                "round-trip failed for {text}"
+            );
+        }
+    }
+
+    #[test]
+    fn sal_parses_to_shl() {
+        // SAL and SHL assemble identically; the parser folds `sal` into `Shl`.
+        assert_eq!(
+            x86_ir_from_mnemonic("sal", "rax, 2").unwrap().unwrap(),
+            X86Instruction::Shl {
+                rd: X86Register::RAX,
+                imm: 2
+            }
+        );
+    }
+
+    #[test]
+    fn shift_with_register_count_is_rejected() {
+        // The CL-register-count form is deferred: `shl rax, rcx` is an
+        // unsupported shape and surfaces as Ok(None), not a Shl.
+        assert!(x86_ir_from_mnemonic("shl", "rax, rcx").unwrap().is_none());
+        assert!(x86_ir_from_mnemonic("shr", "rax, rcx").unwrap().is_none());
+        assert!(x86_ir_from_mnemonic("sar", "rax, rcx").unwrap().is_none());
+        // A single operand (no count) is also an unsupported shape.
+        assert!(x86_ir_from_mnemonic("shl", "rax").unwrap().is_none());
+    }
+
+    #[test]
+    fn shift_round_trip_through_mode_aware_binary_path() {
+        assert_eq!(
+            x86_ir_from_mnemonic_for_mode("shl", "rax, 1", X86ParseMode::Mode64)
+                .unwrap()
+                .unwrap(),
+            X86Instruction::Shl {
+                rd: X86Register::RAX,
+                imm: 1
+            }
+        );
+        assert_eq!(
+            x86_ir_from_mnemonic_for_mode("sar", "eax, 4", X86ParseMode::Mode32)
+                .unwrap()
+                .unwrap(),
+            X86Instruction::Sar {
+                rd: X86Register::RAX,
+                imm: 4
+            }
+        );
+    }
+
+    #[test]
     fn neg_not_round_trip_through_mode_aware_binary_path() {
         assert_eq!(
             x86_ir_from_mnemonic_for_mode("neg", "rax", X86ParseMode::Mode64)
@@ -970,8 +1083,12 @@ mod tests {
     fn x86_ir_unsupported_mnemonic_returns_none() {
         assert!(x86_ir_from_mnemonic("ret", "").unwrap().is_none());
         assert!(x86_ir_from_mnemonic("jmp", "0x1234").unwrap().is_none());
-        // Two-operand "shl" not in the minimal set.
-        assert!(x86_ir_from_mnemonic("shl", "rax, 1").unwrap().is_none());
+        // `lea` is outside the supported set (memory operands unmodelled).
+        assert!(
+            x86_ir_from_mnemonic("lea", "rax, [rbx+1]")
+                .unwrap()
+                .is_none()
+        );
     }
 
     // ---- New: parse_x86_assembly_string ----

--- a/src/semantics/concrete_x86.rs
+++ b/src/semantics/concrete_x86.rs
@@ -45,6 +45,9 @@ pub fn apply_instruction_concrete_x86(
         X86Instruction::Not { rd } => apply_not(&mut state, *rd),
         X86Instruction::Inc { rd } => apply_inc(&mut state, *rd),
         X86Instruction::Dec { rd } => apply_dec(&mut state, *rd),
+        X86Instruction::Shl { rd, imm } => apply_shift(&mut state, *rd, *imm, ShiftKind::Shl),
+        X86Instruction::Shr { rd, imm } => apply_shift(&mut state, *rd, *imm, ShiftKind::Shr),
+        X86Instruction::Sar { rd, imm } => apply_shift(&mut state, *rd, *imm, ShiftKind::Sar),
         X86Instruction::Cmov { rd, rs, cond } => {
             if state.get_flags().evaluate(*cond) {
                 let v = state.get_register(*rs);
@@ -141,6 +144,101 @@ fn apply_dec(state: &mut X86ConcreteMachineState, rd: crate::isa::x86::X86Regist
     state.set_register(rd, ConcreteValue::new(result));
     let mut flags = Eflags::from_sub(old, 1, result, state.width());
     flags.cf = prev_cf;
+    state.set_flags(flags);
+}
+
+#[derive(Clone, Copy)]
+enum ShiftKind {
+    Shl,
+    Shr,
+    Sar,
+}
+
+// Mask a value to the operand width (low `width` bits).
+fn mask_width(value: u64, width: u32) -> u64 {
+    match width {
+        64 => value,
+        32 => value & 0xffff_ffff,
+        16 => value & 0xffff,
+        8 => value & 0xff,
+        _ => unreachable!("unsupported width: {}", width),
+    }
+}
+
+// Top (sign) bit of a width-`width` value.
+fn msb(value: u64, width: u32) -> bool {
+    (mask_width(value, width) >> (width - 1)) & 1 == 1
+}
+
+// Immediate-count shift. The count is a concrete compile-time value, so we
+// branch on it directly rather than modelling a symbolic count.
+//
+// x86 masks the count to `width-1` (0x1f at width 32, 0x3f at width 64). A
+// masked count of 0 is the load-bearing case: the result and ALL flags are
+// left completely unchanged (a shift by 0 touches nothing). For a nonzero
+// count, SF/ZF/PF come from the result; CF is the last bit shifted out; OF is
+// architecturally defined only for count 1.
+//
+// OF for count > 1 is UNDEFINED on real hardware. We deliberately model it
+// with the SAME formula as count == 1 — a fixed, deterministic value. Since
+// both the target and candidate sequences go through this identical lowering,
+// equivalence checking stays internally consistent; downstream consumers must
+// not rely on OF after a count > 1 shift because the architecture leaves it
+// undefined.
+fn apply_shift(
+    state: &mut X86ConcreteMachineState,
+    rd: crate::isa::x86::X86Register,
+    imm: i64,
+    kind: ShiftKind,
+) {
+    let width = state.width();
+    let mask = u64::from(width - 1);
+    let eff = (imm as u64) & mask;
+    let old = mask_width(state.get_register(rd).as_u64(), width);
+
+    // Count masks to 0: leave rd and every flag untouched.
+    if eff == 0 {
+        return;
+    }
+
+    let result = match kind {
+        ShiftKind::Shl => old << eff,
+        ShiftKind::Shr => old >> eff,
+        // Arithmetic right shift: sign-extend within the operand width.
+        ShiftKind::Sar => {
+            let sign = msb(old, width);
+            let logical = old >> eff;
+            if sign {
+                // Set the top `eff` bits that the logical shift cleared.
+                let fill = mask_width(!0u64 << (width as u64 - eff), width);
+                logical | fill
+            } else {
+                logical
+            }
+        }
+    };
+    let result = mask_width(result, width);
+
+    // CF is the last bit shifted out of the source.
+    let cf = match kind {
+        // SHL: the bit at index `width - eff` of the original operand.
+        ShiftKind::Shl => (old >> (width as u64 - eff)) & 1 == 1,
+        // SHR / SAR: the bit at index `eff - 1` of the original operand.
+        ShiftKind::Shr | ShiftKind::Sar => (old >> (eff - 1)) & 1 == 1,
+    };
+
+    // OF: defined for count == 1 only; we reuse the count-1 formula for all
+    // nonzero counts (see the function comment).
+    let of = match kind {
+        ShiftKind::Shl => msb(result, width) ^ cf,
+        ShiftKind::Shr => msb(old, width),
+        ShiftKind::Sar => false,
+    };
+
+    state.set_register(rd, ConcreteValue::new(result));
+    let mut flags = Eflags::from_logical(result, width);
+    flags.cf = cf;
+    flags.of = of;
     state.set_flags(flags);
 }
 
@@ -501,6 +599,146 @@ mod tests {
                     "{instr:?} must preserve CF (incoming CF = {cf_in})"
                 );
             }
+        }
+    }
+
+    #[test]
+    fn shl_shifts_left_and_sets_zf_sf() {
+        // shl rax, 4 of 0x0F00_0000_0000_0000 -> 0xF000_0000_0000_0000:
+        // SF set (MSB), ZF clear.
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(0x0F00_0000_0000_0000));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::Shl {
+                rd: X86Register::RAX,
+                imm: 4,
+            },
+        );
+        assert_eq!(
+            after.get_register(X86Register::RAX).as_u64(),
+            0xF000_0000_0000_0000
+        );
+        let flags = after.get_flags();
+        assert!(flags.sf, "shl result MSB set -> SF");
+        assert!(!flags.zf);
+
+        // shl that shifts every bit out -> 0: ZF set.
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(1u64 << 60));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::Shl {
+                rd: X86Register::RAX,
+                imm: 8,
+            },
+        );
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 0);
+        assert!(after.get_flags().zf, "all bits shifted out -> ZF set");
+    }
+
+    // Known-concrete CF case from the DoD: `shr rax, 1` of an odd value sets
+    // CF = 1 (the low bit shifted out).
+    #[test]
+    fn shr_odd_value_sets_carry_from_low_bit() {
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(0b1011));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::Shr {
+                rd: X86Register::RAX,
+                imm: 1,
+            },
+        );
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 0b101);
+        assert!(
+            after.get_flags().cf,
+            "shr of an odd value shifts a 1 out -> CF set"
+        );
+
+        // Even value: low bit is 0, so CF clear.
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(0b1010));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::Shr {
+                rd: X86Register::RAX,
+                imm: 1,
+            },
+        );
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 0b101);
+        assert!(!after.get_flags().cf, "shr of an even value -> CF clear");
+    }
+
+    #[test]
+    fn sar_preserves_sign_and_sets_carry() {
+        // sar of a negative value sign-extends; CF = original bit (eff-1).
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(0x8000_0000_0000_0001));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::Sar {
+                rd: X86Register::RAX,
+                imm: 1,
+            },
+        );
+        // 0x8000_0000_0000_0001 >>s 1 = 0xC000_0000_0000_0000.
+        assert_eq!(
+            after.get_register(X86Register::RAX).as_u64(),
+            0xC000_0000_0000_0000
+        );
+        let flags = after.get_flags();
+        assert!(flags.sf, "sar of a negative value keeps the sign -> SF");
+        assert!(flags.cf, "sar shifts the set low bit out -> CF set");
+    }
+
+    // The load-bearing eff == 0 case: a shift by 0 (after masking) leaves the
+    // register AND every flag untouched. We seed distinctive flag values and
+    // assert they survive unchanged for shl/shr/sar.
+    #[test]
+    fn shift_by_zero_preserves_register_and_all_flags() {
+        for instr in [
+            X86Instruction::Shl {
+                rd: X86Register::RAX,
+                imm: 0,
+            },
+            X86Instruction::Shr {
+                rd: X86Register::RAX,
+                imm: 0,
+            },
+            X86Instruction::Sar {
+                rd: X86Register::RAX,
+                imm: 0,
+            },
+            // A count of 64 masks to 0 at width 64 (mask = 0x3f), so it is also
+            // a no-op even though the raw count is nonzero.
+            X86Instruction::Shl {
+                rd: X86Register::RAX,
+                imm: 64,
+            },
+        ] {
+            let mut state = X86ConcreteMachineState::new_zeroed(64);
+            state.set_register(X86Register::RAX, ConcreteValue::new(0xDEAD_BEEF));
+            let seeded = Eflags {
+                cf: true,
+                pf: true,
+                af: true,
+                zf: true,
+                sf: true,
+                of: true,
+            };
+            state.set_flags(seeded);
+            let after = apply_instruction_concrete_x86(state, &instr);
+            assert_eq!(
+                after.get_register(X86Register::RAX).as_u64(),
+                0xDEAD_BEEF,
+                "{instr:?} (eff==0) must leave rd unchanged"
+            );
+            assert_eq!(
+                after.get_flags(),
+                seeded,
+                "{instr:?} (eff==0) must preserve ALL flags"
+            );
         }
     }
 

--- a/src/semantics/cost_x86.rs
+++ b/src/semantics/cost_x86.rs
@@ -62,6 +62,11 @@ fn instruction_code_size(instr: &X86Instruction, width: u32) -> u64 {
         // INC / DEC are single-operand `FF /0` / `FF /1` = 2 bytes (+REX.W).
         | X86Instruction::Inc { .. }
         | X86Instruction::Dec { .. } => 2 + rex,
+        // SHL / SHR / SAR by imm8 are `C1 /n ib` = opcode + ModR/M + imm8
+        // = 3 bytes (+REX.W).
+        X86Instruction::Shl { .. }
+        | X86Instruction::Shr { .. }
+        | X86Instruction::Sar { .. } => 3 + rex,
         X86Instruction::AddImm { .. }
         | X86Instruction::SubImm { .. }
         | X86Instruction::AndImm { .. }

--- a/src/semantics/smt_x86.rs
+++ b/src/semantics/smt_x86.rs
@@ -227,6 +227,77 @@ pub fn compute_eflags_logical(result: &BV, width: u32) -> EflagsBvs {
     }
 }
 
+#[derive(Clone, Copy)]
+enum ShiftKind {
+    Shl,
+    Shr,
+    Sar,
+}
+
+/// Lower an immediate-count shift symbolically. The count is a CONCRETE IR
+/// value, so we mask it in Rust and branch on the result — there is no
+/// symbolic-count handling. The flag model mirrors the concrete interpreter
+/// (`semantics::concrete_x86::apply_shift`) bit-for-bit:
+///
+/// * `eff == 0`: leave `rd` and ALL flags untouched (a shift by 0 is a no-op).
+/// * `eff != 0`: SF/ZF/PF from the result; CF is the last bit shifted out
+///   (`extract` of the exact source bit index); OF is architecturally defined
+///   only for count 1. For count > 1 OF is UNDEFINED on hardware — we model it
+///   with the SAME formula as count 1 (a deterministic value). Target and
+///   candidate share this lowering, so equivalence stays internally
+///   consistent; downstream code must not rely on OF after a count > 1 shift.
+fn apply_shift_smt(
+    state: &mut MachineStateX86,
+    rd: crate::isa::x86::X86Register,
+    imm: i64,
+    kind: ShiftKind,
+) {
+    let width = state.width();
+    let mask = u64::from(width - 1);
+    let eff = (imm as u64) & mask;
+
+    // Count masks to 0: no register or flag change.
+    if eff == 0 {
+        return;
+    }
+
+    let old = state.get_register(rd).clone();
+    let amount = BV::from_u64(eff, width);
+    let result = match kind {
+        ShiftKind::Shl => old.bvshl(&amount),
+        ShiftKind::Shr => old.bvlshr(&amount),
+        ShiftKind::Sar => old.bvashr(&amount),
+    };
+
+    // CF is the last bit shifted out of the original operand. Since `eff` is
+    // concrete we extract the exact bit index.
+    let cf = match kind {
+        // SHL: original bit at index `width - eff`.
+        ShiftKind::Shl => {
+            let bit = width - eff as u32;
+            old.extract(bit, bit)
+        }
+        // SHR / SAR: original bit at index `eff - 1`.
+        ShiftKind::Shr | ShiftKind::Sar => {
+            let bit = eff as u32 - 1;
+            old.extract(bit, bit)
+        }
+    };
+
+    // OF: count-1 formula, reused for all nonzero counts (see doc comment).
+    let of = match kind {
+        ShiftKind::Shl => top_bit_bv(&result, width).bvxor(&cf),
+        ShiftKind::Shr => top_bit_bv(&old, width),
+        ShiftKind::Sar => bv_zero(),
+    };
+
+    let mut flags = compute_eflags_logical(&result, width);
+    flags.cf = cf;
+    flags.of = of;
+    state.set_register(rd, result);
+    state.set_flags(flags);
+}
+
 /// Apply a single x86 instruction symbolically. Arithmetic / logic /
 /// CMP arms bind the five tracked flag BVs via `compute_eflags_*`;
 /// CMOV reads them via `x86_condition_to_smt`.
@@ -399,6 +470,12 @@ pub fn apply_instruction(
             state.set_register(*rd, result);
             state.set_flags(flags);
         }
+        // Immediate-count shifts. The count is a concrete IR value, so we branch
+        // on the masked count at lowering time — no symbolic-count handling is
+        // needed. See `apply_shift_smt`.
+        X86Instruction::Shl { rd, imm } => apply_shift_smt(&mut state, *rd, *imm, ShiftKind::Shl),
+        X86Instruction::Shr { rd, imm } => apply_shift_smt(&mut state, *rd, *imm, ShiftKind::Shr),
+        X86Instruction::Sar { rd, imm } => apply_shift_smt(&mut state, *rd, *imm, ShiftKind::Sar),
         X86Instruction::Cmov { rd, rs, cond } => {
             let pred = x86_condition_to_smt(*cond, state.get_flags());
             let rs_val = state.get_register(*rs).clone();
@@ -896,6 +973,132 @@ mod tests {
                 "SUB-1's CF must be able to differ from the incoming CF"
             );
         }
+    }
+
+    // --- symbolic SHL / SHR / SAR ---
+
+    // The DoD SHL theorem: `shl rd, 1` is equivalent to `add rd, rd` on the
+    // RESULT, ZF, and SF. (CF, OF, and PF may differ — `add` derives CF from
+    // the addition and OF from signed overflow, while SHL's CF is the bit
+    // shifted out and OF is `MSB(result) XOR CF`; we deliberately assert only
+    // result + ZF + SF agree.) We prove the negation of that conjunction is
+    // unsat over a shared symbolic input.
+    #[test]
+    fn shl_one_matches_add_self_on_result_zf_sf() {
+        let prefix = "shared";
+        let s_shl = MachineStateX86::new_symbolic(prefix, 64);
+        let s_add = MachineStateX86::new_symbolic(prefix, 64);
+
+        let after_shl = apply_instruction(
+            s_shl,
+            &X86Instruction::Shl {
+                rd: X86Register::RAX,
+                imm: 1,
+            },
+        );
+        // `add rax, rax` doubles rax, exactly like a 1-bit left shift.
+        let after_add = apply_instruction(
+            s_add,
+            &X86Instruction::AddReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RAX,
+            },
+        );
+
+        let shl_flags = after_shl.get_flags();
+        let add_flags = after_add.get_flags();
+
+        let solver = Solver::new();
+        solver.assert(z3::ast::Bool::or(&[
+            &after_shl
+                .get_register(X86Register::RAX)
+                .eq(after_add.get_register(X86Register::RAX))
+                .not(),
+            &shl_flags.zf.eq(add_flags.zf).not(),
+            &shl_flags.sf.eq(add_flags.sf).not(),
+        ]));
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "shl rax, 1 and add rax, rax must agree on result, ZF and SF"
+        );
+    }
+
+    // The eff == 0 case: a shift whose masked count is 0 must leave the
+    // register AND all five tracked flags BIT-IDENTICAL to the incoming state.
+    // We prove the disjunction "rd changed OR any flag changed" is unsat.
+    #[test]
+    fn shift_by_zero_preserves_register_and_all_flags_smt() {
+        for instr in [
+            X86Instruction::Shl {
+                rd: X86Register::RAX,
+                imm: 0,
+            },
+            X86Instruction::Shr {
+                rd: X86Register::RAX,
+                imm: 0,
+            },
+            X86Instruction::Sar {
+                rd: X86Register::RAX,
+                imm: 0,
+            },
+            // 64 masks to 0 at width 64.
+            X86Instruction::Sar {
+                rd: X86Register::RAX,
+                imm: 64,
+            },
+        ] {
+            let before = MachineStateX86::new_symbolic("s", 64);
+            let old_reg = before.get_register(X86Register::RAX).clone();
+            let old_flags = before.get_flags();
+            let (old_cf, old_pf, old_zf, old_sf, old_of) = (
+                old_flags.cf.clone(),
+                old_flags.pf.clone(),
+                old_flags.zf.clone(),
+                old_flags.sf.clone(),
+                old_flags.of.clone(),
+            );
+
+            let after = apply_instruction(before, &instr);
+            let after_flags = after.get_flags();
+
+            let solver = Solver::new();
+            solver.assert(z3::ast::Bool::or(&[
+                &after.get_register(X86Register::RAX).eq(&old_reg).not(),
+                &after_flags.cf.eq(&old_cf).not(),
+                &after_flags.pf.eq(&old_pf).not(),
+                &after_flags.zf.eq(&old_zf).not(),
+                &after_flags.sf.eq(&old_sf).not(),
+                &after_flags.of.eq(&old_of).not(),
+            ]));
+            assert_eq!(
+                solver.check(),
+                SatResult::Unsat,
+                "{instr:?} (eff==0) must preserve rd and every flag"
+            );
+        }
+    }
+
+    // CF correctness for SHR: `shr rax, 1` sets CF to the original low bit.
+    // We prove `cf == rax[0]` is always true (negation unsat).
+    #[test]
+    fn shr_one_cf_equals_original_low_bit() {
+        let state = MachineStateX86::new_symbolic("s", 64);
+        let orig_low = state.get_register(X86Register::RAX).extract(0, 0);
+        let after = apply_instruction(
+            state,
+            &X86Instruction::Shr {
+                rd: X86Register::RAX,
+                imm: 1,
+            },
+        );
+        let solver = Solver::new();
+        solver.assert(after.get_flags().cf.eq(&orig_low).not());
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "shr rax, 1 must set CF to the original low bit"
+        );
     }
 
     // --- symbolic CMOV ---


### PR DESCRIPTION
Closes #628.

Adds immediate-count shifts `Shl`/`Shr`/`Sar` (`sal` parses to `Shl`). CL-register count form deferred.

**Flag model** (count is a concrete immediate, so the lowering branches on it): `eff = (imm as u64) & (width-1)`.
- `eff == 0`: register and **all flags preserved** (shift-by-0 is a no-op).
- `eff != 0`: SF/ZF/PF from the result; CF = the last bit shifted out, extracted at the exact source bit index — SHL: `width-eff`, SHR/SAR: `eff-1`; OF (defined only for count==1) — SHL `MSB(result)^CF`, SHR `MSB(orig)`, SAR `0`. For count>1 OF is architecturally undefined; modeled deterministically with the count==1 formula and documented (target & candidate share the lowering, so equivalence stays internally consistent).

Z3: `bvshl`/`bvlshr`/`bvashr` via a shared `apply_shift_smt` helper (concrete mirror in `concrete_x86.rs`). Encodability: the count must fit `imm8` (`can_assemble` rejects otherwise); assembler emits `shl/shr/sar Rq(rd), imm8` (SAL≡SHL, disassembles as `shl`).

**CMOV invariant**: inserted at 20/21/22 before CMOV → `…18 Inc,19 Dec,20 Shl,21 Shr,22 Sar,23 Cmov`; `X86_REWRITABLE_OPCODE_COUNT` 21→24; Cmov stays last (23 = COUNT−1). Shifts use the shared `imm` dispatch slot (no extra RNG draw), so no seed retune was needed; parity + `opcode_dispatch_is_consistent` green.

**DoD SMT theorem** `shl_one_matches_add_self_on_result_zf_sf`: `shl rd, 1` ≡ `add rd, rd` on result + ZF + SF. Plus 13 more tests (parser round-trip incl. sal→shl + rejection, concrete ZF/SF/CF/sign-extension, `eff==0` preserves all in concrete+SMT, SMT shr CF==low bit, assembler Capstone round-trips 64/32).

`./ci_check.sh` + `RUSTFLAGS="-D warnings" cargo build` pass; clippy adds no new lints in changed files; 1360 lib tests green.