### PR TITLE
x86: add ROL/ROR immediate-count rotates (#629)

### DIFF
--- a/docs/capability.md
+++ b/docs/capability.md
@@ -100,6 +100,7 @@ Rewritable straight-line mnemonic families:
 - `mov`, `add`, `sub`, `and`, `or`, `xor`, `cmp`, `test`
 - Single-operand: `neg`, `not`, `inc`, `dec`
 - Immediate-count shifts: `shl`/`sal`, `shr`, `sar`
+- Immediate-count rotates: `rol`, `ror`
 - Conditional moves: `cmov<cond>`
 
 The data-movement/arithmetic/logical/comparison families have register and
@@ -119,8 +120,16 @@ last bit shifted out. OF is architecturally defined only for a count of 1 and
 is UNDEFINED for larger counts; the model uses the count-1 OF formula for every
 nonzero count as a deterministic, internally-consistent value, so downstream
 code must not rely on OF after a count > 1 shift. `sal` assembles identically to
-`shl` and parses to the same IR. `cmov<cond>` has register operands and reads
-EFLAGS without modifying them.
+`shl` and parses to the same IR. `rol` and `ror` are immediate-count rotates
+(the CL-register-count form is not yet modelled) and differ from the shifts in
+their flag effect: a rotate touches ONLY CF (plus OF for a count of 1) and
+PRESERVES SF/ZF/PF/AF. A masked count of 0 leaves the register and ALL flags
+unchanged. For a nonzero count, `rol` sets CF to bit 0 of the result (the bit
+rotated out of the MSB) and `ror` sets CF to the result's MSB; OF is defined only
+for a count of 1 (`rol`: `MSB(result) XOR CF`; `ror`: XOR of the result's two
+most-significant bits) and, like the shifts, is preserved (left at its incoming
+value) for count > 1. `cmov<cond>` has register operands and reads EFLAGS without
+modifying them.
 
 The x86 IR does not yet carry operand width. To avoid rewriting partial-width
 operations as full-width operations, the binary optimization path currently

--- a/src/assembler/x86.rs
+++ b/src/assembler/x86.rs
@@ -237,6 +237,18 @@ fn encode_64(ops: &mut dynasmrt::x64::Assembler, instr: &X86Instruction) -> Resu
             dynasm!(ops ; .arch x64 ; sar Rq(rd), BYTE count);
             Ok(())
         }
+        X86Instruction::Rol { rd, imm } => {
+            let rd = reg_index(*rd)?;
+            let count = shift_count_imm8(*imm)?;
+            dynasm!(ops ; .arch x64 ; rol Rq(rd), BYTE count);
+            Ok(())
+        }
+        X86Instruction::Ror { rd, imm } => {
+            let rd = reg_index(*rd)?;
+            let count = shift_count_imm8(*imm)?;
+            dynasm!(ops ; .arch x64 ; ror Rq(rd), BYTE count);
+            Ok(())
+        }
         X86Instruction::Cmov { rd, rs, cond } => {
             let rd = reg_index(*rd)?;
             let rs = reg_index(*rs)?;
@@ -449,6 +461,18 @@ fn encode_32(ops: &mut dynasmrt::x86::Assembler, instr: &X86Instruction) -> Resu
             let rd = reg_index_32(*rd)?;
             let count = shift_count_imm8(*imm)?;
             dynasm!(ops ; .arch x86 ; sar Rd(rd), BYTE count);
+            Ok(())
+        }
+        X86Instruction::Rol { rd, imm } => {
+            let rd = reg_index_32(*rd)?;
+            let count = shift_count_imm8(*imm)?;
+            dynasm!(ops ; .arch x86 ; rol Rd(rd), BYTE count);
+            Ok(())
+        }
+        X86Instruction::Ror { rd, imm } => {
+            let rd = reg_index_32(*rd)?;
+            let count = shift_count_imm8(*imm)?;
+            dynasm!(ops ; .arch x86 ; ror Rd(rd), BYTE count);
             Ok(())
         }
         X86Instruction::Cmov { rd, rs, cond } => {
@@ -906,6 +930,55 @@ mod tests {
             },
             "sar",
             &["ebx", "4"],
+        );
+    }
+
+    #[test]
+    fn rotate_variants_x86_64() {
+        check_x86_64(
+            X86Instruction::Rol {
+                rd: X86Register::RAX,
+                imm: 1,
+            },
+            "rol",
+            &["rax", "1"],
+        );
+        check_x86_64(
+            X86Instruction::Ror {
+                rd: X86Register::RBX,
+                imm: 5,
+            },
+            "ror",
+            &["rbx", "5"],
+        );
+        // Extended register round-trips too.
+        check_x86_64(
+            X86Instruction::Rol {
+                rd: X86Register::R9,
+                imm: 7,
+            },
+            "rol",
+            &["r9", "7"],
+        );
+    }
+
+    #[test]
+    fn rotate_variants_x86_32() {
+        check_x86_32(
+            X86Instruction::Rol {
+                rd: X86Register::RAX,
+                imm: 2,
+            },
+            "rol",
+            &["eax", "2"],
+        );
+        check_x86_32(
+            X86Instruction::Ror {
+                rd: X86Register::RDX,
+                imm: 4,
+            },
+            "ror",
+            &["edx", "4"],
         );
     }
 

