### PR TITLE
x86: add two/three-operand IMUL (signed multiply) (#630)

### DIFF
--- a/docs/capability.md
+++ b/docs/capability.md
@@ -101,6 +101,7 @@ Rewritable straight-line mnemonic families:
 - Single-operand: `neg`, `not`, `inc`, `dec`
 - Immediate-count shifts: `shl`/`sal`, `shr`, `sar`
 - Immediate-count rotates: `rol`, `ror`
+- Signed multiply: `imul` (2-operand `imul rd, rs` and 3-operand `imul rd, rs, imm`)
 - Conditional moves: `cmov<cond>`
 
 The data-movement/arithmetic/logical/comparison families have register and
@@ -128,8 +129,18 @@ unchanged. For a nonzero count, `rol` sets CF to bit 0 of the result (the bit
 rotated out of the MSB) and `ror` sets CF to the result's MSB; OF is defined only
 for a count of 1 (`rol`: `MSB(result) XOR CF`; `ror`: XOR of the result's two
 most-significant bits) and, like the shifts, is preserved (left at its incoming
-value) for count > 1. `cmov<cond>` has register operands and reads EFLAGS without
-modifying them.
+value) for count > 1. `imul` is signed multiply in two single-destination forms:
+the two-operand `imul rd, rs` computes `rd = rd * rs` (low `width` bits, `rd`
+read and written) and the three-operand `imul rd, rs, imm` computes
+`rd = rs * imm` (`rd` written only). For both, only CF and OF are
+architecturally defined: they are set iff the FULL signed product does not fit
+the truncated `width`-bit destination (signed overflow), and cleared otherwise.
+SF/ZF/PF are Intel-UNDEFINED; the model derives them deterministically from the
+truncated result (SF = MSB, ZF = result == 0, PF = low-byte parity) so the
+shared concrete/SMT lowering stays internally consistent (target and candidate
+agree), and AF follows the existing convention. The one-operand widening form
+(`imul rs`, writing RDX:RAX) is deferred. `cmov<cond>` has register operands and
+reads EFLAGS without modifying them.
 
 The x86 IR does not yet carry operand width. To avoid rewriting partial-width
 operations as full-width operations, the binary optimization path currently

--- a/src/assembler/x86.rs
+++ b/src/assembler/x86.rs
@@ -249,6 +249,19 @@ fn encode_64(ops: &mut dynasmrt::x64::Assembler, instr: &X86Instruction) -> Resu
             dynasm!(ops ; .arch x64 ; ror Rq(rd), BYTE count);
             Ok(())
         }
+        X86Instruction::ImulReg { rd, rs } => {
+            let rd = reg_index(*rd)?;
+            let rs = reg_index(*rs)?;
+            dynasm!(ops ; .arch x64 ; imul Rq(rd), Rq(rs));
+            Ok(())
+        }
+        X86Instruction::ImulRegImm { rd, rs, imm } => {
+            let rd = reg_index(*rd)?;
+            let rs = reg_index(*rs)?;
+            let imm = signed_imm_i32(*imm)?;
+            dynasm!(ops ; .arch x64 ; imul Rq(rd), Rq(rs), imm);
+            Ok(())
+        }
         X86Instruction::Cmov { rd, rs, cond } => {
             let rd = reg_index(*rd)?;
             let rs = reg_index(*rs)?;
@@ -473,6 +486,19 @@ fn encode_32(ops: &mut dynasmrt::x86::Assembler, instr: &X86Instruction) -> Resu
             let rd = reg_index_32(*rd)?;
             let count = shift_count_imm8(*imm)?;
             dynasm!(ops ; .arch x86 ; ror Rd(rd), BYTE count);
+            Ok(())
+        }
+        X86Instruction::ImulReg { rd, rs } => {
+            let rd = reg_index_32(*rd)?;
+            let rs = reg_index_32(*rs)?;
+            dynasm!(ops ; .arch x86 ; imul Rd(rd), Rd(rs));
+            Ok(())
+        }
+        X86Instruction::ImulRegImm { rd, rs, imm } => {
+            let rd = reg_index_32(*rd)?;
+            let rs = reg_index_32(*rs)?;
+            let imm = signed_imm_i32(*imm)?;
+            dynasm!(ops ; .arch x86 ; imul Rd(rd), Rd(rs), imm);
             Ok(())
         }
         X86Instruction::Cmov { rd, rs, cond } => {
@@ -979,6 +1005,59 @@ mod tests {
             },
             "ror",
             &["edx", "4"],
+        );
+    }
+
+    #[test]
+    fn imul_variants_x86_64() {
+        // Two-operand `imul rd, rs` (0F AF /r).
+        check_x86_64(
+            X86Instruction::ImulReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            "imul",
+            &["rax", "rbx"],
+        );
+        // Three-operand `imul rd, rs, imm` (69 /r id).
+        check_x86_64(
+            X86Instruction::ImulRegImm {
+                rd: X86Register::RCX,
+                rs: X86Register::RDX,
+                imm: 4,
+            },
+            "imul",
+            &["rcx", "rdx", "4"],
+        );
+        // Extended register source round-trips too.
+        check_x86_64(
+            X86Instruction::ImulReg {
+                rd: X86Register::R9,
+                rs: X86Register::RAX,
+            },
+            "imul",
+            &["r9", "rax"],
+        );
+    }
+
+    #[test]
+    fn imul_variants_x86_32() {
+        check_x86_32(
+            X86Instruction::ImulReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            "imul",
+            &["eax", "ebx"],
+        );
+        check_x86_32(
+            X86Instruction::ImulRegImm {
+                rd: X86Register::RCX,
+                rs: X86Register::RDX,
+                imm: 7,
+            },
+            "imul",
+            &["ecx", "edx", "7"],
         );
     }
 

