### PR TITLE
x86: add LEA (register-base + displacement) (#627)

### DIFF
--- a/docs/capability.md
+++ b/docs/capability.md
@@ -102,6 +102,7 @@ Rewritable straight-line mnemonic families:
 - Immediate-count shifts: `shl`/`sal`, `shr`, `sar`
 - Immediate-count rotates: `rol`, `ror`
 - Signed multiply: `imul` (2-operand `imul rd, rs` and 3-operand `imul rd, rs, imm`)
+- Load effective address: `lea` (register-base + displacement only)
 - Conditional moves: `cmov<cond>`
 
 The data-movement/arithmetic/logical/comparison families have register and
@@ -139,8 +140,13 @@ SF/ZF/PF are Intel-UNDEFINED; the model derives them deterministically from the
 truncated result (SF = MSB, ZF = result == 0, PF = low-byte parity) so the
 shared concrete/SMT lowering stays internally consistent (target and candidate
 agree), and AF follows the existing convention. The one-operand widening form
-(`imul rs`, writing RDX:RAX) is deferred. `cmov<cond>` has register operands and
-reads EFLAGS without modifying them.
+(`imul rs`, writing RDX:RAX) is deferred. `lea` is modelled only in its minimal
+register-base + displacement form, `lea rd, [base + disp]`, computing
+`rd = base + disp` (wrapping at width). It is non-destructive (`base` is read,
+`rd` is purely written, like `mov`) and affects NO flags. The index*scale
+(`[base + index*scale + disp]`) and RIP/EIP-relative addressing forms are
+deferred and rejected as unsupported shapes. `cmov<cond>` has register operands
+and reads EFLAGS without modifying them.
 
 The x86 IR does not yet carry operand width. To avoid rewriting partial-width
 operations as full-width operations, the binary optimization path currently

--- a/src/assembler/x86.rs
+++ b/src/assembler/x86.rs
@@ -262,6 +262,13 @@ fn encode_64(ops: &mut dynasmrt::x64::Assembler, instr: &X86Instruction) -> Resu
             dynasm!(ops ; .arch x64 ; imul Rq(rd), Rq(rs), imm);
             Ok(())
         }
+        X86Instruction::Lea { rd, base, disp } => {
+            let rd = reg_index(*rd)?;
+            let base = reg_index(*base)?;
+            let disp = signed_imm_i32(*disp)?;
+            dynasm!(ops ; .arch x64 ; lea Rq(rd), [Rq(base) + disp]);
+            Ok(())
+        }
         X86Instruction::Cmov { rd, rs, cond } => {
             let rd = reg_index(*rd)?;
             let rs = reg_index(*rs)?;
@@ -499,6 +506,13 @@ fn encode_32(ops: &mut dynasmrt::x86::Assembler, instr: &X86Instruction) -> Resu
             let rs = reg_index_32(*rs)?;
             let imm = signed_imm_i32(*imm)?;
             dynasm!(ops ; .arch x86 ; imul Rd(rd), Rd(rs), imm);
+            Ok(())
+        }
+        X86Instruction::Lea { rd, base, disp } => {
+            let rd = reg_index_32(*rd)?;
+            let base = reg_index_32(*base)?;
+            let disp = signed_imm_i32(*disp)?;
+            dynasm!(ops ; .arch x86 ; lea Rd(rd), [Rd(base) + disp]);
             Ok(())
         }
         X86Instruction::Cmov { rd, rs, cond } => {
@@ -1058,6 +1072,66 @@ mod tests {
             },
             "imul",
             &["ecx", "edx", "7"],
+        );
+    }
+
+    // LEA `rd, [base + disp]` (8D /r). Capstone may canonicalize the disp
+    // formatting (hex, sign placement), so we assert the mnemonic is `lea` and
+    // the operand string mentions the destination and base registers plus the
+    // displacement magnitude — robust against `1` vs `0x1` rendering.
+    #[test]
+    fn lea_variants_x86_64() {
+        // Bare base (disp == 0).
+        check_x86_64(
+            X86Instruction::Lea {
+                rd: X86Register::RAX,
+                base: X86Register::RBX,
+                disp: 0,
+            },
+            "lea",
+            &["rax", "rbx"],
+        );
+        // Positive displacement.
+        check_x86_64(
+            X86Instruction::Lea {
+                rd: X86Register::RAX,
+                base: X86Register::RBX,
+                disp: 0x10,
+            },
+            "lea",
+            &["rax", "rbx", "0x10"],
+        );
+        // Extended base register round-trips.
+        check_x86_64(
+            X86Instruction::Lea {
+                rd: X86Register::R9,
+                base: X86Register::RAX,
+                disp: 1,
+            },
+            "lea",
+            &["r9", "rax"],
+        );
+    }
+
+    #[test]
+    fn lea_variants_x86_32() {
+        check_x86_32(
+            X86Instruction::Lea {
+                rd: X86Register::RAX,
+                base: X86Register::RBX,
+                disp: 0,
+            },
+            "lea",
+            &["eax", "ebx"],
+        );
+        check_x86_32(
+            X86Instruction::Lea {
+                rd: X86Register::RCX,
+                base: X86Register::RDX,
+                disp: 0x20,
+            },
+            "lea",
+            &["ecx", "edx", "0x20"],
         );
     }
 

--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -385,6 +385,17 @@ pub enum X86Instruction {
         rs: X86Register,
         imm: i64,
     },
+    /// `lea rd, [base + disp]` — load effective address in its minimal
+    /// register-base + displacement form: `rd = base + disp` (wrapping at
+    /// width). NON-destructive: `base` is read, `rd` is purely WRITTEN (not
+    /// read), exactly like `MovReg`. Affects NO flags. The `index*scale` and
+    /// RIP-relative addressing forms are deferred; the parser rejects them as
+    /// unsupported shapes.
+    Lea {
+        rd: X86Register,
+        base: X86Register,
+        disp: i64,
+    },
     /// `cmovCC rd, rs` — conditional move. Reads EFLAGS;
     /// when `cond` holds, writes `rd = rs`; otherwise `rd` is unchanged.
     /// Does not modify EFLAGS.