--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -348,6 +348,25 @@ pub enum X86Instruction {
     /// original bit `eff - 1`, OF (count 1 only) = 0. The CL-register-count form
     /// is not modelled.
     Sar { rd: X86Register, imm: i64 },
+    /// `rol rd, imm` — rotate left by a compile-time COUNT. Reads and writes
+    /// `rd`. `imm` is masked to `width-1` like the shifts. **Unlike the shifts,
+    /// rotates touch ONLY CF (plus OF for count 1); SF/ZF/PF/AF are PRESERVED**.
+    /// A masked count of 0 leaves `rd` and ALL flags unchanged. Otherwise
+    /// `rd = rotate_left(rd, eff)`, CF = bit 0 of the result (the bit rotated
+    /// from the MSB into the LSB), and OF (architecturally defined only for
+    /// count 1) = `MSB(result) XOR CF`. For count != 1 OF is UNDEFINED, so the
+    /// model preserves the incoming OF. The CL-register-count form is not
+    /// modelled.
+    Rol { rd: X86Register, imm: i64 },
+    /// `ror rd, imm` — rotate right by a compile-time COUNT. Reads and writes
+    /// `rd`. `imm` is masked like `rol`, and the same partial-flag model
+    /// applies: only CF (plus OF for count 1) changes; SF/ZF/PF/AF are
+    /// PRESERVED; a masked count of 0 is a full no-op. Otherwise
+    /// `rd = rotate_right(rd, eff)`, CF = the MSB (bit `width-1`) of the result,
+    /// and OF (count 1 only) = XOR of the result's two most-significant bits
+    /// (`MSB(result) XOR bit width-2`). For count != 1 OF is UNDEFINED so the
+    /// incoming OF is preserved. The CL-register-count form is not modelled.
+    Ror { rd: X86Register, imm: i64 },
     /// `cmovCC rd, rs` — conditional move. Reads EFLAGS;
     /// when `cond` holds, writes `rd = rs`; otherwise `rd` is unchanged.
     /// Does not modify EFLAGS.
@@ -385,6 +404,8 @@ impl X86Instruction {
             | X86Instruction::Shl { rd, .. }
             | X86Instruction::Shr { rd, .. }
             | X86Instruction::Sar { rd, .. }
+            | X86Instruction::Rol { rd, .. }
+            | X86Instruction::Ror { rd, .. }
             | X86Instruction::Cmov { rd, .. } => Some(*rd),
             // CMP and TEST discard their result; only EFLAGS is written.
             X86Instruction::CmpReg { .. }
@@ -412,6 +433,8 @@ impl X86Instruction {
             X86Instruction::Shl { .. } => "shl",
             X86Instruction::Shr { .. } => "shr",
             X86Instruction::Sar { .. } => "sar",
+            X86Instruction::Rol { .. } => "rol",
+            X86Instruction::Ror { .. } => "ror",
             X86Instruction::Cmov { cond, .. } => cond.cmov_mnemonic(),
             X86Instruction::Jcc { cond } => cond.jcc_mnemonic(),
         }
@@ -440,7 +463,10 @@ impl X86Instruction {
             // SHL / SHR / SAR read and write rd; the count is an immediate.
             | X86Instruction::Shl { rd, .. }
             | X86Instruction::Shr { rd, .. }
-            | X86Instruction::Sar { rd, .. } => vec![*rd],
+            | X86Instruction::Sar { rd, .. }
+            // ROL / ROR read and write rd; the rotate count is an immediate.
+            | X86Instruction::Rol { rd, .. }
+            | X86Instruction::Ror { rd, .. } => vec![*rd],
             X86Instruction::CmpReg { rn, rs } => vec![*rn, *rs],
             X86Instruction::CmpImm { rn, .. } => vec![*rn],
             // TEST reads both operands (or just rn for the immediate form) and
@@ -504,11 +530,13 @@ impl InstructionType for X86Instruction {
             X86Instruction::Shl { .. } => 20,
             X86Instruction::Shr { .. } => 21,
             X86Instruction::Sar { .. } => 22,
-            // Cmov MUST stay the last rewritable opcode (COUNT - 1 == 23):
+            X86Instruction::Rol { .. } => 23,
+            X86Instruction::Ror { .. } => 24,
+            // Cmov MUST stay the last rewritable opcode (COUNT - 1 == 25):
             // the CMOV distinct-register draw at both generation sites is
             // gated on `opcode == X86_REWRITABLE_OPCODE_COUNT - 1`.
-            X86Instruction::Cmov { .. } => 23,
-            X86Instruction::Jcc { .. } => 24,
+            X86Instruction::Cmov { .. } => 25,
+            X86Instruction::Jcc { .. } => 26,
         }
     }
 
@@ -549,10 +577,12 @@ impl fmt::Display for X86Instruction {
             | X86Instruction::AndImm { rd, imm }
             | X86Instruction::OrImm { rd, imm }
             | X86Instruction::XorImm { rd, imm }
-            // SHL / SHR / SAR render `mnemonic rd, count`.
+            // SHL / SHR / SAR / ROL / ROR render `mnemonic rd, count`.
             | X86Instruction::Shl { rd, imm }
             | X86Instruction::Shr { rd, imm }
-            | X86Instruction::Sar { rd, imm } => write!(f, "{} {}, {}", mn, rd, imm),
+            | X86Instruction::Sar { rd, imm }
+            | X86Instruction::Rol { rd, imm }
+            | X86Instruction::Ror { rd, imm } => write!(f, "{} {}, {}", mn, rd, imm),
             X86Instruction::CmpReg { rn, rs } | X86Instruction::TestReg { rn, rs } => {
                 write!(f, "{} {}, {}", mn, rn, rs)
             }
@@ -846,12 +876,14 @@ impl crate::isa::traits::Assembler<X86Instruction> for X86_64 {
             | X86Instruction::XorImm { imm, .. }
             | X86Instruction::CmpImm { imm, .. }
             | X86Instruction::TestImm { imm, .. } => x86_signed_imm32_ok(*imm),
-            // SHL / SHR / SAR encode their count as imm8: reject any count that
-            // does not fit a single byte so the search never proposes an
-            // unencodable shift.
+            // SHL / SHR / SAR / ROL / ROR encode their count as imm8: reject any
+            // count that does not fit a single byte so the search never proposes
+            // an unencodable shift or rotate.
             X86Instruction::Shl { imm, .. }
             | X86Instruction::Shr { imm, .. }
-            | X86Instruction::Sar { imm, .. } => x86_shift_count_imm8_ok(*imm),
+            | X86Instruction::Sar { imm, .. }
+            | X86Instruction::Rol { imm, .. }
+            | X86Instruction::Ror { imm, .. } => x86_shift_count_imm8_ok(*imm),
             X86Instruction::MovReg { .. }
             | X86Instruction::MovImm { .. }
             | X86Instruction::AddReg { .. }
@@ -902,10 +934,13 @@ impl crate::isa::traits::Assembler<X86Instruction> for X86_32 {
             X86Instruction::CmpImm { rn, imm } | X86Instruction::TestImm { rn, imm } => {
                 reg_ok_32(*rn) && x86_imm32_bitpattern_ok(*imm)
             }
-            // SHL / SHR / SAR: legal 32-bit register plus an imm8 count.
+            // SHL / SHR / SAR / ROL / ROR: legal 32-bit register plus an imm8
+            // count.
             X86Instruction::Shl { rd, imm }
             | X86Instruction::Shr { rd, imm }
-            | X86Instruction::Sar { rd, imm } => reg_ok_32(*rd) && x86_shift_count_imm8_ok(*imm),
+            | X86Instruction::Sar { rd, imm }
+            | X86Instruction::Rol { rd, imm }
+            | X86Instruction::Ror { rd, imm } => reg_ok_32(*rd) && x86_shift_count_imm8_ok(*imm),
             X86Instruction::Neg { rd }
             | X86Instruction::Not { rd }
             | X86Instruction::Inc { rd }
@@ -1115,11 +1150,13 @@ impl X86Mutator {
                 | X86Instruction::XorImm { imm, .. }
                 | X86Instruction::CmpImm { imm, .. }
                 | X86Instruction::TestImm { imm, .. } => *imm = self.pick_non_mov_immediate(rng),
-                // SHL / SHR / SAR carry a shift count; mutate it from the
-                // imm8-encodable pool even with no register pool.
+                // SHL / SHR / SAR / ROL / ROR carry an imm8 count; mutate it
+                // from the imm8-encodable pool even with no register pool.
                 X86Instruction::Shl { imm, .. }
                 | X86Instruction::Shr { imm, .. }
-                | X86Instruction::Sar { imm, .. } => *imm = self.pick_shift_count(rng),
+                | X86Instruction::Sar { imm, .. }
+                | X86Instruction::Rol { imm, .. }
+                | X86Instruction::Ror { imm, .. } => *imm = self.pick_shift_count(rng),
                 X86Instruction::MovReg { .. }
                 | X86Instruction::AddReg { .. }
                 | X86Instruction::SubReg { .. }
@@ -1188,11 +1225,13 @@ impl X86Mutator {
                     *imm = self.pick_non_mov_immediate(rng);
                 }
             }
-            // SHL / SHR / SAR mutate either the destination register or the
-            // imm8 shift count.
+            // SHL / SHR / SAR / ROL / ROR mutate either the destination register
+            // or the imm8 count.
             X86Instruction::Shl { rd, imm }
             | X86Instruction::Shr { rd, imm }
-            | X86Instruction::Sar { rd, imm } => {
+            | X86Instruction::Sar { rd, imm }
+            | X86Instruction::Rol { rd, imm }
+            | X86Instruction::Ror { rd, imm } => {
                 if rng.random_bool(0.5) {
                     *rd = self.pick_register(rng).expect("register pool is non-empty");
                 } else {
@@ -1332,6 +1371,20 @@ impl X86Mutator {
                     _ => X86Instruction::Sar { rd, imm },
                 }
             }
+            // ROL / ROR share the reg-plus-count shape but a distinct
+            // (CF/OF-only) flag model, so they bridge only to each other —
+            // never to a shift, whose SF/ZF/PF semantics differ. Carry the
+            // current count through, re-drawing only if it became unencodable.
+            // The draw range includes the current variant, so it may be an
+            // identity mutation.
+            X86Instruction::Rol { rd, imm } | X86Instruction::Ror { rd, imm } => {
+                let imm = self.keep_or_pick_shift_count(rng, imm);
+                if rng.random_bool(0.5) {
+                    X86Instruction::Rol { rd, imm }
+                } else {
+                    X86Instruction::Ror { rd, imm }
+                }
+            }
             // Cmov has a unique shape (rd, rs, cond) with no opcode-shape
             // siblings; keep it unchanged in the opcode-bridge mutator.
             X86Instruction::Cmov { .. } => current,
@@ -1407,18 +1460,19 @@ impl crate::isa::traits::ISAMutator<X86Instruction> for X86Mutator {
 pub struct X86InstructionGenerator;
 
 // One entry per rewritable opcode family: 6 reg-reg + 6 reg-imm + CMP + TEST
-// (each reg/imm) + NEG + NOT + INC + DEC + SHL + SHR + SAR + CMOVcc. CMOVcc
-// counts as a single family here even though `generate_all` expands it across
-// all 16 `X86Condition::ALL` variants per register pair.
+// (each reg/imm) + NEG + NOT + INC + DEC + SHL + SHR + SAR + ROL + ROR +
+// CMOVcc. CMOVcc counts as a single family here even though `generate_all`
+// expands it across all 16 `X86Condition::ALL` variants per register pair.
 //
-// CMOV MUST remain the LAST opcode (index COUNT - 1 == 23): both
+// CMOV MUST remain the LAST opcode (index COUNT - 1 == 25): both
 // `X86Mutator::random_instruction` and
 // `generate_random_rewritable_x86_instruction` gate the extra distinct-source
 // CMOV draw on `opcode == X86_REWRITABLE_OPCODE_COUNT - 1`. New flag-only
-// families (CMP, TEST), single-operand families (NEG, NOT, INC, DEC), and the
-// immediate-count shift families (SHL, SHR, SAR) are inserted before CMOV in
+// families (CMP, TEST), single-operand families (NEG, NOT, INC, DEC), the
+// immediate-count shift families (SHL, SHR, SAR), and the immediate-count
+// rotate families (ROL, ROR) are inserted before CMOV in
 // `build_x86_instruction_by_opcode` to preserve that invariant.
-const X86_REWRITABLE_OPCODE_COUNT: u8 = 24;
+const X86_REWRITABLE_OPCODE_COUNT: u8 = 26;
 
 fn has_distinct_register_pair(registers: &[X86Register]) -> bool {
     let Some(first) = registers.first() else {
@@ -1433,7 +1487,7 @@ fn has_distinct_register_pair(registers: &[X86Register]) -> bool {
 /// `X86Mutator::random_instruction` and
 /// `generate_random_rewritable_x86_instruction` both delegate here so the two
 /// dispatch tables cannot drift (see issue #348). Operand drawing and RNG draw
-/// order stay at the call sites; the CMOV slot (opcode 23, the last index)
+/// order stay at the call sites; the CMOV slot (opcode 25, the last index)
 /// consumes the `rs` the caller resolved via `pick_register_except` so
 /// `rs != rd`.
 ///
@@ -1476,9 +1530,14 @@ pub(crate) fn build_x86_instruction_by_opcode(
         20 => X86Instruction::Shl { rd, imm },
         21 => X86Instruction::Shr { rd, imm },
         22 => X86Instruction::Sar { rd, imm },
-        // Cmov stays last (index 23 == X86_REWRITABLE_OPCODE_COUNT - 1) so the
+        // ROL / ROR consume `rd` plus the shared `imm` rotate count, exactly
+        // like the shifts — no extra RNG draw, so the two dispatch sites stay
+        // in lock-step on the shared `imm`.
+        23 => X86Instruction::Rol { rd, imm },
+        24 => X86Instruction::Ror { rd, imm },
+        // Cmov stays last (index 25 == X86_REWRITABLE_OPCODE_COUNT - 1) so the
         // CMOV distinct-register draw at the two generation sites stays correct.
-        23 => X86Instruction::Cmov { rd, rs, cond },
+        25 => X86Instruction::Cmov { rd, rs, cond },
         _ => unreachable!("opcode out of range"),
     }
 }
@@ -1615,6 +1674,17 @@ impl InstructionGenerator<X86Instruction> for X86InstructionGenerator {
                 out.push(X86Instruction::Sar { rd, imm });
             }
         }
+        // Immediate-count rotates (ROL, ROR): same imm8-count shape as the
+        // shifts, so only imm8-encodable counts yield a candidate.
+        for &rd in registers {
+            for &imm in immediates {
+                if !x86_shift_count_imm8_ok(imm) {
+                    continue;
+                }
+                out.push(X86Instruction::Rol { rd, imm });
+                out.push(X86Instruction::Ror { rd, imm });
+            }
+        }
         // CMOVcc is rewritable and reads flags, so enumerate every
         // condition for each non-identical register pair. Jcc remains
         // excluded.
@@ -1713,6 +1783,9 @@ fn with_destination(instr: X86Instruction, new_rd: X86Register) -> X86Instructio
         X86Instruction::Shl { imm, .. } => X86Instruction::Shl { rd: new_rd, imm },
         X86Instruction::Shr { imm, .. } => X86Instruction::Shr { rd: new_rd, imm },
         X86Instruction::Sar { imm, .. } => X86Instruction::Sar { rd: new_rd, imm },
+        // ROL / ROR likewise redirect the destination, carrying the count.
+        X86Instruction::Rol { imm, .. } => X86Instruction::Rol { rd: new_rd, imm },
+        X86Instruction::Ror { imm, .. } => X86Instruction::Ror { rd: new_rd, imm },
         X86Instruction::Cmov { rd, rs, cond } => X86Instruction::Cmov {
             rd: if new_rd == rs { rd } else { new_rd },
             rs,
@@ -1767,6 +1840,24 @@ fn with_sources(instr: X86Instruction, new_rs: X86Register, new_imm: i64) -> X86
             },
         },
         X86Instruction::Sar { rd, imm } => X86Instruction::Sar {
+            rd,
+            imm: if x86_shift_count_imm8_ok(new_imm) {
+                new_imm
+            } else {
+                imm
+            },
+        },
+        // ROL / ROR vary the rotate count via `new_imm` when it is imm8-encodable;
+        // otherwise keep the existing count so the result stays assemblable.
+        X86Instruction::Rol { rd, imm } => X86Instruction::Rol {
+            rd,
+            imm: if x86_shift_count_imm8_ok(new_imm) {
+                new_imm
+            } else {
+                imm
+            },
+        },
+        X86Instruction::Ror { rd, imm } => X86Instruction::Ror {
             rd,
             imm: if x86_shift_count_imm8_ok(new_imm) {
                 new_imm
@@ -1833,13 +1924,18 @@ mod tests {
             .count();
         // 8 reg-reg families + 8 reg-imm families + 4 single-operand families
         // (NEG, NOT, INC, DEC) + 3 shift families (SHL, SHR, SAR over imm8
-        // counts) + CMOVcc over distinct pairs.
-        let expected_len =
-            8 * n * n + 8 * n * m + 4 * n + 3 * n * shift_m + n * (n - 1) * X86Condition::ALL.len();
+        // counts) + 2 rotate families (ROL, ROR over imm8 counts) + CMOVcc over
+        // distinct pairs.
+        let expected_len = 8 * n * n
+            + 8 * n * m
+            + 4 * n
+            + 3 * n * shift_m
+            + 2 * n * shift_m
+            + n * (n - 1) * X86Condition::ALL.len();
         assert_eq!(
             all.len(),
             expected_len,
-            "generate_all should only prune CMOV self-pairs and non-imm8 shift counts from the full pool"
+            "generate_all should only prune CMOV self-pairs and non-imm8 shift/rotate counts from the full pool"
         );
 
         // For each opcode_id, at least one variant must appear.
@@ -2007,12 +2103,14 @@ mod tests {
                 | X86Instruction::XorImm { imm, .. }
                 | X86Instruction::CmpImm { imm, .. }
                 | X86Instruction::TestImm { imm, .. }
-                // Shifts draw their count from the same shared `imm` slot in
-                // `generate_random_rewritable_x86_instruction`, so it is in the
-                // pool too.
+                // Shifts and rotates draw their count from the same shared
+                // `imm` slot in `generate_random_rewritable_x86_instruction`,
+                // so it is in the pool too.
                 | X86Instruction::Shl { imm, .. }
                 | X86Instruction::Shr { imm, .. }
-                | X86Instruction::Sar { imm, .. } => {
+                | X86Instruction::Sar { imm, .. }
+                | X86Instruction::Rol { imm, .. }
+                | X86Instruction::Ror { imm, .. } => {
                     assert!(imms.contains(&imm), "immediate {} outside pool", imm);
                 }
                 X86Instruction::MovReg { .. }
@@ -3123,10 +3221,13 @@ mod tests {
                 | X86Instruction::XorImm { imm, .. }
                 | X86Instruction::CmpImm { imm, .. }
                 | X86Instruction::TestImm { imm, .. }
-                // Shifts carry the same shared `imm` draw (0 for an empty pool).
+                // Shifts and rotates carry the same shared `imm` draw (0 for an
+                // empty pool).
                 | X86Instruction::Shl { imm, .. }
                 | X86Instruction::Shr { imm, .. }
-                | X86Instruction::Sar { imm, .. } => {
+                | X86Instruction::Sar { imm, .. }
+                | X86Instruction::Rol { imm, .. }
+                | X86Instruction::Ror { imm, .. } => {
                     saw_immediate_form = true;
                     assert_eq!(imm, 0);
                 }
@@ -3222,8 +3323,10 @@ mod tests {
             (20, X86Instruction::Shl { rd, imm }),
             (21, X86Instruction::Shr { rd, imm }),
             (22, X86Instruction::Sar { rd, imm }),
-            // Cmov stays last at COUNT - 1 == 23.
-            (23, X86Instruction::Cmov { rd, rs, cond }),
+            (23, X86Instruction::Rol { rd, imm }),
+            (24, X86Instruction::Ror { rd, imm }),
+            // Cmov stays last at COUNT - 1 == 25.
+            (25, X86Instruction::Cmov { rd, rs, cond }),
         ];
 
         for (opcode, want) in expected {
@@ -3260,7 +3363,9 @@ mod tests {
             (20, "shl"),
             (21, "shr"),
             (22, "sar"),
-            (23, "cmove"),
+            (23, "rol"),
+            (24, "ror"),
+            (25, "cmove"),
         ];
         for (opcode, mnem) in mnemonics {
             assert_eq!(
@@ -3702,11 +3807,14 @@ mod tests {
                     | X86Instruction::XorImm { .. }
                     | X86Instruction::CmpImm { .. }
                     | X86Instruction::TestImm { .. }
-                    // Shifts carry an imm8 count; the same encodability
-                    // invariant applies — `can_assemble` must accept them.
+                    // Shifts and rotates carry an imm8 count; the same
+                    // encodability invariant applies — `can_assemble` must
+                    // accept them.
                     | X86Instruction::Shl { .. }
                     | X86Instruction::Shr { .. }
-                    | X86Instruction::Sar { .. } => {
+                    | X86Instruction::Sar { .. }
+                    | X86Instruction::Rol { .. }
+                    | X86Instruction::Ror { .. } => {
                         saw_non_mov_immediate = true;
                         assert!(
                             <X86_64 as Assembler<X86Instruction>>::can_assemble(&X86_64, instr),

--- a/src/parser/x86.rs
+++ b/src/parser/x86.rs
@@ -401,6 +401,8 @@ fn x86_ir_from_mnemonic_impl(
             | "sal"
             | "shr"
             | "sar"
+            | "rol"
+            | "ror"
     ) {
         return Ok(None);
     }
@@ -467,6 +469,16 @@ fn x86_ir_from_mnemonic_impl(
             })),
             X86Operand::Register(_) => Ok(None),
         },
+        // ROL/ROR take a register plus an immediate COUNT. Only the
+        // immediate-count form is modelled — the register (CL) count form is
+        // deferred and surfaces as `Ok(None)` (an unsupported shape).
+        "rol" | "ror" => match src_op {
+            X86Operand::Immediate(imm) => Ok(Some(match mnemonic.as_str() {
+                "rol" => X86Instruction::Rol { rd, imm },
+                _ => X86Instruction::Ror { rd, imm },
+            })),
+            X86Operand::Register(_) => Ok(None),
+        },
         _ => Ok(None),
     }
 }
@@ -479,8 +491,8 @@ fn x86_ir_from_mnemonic_impl(
 /// (`name:`), directives (`.foo`), and instructions whose mnemonic is
 /// one of the supported families (mov, add, sub, and, or, xor, cmp,
 /// test, the single-operand neg/not/inc/dec, the immediate-count shifts
-/// shl/sal/shr/sar, plus the conditional cmovCC and jCC variants). Anything
-/// else is a parse error.
+/// shl/sal/shr/sar, the immediate-count rotates rol/ror, plus the conditional
+/// cmovCC and jCC variants). Anything else is a parse error.
 pub fn parse_x86_assembly_string(
     content: &str,
     source_name: String,
@@ -1053,6 +1065,74 @@ mod tests {
                 .unwrap()
                 .unwrap(),
             X86Instruction::Sar {
+                rd: X86Register::RAX,
+                imm: 4
+            }
+        );
+    }
+
+    #[test]
+    fn rotate_parse_register_plus_count_and_round_trip_display() {
+        // rol / ror parse to the immediate-count variants and Display
+        // round-trips back to the same IR.
+        let rol = x86_ir_from_mnemonic("rol", "rax, 1").unwrap().unwrap();
+        assert_eq!(
+            rol,
+            X86Instruction::Rol {
+                rd: X86Register::RAX,
+                imm: 1
+            }
+        );
+        assert_eq!(rol.to_string(), "rol rax, 1");
+
+        let ror = x86_ir_from_mnemonic("ror", "rbx, 5").unwrap().unwrap();
+        assert_eq!(
+            ror,
+            X86Instruction::Ror {
+                rd: X86Register::RBX,
+                imm: 5
+            }
+        );
+        assert_eq!(ror.to_string(), "ror rbx, 5");
+
+        for instr in [rol, ror] {
+            let text = instr.to_string();
+            let (mnemonic, ops) = text.split_once(char::is_whitespace).unwrap();
+            assert_eq!(
+                x86_ir_from_mnemonic(mnemonic, ops).unwrap().unwrap(),
+                instr,
+                "round-trip failed for {text}"
+            );
+        }
+    }
+
+    #[test]
+    fn rotate_with_register_count_is_rejected() {
+        // The CL-register-count form is deferred: `rol rax, rcx` is an
+        // unsupported shape and surfaces as Ok(None), not a Rol.
+        assert!(x86_ir_from_mnemonic("rol", "rax, rcx").unwrap().is_none());
+        assert!(x86_ir_from_mnemonic("ror", "rax, rcx").unwrap().is_none());
+        // A single operand (no count) is also an unsupported shape.
+        assert!(x86_ir_from_mnemonic("rol", "rax").unwrap().is_none());
+        assert!(x86_ir_from_mnemonic("ror", "rbx").unwrap().is_none());
+    }
+
+    #[test]
+    fn rotate_round_trip_through_mode_aware_binary_path() {
+        assert_eq!(
+            x86_ir_from_mnemonic_for_mode("rol", "rax, 1", X86ParseMode::Mode64)
+                .unwrap()
+                .unwrap(),
+            X86Instruction::Rol {
+                rd: X86Register::RAX,
+                imm: 1
+            }
+        );
+        assert_eq!(
+            x86_ir_from_mnemonic_for_mode("ror", "eax, 4", X86ParseMode::Mode32)
+                .unwrap()
+                .unwrap(),
+            X86Instruction::Ror {
                 rd: X86Register::RAX,
                 imm: 4
             }

--- a/src/semantics/concrete_x86.rs
+++ b/src/semantics/concrete_x86.rs
@@ -48,6 +48,8 @@ pub fn apply_instruction_concrete_x86(
         X86Instruction::Shl { rd, imm } => apply_shift(&mut state, *rd, *imm, ShiftKind::Shl),
         X86Instruction::Shr { rd, imm } => apply_shift(&mut state, *rd, *imm, ShiftKind::Shr),
         X86Instruction::Sar { rd, imm } => apply_shift(&mut state, *rd, *imm, ShiftKind::Sar),
+        X86Instruction::Rol { rd, imm } => apply_rotate(&mut state, *rd, *imm, RotateKind::Rol),
+        X86Instruction::Ror { rd, imm } => apply_rotate(&mut state, *rd, *imm, RotateKind::Ror),
         X86Instruction::Cmov { rd, rs, cond } => {
             if state.get_flags().evaluate(*cond) {
                 let v = state.get_register(*rs);
@@ -239,6 +241,80 @@ fn apply_shift(
     let mut flags = Eflags::from_logical(result, width);
     flags.cf = cf;
     flags.of = of;
+    state.set_flags(flags);
+}
+
+#[derive(Clone, Copy)]
+enum RotateKind {
+    Rol,
+    Ror,
+}
+
+// Immediate-count rotate. Like the shifts the count is a concrete compile-time
+// value masked to `width-1` (`eff`). The CRUCIAL difference from the shifts is
+// the flag model: rotates touch ONLY CF (plus OF for count 1). SF/ZF/PF/AF are
+// PRESERVED — this is a PARTIAL flag update, so we read the prior flags and keep
+// SF/ZF/PF/AF, overriding only CF (and OF when count == 1).
+//
+// * `eff == 0`: the rotate is a complete no-op — leave `rd` and every flag
+//   untouched.
+// * `eff != 0`:
+//   - ROL: `result = rotate_left(rd, eff)`; CF = bit 0 of the result (the bit
+//     rotated from the MSB into the LSB). OF (count 1 only) = `MSB(result) XOR
+//     CF`.
+//   - ROR: `result = rotate_right(rd, eff)`; CF = the MSB (bit `width-1`) of the
+//     result. OF (count 1 only) = `MSB(result) XOR (bit width-2 of result)` (the
+//     XOR of the result's two most-significant bits).
+//   - For count != 1 OF is architecturally UNDEFINED, so we PRESERVE the
+//     incoming OF (deterministic and internally consistent: target and candidate
+//     share this lowering).
+fn apply_rotate(
+    state: &mut X86ConcreteMachineState,
+    rd: crate::isa::x86::X86Register,
+    imm: i64,
+    kind: RotateKind,
+) {
+    let width = state.width();
+    let mask = u64::from(width - 1);
+    let eff = (imm as u64) & mask;
+
+    // Count masks to 0: leave rd and every flag untouched.
+    if eff == 0 {
+        return;
+    }
+
+    let old = mask_width(state.get_register(rd).as_u64(), width);
+    let eff_u32 = eff as u32;
+
+    // `(old << eff) | (old >>u (width - eff))` for ROL (and the mirror for ROR),
+    // masked back to the operand width.
+    let result = match kind {
+        RotateKind::Rol => (old << eff_u32) | (old >> (width - eff_u32)),
+        RotateKind::Ror => (old >> eff_u32) | (old << (width - eff_u32)),
+    };
+    let result = mask_width(result, width);
+
+    let cf = match kind {
+        // ROL: CF = bit 0 of the result.
+        RotateKind::Rol => result & 1 == 1,
+        // ROR: CF = the MSB (bit width-1) of the result.
+        RotateKind::Ror => msb(result, width),
+    };
+
+    // Start from the PRIOR flags so SF/ZF/PF/AF are preserved, then override CF.
+    let mut flags = state.get_flags();
+    flags.cf = cf;
+    // OF is defined for count == 1 only. For any other count it is undefined, so
+    // we keep the prior OF (already carried over by cloning the flags above).
+    if eff == 1 {
+        flags.of = match kind {
+            RotateKind::Rol => msb(result, width) ^ cf,
+            // XOR of the result's two most-significant bits.
+            RotateKind::Ror => msb(result, width) ^ ((result >> (width - 2)) & 1 == 1),
+        };
+    }
+
+    state.set_register(rd, ConcreteValue::new(result));
     state.set_flags(flags);
 }
 
@@ -738,6 +814,192 @@ mod tests {
                 after.get_flags(),
                 seeded,
                 "{instr:?} (eff==0) must preserve ALL flags"
+            );
+        }
+    }
+
+    #[test]
+    fn rol_rotates_left_and_sets_carry_from_lsb() {
+        // rol rax, 1 of MSB-set value: 0x8000... -> 0x0000...0001. CF = bit 0
+        // of the result = 1.
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(0x8000_0000_0000_0000));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::Rol {
+                rd: X86Register::RAX,
+                imm: 1,
+            },
+        );
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 1);
+        assert!(
+            after.get_flags().cf,
+            "rol moved the MSB into bit 0 -> CF set"
+        );
+        // OF (count 1) = MSB(result) XOR CF = 0 XOR 1 = 1.
+        assert!(after.get_flags().of, "rol count 1: OF = MSB(result) XOR CF");
+
+        // rol of a value whose MSB is 0: CF = 0.
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(0x1));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::Rol {
+                rd: X86Register::RAX,
+                imm: 1,
+            },
+        );
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 0b10);
+        assert!(!after.get_flags().cf, "rol of bit 0 only -> CF clear");
+    }
+
+    #[test]
+    fn ror_rotates_right_and_sets_carry_from_msb() {
+        // ror rax, 1 of an odd value: bit 0 wraps to the MSB and becomes CF.
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(0x1));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::Ror {
+                rd: X86Register::RAX,
+                imm: 1,
+            },
+        );
+        assert_eq!(
+            after.get_register(X86Register::RAX).as_u64(),
+            0x8000_0000_0000_0000
+        );
+        assert!(
+            after.get_flags().cf,
+            "ror wrapped bit 0 into the MSB -> CF = result MSB = 1"
+        );
+
+        // ror of an even value: result MSB is 0, so CF clear.
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(0b10));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::Ror {
+                rd: X86Register::RAX,
+                imm: 1,
+            },
+        );
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 0b1);
+        assert!(!after.get_flags().cf, "ror of an even value -> CF clear");
+    }
+
+    // The load-bearing rotate distinction: SF/ZF/PF/AF are PRESERVED across a
+    // rotate (only CF and, for count 1, OF change). Seed distinctive SF/ZF/PF/AF
+    // and assert they survive.
+    #[test]
+    fn rotate_preserves_sf_zf_pf_af() {
+        for instr in [
+            X86Instruction::Rol {
+                rd: X86Register::RAX,
+                imm: 3,
+            },
+            X86Instruction::Ror {
+                rd: X86Register::RAX,
+                imm: 3,
+            },
+        ] {
+            let mut state = X86ConcreteMachineState::new_zeroed(64);
+            // A nonzero, non-zero-result value so the "natural" SF/ZF/PF would
+            // differ from the seeded ones if the rotate (wrongly) recomputed
+            // them.
+            state.set_register(X86Register::RAX, ConcreteValue::new(0x1));
+            let seeded = Eflags {
+                cf: false,
+                pf: true,
+                af: true,
+                zf: true,
+                sf: true,
+                of: false,
+            };
+            state.set_flags(seeded);
+            let after = apply_instruction_concrete_x86(state, &instr);
+            let flags = after.get_flags();
+            assert_eq!(flags.sf, seeded.sf, "{instr:?} must preserve SF");
+            assert_eq!(flags.zf, seeded.zf, "{instr:?} must preserve ZF");
+            assert_eq!(flags.pf, seeded.pf, "{instr:?} must preserve PF");
+            assert_eq!(flags.af, seeded.af, "{instr:?} must preserve AF");
+            // count == 3 (!= 1): OF is undefined, so the model preserves it.
+            assert_eq!(
+                flags.of, seeded.of,
+                "{instr:?} count != 1 must preserve incoming OF"
+            );
+        }
+    }
+
+    // A masked count of 0 is a complete no-op: register AND every flag, including
+    // CF and OF, are left untouched.
+    #[test]
+    fn rotate_by_zero_preserves_register_and_all_flags() {
+        for instr in [
+            X86Instruction::Rol {
+                rd: X86Register::RAX,
+                imm: 0,
+            },
+            X86Instruction::Ror {
+                rd: X86Register::RAX,
+                imm: 0,
+            },
+            // A count of 64 masks to 0 at width 64 (mask = 0x3f), so it is also a
+            // no-op even though the raw count is nonzero.
+            X86Instruction::Rol {
+                rd: X86Register::RAX,
+                imm: 64,
+            },
+        ] {
+            let mut state = X86ConcreteMachineState::new_zeroed(64);
+            state.set_register(X86Register::RAX, ConcreteValue::new(0xDEAD_BEEF));
+            let seeded = Eflags {
+                cf: true,
+                pf: true,
+                af: true,
+                zf: true,
+                sf: true,
+                of: true,
+            };
+            state.set_flags(seeded);
+            let after = apply_instruction_concrete_x86(state, &instr);
+            assert_eq!(
+                after.get_register(X86Register::RAX).as_u64(),
+                0xDEAD_BEEF,
+                "{instr:?} (eff==0) must leave rd unchanged"
+            );
+            assert_eq!(
+                after.get_flags(),
+                seeded,
+                "{instr:?} (eff==0) must preserve ALL flags"
+            );
+        }
+    }
+
+    // Cross-check the rotate result against the shift-construction identity from
+    // the DoD: `rol rd, 1` == `(rd << 1) | (rd >>u (width-1))`.
+    #[test]
+    fn rol_by_one_matches_shift_construction() {
+        for value in [0x1u64, 0x8000_0000_0000_0000, 0xDEAD_BEEF, u64::MAX, 0x5555] {
+            let mut state = X86ConcreteMachineState::new_zeroed(64);
+            state.set_register(X86Register::RAX, ConcreteValue::new(value));
+            let after = apply_instruction_concrete_x86(
+                state,
+                &X86Instruction::Rol {
+                    rd: X86Register::RAX,
+                    imm: 1,
+                },
+            );
+            // The DoD cross-check is precisely that `rol rd, 1` equals this
+            // hand-written shift construction, so spell it out rather than
+            // collapsing it into `rotate_left` (which would make the test
+            // tautological).
+            #[allow(clippy::manual_rotate)]
+            let expected = (value << 1) | (value >> 63);
+            assert_eq!(
+                after.get_register(X86Register::RAX).as_u64(),
+                expected,
+                "rol {value:#x}, 1 must equal (v << 1) | (v >>u 63)"
             );
         }
     }

--- a/src/semantics/cost_x86.rs
+++ b/src/semantics/cost_x86.rs
@@ -62,11 +62,13 @@ fn instruction_code_size(instr: &X86Instruction, width: u32) -> u64 {
         // INC / DEC are single-operand `FF /0` / `FF /1` = 2 bytes (+REX.W).
         | X86Instruction::Inc { .. }
         | X86Instruction::Dec { .. } => 2 + rex,
-        // SHL / SHR / SAR by imm8 are `C1 /n ib` = opcode + ModR/M + imm8
-        // = 3 bytes (+REX.W).
+        // SHL / SHR / SAR / ROL / ROR by imm8 are `C1 /n ib` = opcode + ModR/M
+        // + imm8 = 3 bytes (+REX.W).
         X86Instruction::Shl { .. }
         | X86Instruction::Shr { .. }
-        | X86Instruction::Sar { .. } => 3 + rex,
+        | X86Instruction::Sar { .. }
+        | X86Instruction::Rol { .. }
+        | X86Instruction::Ror { .. } => 3 + rex,
         X86Instruction::AddImm { .. }
         | X86Instruction::SubImm { .. }
         | X86Instruction::AndImm { .. }
@@ -230,6 +232,35 @@ mod tests {
         // CMOV is `0F 4x ModR/M` = 3 bytes, +1 for REX.W on x86-64.
         assert_eq!(instruction_cost(&cmov, &CostMetric::CodeSize, 64), 4);
         assert_eq!(instruction_cost(&cmov, &CostMetric::CodeSize, 32), 3);
+    }
+
+    #[test]
+    fn rotate_code_size_and_latency_mirror_shifts() {
+        // ROL / ROR by imm8 are `C1 /n ib` = 3 bytes (+REX.W on x86-64 -> 4),
+        // identical to the shifts; latency 1.
+        for instr in [
+            X86Instruction::Rol {
+                rd: X86Register::RAX,
+                imm: 3,
+            },
+            X86Instruction::Ror {
+                rd: X86Register::RBX,
+                imm: 5,
+            },
+        ] {
+            // Mirror the shift cost exactly.
+            let shift = X86Instruction::Shl {
+                rd: X86Register::RAX,
+                imm: 3,
+            };
+            assert_eq!(
+                instruction_cost(&instr, &CostMetric::CodeSize, 64),
+                instruction_cost(&shift, &CostMetric::CodeSize, 64),
+            );
+            assert_eq!(instruction_cost(&instr, &CostMetric::CodeSize, 64), 4);
+            assert_eq!(instruction_cost(&instr, &CostMetric::CodeSize, 32), 3);
+            assert_eq!(instruction_cost(&instr, &CostMetric::Latency, 64), 1);
+        }
     }
 
     #[test]

--- a/src/semantics/smt_x86.rs
+++ b/src/semantics/smt_x86.rs
@@ -298,6 +298,80 @@ fn apply_shift_smt(
     state.set_flags(flags);
 }
 
+#[derive(Clone, Copy)]
+enum RotateKind {
+    Rol,
+    Ror,
+}
+
+/// Lower an immediate-count rotate symbolically. Mirrors the concrete
+/// interpreter (`semantics::concrete_x86::apply_rotate`) bit-for-bit. The count
+/// is a CONCRETE IR value, so we mask it in Rust and branch on the result.
+///
+/// The flag model is the load-bearing difference from the shifts: rotates touch
+/// ONLY CF (plus OF for count 1). SF/ZF/PF/AF are PRESERVED. We therefore start
+/// from the PRIOR flag BVs (carrying SF/ZF/PF/AF forward unchanged) and override
+/// only CF, plus OF when the masked count is 1.
+///
+/// * `eff == 0`: leave `rd` and ALL flags untouched (a rotate by 0 is a no-op).
+/// * `eff != 0`:
+///   - ROL: `result = bvrotl(rd, eff)`; CF = bit 0 of the result. OF (count 1
+///     only) = `MSB(result) XOR CF`.
+///   - ROR: `result = bvrotr(rd, eff)`; CF = the MSB (bit `width-1`) of the
+///     result. OF (count 1 only) = XOR of the result's two most-significant bits.
+///   - For count != 1 OF is UNDEFINED on hardware; we preserve the incoming OF.
+fn apply_rotate_smt(
+    state: &mut MachineStateX86,
+    rd: crate::isa::x86::X86Register,
+    imm: i64,
+    kind: RotateKind,
+) {
+    let width = state.width();
+    let mask = u64::from(width - 1);
+    let eff = (imm as u64) & mask;
+
+    // Count masks to 0: no register or flag change.
+    if eff == 0 {
+        return;
+    }
+
+    let old = state.get_register(rd).clone();
+    let amount = BV::from_u64(eff, width);
+    let result = match kind {
+        RotateKind::Rol => old.bvrotl(&amount),
+        RotateKind::Ror => old.bvrotr(&amount),
+    };
+
+    // CF is extracted from the result. ROL: bit 0; ROR: the MSB.
+    let cf = match kind {
+        RotateKind::Rol => result.extract(0, 0),
+        RotateKind::Ror => top_bit_bv(&result, width),
+    };
+
+    // Start from the PRIOR flags so SF/ZF/PF (and OF for count != 1) carry over
+    // unchanged; override CF, and OF only when the masked count is exactly 1.
+    let prior = state.get_flags();
+    let mut flags = EflagsBvs {
+        cf: cf.clone(),
+        pf: prior.pf.clone(),
+        zf: prior.zf.clone(),
+        sf: prior.sf.clone(),
+        of: prior.of.clone(),
+    };
+    if eff == 1 {
+        flags.of = match kind {
+            RotateKind::Rol => top_bit_bv(&result, width).bvxor(&cf),
+            // XOR of the result's two most-significant bits.
+            RotateKind::Ror => {
+                top_bit_bv(&result, width).bvxor(result.extract(width - 2, width - 2))
+            }
+        };
+    }
+
+    state.set_register(rd, result);
+    state.set_flags(flags);
+}
+
 /// Apply a single x86 instruction symbolically. Arithmetic / logic /
 /// CMP arms bind the five tracked flag BVs via `compute_eflags_*`;
 /// CMOV reads them via `x86_condition_to_smt`.
@@ -476,6 +550,11 @@ pub fn apply_instruction(
         X86Instruction::Shl { rd, imm } => apply_shift_smt(&mut state, *rd, *imm, ShiftKind::Shl),
         X86Instruction::Shr { rd, imm } => apply_shift_smt(&mut state, *rd, *imm, ShiftKind::Shr),
         X86Instruction::Sar { rd, imm } => apply_shift_smt(&mut state, *rd, *imm, ShiftKind::Sar),
+        // Immediate-count rotates. Same concrete-count handling as the shifts,
+        // but a partial flag update (only CF, plus OF for count 1) — see
+        // `apply_rotate_smt`.
+        X86Instruction::Rol { rd, imm } => apply_rotate_smt(&mut state, *rd, *imm, RotateKind::Rol),
+        X86Instruction::Ror { rd, imm } => apply_rotate_smt(&mut state, *rd, *imm, RotateKind::Ror),
         X86Instruction::Cmov { rd, rs, cond } => {
             let pred = x86_condition_to_smt(*cond, state.get_flags());
             let rs_val = state.get_register(*rs).clone();
@@ -1098,6 +1177,219 @@ mod tests {
             solver.check(),
             SatResult::Unsat,
             "shr rax, 1 must set CF to the original low bit"
+        );
+    }
+
+    // --- symbolic ROL / ROR ---
+
+    // The DoD ROL theorem: `rol rd, 1` produces the same RESULT as the
+    // shift-construction `(rd << 1) | (rd >>u (width-1))`. We prove the negation
+    // of the result equality is unsat over a shared symbolic input.
+    #[test]
+    fn rol_one_result_matches_shift_construction() {
+        let state = MachineStateX86::new_symbolic("s", 64);
+        let old = state.get_register(X86Register::RAX).clone();
+        // (rd << 1) | (rd >>u 63).
+        let constructed = old
+            .bvshl(BV::from_u64(1, 64))
+            .bvor(old.bvlshr(BV::from_u64(63, 64)));
+        let after = apply_instruction(
+            state,
+            &X86Instruction::Rol {
+                rd: X86Register::RAX,
+                imm: 1,
+            },
+        );
+        let solver = Solver::new();
+        solver.assert(after.get_register(X86Register::RAX).eq(&constructed).not());
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "rol rax, 1 must equal (rax << 1) | (rax >>u 63)"
+        );
+    }
+
+    // The DoD ROR theorem: `ror rd, 1` equals `(rd >>u 1) | (rd << (width-1))`.
+    #[test]
+    fn ror_one_result_matches_shift_construction() {
+        let state = MachineStateX86::new_symbolic("s", 64);
+        let old = state.get_register(X86Register::RAX).clone();
+        // (rd >>u 1) | (rd << 63).
+        let constructed = old
+            .bvlshr(BV::from_u64(1, 64))
+            .bvor(old.bvshl(BV::from_u64(63, 64)));
+        let after = apply_instruction(
+            state,
+            &X86Instruction::Ror {
+                rd: X86Register::RAX,
+                imm: 1,
+            },
+        );
+        let solver = Solver::new();
+        solver.assert(after.get_register(X86Register::RAX).eq(&constructed).not());
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "ror rax, 1 must equal (rax >>u 1) | (rax << 63)"
+        );
+    }
+
+    // The load-bearing rotate flag model: SF/ZF/PF are PRESERVED across a rotate
+    // (only CF, plus OF for count 1, changes). We seed the incoming SF/ZF/PF,
+    // rotate, and prove they survive bit-identically (negation unsat). We also
+    // prove CF equals the rotated-out bit for both ROL (result bit 0) and ROR
+    // (result MSB).
+    #[test]
+    fn rotate_preserves_sf_zf_pf_and_binds_cf() {
+        // ROL by 3: SF/ZF/PF unchanged; CF == result bit 0.
+        {
+            let state = MachineStateX86::new_symbolic("s", 64);
+            let old_flags = state.get_flags();
+            let (old_sf, old_zf, old_pf) = (
+                old_flags.sf.clone(),
+                old_flags.zf.clone(),
+                old_flags.pf.clone(),
+            );
+            let after = apply_instruction(
+                state,
+                &X86Instruction::Rol {
+                    rd: X86Register::RAX,
+                    imm: 3,
+                },
+            );
+            let f = after.get_flags();
+            let solver = Solver::new();
+            solver.assert(z3::ast::Bool::or(&[
+                &f.sf.eq(&old_sf).not(),
+                &f.zf.eq(&old_zf).not(),
+                &f.pf.eq(&old_pf).not(),
+            ]));
+            assert_eq!(
+                solver.check(),
+                SatResult::Unsat,
+                "ROL must preserve SF/ZF/PF"
+            );
+
+            // CF == bit 0 of the rotated result.
+            let cf_solver = Solver::new();
+            let result_bit0 = after.get_register(X86Register::RAX).extract(0, 0);
+            cf_solver.assert(f.cf.eq(&result_bit0).not());
+            assert_eq!(
+                cf_solver.check(),
+                SatResult::Unsat,
+                "ROL CF must equal the result's bit 0"
+            );
+        }
+        // ROR by 3: SF/ZF/PF unchanged; CF == result MSB.
+        {
+            let state = MachineStateX86::new_symbolic("s", 64);
+            let old_flags = state.get_flags();
+            let (old_sf, old_zf, old_pf) = (
+                old_flags.sf.clone(),
+                old_flags.zf.clone(),
+                old_flags.pf.clone(),
+            );
+            let after = apply_instruction(
+                state,
+                &X86Instruction::Ror {
+                    rd: X86Register::RAX,
+                    imm: 3,
+                },
+            );
+            let f = after.get_flags();
+            let solver = Solver::new();
+            solver.assert(z3::ast::Bool::or(&[
+                &f.sf.eq(&old_sf).not(),
+                &f.zf.eq(&old_zf).not(),
+                &f.pf.eq(&old_pf).not(),
+            ]));
+            assert_eq!(
+                solver.check(),
+                SatResult::Unsat,
+                "ROR must preserve SF/ZF/PF"
+            );
+
+            // CF == the rotated result's MSB (bit 63).
+            let cf_solver = Solver::new();
+            let result_msb = after.get_register(X86Register::RAX).extract(63, 63);
+            cf_solver.assert(f.cf.eq(&result_msb).not());
+            assert_eq!(
+                cf_solver.check(),
+                SatResult::Unsat,
+                "ROR CF must equal the result's MSB"
+            );
+        }
+    }
+
+    // The eff == 0 rotate case: a masked count of 0 leaves the register AND all
+    // five tracked flags bit-identical to the incoming state.
+    #[test]
+    fn rotate_by_zero_preserves_register_and_all_flags_smt() {
+        for instr in [
+            X86Instruction::Rol {
+                rd: X86Register::RAX,
+                imm: 0,
+            },
+            X86Instruction::Ror {
+                rd: X86Register::RAX,
+                imm: 0,
+            },
+            // 64 masks to 0 at width 64.
+            X86Instruction::Ror {
+                rd: X86Register::RAX,
+                imm: 64,
+            },
+        ] {
+            let before = MachineStateX86::new_symbolic("s", 64);
+            let old_reg = before.get_register(X86Register::RAX).clone();
+            let old_flags = before.get_flags();
+            let (old_cf, old_pf, old_zf, old_sf, old_of) = (
+                old_flags.cf.clone(),
+                old_flags.pf.clone(),
+                old_flags.zf.clone(),
+                old_flags.sf.clone(),
+                old_flags.of.clone(),
+            );
+
+            let after = apply_instruction(before, &instr);
+            let after_flags = after.get_flags();
+
+            let solver = Solver::new();
+            solver.assert(z3::ast::Bool::or(&[
+                &after.get_register(X86Register::RAX).eq(&old_reg).not(),
+                &after_flags.cf.eq(&old_cf).not(),
+                &after_flags.pf.eq(&old_pf).not(),
+                &after_flags.zf.eq(&old_zf).not(),
+                &after_flags.sf.eq(&old_sf).not(),
+                &after_flags.of.eq(&old_of).not(),
+            ]));
+            assert_eq!(
+                solver.check(),
+                SatResult::Unsat,
+                "{instr:?} (eff==0) must preserve rd and every flag"
+            );
+        }
+    }
+
+    // OF is preserved for a rotate count != 1 (architecturally undefined). After
+    // `rol rd, 3` the OF must equal the incoming OF.
+    #[test]
+    fn rotate_count_not_one_preserves_of() {
+        let before = MachineStateX86::new_symbolic("s", 64);
+        let old_of = before.get_flags().of.clone();
+        let after = apply_instruction(
+            before,
+            &X86Instruction::Rol {
+                rd: X86Register::RAX,
+                imm: 3,
+            },
+        );
+        let solver = Solver::new();
+        solver.assert(after.get_flags().of.eq(&old_of).not());
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "rotate count != 1 must leave OF == the incoming OF"
         );
     }
 


### PR DESCRIPTION
Closes #629.

Adds immediate-count rotates `Rol { rd, imm }` / `Ror { rd, imm }` (CL form deferred).

**Partial-flag model** (distinct from shifts): rotates touch ONLY CF, plus OF for count==1; **SF/ZF/PF/AF are preserved**. `eff = (imm as u64) & (width-1)`.
- `eff == 0`: register and all flags unchanged (no-op).
- `eff != 0`: ROL `result = bvrotl(rd, eff)`, CF = bit 0 of result, OF(count==1) = `MSB(result) XOR CF`; ROR `result = bvrotr(rd, eff)`, CF = MSB of result, OF(count==1) = `MSB(result) XOR bit(width-2)`. For count≠1, OF is architecturally undefined → the incoming OF is preserved. The new flags are built from the prior flags (SF/ZF/PF/OF cloned) with only CF (and count==1 OF) overridden. Verified against the Intel SDM and a standalone cross-check.

Z3 `bvrotl`/`bvrotr` with concrete `eff`.

**CMOV invariant**: inserted at 23/24 before CMOV → `…20 Shl,21 Shr,22 Sar,23 Rol,24 Ror,25 Cmov`; `X86_REWRITABLE_OPCODE_COUNT` 24→26; Cmov stays last (25 = COUNT−1). No seed retune needed; parity + `opcode_dispatch_is_consistent` green.

**DoD tests**: `rol_one_result_matches_shift_construction` / `ror_…` prove the result equals the `(rd<<1)|(rd>>u63)` / `(rd>>u1)|(rd<<63)` construction; `rotate_preserves_sf_zf_pf_and_binds_cf`, `rotate_by_zero_preserves_register_and_all_flags_smt`, `rotate_count_not_one_preserves_of`, plus concrete siblings and assembler Capstone round-trips.

`./ci_check.sh` + `RUSTFLAGS="-D warnings" cargo build` pass; clippy adds zero new lints in changed files (baseline 18 pre-existing, unchanged); 1376 lib tests green.