--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -367,6 +367,24 @@ pub enum X86Instruction {
     /// (`MSB(result) XOR bit width-2`). For count != 1 OF is UNDEFINED so the
     /// incoming OF is preserved. The CL-register-count form is not modelled.
     Ror { rd: X86Register, imm: i64 },
+    /// `imul rd, rs` — two-operand signed multiply: `rd = rd * rs` (low
+    /// `width` bits). Reads and writes `rd`, so `rd` is both source and
+    /// destination (destructive form). Only CF and OF are architecturally
+    /// defined: they are set iff the FULL signed product does not fit the
+    /// truncated `width`-bit destination; SF/ZF/PF/AF are Intel-UNDEFINED.
+    /// We model SF/ZF/PF deterministically from the truncated result (see
+    /// `concrete_x86::apply_imul`).
+    ImulReg { rd: X86Register, rs: X86Register },
+    /// `imul rd, rs, imm` — three-operand signed multiply: `rd = rs * imm`
+    /// (low `width` bits). The project's FIRST 3-operand x86 variant. `rd` is
+    /// purely WRITTEN (not read), so `source_registers()` is just `[rs]`. Same
+    /// flag model as `ImulReg`: CF/OF on signed overflow, SF/ZF/PF
+    /// Intel-undefined and modelled deterministically.
+    ImulRegImm {
+        rd: X86Register,
+        rs: X86Register,
+        imm: i64,
+    },
     /// `cmovCC rd, rs` — conditional move. Reads EFLAGS;
     /// when `cond` holds, writes `rd = rs`; otherwise `rd` is unchanged.
     /// Does not modify EFLAGS.
@@ -406,6 +424,8 @@ impl X86Instruction {
             | X86Instruction::Sar { rd, .. }
             | X86Instruction::Rol { rd, .. }
             | X86Instruction::Ror { rd, .. }
+            | X86Instruction::ImulReg { rd, .. }
+            | X86Instruction::ImulRegImm { rd, .. }
             | X86Instruction::Cmov { rd, .. } => Some(*rd),
             // CMP and TEST discard their result; only EFLAGS is written.
             X86Instruction::CmpReg { .. }
@@ -435,6 +455,7 @@ impl X86Instruction {
             X86Instruction::Sar { .. } => "sar",
             X86Instruction::Rol { .. } => "rol",
             X86Instruction::Ror { .. } => "ror",
+            X86Instruction::ImulReg { .. } | X86Instruction::ImulRegImm { .. } => "imul",
             X86Instruction::Cmov { cond, .. } => cond.cmov_mnemonic(),
             X86Instruction::Jcc { cond } => cond.jcc_mnemonic(),
         }
@@ -454,7 +475,11 @@ impl X86Instruction {
             | X86Instruction::SubReg { rd, rs }
             | X86Instruction::AndReg { rd, rs }
             | X86Instruction::OrReg { rd, rs }
+            // IMUL rd, rs is destructive (`rd = rd * rs`), so rd is read too.
+            | X86Instruction::ImulReg { rd, rs }
             | X86Instruction::XorReg { rd, rs } => vec![*rd, *rs],
+            // IMUL rd, rs, imm writes rd purely from `rs * imm`; rd is NOT read.
+            X86Instruction::ImulRegImm { rs, .. } => vec![*rs],
             X86Instruction::AddImm { rd, .. }
             | X86Instruction::SubImm { rd, .. }
             | X86Instruction::AndImm { rd, .. }
@@ -532,11 +557,13 @@ impl InstructionType for X86Instruction {
             X86Instruction::Sar { .. } => 22,
             X86Instruction::Rol { .. } => 23,
             X86Instruction::Ror { .. } => 24,
-            // Cmov MUST stay the last rewritable opcode (COUNT - 1 == 25):
+            X86Instruction::ImulReg { .. } => 25,
+            X86Instruction::ImulRegImm { .. } => 26,
+            // Cmov MUST stay the last rewritable opcode (COUNT - 1 == 27):
             // the CMOV distinct-register draw at both generation sites is
             // gated on `opcode == X86_REWRITABLE_OPCODE_COUNT - 1`.
-            X86Instruction::Cmov { .. } => 25,
-            X86Instruction::Jcc { .. } => 26,
+            X86Instruction::Cmov { .. } => 27,
+            X86Instruction::Jcc { .. } => 28,
         }
     }
 
@@ -570,7 +597,11 @@ impl fmt::Display for X86Instruction {
             | X86Instruction::SubReg { rd, rs }
             | X86Instruction::AndReg { rd, rs }
             | X86Instruction::OrReg { rd, rs }
+            // IMUL rd, rs renders like the other two-register forms.
+            | X86Instruction::ImulReg { rd, rs }
             | X86Instruction::XorReg { rd, rs } => write!(f, "{} {}, {}", mn, rd, rs),
+            // The 3-operand IMUL renders `imul rd, rs, imm`.
+            X86Instruction::ImulRegImm { rd, rs, imm } => write!(f, "{} {}, {}, {}", mn, rd, rs, imm),
             X86Instruction::MovImm { rd, imm }
             | X86Instruction::AddImm { rd, imm }
             | X86Instruction::SubImm { rd, imm }
@@ -875,6 +906,8 @@ impl crate::isa::traits::Assembler<X86Instruction> for X86_64 {
             | X86Instruction::OrImm { imm, .. }
             | X86Instruction::XorImm { imm, .. }
             | X86Instruction::CmpImm { imm, .. }
+            // The 3-operand IMUL immediate encodes as imm32 (`69 /r id`).
+            | X86Instruction::ImulRegImm { imm, .. }
             | X86Instruction::TestImm { imm, .. } => x86_signed_imm32_ok(*imm),
             // SHL / SHR / SAR / ROL / ROR encode their count as imm8: reject any
             // count that does not fit a single byte so the search never proposes
@@ -897,6 +930,8 @@ impl crate::isa::traits::Assembler<X86Instruction> for X86_64 {
             | X86Instruction::Not { .. }
             | X86Instruction::Inc { .. }
             | X86Instruction::Dec { .. }
+            // IMUL rd, rs is `0F AF /r` — always encodable.
+            | X86Instruction::ImulReg { .. }
             | X86Instruction::Cmov { .. }
             | X86Instruction::Jcc { .. } => true,
         }
@@ -921,7 +956,13 @@ impl crate::isa::traits::Assembler<X86Instruction> for X86_32 {
             | X86Instruction::SubReg { rd, rs }
             | X86Instruction::AndReg { rd, rs }
             | X86Instruction::OrReg { rd, rs }
+            // IMUL rd, rs: both registers must be low-8 in 32-bit mode.
+            | X86Instruction::ImulReg { rd, rs }
             | X86Instruction::XorReg { rd, rs } => reg_ok_32(*rd) && reg_ok_32(*rs),
+            // IMUL rd, rs, imm: low-8 registers plus an imm32 immediate.
+            X86Instruction::ImulRegImm { rd, rs, imm } => {
+                reg_ok_32(*rd) && reg_ok_32(*rs) && x86_signed_imm32_ok(*imm)
+            }
             X86Instruction::MovImm { rd, imm }
             | X86Instruction::AddImm { rd, imm }
             | X86Instruction::SubImm { rd, imm }
@@ -1149,6 +1190,8 @@ impl X86Mutator {
                 | X86Instruction::OrImm { imm, .. }
                 | X86Instruction::XorImm { imm, .. }
                 | X86Instruction::CmpImm { imm, .. }
+                // The 3-operand IMUL immediate draws from the imm32 pool too.
+                | X86Instruction::ImulRegImm { imm, .. }
                 | X86Instruction::TestImm { imm, .. } => *imm = self.pick_non_mov_immediate(rng),
                 // SHL / SHR / SAR / ROL / ROR carry an imm8 count; mutate it
                 // from the imm8-encodable pool even with no register pool.
@@ -1169,6 +1212,8 @@ impl X86Mutator {
                 | X86Instruction::Not { .. }
                 | X86Instruction::Inc { .. }
                 | X86Instruction::Dec { .. }
+                // IMUL rd, rs has no immediate, so it is a no-op with no pool.
+                | X86Instruction::ImulReg { .. }
                 | X86Instruction::Jcc { .. } => {}
                 X86Instruction::Cmov { cond, .. } => *cond = self.pick_condition(rng),
             }
@@ -1193,6 +1238,9 @@ impl X86Mutator {
             | X86Instruction::SubReg { rd, rs }
             | X86Instruction::AndReg { rd, rs }
             | X86Instruction::OrReg { rd, rs }
+            // IMUL rd, rs mutates either register slot, like the other reg-reg
+            // forms.
+            | X86Instruction::ImulReg { rd, rs }
             | X86Instruction::XorReg { rd, rs } => {
                 if rng.random_bool(0.5) {
                     *rd = self.pick_register(rng).expect("register pool is non-empty");
@@ -1200,6 +1248,12 @@ impl X86Mutator {
                     *rs = self.pick_register(rng).expect("register pool is non-empty");
                 }
             }
+            // IMUL rd, rs, imm mutates one of the three operand slots.
+            X86Instruction::ImulRegImm { rd, rs, imm } => match rng.random_range(0..3u32) {
+                0 => *rd = self.pick_register(rng).expect("register pool is non-empty"),
+                1 => *rs = self.pick_register(rng).expect("register pool is non-empty"),
+                _ => *imm = self.pick_non_mov_immediate(rng),
+            },
             X86Instruction::AddImm { rd, imm }
             | X86Instruction::SubImm { rd, imm }
             | X86Instruction::AndImm { rd, imm }
@@ -1385,6 +1439,11 @@ impl X86Mutator {
                     X86Instruction::Ror { rd, imm }
                 }
             }
+            // IMUL has a distinct (CF/OF-only-defined) flag model that no other
+            // family shares, so — like Cmov — it has no opcode-shape sibling to
+            // bridge to. Keep both IMUL forms unchanged here; operand mutation
+            // and whole-instruction replacement still explore them.
+            X86Instruction::ImulReg { .. } | X86Instruction::ImulRegImm { .. } => current,
             // Cmov has a unique shape (rd, rs, cond) with no opcode-shape
             // siblings; keep it unchanged in the opcode-bridge mutator.
             X86Instruction::Cmov { .. } => current,
@@ -1461,18 +1520,19 @@ pub struct X86InstructionGenerator;
 
 // One entry per rewritable opcode family: 6 reg-reg + 6 reg-imm + CMP + TEST
 // (each reg/imm) + NEG + NOT + INC + DEC + SHL + SHR + SAR + ROL + ROR +
-// CMOVcc. CMOVcc counts as a single family here even though `generate_all`
-// expands it across all 16 `X86Condition::ALL` variants per register pair.
+// IMUL (2-op) + IMUL (3-op) + CMOVcc. CMOVcc counts as a single family here
+// even though `generate_all` expands it across all 16 `X86Condition::ALL`
+// variants per register pair.
 //
-// CMOV MUST remain the LAST opcode (index COUNT - 1 == 25): both
+// CMOV MUST remain the LAST opcode (index COUNT - 1 == 27): both
 // `X86Mutator::random_instruction` and
 // `generate_random_rewritable_x86_instruction` gate the extra distinct-source
 // CMOV draw on `opcode == X86_REWRITABLE_OPCODE_COUNT - 1`. New flag-only
 // families (CMP, TEST), single-operand families (NEG, NOT, INC, DEC), the
-// immediate-count shift families (SHL, SHR, SAR), and the immediate-count
-// rotate families (ROL, ROR) are inserted before CMOV in
-// `build_x86_instruction_by_opcode` to preserve that invariant.
-const X86_REWRITABLE_OPCODE_COUNT: u8 = 26;
+// immediate-count shift families (SHL, SHR, SAR), the immediate-count
+// rotate families (ROL, ROR), and the two IMUL forms are inserted before CMOV
+// in `build_x86_instruction_by_opcode` to preserve that invariant.
+const X86_REWRITABLE_OPCODE_COUNT: u8 = 28;
 
 fn has_distinct_register_pair(registers: &[X86Register]) -> bool {
     let Some(first) = registers.first() else {
@@ -1535,9 +1595,14 @@ pub(crate) fn build_x86_instruction_by_opcode(
         // in lock-step on the shared `imm`.
         23 => X86Instruction::Rol { rd, imm },
         24 => X86Instruction::Ror { rd, imm },
-        // Cmov stays last (index 25 == X86_REWRITABLE_OPCODE_COUNT - 1) so the
+        // IMUL (2-op) consumes rd + rs; IMUL (3-op) consumes rd + rs + the
+        // shared `imm`. No extra RNG draw, so the two dispatch sites stay in
+        // lock-step on the shared operands.
+        25 => X86Instruction::ImulReg { rd, rs },
+        26 => X86Instruction::ImulRegImm { rd, rs, imm },
+        // Cmov stays last (index 27 == X86_REWRITABLE_OPCODE_COUNT - 1) so the
         // CMOV distinct-register draw at the two generation sites stays correct.
-        25 => X86Instruction::Cmov { rd, rs, cond },
+        27 => X86Instruction::Cmov { rd, rs, cond },
         _ => unreachable!("opcode out of range"),
     }
 }
@@ -1685,6 +1750,26 @@ impl InstructionGenerator<X86Instruction> for X86InstructionGenerator {
                 out.push(X86Instruction::Ror { rd, imm });
             }
         }
+        // IMUL (2-operand): `imul rd, rs` for every (register, register) pair,
+        // including rd == rs (self-multiply is meaningful, unlike self-CMOV).
+        for &rd in registers {
+            for &rs in registers {
+                out.push(X86Instruction::ImulReg { rd, rs });
+            }
+        }
+        // IMUL (3-operand): `imul rd, rs, imm` for every (rd, rs, imm) triple.
+        // The immediate encodes as imm32, so non-imm32 pool entries are skipped
+        // here rather than emitted and later rejected by `can_assemble`.
+        for &rd in registers {
+            for &rs in registers {
+                for &imm in immediates {
+                    if i32::try_from(imm).is_err() {
+                        continue;
+                    }
+                    out.push(X86Instruction::ImulRegImm { rd, rs, imm });
+                }
+            }
+        }
         // CMOVcc is rewritable and reads flags, so enumerate every
         // condition for each non-identical register pair. Jcc remains
         // excluded.
@@ -1786,6 +1871,13 @@ fn with_destination(instr: X86Instruction, new_rd: X86Register) -> X86Instructio
         // ROL / ROR likewise redirect the destination, carrying the count.
         X86Instruction::Rol { imm, .. } => X86Instruction::Rol { rd: new_rd, imm },
         X86Instruction::Ror { imm, .. } => X86Instruction::Ror { rd: new_rd, imm },
+        // IMUL redirects the destination, carrying the source (and imm).
+        X86Instruction::ImulReg { rs, .. } => X86Instruction::ImulReg { rd: new_rd, rs },
+        X86Instruction::ImulRegImm { rs, imm, .. } => X86Instruction::ImulRegImm {
+            rd: new_rd,
+            rs,
+            imm,
+        },
         X86Instruction::Cmov { rd, rs, cond } => X86Instruction::Cmov {
             rd: if new_rd == rs { rd } else { new_rd },
             rs,
@@ -1865,6 +1957,14 @@ fn with_sources(instr: X86Instruction, new_rs: X86Register, new_imm: i64) -> X86
                 imm
             },
         },
+        // IMUL (2-op) varies its source register; (3-op) varies both source
+        // register and immediate.
+        X86Instruction::ImulReg { rd, .. } => X86Instruction::ImulReg { rd, rs: new_rs },
+        X86Instruction::ImulRegImm { rd, .. } => X86Instruction::ImulRegImm {
+            rd,
+            rs: new_rs,
+            imm: new_imm,
+        },
         // Cmov's `rs` is mutated; `cond` and `rd` carry through unchanged.
         X86Instruction::Cmov { rd, rs, cond } => X86Instruction::Cmov {
             rd,
@@ -1922,20 +2022,28 @@ mod tests {
             .iter()
             .filter(|&&imm| u8::try_from(imm).is_ok())
             .count();
+        // The 3-operand IMUL only enumerates over imm32-encodable immediates.
+        let imul_m = imms
+            .iter()
+            .filter(|&&imm| i32::try_from(imm).is_ok())
+            .count();
         // 8 reg-reg families + 8 reg-imm families + 4 single-operand families
         // (NEG, NOT, INC, DEC) + 3 shift families (SHL, SHR, SAR over imm8
-        // counts) + 2 rotate families (ROL, ROR over imm8 counts) + CMOVcc over
-        // distinct pairs.
+        // counts) + 2 rotate families (ROL, ROR over imm8 counts) + IMUL 2-op
+        // (every register pair) + IMUL 3-op (every (rd, rs, imm32) triple) +
+        // CMOVcc over distinct pairs.
         let expected_len = 8 * n * n
             + 8 * n * m
             + 4 * n
             + 3 * n * shift_m
             + 2 * n * shift_m
+            + n * n
+            + n * n * imul_m
             + n * (n - 1) * X86Condition::ALL.len();
         assert_eq!(
             all.len(),
             expected_len,
-            "generate_all should only prune CMOV self-pairs and non-imm8 shift/rotate counts from the full pool"
+            "generate_all should only prune CMOV self-pairs and non-imm8 shift/rotate / non-imm32 imul counts from the full pool"
         );
 
         // For each opcode_id, at least one variant must appear.
@@ -2110,7 +2218,9 @@ mod tests {
                 | X86Instruction::Shr { imm, .. }
                 | X86Instruction::Sar { imm, .. }
                 | X86Instruction::Rol { imm, .. }
-                | X86Instruction::Ror { imm, .. } => {
+                | X86Instruction::Ror { imm, .. }
+                // The 3-operand IMUL draws its immediate from the shared pool.
+                | X86Instruction::ImulRegImm { imm, .. } => {
                     assert!(imms.contains(&imm), "immediate {} outside pool", imm);
                 }
                 X86Instruction::MovReg { .. }
@@ -2125,6 +2235,7 @@ mod tests {
                 | X86Instruction::Not { .. }
                 | X86Instruction::Inc { .. }
                 | X86Instruction::Dec { .. }
+                | X86Instruction::ImulReg { .. }
                 | X86Instruction::Cmov { .. }
                 | X86Instruction::Jcc { .. } => {}
             }
@@ -3227,7 +3338,10 @@ mod tests {
                 | X86Instruction::Shr { imm, .. }
                 | X86Instruction::Sar { imm, .. }
                 | X86Instruction::Rol { imm, .. }
-                | X86Instruction::Ror { imm, .. } => {
+                | X86Instruction::Ror { imm, .. }
+                // The 3-operand IMUL draws its immediate from the same shared
+                // slot, so the empty pool yields 0 here too.
+                | X86Instruction::ImulRegImm { imm, .. } => {
                     saw_immediate_form = true;
                     assert_eq!(imm, 0);
                 }
@@ -3243,6 +3357,7 @@ mod tests {
                 | X86Instruction::Not { .. }
                 | X86Instruction::Inc { .. }
                 | X86Instruction::Dec { .. }
+                | X86Instruction::ImulReg { .. }
                 | X86Instruction::Cmov { .. }
                 | X86Instruction::Jcc { .. } => {}
             }
@@ -3325,8 +3440,10 @@ mod tests {
             (22, X86Instruction::Sar { rd, imm }),
             (23, X86Instruction::Rol { rd, imm }),
             (24, X86Instruction::Ror { rd, imm }),
-            // Cmov stays last at COUNT - 1 == 25.
-            (25, X86Instruction::Cmov { rd, rs, cond }),
+            (25, X86Instruction::ImulReg { rd, rs }),
+            (26, X86Instruction::ImulRegImm { rd, rs, imm }),
+            // Cmov stays last at COUNT - 1 == 27.
+            (27, X86Instruction::Cmov { rd, rs, cond }),
         ];
 
         for (opcode, want) in expected {
@@ -3365,7 +3482,9 @@ mod tests {
             (22, "sar"),
             (23, "rol"),
             (24, "ror"),
-            (25, "cmove"),
+            (25, "imul"),
+            (26, "imul"),
+            (27, "cmove"),
         ];
         for (opcode, mnem) in mnemonics {
             assert_eq!(
@@ -3814,7 +3933,10 @@ mod tests {
                     | X86Instruction::Shr { .. }
                     | X86Instruction::Sar { .. }
                     | X86Instruction::Rol { .. }
-                    | X86Instruction::Ror { .. } => {
+                    | X86Instruction::Ror { .. }
+                    // The 3-operand IMUL immediate is imm32; same encodability
+                    // invariant.
+                    | X86Instruction::ImulRegImm { .. } => {
                         saw_non_mov_immediate = true;
                         assert!(
                             <X86_64 as Assembler<X86Instruction>>::can_assemble(&X86_64, instr),
@@ -3833,6 +3955,7 @@ mod tests {
                     | X86Instruction::Not { .. }
                     | X86Instruction::Inc { .. }
                     | X86Instruction::Dec { .. }
+                    | X86Instruction::ImulReg { .. }
                     | X86Instruction::Cmov { .. }
                     | X86Instruction::Jcc { .. } => {}
                 }

--- a/src/parser/x86.rs
+++ b/src/parser/x86.rs
@@ -382,6 +382,35 @@ fn x86_ir_from_mnemonic_impl(
         }));
     }
 
+    // IMUL is the FIRST x86 instruction with both a two-operand and a
+    // three-operand single-destination form, so it gets its own arity-aware
+    // branch ahead of the strictly-two-operand families below.
+    //   * `imul rd, rs`       -> ImulReg     (rd = rd * rs; rd read + written)
+    //   * `imul rd, rs, imm`  -> ImulRegImm  (rd = rs * imm; rd written only)
+    // The 1-operand RDX:RAX widening form (`imul rax`) is deferred and surfaces
+    // as `Ok(None)` (an unsupported shape), like an unknown mnemonic. The
+    // 3-operand register-source-with-register-count is not an IMUL shape; a
+    // third register operand is rejected here.
+    if mnemonic == "imul" {
+        let parts: Vec<&str> = op_str.split(',').map(|s| s.trim()).collect();
+        match parts.len() {
+            2 => {
+                let rd = parse_x86_register_with_mode(parts[0], mode)?;
+                let rs = parse_x86_register_with_mode(parts[1], mode)?;
+                return Ok(Some(X86Instruction::ImulReg { rd, rs }));
+            }
+            3 => {
+                let rd = parse_x86_register_with_mode(parts[0], mode)?;
+                let rs = parse_x86_register_with_mode(parts[1], mode)?;
+                let imm = parse_x86_immediate(parts[2])?;
+                return Ok(Some(X86Instruction::ImulRegImm { rd, rs, imm }));
+            }
+            // 1-operand widening form (deferred) and any other arity are
+            // unsupported shapes.
+            _ => return Ok(None),
+        }
+    }
+
     // Reject unsupported mnemonics before attempting operand parsing so
     // shapes outside the minimal core (e.g. LEA `rax, [rbx+1]`) surface
     // as "unsupported mnemonic" rather than a confusing downstream
@@ -491,8 +520,9 @@ fn x86_ir_from_mnemonic_impl(
 /// (`name:`), directives (`.foo`), and instructions whose mnemonic is
 /// one of the supported families (mov, add, sub, and, or, xor, cmp,
 /// test, the single-operand neg/not/inc/dec, the immediate-count shifts
-/// shl/sal/shr/sar, the immediate-count rotates rol/ror, plus the conditional
-/// cmovCC and jCC variants). Anything else is a parse error.
+/// shl/sal/shr/sar, the immediate-count rotates rol/ror, the two- and
+/// three-operand signed multiply imul, plus the conditional cmovCC and jCC
+/// variants). Anything else is a parse error.
 pub fn parse_x86_assembly_string(
     content: &str,
     source_name: String,
@@ -1135,6 +1165,80 @@ mod tests {
             X86Instruction::Ror {
                 rd: X86Register::RAX,
                 imm: 4
+            }
+        );
+    }
+
+    #[test]
+    fn imul_parses_two_and_three_operand_forms_and_round_trips_display() {
+        // `imul rax, rbx` -> ImulReg; `imul rax, rbx, 4` -> ImulRegImm. Display
+        // output round-trips back to the same IR for both forms.
+        let two = x86_ir_from_mnemonic("imul", "rax, rbx").unwrap().unwrap();
+        assert_eq!(
+            two,
+            X86Instruction::ImulReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            }
+        );
+        assert_eq!(two.to_string(), "imul rax, rbx");
+
+        let three = x86_ir_from_mnemonic("imul", "rax, rbx, 4")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            three,
+            X86Instruction::ImulRegImm {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+                imm: 4,
+            }
+        );
+        assert_eq!(three.to_string(), "imul rax, rbx, 4");
+
+        for instr in [two, three] {
+            let text = instr.to_string();
+            let (mnemonic, ops) = text.split_once(char::is_whitespace).unwrap();
+            assert_eq!(
+                x86_ir_from_mnemonic(mnemonic, ops).unwrap().unwrap(),
+                instr,
+                "round-trip failed for {text}"
+            );
+        }
+    }
+
+    #[test]
+    fn imul_one_operand_widening_form_is_rejected() {
+        // The 1-operand RDX:RAX widening IMUL is deferred: `imul rax` is an
+        // unsupported shape and surfaces as Ok(None), not an ImulReg.
+        assert!(x86_ir_from_mnemonic("imul", "rax").unwrap().is_none());
+        // A 4-operand shape is also unsupported.
+        assert!(
+            x86_ir_from_mnemonic("imul", "rax, rbx, 4, 5")
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn imul_round_trips_through_mode_aware_binary_path() {
+        assert_eq!(
+            x86_ir_from_mnemonic_for_mode("imul", "rax, rbx", X86ParseMode::Mode64)
+                .unwrap()
+                .unwrap(),
+            X86Instruction::ImulReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            }
+        );
+        assert_eq!(
+            x86_ir_from_mnemonic_for_mode("imul", "eax, ebx, 4", X86ParseMode::Mode32)
+                .unwrap()
+                .unwrap(),
+            X86Instruction::ImulRegImm {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+                imm: 4,
             }
         );
     }

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -1028,12 +1028,14 @@ mod tests {
         let mut search: StochasticSearch<X86_64> = StochasticSearch::new();
         let config = SearchConfig::default()
             .with_stochastic(
-                // Seed retuned from 1 to 2 when INC/DEC raised the rewritable
-                // opcode count to 21, shifting the seeded mutation trajectory
-                // so seed 1 no longer reached `mov rax, rbx` within 500 iters.
+                // Seed retuned to 1 when the two IMUL forms raised the
+                // rewritable opcode count to 28, shifting the seeded mutation
+                // trajectory. A 0..64 seed sweep confirms seed 1 reaches
+                // `mov rax, rbx` within 500 iters (many other seeds also work;
+                // 1 was picked as the lowest passing value).
                 StochasticConfig::default()
                     .with_iterations(500)
-                    .with_seed(2),
+                    .with_seed(1),
             )
             .with_x86_registers(vec![X86Register::RAX, X86Register::RBX, X86Register::RCX])
             .with_immediates(vec![0, 1]);

--- a/src/semantics/concrete_x86.rs
+++ b/src/semantics/concrete_x86.rs
@@ -50,6 +50,16 @@ pub fn apply_instruction_concrete_x86(
         X86Instruction::Sar { rd, imm } => apply_shift(&mut state, *rd, *imm, ShiftKind::Sar),
         X86Instruction::Rol { rd, imm } => apply_rotate(&mut state, *rd, *imm, RotateKind::Rol),
         X86Instruction::Ror { rd, imm } => apply_rotate(&mut state, *rd, *imm, RotateKind::Ror),
+        X86Instruction::ImulReg { rd, rs } => {
+            let lhs = state.get_register(*rd).as_u64();
+            let rhs = state.get_register(*rs).as_u64();
+            apply_imul(&mut state, *rd, lhs, rhs);
+        }
+        X86Instruction::ImulRegImm { rd, rs, imm } => {
+            let lhs = state.get_register(*rs).as_u64();
+            let rhs = *imm as u64;
+            apply_imul(&mut state, *rd, lhs, rhs);
+        }
         X86Instruction::Cmov { rd, rs, cond } => {
             if state.get_flags().evaluate(*cond) {
                 let v = state.get_register(*rs);
@@ -146,6 +156,55 @@ fn apply_dec(state: &mut X86ConcreteMachineState, rd: crate::isa::x86::X86Regist
     state.set_register(rd, ConcreteValue::new(result));
     let mut flags = Eflags::from_sub(old, 1, result, state.width());
     flags.cf = prev_cf;
+    state.set_flags(flags);
+}
+
+// Sign-extend the low `width` bits of `value` to a full i128 (so a width-`width`
+// signed multiply cannot overflow the i128 product).
+fn sign_extend_to_i128(value: u64, width: u32) -> i128 {
+    let masked = mask_width(value, width);
+    // Shift the sign bit up to bit 127, then arithmetic-shift back down.
+    let shift = 128 - width;
+    ((masked as i128) << shift) >> shift
+}
+
+// IMUL (signed multiply) — shared by both the 2-operand (`rd = rd * rs`) and
+// 3-operand (`rd = rs * imm`) forms. `lhs`/`rhs` are the raw register/immediate
+// bit patterns; this function sign-extends each from the operand width, takes
+// the FULL signed product, and writes the low `width` bits to `rd`.
+//
+// FLAG MODEL (Intel SDM): for IMUL only CF and OF are architecturally defined;
+// SF/ZF/PF/AF are UNDEFINED. CF = OF = 1 iff the full signed product does NOT
+// fit the truncated `width`-bit destination (i.e. signed overflow), else 0.
+//
+// SF/ZF/PF are Intel-undefined. We model them DETERMINISTICALLY from the
+// truncated result (the `from_logical` SF/ZF/PF path: SF = MSB, ZF = result==0,
+// PF = parity of the low byte) and AF per the existing convention (false). This
+// is documented as deterministic-undefined: because the target and candidate
+// sequences share this exact lowering (concrete here, SMT in `smt_x86`),
+// equivalence checking stays internally consistent and conservative — it never
+// accepts a rewrite that changes a flag a legitimate program could rely on,
+// since legitimate programs do not read IMUL's undefined flags.
+fn apply_imul(
+    state: &mut X86ConcreteMachineState,
+    rd: crate::isa::x86::X86Register,
+    lhs: u64,
+    rhs: u64,
+) {
+    let width = state.width();
+    let full = sign_extend_to_i128(lhs, width) * sign_extend_to_i128(rhs, width);
+    let result = mask_width(full as u64, width);
+
+    // CF = OF = signed overflow: the full product does not equal the
+    // sign-extension of the truncated result.
+    let overflow = full != sign_extend_to_i128(result, width);
+
+    state.set_register(rd, ConcreteValue::new(result));
+    // SF/ZF/PF from the truncated result (Intel-undefined; modelled
+    // deterministically — see the function comment). CF/OF then overridden.
+    let mut flags = Eflags::from_logical(result, width);
+    flags.cf = overflow;
+    flags.of = overflow;
     state.set_flags(flags);
 }
 
@@ -1002,6 +1061,155 @@ mod tests {
                 "rol {value:#x}, 1 must equal (v << 1) | (v >>u 63)"
             );
         }
+    }
+
+    #[test]
+    fn imul_reg_multiplies_and_clears_cf_of_when_product_fits() {
+        // imul rax, rbx with small operands: 6 * 7 = 42 fits the 64-bit
+        // destination, so CF = OF = 0.
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(6));
+        state.set_register(X86Register::RBX, ConcreteValue::new(7));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::ImulReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+        );
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 42);
+        let flags = after.get_flags();
+        assert!(!flags.cf, "product fits -> CF clear");
+        assert!(!flags.of, "product fits -> OF clear");
+        // SF/ZF modelled deterministically from the truncated result.
+        assert!(!flags.zf);
+        assert!(!flags.sf);
+    }
+
+    #[test]
+    fn imul_reg_signed_negative_product() {
+        // imul of (-3) * 4 = -12: the truncated 64-bit result is -12 and the
+        // full product still fits, so CF = OF = 0 and SF (modelled) is set.
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new((-3i64) as u64));
+        state.set_register(X86Register::RBX, ConcreteValue::new(4));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::ImulReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+        );
+        assert_eq!(
+            after.get_register(X86Register::RAX).as_u64(),
+            (-12i64) as u64
+        );
+        let flags = after.get_flags();
+        assert!(!flags.cf, "(-3)*4 fits -> CF clear");
+        assert!(!flags.of);
+        assert!(flags.sf, "negative result -> SF set (deterministic model)");
+    }
+
+    #[test]
+    fn imul_reg_overflow_sets_cf_and_of() {
+        // imul rax, rbx where the full signed product overflows 64 bits:
+        // (1<<40) * (1<<40) = 1<<80, which does NOT fit -> CF = OF = 1.
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(1u64 << 40));
+        state.set_register(X86Register::RBX, ConcreteValue::new(1u64 << 40));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::ImulReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+        );
+        // Low 64 bits of 1<<80 are 0.
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 0);
+        let flags = after.get_flags();
+        assert!(flags.cf, "product overflows -> CF set");
+        assert!(flags.of, "product overflows -> OF set");
+    }
+
+    #[test]
+    fn imul_reg_imm_writes_rs_times_imm() {
+        // imul rax, rbx, 4: rax = rbx * 4 (rax is purely written, NOT read).
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(0xdead));
+        state.set_register(X86Register::RBX, ConcreteValue::new(5));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::ImulRegImm {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+                imm: 4,
+            },
+        );
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 20);
+        let flags = after.get_flags();
+        assert!(!flags.cf);
+        assert!(!flags.of);
+    }
+
+    // The DoD result identity, concrete form: `imul rd, rs, 4` produces the
+    // same truncated value as `rs << 2` (multiply by a power of two).
+    #[test]
+    fn imul_reg_imm_by_power_of_two_matches_shift_construction() {
+        for value in [0u64, 1, 5, 0xdead_beef, u64::MAX, 1u64 << 62] {
+            let mut state = X86ConcreteMachineState::new_zeroed(64);
+            state.set_register(X86Register::RBX, ConcreteValue::new(value));
+            let after = apply_instruction_concrete_x86(
+                state,
+                &X86Instruction::ImulRegImm {
+                    rd: X86Register::RAX,
+                    rs: X86Register::RBX,
+                    imm: 4,
+                },
+            );
+            assert_eq!(
+                after.get_register(X86Register::RAX).as_u64(),
+                value.wrapping_shl(2),
+                "imul {value:#x}, 4 must equal value << 2 (truncated)"
+            );
+        }
+    }
+
+    // The 32-bit overflow boundary differs from 64-bit: 0x10000 * 0x10000 =
+    // 0x1_0000_0000 overflows a 32-bit destination (CF=OF=1) but fits a 64-bit
+    // one. Pin both widths to guard width-awareness.
+    #[test]
+    fn imul_overflow_is_width_aware() {
+        // width 32: 0x10000 * 0x10000 overflows.
+        let mut s32 = X86ConcreteMachineState::new_zeroed(32);
+        s32.set_register(X86Register::RAX, ConcreteValue::new(0x10000));
+        s32.set_register(X86Register::RBX, ConcreteValue::new(0x10000));
+        let after32 = apply_instruction_concrete_x86(
+            s32,
+            &X86Instruction::ImulReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+        );
+        assert!(after32.get_flags().cf, "32-bit product overflows -> CF set");
+        assert!(after32.get_flags().of);
+
+        // width 64: the same operands fit.
+        let mut s64 = X86ConcreteMachineState::new_zeroed(64);
+        s64.set_register(X86Register::RAX, ConcreteValue::new(0x10000));
+        s64.set_register(X86Register::RBX, ConcreteValue::new(0x10000));
+        let after64 = apply_instruction_concrete_x86(
+            s64,
+            &X86Instruction::ImulReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+        );
+        assert_eq!(
+            after64.get_register(X86Register::RAX).as_u64(),
+            0x1_0000_0000
+        );
+        assert!(!after64.get_flags().cf, "64-bit product fits -> CF clear");
+        assert!(!after64.get_flags().of);
     }
 
     #[test]

--- a/src/semantics/cost_x86.rs
+++ b/src/semantics/cost_x86.rs
@@ -68,7 +68,12 @@ fn instruction_code_size(instr: &X86Instruction, width: u32) -> u64 {
         | X86Instruction::Shr { .. }
         | X86Instruction::Sar { .. }
         | X86Instruction::Rol { .. }
+        // IMUL rd, rs is `0F AF /r` = opcode (2) + ModR/M = 3 bytes (+REX.W).
+        | X86Instruction::ImulReg { .. }
         | X86Instruction::Ror { .. } => 3 + rex,
+        // IMUL rd, rs, imm is `69 /r id` = opcode + ModR/M + 4-byte imm
+        // = 6 bytes (+REX.W), mirroring the reg-imm arithmetic sizing.
+        X86Instruction::ImulRegImm { .. } => 6 + rex,
         X86Instruction::AddImm { .. }
         | X86Instruction::SubImm { .. }
         | X86Instruction::AndImm { .. }

--- a/src/semantics/smt_x86.rs
+++ b/src/semantics/smt_x86.rs
@@ -372,6 +372,47 @@ fn apply_rotate_smt(
     state.set_flags(flags);
 }
 
+/// Lower a signed multiply (IMUL) symbolically — shared by the 2-operand
+/// (`rd = rd * rs`) and 3-operand (`rd = rs * imm`) forms. `lhs`/`rhs` are the
+/// width-`width` operand BVs; the result is the low `width` bits of the signed
+/// product written to `rd`.
+///
+/// FLAG MODEL (mirrors `concrete_x86::apply_imul` bit-for-bit): only CF and OF
+/// are architecturally defined. We detect signed overflow with a WIDE multiply:
+/// sign-extend both operands to `2*width`, `bvmul`, and check whether the full
+/// product equals the sign-extension of the truncated `width`-bit result. CF =
+/// OF = NOT(fits).
+///
+/// SF/ZF/PF are Intel-UNDEFINED; we model them deterministically from the
+/// truncated result via `compute_eflags_logical` (SF = MSB, ZF = result == 0,
+/// PF = low-byte parity). Both target and candidate share this lowering, so
+/// equivalence stays internally consistent and conservative. AF is not modelled
+/// (see module docs).
+fn apply_imul_smt(
+    state: &mut MachineStateX86,
+    rd: crate::isa::x86::X86Register,
+    lhs: &BV,
+    rhs: &BV,
+) {
+    let width = state.width();
+    // `sign_ext(width)` adds `width` bits, giving a 2*width-bit BV.
+    let wide = lhs.sign_ext(width).bvmul(rhs.sign_ext(width));
+    let result = lhs.bvmul(rhs);
+
+    // `result fits` iff the full 2*width product equals the sign-extension of
+    // the truncated low-`width` result; signed overflow is the negation.
+    let fits = wide.eq(result.sign_ext(width));
+    let overflow = fits.ite(&bv_zero(), &bv_one());
+
+    // SF/ZF/PF from the truncated result (Intel-undefined; modelled
+    // deterministically). CF/OF then overridden with the overflow bit.
+    let mut flags = compute_eflags_logical(&result, width);
+    flags.cf = overflow.clone();
+    flags.of = overflow;
+    state.set_register(rd, result);
+    state.set_flags(flags);
+}
+
 /// Apply a single x86 instruction symbolically. Arithmetic / logic /
 /// CMP arms bind the five tracked flag BVs via `compute_eflags_*`;
 /// CMOV reads them via `x86_condition_to_smt`.
@@ -555,6 +596,18 @@ pub fn apply_instruction(
         // `apply_rotate_smt`.
         X86Instruction::Rol { rd, imm } => apply_rotate_smt(&mut state, *rd, *imm, RotateKind::Rol),
         X86Instruction::Ror { rd, imm } => apply_rotate_smt(&mut state, *rd, *imm, RotateKind::Ror),
+        // IMUL (2-op): `rd = rd * rs`. rd is both source and destination.
+        X86Instruction::ImulReg { rd, rs } => {
+            let lhs = state.get_register(*rd).clone();
+            let rhs = state.get_register(*rs).clone();
+            apply_imul_smt(&mut state, *rd, &lhs, &rhs);
+        }
+        // IMUL (3-op): `rd = rs * imm`. rd is purely written.
+        X86Instruction::ImulRegImm { rd, rs, imm } => {
+            let lhs = state.get_register(*rs).clone();
+            let rhs = state.imm_bv(*imm);
+            apply_imul_smt(&mut state, *rd, &lhs, &rhs);
+        }
         X86Instruction::Cmov { rd, rs, cond } => {
             let pred = x86_condition_to_smt(*cond, state.get_flags());
             let rs_val = state.get_register(*rs).clone();
@@ -1769,6 +1822,149 @@ mod tests {
             0x1111_2222_3333_4444,
             0xAAAA_BBBB_CCCC_DDDD,
         );
+    }
+
+    // --- symbolic IMUL ---
+
+    // The DoD IMUL theorem: `imul rd, rs, 4` produces the same RESULT as the
+    // power-of-two shift `rs << 2`. We prove the negation of the truncated
+    // result equality is unsat over a shared symbolic input.
+    #[test]
+    fn imul_reg_imm_by_four_matches_shift_left_two() {
+        let state = MachineStateX86::new_symbolic("s", 64);
+        let rbx = state.get_register(X86Register::RBX).clone();
+        // rs << 2 at width 64.
+        let shifted = rbx.bvshl(BV::from_u64(2, 64));
+        let after = apply_instruction(
+            state,
+            &X86Instruction::ImulRegImm {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+                imm: 4,
+            },
+        );
+        let solver = Solver::new();
+        solver.assert(after.get_register(X86Register::RAX).eq(&shifted).not());
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "imul rd, rbx, 4 must equal rbx << 2 on the truncated result"
+        );
+    }
+
+    // IMUL result is a plain bvmul of the (sign-irrelevant for the low bits)
+    // operands: `imul rax, rbx` writes `rax * rbx` truncated.
+    #[test]
+    fn imul_reg_result_equals_bvmul() {
+        let state = MachineStateX86::new_symbolic("s", 64);
+        let rax = state.get_register(X86Register::RAX).clone();
+        let rbx = state.get_register(X86Register::RBX).clone();
+        let product = rax.bvmul(&rbx);
+        let after = apply_instruction(
+            state,
+            &X86Instruction::ImulReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+        );
+        let solver = Solver::new();
+        solver.assert(after.get_register(X86Register::RAX).eq(&product).not());
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "imul rax, rbx must write rax * rbx (truncated)"
+        );
+    }
+
+    // CF/OF overflow correctness: CF = OF, and CF = 1 iff the FULL signed
+    // product does not fit the truncated destination. We prove CF == OF always,
+    // and that CF == (signext64(rax)*signext64(rbx) != signext64(low64 product))
+    // — i.e. the wide-multiply overflow predicate — over a shared symbolic input.
+    #[test]
+    fn imul_reg_cf_of_track_signed_overflow() {
+        let state = MachineStateX86::new_symbolic("s", 64);
+        let rax = state.get_register(X86Register::RAX).clone();
+        let rbx = state.get_register(X86Register::RBX).clone();
+        let after = apply_instruction(
+            state,
+            &X86Instruction::ImulReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+        );
+        let cf = after.get_flags().cf.clone();
+        let of = after.get_flags().of.clone();
+
+        // Reference overflow predicate built independently of the lowering.
+        let wide = rax.sign_ext(64).bvmul(rbx.sign_ext(64));
+        let low = rax.bvmul(&rbx);
+        let fits = wide.eq(low.sign_ext(64));
+        let cf_one = BV::from_u64(1, 1);
+
+        // (1) CF == OF always.
+        {
+            let solver = Solver::new();
+            solver.assert(cf.eq(&of).not());
+            assert_eq!(solver.check(), SatResult::Unsat, "IMUL CF must equal OF");
+        }
+        // (2) CF == 1 iff NOT fits (signed overflow).
+        {
+            let solver = Solver::new();
+            let overflow = fits.not();
+            let iff = cf.eq(&cf_one).iff(&overflow);
+            solver.assert(iff.not());
+            assert_eq!(
+                solver.check(),
+                SatResult::Unsat,
+                "IMUL CF must be set iff the full signed product overflows the destination"
+            );
+        }
+    }
+
+    // Concrete/SMT parity for the 2-operand IMUL (rd = rax, rs = rbx) over the
+    // shared sample grid, covering result + all five tracked flags. This pins
+    // that the SMT lowering agrees with the concrete interpreter (including the
+    // deterministically-modelled SF/ZF/PF) for non-overflowing and overflowing
+    // inputs alike.
+    #[test]
+    fn parity_imul_reg() {
+        let instr = X86Instruction::ImulReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+        };
+        for &(a, b) in PARITY_SAMPLES {
+            assert_x86_concrete_smt_parity(&instr, a, b);
+        }
+    }
+
+    // Concrete/SMT parity for the 3-operand IMUL. The generic harness assumes
+    // `rd = rax`, `rs = rbx`, so `imul rax, rbx, imm` fits it directly: rax is
+    // purely written from rbx*imm.
+    #[test]
+    fn parity_imul_reg_imm() {
+        for imm in [
+            0i64,
+            1,
+            2,
+            4,
+            -1,
+            -4,
+            1000,
+            i32::MAX as i64,
+            i32::MIN as i64,
+        ] {
+            let instr = X86Instruction::ImulRegImm {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+                imm,
+            };
+            for &(a, b) in PARITY_SAMPLES {
+                // `a` (the rax pre-value) is irrelevant to the 3-operand form;
+                // the harness still seeds it, which is harmless since rd is
+                // purely written.
+                assert_x86_concrete_smt_parity(&instr, a, b);
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #630.

Adds signed multiply `ImulReg { rd, rs }` (`rd = rd*rs`) and the project's first 3-operand variant `ImulRegImm { rd, rs, imm }` (`rd = rs*imm`), low `width` bits. The 1-operand RDX:RAX widening form is deferred.

**Flag model** (Intel SDM): only CF/OF defined. CF = OF = 1 iff the full signed product doesn't fit the truncated destination — detected by a wide multiply: `wide = sign_ext(lhs)·sign_ext(rhs)`, `fits = wide == sext(result)`, `cf = of = !fits` (width-aware, verified at 32 and 64). SF/ZF/PF are Intel-undefined; modeled deterministically from the truncated result (documented; target & candidate share the lowering so equivalence stays internally consistent and conservative).

**source_registers**: `ImulReg → [rd, rs]` (rd read+written); `ImulRegImm → [rs]` (rd purely written).

**3-operand parser branch**: new arity-aware `imul` handling — 2 comma-parts → `ImulReg`, 3 → `ImulRegImm`, 1 (widening, deferred) → unsupported.

**CMOV invariant**: inserted at 25/26 before CMOV → `…23 Rol,24 Ror,25 ImulReg,26 ImulRegImm,27 Cmov`; `X86_REWRITABLE_OPCODE_COUNT` 26→28; Cmov stays last (27 = COUNT−1). Parity + `opcode_dispatch_is_consistent` green.

**DoD** `imul_reg_imm_by_four_matches_shift_left_two` (`imul rd,rs,4` ≡ `rs<<2`), plus overflow tests (`imul_reg_overflow_sets_cf_and_of`, `imul_overflow_is_width_aware`, SMT `imul_reg_cf_of_track_signed_overflow`), concrete↔SMT parity, and assembler Capstone round-trips.

Stochastic e2e seed retuned 2→1 (0..64 sweep; assertion kept) for the 28-opcode trajectory shift. `./ci_check.sh` + `RUSTFLAGS="-D warnings" cargo build` pass; clippy clean in changed files (5 needless-borrow lints in new SMT code fixed); 1392 lib tests green.