@@ -426,6 +437,7 @@ impl X86Instruction {
             | X86Instruction::Ror { rd, .. }
             | X86Instruction::ImulReg { rd, .. }
             | X86Instruction::ImulRegImm { rd, .. }
+            | X86Instruction::Lea { rd, .. }
             | X86Instruction::Cmov { rd, .. } => Some(*rd),
             // CMP and TEST discard their result; only EFLAGS is written.
             X86Instruction::CmpReg { .. }
@@ -456,6 +468,7 @@ impl X86Instruction {
             X86Instruction::Rol { .. } => "rol",
             X86Instruction::Ror { .. } => "ror",
             X86Instruction::ImulReg { .. } | X86Instruction::ImulRegImm { .. } => "imul",
+            X86Instruction::Lea { .. } => "lea",
             X86Instruction::Cmov { cond, .. } => cond.cmov_mnemonic(),
             X86Instruction::Jcc { cond } => cond.jcc_mnemonic(),
         }
@@ -480,6 +493,9 @@ impl X86Instruction {
             | X86Instruction::XorReg { rd, rs } => vec![*rd, *rs],
             // IMUL rd, rs, imm writes rd purely from `rs * imm`; rd is NOT read.
             X86Instruction::ImulRegImm { rs, .. } => vec![*rs],
+            // LEA writes rd purely from `base + disp`; rd is NOT read (it is
+            // non-destructive, like MovReg). Only `base` is a source.
+            X86Instruction::Lea { base, .. } => vec![*base],
             X86Instruction::AddImm { rd, .. }
             | X86Instruction::SubImm { rd, .. }
             | X86Instruction::AndImm { rd, .. }
@@ -559,11 +575,12 @@ impl InstructionType for X86Instruction {
             X86Instruction::Ror { .. } => 24,
             X86Instruction::ImulReg { .. } => 25,
             X86Instruction::ImulRegImm { .. } => 26,
-            // Cmov MUST stay the last rewritable opcode (COUNT - 1 == 27):
+            X86Instruction::Lea { .. } => 27,
+            // Cmov MUST stay the last rewritable opcode (COUNT - 1 == 28):
             // the CMOV distinct-register draw at both generation sites is
             // gated on `opcode == X86_REWRITABLE_OPCODE_COUNT - 1`.
-            X86Instruction::Cmov { .. } => 27,
-            X86Instruction::Jcc { .. } => 28,
+            X86Instruction::Cmov { .. } => 28,
+            X86Instruction::Jcc { .. } => 29,
         }
     }
 
@@ -572,16 +589,18 @@ impl InstructionType for X86Instruction {
     }
 
     fn has_side_effects(&self) -> bool {
-        // MOV / NOT / CMOV / Jcc do not write EFLAGS (CMOV and Jcc read
+        // MOV / NOT / LEA / CMOV / Jcc do not write EFLAGS (CMOV and Jcc read
         // them, but reading is not a side effect on observable state; NOT
         // is bitwise complement and leaves EFLAGS untouched, exactly like
-        // MOV). Every other variant — including NEG — sets or clobbers flag
-        // bits, which is observable state beyond the destination register.
+        // MOV; LEA is pure address arithmetic that writes only its destination
+        // register). Every other variant — including NEG — sets or clobbers
+        // flag bits, which is observable state beyond the destination register.
         !matches!(
             self,
             X86Instruction::MovReg { .. }
                 | X86Instruction::MovImm { .. }
                 | X86Instruction::Not { .. }
+                | X86Instruction::Lea { .. }
                 | X86Instruction::Cmov { .. }
                 | X86Instruction::Jcc { .. }
         )
@@ -602,6 +621,18 @@ impl fmt::Display for X86Instruction {
             | X86Instruction::XorReg { rd, rs } => write!(f, "{} {}, {}", mn, rd, rs),
             // The 3-operand IMUL renders `imul rd, rs, imm`.
             X86Instruction::ImulRegImm { rd, rs, imm } => write!(f, "{} {}, {}, {}", mn, rd, rs, imm),
+            // LEA renders its memory operand in Intel bracket syntax. A zero
+            // displacement renders as bare `[base]`; a positive disp as
+            // `[base + disp]`; a negative disp as `[base - |disp|]`. All three
+            // forms round-trip through the bracket parse path in
+            // `parser::x86::x86_ir_from_mnemonic`.
+            X86Instruction::Lea { rd, base, disp } => match (*disp).cmp(&0) {
+                std::cmp::Ordering::Equal => write!(f, "{} {}, [{}]", mn, rd, base),
+                std::cmp::Ordering::Greater => write!(f, "{} {}, [{} + {}]", mn, rd, base, disp),
+                std::cmp::Ordering::Less => {
+                    write!(f, "{} {}, [{} - {}]", mn, rd, base, disp.unsigned_abs())
+                }
+            },
             X86Instruction::MovImm { rd, imm }
             | X86Instruction::AddImm { rd, imm }
             | X86Instruction::SubImm { rd, imm }
@@ -705,15 +736,17 @@ impl ISA for X86_32 {
 }
 
 /// Helper used by both `FlagsAnalysis<X86Instruction> for X86_64` and
-/// `for X86_32`. MOV / CMOV / Jcc do not write EFLAGS — CMOV and Jcc
-/// read them via `x86_reads_flags` but do not modify any flag bit.
-/// Every other variant in the current set writes EFLAGS.
+/// `for X86_32`. MOV / NOT / LEA / CMOV / Jcc do not write EFLAGS — CMOV and
+/// Jcc read them via `x86_reads_flags` but do not modify any flag bit; LEA is
+/// pure address arithmetic. Every other variant in the current set writes
+/// EFLAGS.
 fn x86_modifies_flags(instr: &X86Instruction) -> bool {
     !matches!(
         instr,
         X86Instruction::MovReg { .. }
             | X86Instruction::MovImm { .. }
             | X86Instruction::Not { .. }
+            | X86Instruction::Lea { .. }
             | X86Instruction::Cmov { .. }
             | X86Instruction::Jcc { .. }
     )
@@ -908,6 +941,8 @@ impl crate::isa::traits::Assembler<X86Instruction> for X86_64 {
             | X86Instruction::CmpImm { imm, .. }
             // The 3-operand IMUL immediate encodes as imm32 (`69 /r id`).
             | X86Instruction::ImulRegImm { imm, .. }
+            // LEA's displacement encodes as a signed disp32 in the ModRM/SIB.
+            | X86Instruction::Lea { disp: imm, .. }
             | X86Instruction::TestImm { imm, .. } => x86_signed_imm32_ok(*imm),
             // SHL / SHR / SAR / ROL / ROR encode their count as imm8: reject any
             // count that does not fit a single byte so the search never proposes
@@ -962,6 +997,10 @@ impl crate::isa::traits::Assembler<X86Instruction> for X86_32 {
             // IMUL rd, rs, imm: low-8 registers plus an imm32 immediate.
             X86Instruction::ImulRegImm { rd, rs, imm } => {
                 reg_ok_32(*rd) && reg_ok_32(*rs) && x86_signed_imm32_ok(*imm)
+            }
+            // LEA rd, [base + disp]: low-8 registers plus a signed disp32.
+            X86Instruction::Lea { rd, base, disp } => {
+                reg_ok_32(*rd) && reg_ok_32(*base) && x86_signed_imm32_ok(*disp)
             }
             X86Instruction::MovImm { rd, imm }
             | X86Instruction::AddImm { rd, imm }
@@ -1193,6 +1232,9 @@ impl X86Mutator {
                 // The 3-operand IMUL immediate draws from the imm32 pool too.
                 | X86Instruction::ImulRegImm { imm, .. }
                 | X86Instruction::TestImm { imm, .. } => *imm = self.pick_non_mov_immediate(rng),
+                // LEA's displacement is a signed disp32; mutate it from the
+                // non-MOV (imm32) pool even with no register pool.
+                X86Instruction::Lea { disp, .. } => *disp = self.pick_non_mov_immediate(rng),
                 // SHL / SHR / SAR / ROL / ROR carry an imm8 count; mutate it
                 // from the imm8-encodable pool even with no register pool.
                 X86Instruction::Shl { imm, .. }
@@ -1253,6 +1295,13 @@ impl X86Mutator {
                 0 => *rd = self.pick_register(rng).expect("register pool is non-empty"),
                 1 => *rs = self.pick_register(rng).expect("register pool is non-empty"),
                 _ => *imm = self.pick_non_mov_immediate(rng),
+            },
+            // LEA rd, [base + disp] mutates one of the three operand slots: the
+            // destination register, the base register, or the disp32.
+            X86Instruction::Lea { rd, base, disp } => match rng.random_range(0..3u32) {
+                0 => *rd = self.pick_register(rng).expect("register pool is non-empty"),
+                1 => *base = self.pick_register(rng).expect("register pool is non-empty"),
+                _ => *disp = self.pick_non_mov_immediate(rng),
             },
             X86Instruction::AddImm { rd, imm }
             | X86Instruction::SubImm { rd, imm }
@@ -1444,6 +1493,11 @@ impl X86Mutator {
             // bridge to. Keep both IMUL forms unchanged here; operand mutation
             // and whole-instruction replacement still explore them.
             X86Instruction::ImulReg { .. } | X86Instruction::ImulRegImm { .. } => current,
+            // LEA has a unique (rd, base, disp) shape and a flag-free model that
+            // no other family shares, so — like IMUL and Cmov — it has no
+            // opcode-shape sibling to bridge to. Keep it unchanged; operand
+            // mutation and whole-instruction replacement still explore it.
+            X86Instruction::Lea { .. } => current,
             // Cmov has a unique shape (rd, rs, cond) with no opcode-shape
             // siblings; keep it unchanged in the opcode-bridge mutator.
             X86Instruction::Cmov { .. } => current,
@@ -1524,15 +1578,15 @@ pub struct X86InstructionGenerator;
 // even though `generate_all` expands it across all 16 `X86Condition::ALL`
 // variants per register pair.
 //
-// CMOV MUST remain the LAST opcode (index COUNT - 1 == 27): both
+// CMOV MUST remain the LAST opcode (index COUNT - 1 == 28): both
 // `X86Mutator::random_instruction` and
 // `generate_random_rewritable_x86_instruction` gate the extra distinct-source
 // CMOV draw on `opcode == X86_REWRITABLE_OPCODE_COUNT - 1`. New flag-only
 // families (CMP, TEST), single-operand families (NEG, NOT, INC, DEC), the
 // immediate-count shift families (SHL, SHR, SAR), the immediate-count
-// rotate families (ROL, ROR), and the two IMUL forms are inserted before CMOV
-// in `build_x86_instruction_by_opcode` to preserve that invariant.
-const X86_REWRITABLE_OPCODE_COUNT: u8 = 28;
+// rotate families (ROL, ROR), the two IMUL forms, and LEA are inserted before
+// CMOV in `build_x86_instruction_by_opcode` to preserve that invariant.
+const X86_REWRITABLE_OPCODE_COUNT: u8 = 29;
 
 fn has_distinct_register_pair(registers: &[X86Register]) -> bool {
     let Some(first) = registers.first() else {
@@ -1547,9 +1601,9 @@ fn has_distinct_register_pair(registers: &[X86Register]) -> bool {
 /// `X86Mutator::random_instruction` and
 /// `generate_random_rewritable_x86_instruction` both delegate here so the two
 /// dispatch tables cannot drift (see issue #348). Operand drawing and RNG draw
-/// order stay at the call sites; the CMOV slot (opcode 25, the last index)
-/// consumes the `rs` the caller resolved via `pick_register_except` so
-/// `rs != rd`.
+/// order stay at the call sites; the CMOV slot (the last index,
+/// `X86_REWRITABLE_OPCODE_COUNT - 1`) consumes the `rs` the caller resolved
+/// via `pick_register_except` so `rs != rd`.
 ///
 /// Keep this in lock-step with `X86_REWRITABLE_OPCODE_COUNT` and the
 /// `opcode_dispatch_is_consistent` test, which pins the full mapping.
@@ -1600,9 +1654,17 @@ pub(crate) fn build_x86_instruction_by_opcode(
         // lock-step on the shared operands.
         25 => X86Instruction::ImulReg { rd, rs },
         26 => X86Instruction::ImulRegImm { rd, rs, imm },
-        // Cmov stays last (index 27 == X86_REWRITABLE_OPCODE_COUNT - 1) so the
+        // LEA consumes rd as the destination, rs as the base register, and the
+        // shared `imm` as the displacement. No extra RNG draw, so the two
+        // dispatch sites stay in lock-step on the shared operands.
+        27 => X86Instruction::Lea {
+            rd,
+            base: rs,
+            disp: imm,
+        },
+        // Cmov stays last (index 28 == X86_REWRITABLE_OPCODE_COUNT - 1) so the
         // CMOV distinct-register draw at the two generation sites stays correct.
-        27 => X86Instruction::Cmov { rd, rs, cond },
+        28 => X86Instruction::Cmov { rd, rs, cond },
         _ => unreachable!("opcode out of range"),
     }
 }
@@ -1770,6 +1832,21 @@ impl InstructionGenerator<X86Instruction> for X86InstructionGenerator {
                 }
             }
         }
+        // LEA: `lea rd, [base + disp]` for every (rd, base, disp) triple,
+        // including rd == base (self-base is meaningful: it adds disp to rd).
+        // The displacement encodes as a signed disp32, so non-imm32 pool
+        // entries are skipped here rather than emitted and later rejected by
+        // `can_assemble`.
+        for &rd in registers {
+            for &base in registers {
+                for &disp in immediates {
+                    if i32::try_from(disp).is_err() {
+                        continue;
+                    }
+                    out.push(X86Instruction::Lea { rd, base, disp });
+                }
+            }
+        }
         // CMOVcc is rewritable and reads flags, so enumerate every
         // condition for each non-identical register pair. Jcc remains
         // excluded.
@@ -1878,6 +1955,12 @@ fn with_destination(instr: X86Instruction, new_rd: X86Register) -> X86Instructio
             rs,
             imm,
         },
+        // LEA redirects the destination, carrying the base and displacement.
+        X86Instruction::Lea { base, disp, .. } => X86Instruction::Lea {
+            rd: new_rd,
+            base,
+            disp,
+        },
         X86Instruction::Cmov { rd, rs, cond } => X86Instruction::Cmov {
             rd: if new_rd == rs { rd } else { new_rd },
             rs,
@@ -1965,6 +2048,12 @@ fn with_sources(instr: X86Instruction, new_rs: X86Register, new_imm: i64) -> X86
             rs: new_rs,
             imm: new_imm,
         },
+        // LEA varies both its base register and the displacement.
+        X86Instruction::Lea { rd, .. } => X86Instruction::Lea {
+            rd,
+            base: new_rs,
+            disp: new_imm,
+        },
         // Cmov's `rs` is mutated; `cond` and `rd` carry through unchanged.
         X86Instruction::Cmov { rd, rs, cond } => X86Instruction::Cmov {
             rd,
@@ -2022,16 +2111,18 @@ mod tests {
             .iter()
             .filter(|&&imm| u8::try_from(imm).is_ok())
             .count();
-        // The 3-operand IMUL only enumerates over imm32-encodable immediates.
+        // The 3-operand IMUL only enumerates over imm32-encodable immediates;
+        // LEA enumerates over imm32-encodable displacements with the same filter.
         let imul_m = imms
             .iter()
             .filter(|&&imm| i32::try_from(imm).is_ok())
             .count();
+        let lea_m = imul_m;
         // 8 reg-reg families + 8 reg-imm families + 4 single-operand families
         // (NEG, NOT, INC, DEC) + 3 shift families (SHL, SHR, SAR over imm8
         // counts) + 2 rotate families (ROL, ROR over imm8 counts) + IMUL 2-op
         // (every register pair) + IMUL 3-op (every (rd, rs, imm32) triple) +
-        // CMOVcc over distinct pairs.
+        // LEA (every (rd, base, disp32) triple) + CMOVcc over distinct pairs.
         let expected_len = 8 * n * n
             + 8 * n * m
             + 4 * n
@@ -2039,11 +2130,12 @@ mod tests {
             + 2 * n * shift_m
             + n * n
             + n * n * imul_m
+            + n * n * lea_m
             + n * (n - 1) * X86Condition::ALL.len();
         assert_eq!(
             all.len(),
             expected_len,
-            "generate_all should only prune CMOV self-pairs and non-imm8 shift/rotate / non-imm32 imul counts from the full pool"
+            "generate_all should only prune CMOV self-pairs and non-imm8 shift/rotate / non-imm32 imul/lea counts from the full pool"
         );
 
         // For each opcode_id, at least one variant must appear.
@@ -2220,7 +2312,9 @@ mod tests {
                 | X86Instruction::Rol { imm, .. }
                 | X86Instruction::Ror { imm, .. }
                 // The 3-operand IMUL draws its immediate from the shared pool.
-                | X86Instruction::ImulRegImm { imm, .. } => {
+                | X86Instruction::ImulRegImm { imm, .. }
+                // LEA draws its displacement from the same shared `imm` slot.
+                | X86Instruction::Lea { disp: imm, .. } => {
                     assert!(imms.contains(&imm), "immediate {} outside pool", imm);
                 }
                 X86Instruction::MovReg { .. }
@@ -3341,7 +3435,9 @@ mod tests {
                 | X86Instruction::Ror { imm, .. }
                 // The 3-operand IMUL draws its immediate from the same shared
                 // slot, so the empty pool yields 0 here too.
-                | X86Instruction::ImulRegImm { imm, .. } => {
+                | X86Instruction::ImulRegImm { imm, .. }
+                // LEA's displacement comes from the same shared slot (0 here).
+                | X86Instruction::Lea { disp: imm, .. } => {
                     saw_immediate_form = true;
                     assert_eq!(imm, 0);
                 }
@@ -3442,8 +3538,16 @@ mod tests {
             (24, X86Instruction::Ror { rd, imm }),
             (25, X86Instruction::ImulReg { rd, rs }),
             (26, X86Instruction::ImulRegImm { rd, rs, imm }),
-            // Cmov stays last at COUNT - 1 == 27.
-            (27, X86Instruction::Cmov { rd, rs, cond }),
+            (
+                27,
+                X86Instruction::Lea {
+                    rd,
+                    base: rs,
+                    disp: imm,
+                },
+            ),
+            // Cmov stays last at COUNT - 1 == 28.
+            (28, X86Instruction::Cmov { rd, rs, cond }),
         ];
 
         for (opcode, want) in expected {
@@ -3484,7 +3588,8 @@ mod tests {
             (24, "ror"),
             (25, "imul"),
             (26, "imul"),
-            (27, "cmove"),
+            (27, "lea"),
+            (28, "cmove"),
         ];
         for (opcode, mnem) in mnemonics {
             assert_eq!(
@@ -3935,8 +4040,10 @@ mod tests {
                     | X86Instruction::Rol { .. }
                     | X86Instruction::Ror { .. }
                     // The 3-operand IMUL immediate is imm32; same encodability
-                    // invariant.
-                    | X86Instruction::ImulRegImm { .. } => {
+                    // invariant. LEA's displacement is also a disp32 with the
+                    // same encodability requirement.
+                    | X86Instruction::ImulRegImm { .. }
+                    | X86Instruction::Lea { .. } => {
                         saw_non_mov_immediate = true;
                         assert!(
                             <X86_64 as Assembler<X86Instruction>>::can_assemble(&X86_64, instr),

--- a/src/parser/x86.rs
+++ b/src/parser/x86.rs
@@ -411,10 +411,29 @@ fn x86_ir_from_mnemonic_impl(
         }
     }
 
+    // LEA is the FIRST x86 instruction with a memory (bracket) operand. Only
+    // the minimal register-base + displacement form is modelled:
+    //   * `lea rd, [base]`        -> Lea { rd, base, disp: 0 }
+    //   * `lea rd, [base + disp]` -> Lea { rd, base, disp }
+    //   * `lea rd, [base - disp]` -> Lea { rd, base, disp: -disp }
+    // The index*scale, second-register, and RIP-relative forms are DEFERRED and
+    // surface as `Ok(None)` (an unsupported shape), like an unknown mnemonic.
+    // See `parse_x86_lea_memory_operand` for the bracket grammar and rejections.
+    if mnemonic == "lea" {
+        let parts: Vec<&str> = op_str.split(',').map(|s| s.trim()).collect();
+        if parts.len() != 2 {
+            return Ok(None);
+        }
+        let rd = parse_x86_register_with_mode(parts[0], mode)?;
+        let Some((base, disp)) = parse_x86_lea_memory_operand(parts[1], mode)? else {
+            return Ok(None);
+        };
+        return Ok(Some(X86Instruction::Lea { rd, base, disp }));
+    }
+
     // Reject unsupported mnemonics before attempting operand parsing so
-    // shapes outside the minimal core (e.g. LEA `rax, [rbx+1]`) surface
-    // as "unsupported mnemonic" rather than a confusing downstream
-    // immediate parse error.
+    // shapes outside the minimal core surface as "unsupported mnemonic"
+    // rather than a confusing downstream immediate parse error.
     if !matches!(
         mnemonic.as_str(),
         "mov"
@@ -512,6 +531,82 @@ fn x86_ir_from_mnemonic_impl(
     }
 }
 
+/// Parse the LEA memory operand in its minimal register-base + displacement
+/// form. The accepted grammar (Intel bracket syntax, as Capstone emits) is:
+///
+/// ```text
+///   mem  := '[' base ']'
+///         | '[' base '+' disp ']'
+///         | '[' base '-' disp ']'
+///   base := <register>
+///   disp := <immediate>   (decimal or hex, fits a signed 32-bit displacement)
+/// ```
+///
+/// Returns `Ok(Some((base, disp)))` on a match, or `Ok(None)` for any DEFERRED
+/// shape so the caller surfaces it as an unsupported instruction (like an
+/// unknown mnemonic). The deferred shapes that yield `Ok(None)` are: anything
+/// without the surrounding brackets; an index*scale term (`*`); a second
+/// register (`[base + index]`); a compound `[base + index + disp]`; and
+/// RIP/EIP-relative bases (the register parse rejects `rip`/`eip`).
+///
+/// A register parse error on the base (e.g. an extended register in 32-bit
+/// mode) propagates as `Err`, matching the other register-operand families.
+fn parse_x86_lea_memory_operand(
+    op_str: &str,
+    mode: Option<X86ParseMode>,
+) -> Result<Option<(X86Register, i64)>, String> {
+    let trimmed = op_str.trim();
+    // Must be a bracketed memory operand: `[ ... ]`.
+    let Some(inner) = trimmed.strip_prefix('[').and_then(|s| s.strip_suffix(']')) else {
+        return Ok(None);
+    };
+    let inner = inner.trim();
+
+    // index*scale is a deferred form.
+    if inner.contains('*') {
+        return Ok(None);
+    }
+
+    // Split into a base term and an optional signed displacement. A `+`/`-`
+    // separates the base from the displacement; more than one separator (e.g.
+    // `[base + index + disp]`) is a deferred compound form.
+    let (base_str, disp) = match inner.find(['+', '-']) {
+        None => (inner, 0i64),
+        Some(pos) => {
+            let base_str = inner[..pos].trim();
+            let rest = inner[pos..].trim();
+            // A second `+`/`-` in the remainder means a compound term — deferred.
+            if rest[1..].contains(['+', '-']) {
+                return Ok(None);
+            }
+            // The displacement must parse as an immediate. If it instead names a
+            // register (`[base + index]`), it is a deferred second-register form,
+            // not a parse error.
+            let sign = &rest[..1];
+            let magnitude = rest[1..].trim();
+            let Ok(mag) = parse_x86_immediate(magnitude) else {
+                return Ok(None);
+            };
+            let disp = if sign == "-" { -mag } else { mag };
+            (base_str, disp)
+        }
+    };
+
+    if base_str.is_empty() {
+        return Ok(None);
+    }
+    // RIP/EIP-relative addressing is a deferred form; surface it as `Ok(None)`
+    // rather than a register-parse error so it is treated as an unsupported
+    // shape like the index*scale and second-register forms above.
+    if matches!(base_str.to_lowercase().as_str(), "rip" | "eip") {
+        return Ok(None);
+    }
+    // The base must be a register; a register parse error (e.g. width/mode
+    // mismatch) propagates as `Err`.
+    let base = parse_x86_register_with_mode(base_str, mode)?;
+    Ok(Some((base, disp)))
+}
+
 /// Parse an Intel-syntax x86 assembly text into a sequence of
 /// `X86Instruction`s. Mirrors `crate::parser::parse_assembly_string`
 /// for the AArch64 path.
@@ -521,8 +616,9 @@ fn x86_ir_from_mnemonic_impl(
 /// one of the supported families (mov, add, sub, and, or, xor, cmp,
 /// test, the single-operand neg/not/inc/dec, the immediate-count shifts
 /// shl/sal/shr/sar, the immediate-count rotates rol/ror, the two- and
-/// three-operand signed multiply imul, plus the conditional cmovCC and jCC
-/// variants). Anything else is a parse error.
+/// three-operand signed multiply imul, lea in its register-base +
+/// displacement form, plus the conditional cmovCC and jCC variants).
+/// Anything else is a parse error.
 pub fn parse_x86_assembly_string(
     content: &str,
     source_name: String,
@@ -1267,9 +1363,11 @@ mod tests {
     fn x86_ir_unsupported_mnemonic_returns_none() {
         assert!(x86_ir_from_mnemonic("ret", "").unwrap().is_none());
         assert!(x86_ir_from_mnemonic("jmp", "0x1234").unwrap().is_none());
-        // `lea` is outside the supported set (memory operands unmodelled).
+        // `lea` in the minimal register-base + displacement form is now
+        // supported; its DEFERRED shapes (index*scale, second register,
+        // RIP-relative) still surface as `Ok(None)`.
         assert!(
-            x86_ir_from_mnemonic("lea", "rax, [rbx+1]")
+            x86_ir_from_mnemonic("lea", "rax, [rbx + rcx*4]")
                 .unwrap()
                 .is_none()
         );
@@ -1344,8 +1442,11 @@ mod tests {
 
     #[test]
     fn assembly_string_rejects_unsupported_mnemonic() {
-        let err = parse_x86_assembly_string("mov rax, rbx\nlea rax, [rbx+1]", "t".to_string())
-            .unwrap_err();
+        // `lea` with a deferred index*scale memory operand is an unsupported
+        // shape (the minimal register-base + displacement LEA is supported).
+        let err =
+            parse_x86_assembly_string("mov rax, rbx\nlea rax, [rbx + rcx*4]", "t".to_string())
+                .unwrap_err();
         assert_eq!(err.line_number, 2);
         assert!(
             err.message.contains("unsupported"),
@@ -1567,5 +1668,130 @@ mod tests {
                 mn
             );
         }
+    }
+
+    // ---- LEA (register-base + displacement) ----
+
+    #[test]
+    fn lea_parses_base_plus_disp_forms_and_round_trips_display() {
+        // `[base + disp]`, bare `[base]`, and `[base - disp]` parse to Lea.
+        let cases = [
+            (
+                "rax, [rbx + 1]",
+                X86Instruction::Lea {
+                    rd: X86Register::RAX,
+                    base: X86Register::RBX,
+                    disp: 1,
+                },
+            ),
+            (
+                "rax, [rbx]",
+                X86Instruction::Lea {
+                    rd: X86Register::RAX,
+                    base: X86Register::RBX,
+                    disp: 0,
+                },
+            ),
+            (
+                "rax, [rbx - 8]",
+                X86Instruction::Lea {
+                    rd: X86Register::RAX,
+                    base: X86Register::RBX,
+                    disp: -8,
+                },
+            ),
+        ];
+        for (ops, want) in cases {
+            let got = x86_ir_from_mnemonic("lea", ops)
+                .unwrap_or_else(|e| panic!("parse `lea {ops}`: {e}"))
+                .unwrap_or_else(|| panic!("parse `lea {ops}` produced None"));
+            assert_eq!(got, want, "parse mismatch for `lea {ops}`");
+        }
+
+        // Display → parse round-trip for each of the three displacement signs.
+        for instr in cases.map(|(_, want)| want) {
+            let text = instr.to_string();
+            let (mnemonic, rest) = text.split_once(char::is_whitespace).unwrap();
+            assert_eq!(
+                x86_ir_from_mnemonic(mnemonic, rest).unwrap().unwrap(),
+                instr,
+                "Display round-trip failed for `{text}`"
+            );
+        }
+
+        // Pin the exact Display rendering of each sign.
+        assert_eq!(
+            X86Instruction::Lea {
+                rd: X86Register::RAX,
+                base: X86Register::RBX,
+                disp: 1,
+            }
+            .to_string(),
+            "lea rax, [rbx + 1]"
+        );
+        assert_eq!(
+            X86Instruction::Lea {
+                rd: X86Register::RAX,
+                base: X86Register::RBX,
+                disp: 0,
+            }
+            .to_string(),
+            "lea rax, [rbx]"
+        );
+        assert_eq!(
+            X86Instruction::Lea {
+                rd: X86Register::RAX,
+                base: X86Register::RBX,
+                disp: -8,
+            }
+            .to_string(),
+            "lea rax, [rbx - 8]"
+        );
+    }
+
+    #[test]
+    fn lea_accepts_capstone_hex_displacements_in_binary_path() {
+        // Capstone emits hex displacements in Intel syntax; the mode-aware
+        // binary path must accept them.
+        assert_eq!(
+            x86_ir_from_mnemonic_for_mode("lea", "rax, [rbx + 0x10]", X86ParseMode::Mode64)
+                .unwrap()
+                .unwrap(),
+            X86Instruction::Lea {
+                rd: X86Register::RAX,
+                base: X86Register::RBX,
+                disp: 0x10,
+            }
+        );
+        assert_eq!(
+            x86_ir_from_mnemonic_for_mode("lea", "eax, [ebx - 0x10]", X86ParseMode::Mode32)
+                .unwrap()
+                .unwrap(),
+            X86Instruction::Lea {
+                rd: X86Register::RAX,
+                base: X86Register::RBX,
+                disp: -0x10,
+            }
+        );
+    }
+
+    #[test]
+    fn lea_rejects_deferred_memory_operand_forms_as_unsupported() {
+        // Index*scale, a second register, a compound base+index+disp, and
+        // RIP-relative addressing are DEFERRED — each surfaces as `Ok(None)`
+        // (an unsupported shape), not a parse error.
+        for ops in [
+            "rax, [rbx + rcx]",
+            "rax, [rbx + rcx*4]",
+            "rax, [rbx + rcx + 1]",
+            "rax, [rip + 0x100]",
+        ] {
+            assert!(
+                x86_ir_from_mnemonic("lea", ops).unwrap().is_none(),
+                "`lea {ops}` should be an unsupported (deferred) shape"
+            );
+        }
+        // A non-bracket second operand is also unsupported.
+        assert!(x86_ir_from_mnemonic("lea", "rax, rbx").unwrap().is_none());
     }
 }

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -1028,14 +1028,14 @@ mod tests {
         let mut search: StochasticSearch<X86_64> = StochasticSearch::new();
         let config = SearchConfig::default()
             .with_stochastic(
-                // Seed retuned to 1 when the two IMUL forms raised the
-                // rewritable opcode count to 28, shifting the seeded mutation
-                // trajectory. A 0..64 seed sweep confirms seed 1 reaches
-                // `mov rax, rbx` within 500 iters (many other seeds also work;
-                // 1 was picked as the lowest passing value).
+                // Seed retuned to 2 when LEA raised the rewritable opcode count
+                // to 29, shifting the seeded mutation trajectory. A 0..64 seed
+                // sweep confirms seed 2 reaches `mov rax, rbx` within 500 iters
+                // (many other seeds also work; 2 was picked as the lowest
+                // passing value).
                 StochasticConfig::default()
                     .with_iterations(500)
-                    .with_seed(1),
+                    .with_seed(2),
             )
             .with_x86_registers(vec![X86Register::RAX, X86Register::RBX, X86Register::RCX])
             .with_immediates(vec![0, 1]);

--- a/src/semantics/concrete_x86.rs
+++ b/src/semantics/concrete_x86.rs
@@ -60,6 +60,14 @@ pub fn apply_instruction_concrete_x86(
             let rhs = *imm as u64;
             apply_imul(&mut state, *rd, lhs, rhs);
         }
+        // LEA computes `rd = base + disp` (wrapping at width) and writes NO
+        // flags — pure address arithmetic, like MovReg. `set_register` masks
+        // the result to the state width.
+        X86Instruction::Lea { rd, base, disp } => {
+            let base = state.get_register(*base).as_u64();
+            let result = base.wrapping_add(*disp as u64);
+            state.set_register(*rd, ConcreteValue::new(result));
+        }
         X86Instruction::Cmov { rd, rs, cond } => {
             if state.get_flags().evaluate(*cond) {
                 let v = state.get_register(*rs);
@@ -1506,5 +1514,67 @@ mod tests {
             },
         );
         assert_eq!(after.get_register(X86Register::RAX).as_u64(), 0xaa);
+    }
+
+    #[test]
+    fn lea_computes_base_plus_disp_and_leaves_flags_unchanged() {
+        // LEA writes `rd = base + disp` (wrapping at width) and must NOT touch
+        // EFLAGS. Establish a non-trivial incoming flag state, then assert it
+        // survives the LEA byte-for-byte while rd takes the address value.
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RBX, ConcreteValue::new(0x1000));
+        state.set_register(X86Register::RCX, ConcreteValue::new(5));
+        let state = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::CmpImm {
+                rn: X86Register::RCX,
+                imm: 9,
+            },
+        );
+        let flags_before = state.get_flags();
+
+        // Positive displacement.
+        let after = apply_instruction_concrete_x86(
+            state.clone(),
+            &X86Instruction::Lea {
+                rd: X86Register::RAX,
+                base: X86Register::RBX,
+                disp: 0x20,
+            },
+        );
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 0x1020);
+        assert_eq!(
+            after.get_flags(),
+            flags_before,
+            "LEA must leave EFLAGS unchanged"
+        );
+
+        // Negative displacement wraps via two's complement add.
+        let after_neg = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::Lea {
+                rd: X86Register::RAX,
+                base: X86Register::RBX,
+                disp: -0x10,
+            },
+        );
+        assert_eq!(after_neg.get_register(X86Register::RAX).as_u64(), 0x0ff0);
+    }
+
+    #[test]
+    fn lea_wraps_at_width_32() {
+        // At width 32 the result is masked to the low 32 bits.
+        let mut state = X86ConcreteMachineState::new_zeroed(32);
+        state.set_register(X86Register::RBX, ConcreteValue::new(0xffff_fff8));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::Lea {
+                rd: X86Register::RAX,
+                base: X86Register::RBX,
+                disp: 0x10,
+            },
+        );
+        // 0xffff_fff8 + 0x10 = 0x1_0000_0008, masked to 32 bits = 0x8.
+        assert_eq!(after.get_register(X86Register::RAX).as_u64(), 0x8);
     }
 }

--- a/src/semantics/cost_x86.rs
+++ b/src/semantics/cost_x86.rs
@@ -74,6 +74,10 @@ fn instruction_code_size(instr: &X86Instruction, width: u32) -> u64 {
         // IMUL rd, rs, imm is `69 /r id` = opcode + ModR/M + 4-byte imm
         // = 6 bytes (+REX.W), mirroring the reg-imm arithmetic sizing.
         X86Instruction::ImulRegImm { .. } => 6 + rex,
+        // LEA rd, [base + disp] is `8D /r` = opcode + ModR/M, plus a possible
+        // SIB byte (when base is RSP/R12) and a 4-byte disp32 = up to 7 bytes
+        // (+REX.W). A conservative upper bound for length-based pruning.
+        X86Instruction::Lea { .. } => 7 + rex,
         X86Instruction::AddImm { .. }
         | X86Instruction::SubImm { .. }
         | X86Instruction::AndImm { .. }

--- a/src/semantics/smt_x86.rs
+++ b/src/semantics/smt_x86.rs
@@ -608,6 +608,16 @@ pub fn apply_instruction(
             let rhs = state.imm_bv(*imm);
             apply_imul_smt(&mut state, *rd, &lhs, &rhs);
         }
+        // LEA computes `rd = base + disp` (wrapping at width) and leaves EFLAGS
+        // UNCHANGED — pure address arithmetic, exactly like MOV/NOT, which write
+        // only their register and carry the incoming flag BVs forward untouched.
+        // `disp` lowers as an immediate at the operand width.
+        X86Instruction::Lea { rd, base, disp } => {
+            let base = state.get_register(*base).clone();
+            let disp = state.imm_bv(*disp);
+            let result = base.bvadd(&disp);
+            state.set_register(*rd, result);
+        }
         X86Instruction::Cmov { rd, rs, cond } => {
             let pred = x86_condition_to_smt(*cond, state.get_flags());
             let rs_val = state.get_register(*rs).clone();
@@ -960,6 +970,102 @@ mod tests {
             solver.check(),
             SatResult::Unsat,
             "NOT must leave every EFLAGS bit unchanged"
+        );
+    }
+
+    // --- symbolic LEA (DoD theorem) ---
+
+    // The KEY LEA theorem (issue #627 DoD): `lea rd, [rs + imm]` agrees with
+    // `mov rd, rs; add rd, imm` on the RESULT (rd == rs + imm). They differ on
+    // FLAGS — LEA writes none while the mov+add sets them from the addition —
+    // so we prove RESULT-equivalence here and flag-preservation separately
+    // below. Both sides run over states with the same symbolic prefix, so the
+    // incoming rs (rbx) and the incoming flags are shared.
+    #[test]
+    fn lea_result_equals_mov_then_add_immediate() {
+        for imm in [
+            0i64,
+            1,
+            -8,
+            0x1000,
+            -0x1000,
+            i32::MAX as i64,
+            i32::MIN as i64,
+        ] {
+            let prefix = "shared";
+            let s_lea = MachineStateX86::new_symbolic(prefix, 64);
+            let s_movadd = MachineStateX86::new_symbolic(prefix, 64);
+
+            let after_lea = apply_instruction(
+                s_lea,
+                &X86Instruction::Lea {
+                    rd: X86Register::RAX,
+                    base: X86Register::RBX,
+                    disp: imm,
+                },
+            );
+            let after_movadd = apply_sequence(
+                s_movadd,
+                &[
+                    X86Instruction::MovReg {
+                        rd: X86Register::RAX,
+                        rs: X86Register::RBX,
+                    },
+                    X86Instruction::AddImm {
+                        rd: X86Register::RAX,
+                        imm,
+                    },
+                ],
+            );
+
+            let solver = Solver::new();
+            solver.assert(
+                after_lea
+                    .get_register(X86Register::RAX)
+                    .eq(after_movadd.get_register(X86Register::RAX))
+                    .not(),
+            );
+            assert_eq!(
+                solver.check(),
+                SatResult::Unsat,
+                "lea rd,[rs+{imm}] must equal mov rd,rs; add rd,{imm} on the result"
+            );
+        }
+    }
+
+    #[test]
+    fn lea_leaves_all_flags_unchanged() {
+        // LEA is pure address arithmetic: every tracked flag BV after LEA must
+        // be identical to the incoming one (unlike the mov+add it rewrites,
+        // whose ADD sets CF/OF/SF/ZF/PF). This is why the equivalence above is
+        // result-only.
+        let s0 = MachineStateX86::new_symbolic("s", 64);
+        let cf0 = s0.get_flags().cf.clone();
+        let pf0 = s0.get_flags().pf.clone();
+        let zf0 = s0.get_flags().zf.clone();
+        let sf0 = s0.get_flags().sf.clone();
+        let of0 = s0.get_flags().of.clone();
+        let s1 = apply_instruction(
+            s0,
+            &X86Instruction::Lea {
+                rd: X86Register::RAX,
+                base: X86Register::RBX,
+                disp: 0x10,
+            },
+        );
+        let f = s1.get_flags();
+        let solver = Solver::new();
+        solver.assert(z3::ast::Bool::or(&[
+            &f.cf.eq(&cf0).not(),
+            &f.pf.eq(&pf0).not(),
+            &f.zf.eq(&zf0).not(),
+            &f.sf.eq(&sf0).not(),
+            &f.of.eq(&of0).not(),
+        ]));
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "LEA must leave every EFLAGS bit unchanged"
         );
     }
 


### PR DESCRIPTION
Closes #627.

Adds `Lea { rd, base, disp }` modeling `lea rd, [base + disp]` → `rd = base + disp` (wrapping at width). Non-destructive (reads `base` only) and affects **no flags**. Index*scale and RIP-relative deferred.

**New bracket-operand parse path** (`parse_x86_lea_memory_operand`): accepts `[base]`, `[base + disp]`, `[base - disp]` (decimal/hex signed disp32) on both the assembly-text and Capstone paths. Rejects (→ unsupported `Ok(None)`) any `*` (index*scale), a second register, compound `[base+index+disp]`, and RIP/EIP-relative — all deferred.

**Semantics**: SMT `result = base.bvadd(disp)`, `set_register` only (no `set_flags`, so incoming flags carry forward); concrete `base.wrapping_add(disp)`. `source_registers = [base]` (rd purely written, like MovReg). `lea_leaves_all_flags_unchanged` proves every EFLAGS bit is preserved.

**CMOV invariant**: inserted at 27 before CMOV → `…26 ImulRegImm,27 Lea,28 Cmov`; `X86_REWRITABLE_OPCODE_COUNT` 28→29; Cmov stays last (28 = COUNT−1). Parity + `opcode_dispatch_is_consistent` green.

**DoD** `lea_result_equals_mov_then_add_immediate`: `lea rd,[rs+imm]` ≡ `mov rd,rs; add rd,imm` on the result over 7 displacements (incl. i32::MIN/MAX); plus the flag-preservation theorem, Display round-trip (`lea_parses_base_plus_disp_forms_and_round_trips_display`), reject-tests for deferred forms, and assembler Capstone round-trips (64/32).

Stochastic e2e seed retuned 1→2 (documented 0..64 sweep; assertion kept). `./ci_check.sh` + `RUSTFLAGS="-D warnings" cargo build` pass; clippy clean in changed files; 1401 lib tests green.