### PR TITLE
x86: critical-path latency cost model (faster discriminator for --auto) (#622)

### DIFF
--- a/docs/adr/0009-auto-whole-binary-driver.md
+++ b/docs/adr/0009-auto-whole-binary-driver.md
@@ -154,9 +154,15 @@ can reconstruct *why* the window-selection rules are as conservative as they are
     `src/semantics/cost_x86.rs`). Crucially, the driver does **not** introduce any
     new notion of "faster": it inherits the current cost model verbatim, and that
     model's fidelity is a real limit (see Open questions). Calling `--auto` a
-    "speed optimizer" is therefore only as true as the chosen metric — and on x86
-    today the `latency` metric is a stub equal to instruction count, so `--auto`
-    on `/bin/ls` optimizes *instruction count*, not measured speed.
+    "speed optimizer" is therefore only as true as the chosen metric. The x86
+    `latency` metric is no longer a stub: as of issue #622 it is a critical-path /
+    dependency-aware sequence cost (`critical_path_latency` in
+    `src/semantics/cost_x86.rs`) over an Agner-Fog Skylake per-opcode table, so a
+    serial dependency chain costs more than the same number of independent
+    instructions. It is still an *idealized* out-of-order model (unbounded ports,
+    no front-end / memory effects), but `--auto --cost-metric latency` on x86 now
+    genuinely discriminates dependency-bound from parallel code rather than
+    re-deriving instruction count.
 
 11. **Initial ISA scope is whatever the per-window path already supports.** The
     driver is ISA-agnostic by construction, so it lights up for AArch64 and x86
@@ -221,11 +227,25 @@ maintenance cost, deleting the `--auto` arm leaves the rest of the tool intact.
 - **Cost-model fidelity is the precondition for honestly calling this a speed
   optimizer.** The search accepts a window only when an equivalent candidate has
   strictly lower cost under the selected metric, so "we know it is better" reduces
-  to "the metric says so". Today the `latency` metric is a static, additive
-  per-opcode sum with no modelling of dependency chains, superscalar/out-of-order
-  issue, micro-op fusion, port/throughput contention, or memory latency
-  (`instruction_latency` in `src/semantics/cost.rs` is a hand-tuned Cortex-A72/A76
-  table; the x86 `instruction_latency` in `src/semantics/cost_x86.rs` returns 1
-  for every opcode, i.e. it is identical to instruction count). A real
-  microarchitectural cost model is out of scope for this ADR but is tracked as a
-  separate issue, and `--auto`'s "speed" claim is bounded by it.
+  to "the metric says so". The AArch64 `latency` metric is still a static,
+  additive per-opcode sum (`instruction_latency` in `src/semantics/cost.rs`, a
+  hand-tuned Cortex-A72/A76 table) with no modelling of dependency chains,
+  superscalar/out-of-order issue, micro-op fusion, port/throughput contention, or
+  memory latency. The x86 `latency` metric was a per-opcode flat sum identical to
+  instruction count until issue #622, which replaced it with a critical-path
+  sequence cost (`critical_path_latency` in `src/semantics/cost_x86.rs`): it walks
+  register/EFLAGS def-use chains over an Agner-Fog Skylake per-opcode latency
+  table, so dependency-bound code costs more than independent code, and IMUL
+  (3-cycle) costs more than ADD (1-cycle). It still abstracts away port
+  contention, the front end, and memory latency, so it is an idealized OoO model,
+  not a cycle-accurate one. A fuller microarchitectural cost model (and lifting
+  the same treatment to AArch64) remains out of scope for this ADR and is tracked
+  separately; `--auto`'s "speed" claim is bounded by the model's fidelity.
+
+  Note on pruning: because the x86 critical-path cost is no longer a monotone sum,
+  the enumerative search's per-length pruning lower bound was re-derived to stay a
+  valid lower bound under it — for `latency` the bound is the minimum
+  single-instruction latency in the candidate pool (constant in length), which is
+  `<=` every non-empty sequence's critical path. See the "Pruning soundness"
+  section of the `src/semantics/cost_x86.rs` module doc-comment and
+  `length_cost_lower_bound` in `src/search/enumerative/search.rs`.

--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -708,7 +708,12 @@ impl ISA for X86_32 {
 /// `for X86_32`. MOV / CMOV / Jcc do not write EFLAGS — CMOV and Jcc
 /// read them via `x86_reads_flags` but do not modify any flag bit.
 /// Every other variant in the current set writes EFLAGS.
-fn x86_modifies_flags(instr: &X86Instruction) -> bool {
+///
+/// Crate-visible so the cost model's critical-path latency
+/// (`crate::semantics::cost_x86::critical_path_latency`) can route flag
+/// def-use edges through the same authoritative match arm as the search and
+/// equivalence callers — adding a future flag-writer updates exactly one place.
+pub(crate) fn x86_modifies_flags(instr: &X86Instruction) -> bool {
     !matches!(
         instr,
         X86Instruction::MovReg { .. }
@@ -881,6 +886,17 @@ impl crate::isa::traits::CostModel<X86Instruction> for X86_64 {
     ) -> u64 {
         crate::semantics::cost_x86::instruction_cost(instruction, metric, 64)
     }
+
+    /// Override the trait's `.sum()` default so `Latency` uses the sequence's
+    /// critical path (`cost_x86::sequence_cost`) rather than a flat per-
+    /// instruction sum; `InstructionCount` / `CodeSize` remain sums (issue #622).
+    fn sequence_cost(
+        &self,
+        instructions: &[X86Instruction],
+        metric: &crate::semantics::cost::CostMetric,
+    ) -> u64 {
+        crate::semantics::cost_x86::sequence_cost(instructions, metric, 64)
+    }
 }
 
 impl crate::isa::traits::CostModel<X86Instruction> for X86_32 {
@@ -890,6 +906,15 @@ impl crate::isa::traits::CostModel<X86Instruction> for X86_32 {
         metric: &crate::semantics::cost::CostMetric,
     ) -> u64 {
         crate::semantics::cost_x86::instruction_cost(instruction, metric, 32)
+    }
+
+    /// See the `X86_64` impl: `Latency` is the critical path, others are sums.
+    fn sequence_cost(
+        &self,
+        instructions: &[X86Instruction],
+        metric: &crate::semantics::cost::CostMetric,
+    ) -> u64 {
+        crate::semantics::cost_x86::sequence_cost(instructions, metric, 32)
     }
 }
 

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -17,6 +17,7 @@ use crate::search::SearchAlgorithm;
 use crate::search::candidate::generate_all_encodable_instructions;
 use crate::search::config::{Algorithm, SearchConfig};
 use crate::search::result::{SearchResultFor, SearchStatistics};
+use crate::semantics::cost::CostMetric;
 use crate::semantics::equivalence::{
     EquivalenceConfigFor, check_equivalence_for_metrics, check_equivalence_with_config_metrics,
 };
@@ -468,10 +469,47 @@ where
         .min()
 }
 
-fn length_cost_lower_bound(length: usize, min_instruction_cost: u64, terminator_cost: u64) -> u64 {
-    min_instruction_cost
-        .saturating_mul(length as u64)
-        .saturating_add(terminator_cost)
+/// Valid lower bound on the cost of any candidate of `length` instructions
+/// (plus the pinned terminator), used to prune whole lengths in the search.
+///
+/// **This MUST never exceed the real cost of any sequence of that length**, or
+/// the search would prune valid candidates and become unsound.
+///
+/// - `InstructionCount` / `CodeSize` are monotone per-instruction *sums*, so the
+///   tight, valid bound is `min_per_instruction_cost * length + terminator_cost`.
+/// - `Latency` is NOT a sum: it is the sequence's critical path
+///   (`cost_x86::critical_path_latency`, issue #622). A length-`L` candidate can
+///   have a critical path as small as the latency of a single independent
+///   instruction (e.g. `L` independent 1-cycle ops cost ~1, not `L`), so the
+///   multiply-by-length / add-terminator bound is INVALID here. The only
+///   provably-valid bound is the minimum single-instruction latency in the
+///   candidate pool: every non-empty sequence's critical path is
+///   `>= max_i latency(i) >= min_i latency(i)`, and `min_instruction_cost` /
+///   `terminator_cost` are exactly single-instruction critical paths
+///   (= isolated latencies). The bound is constant in `length` (looser, but
+///   correct — correctness over tightness).
+fn length_cost_lower_bound(
+    metric: &CostMetric,
+    length: usize,
+    min_instruction_cost: u64,
+    terminator_cost: u64,
+) -> u64 {
+    match metric {
+        CostMetric::Latency => {
+            // Critical-path cost: the cheapest non-empty sequence's critical
+            // path is the minimum single-instruction latency over the pool and
+            // the pinned terminator. Never grows with `length` and never
+            // exceeds the real critical path.
+            if terminator_cost == 0 {
+                min_instruction_cost
+            } else {
+                min_instruction_cost.min(terminator_cost)
+            }
+        }
+        CostMetric::InstructionCount | CostMetric::CodeSize => min_instruction_cost
+            .saturating_mul(length as u64)
+            .saturating_add(terminator_cost),
+    }
 }
 
 fn run_length_one<I>(
@@ -674,9 +712,11 @@ where
         let run_lengths = |s: &SharedState<I>| {
             // Search increasing lengths up to target.len()-1 so we never
             // propose a candidate as long as the target. The per-length cost
-            // lower bound is non-decreasing in length and `best_cost` only
-            // falls, so once a length cannot beat the current best no longer
-            // length can either — break out instead of scanning the rest.
+            // lower bound is non-decreasing in length (for the additive metrics
+            // it grows with length; for the critical-path `Latency` metric it is
+            // constant — still non-decreasing) and `best_cost` only falls, so
+            // once a length cannot beat the current best no longer length can
+            // either — break out instead of scanning the rest.
             for length in 1..target.len() {
                 if Self::timed_out(start, config.timeout) || s.stop.load(Ordering::Relaxed) {
                     break;
@@ -684,8 +724,12 @@ where
                 let Some(min_instruction_cost) = min_instruction_cost else {
                     break;
                 };
-                let lower_bound =
-                    length_cost_lower_bound(length, min_instruction_cost, terminator_cost);
+                let lower_bound = length_cost_lower_bound(
+                    &config.cost_metric,
+                    length,
+                    min_instruction_cost,
+                    terminator_cost,
+                );
                 if lower_bound >= s.best_cost.load(Ordering::Acquire) {
                     break;
                 }
@@ -2639,5 +2683,123 @@ mod tests {
         );
         assert!(result.statistics.smt_queries > 0);
         assert!(result.statistics.smt_equivalent > 0);
+    }
+
+    // --- Latency pruning-soundness (issue #622) ---
+    //
+    // The enumerative search prunes whole lengths via `length_cost_lower_bound`.
+    // Under the critical-path `Latency` cost this bound MUST still be a valid
+    // lower bound on the real cost of any sequence of that length, or the search
+    // would prune valid candidates. These tests guard that invariant.
+
+    #[test]
+    fn latency_lower_bound_is_constant_in_length() {
+        use crate::semantics::cost::CostMetric;
+        // For Latency the bound ignores `length` (the critical path of a
+        // length-L independent run is just the cheapest instruction's latency),
+        // so it must NOT grow with length the way the additive metrics do.
+        let m = CostMetric::Latency;
+        let min_instr = 1;
+        let term = 0;
+        assert_eq!(length_cost_lower_bound(&m, 1, min_instr, term), 1);
+        assert_eq!(length_cost_lower_bound(&m, 5, min_instr, term), 1);
+        assert_eq!(length_cost_lower_bound(&m, 50, min_instr, term), 1);
+        // With a terminator the bound is the min of the two single-instruction
+        // latencies, never their sum.
+        assert_eq!(length_cost_lower_bound(&m, 10, 3, 1), 1);
+        assert_eq!(length_cost_lower_bound(&m, 10, 1, 4), 1);
+        // The additive metrics still scale with length.
+        assert_eq!(length_cost_lower_bound(&CostMetric::CodeSize, 5, 2, 1), 11);
+        assert_eq!(
+            length_cost_lower_bound(&CostMetric::InstructionCount, 5, 1, 1),
+            6
+        );
+    }
+
+    proptest::proptest! {
+        #![proptest_config(proptest::prelude::ProptestConfig::with_cases(256))]
+
+        /// Pruning-soundness property: for many random supported x86 sequences,
+        /// the Latency `length_cost_lower_bound` for EVERY length up to the
+        /// sequence length must be `<=` the sequence's real critical-path cost.
+        /// A bound that ever exceeded the real cost would make the enumerative
+        /// search prune valid candidates.
+        #[test]
+        fn latency_length_lower_bound_never_exceeds_real_cost(
+            // Indices into the candidate pool; up to 6 instructions.
+            indices in proptest::collection::vec(proptest::prelude::any::<proptest::sample::Index>(), 1..=6),
+            with_terminator in proptest::prelude::any::<bool>(),
+        ) {
+            use crate::isa::X86_64;
+            use crate::isa::x86::{X86Instruction, X86Register, X86Condition};
+            use crate::semantics::cost::CostMetric;
+
+            let regs = vec![
+                X86Register::RAX,
+                X86Register::RBX,
+                X86Register::RCX,
+                X86Register::RDX,
+            ];
+            let imms = vec![0i64, 1, 7];
+            let pool: Vec<X86Instruction> =
+                <X86_64 as EnumerativeBackend<X86_64>>::enumerate_all(&regs, &imms);
+            proptest::prop_assume!(!pool.is_empty());
+
+            let seq: Vec<X86Instruction> =
+                indices.iter().map(|idx| *idx.get(&pool)).collect();
+
+            // The pinned terminator (x86 Jcc) the search would reattach.
+            let terminator = if with_terminator {
+                Some(X86Instruction::Jcc { cond: X86Condition::NE })
+            } else {
+                None
+            };
+
+            let m = CostMetric::Latency;
+            let cfg = SearchConfig::default().with_cost_metric(m);
+            // Reproduce exactly what `search()` computes for the bound inputs.
+            let min_instruction_cost = pool
+                .iter()
+                .map(|i| {
+                    <X86_64 as EnumerativeBackend<X86_64>>::sequence_cost(
+                        std::slice::from_ref(i),
+                        &cfg,
+                    )
+                })
+                .min()
+                .unwrap();
+            let terminator_cost = terminator
+                .map(|t| {
+                    <X86_64 as EnumerativeBackend<X86_64>>::sequence_cost(
+                        std::slice::from_ref(&t),
+                        &cfg,
+                    )
+                })
+                .unwrap_or(0);
+
+            // The search evaluates candidates of EXACTLY `length` instructions at
+            // each length (plus the pinned terminator). The bound for that length
+            // must not exceed the real cost of any such candidate; we sample one
+            // real candidate per length — the random prefix of that length.
+            for length in 1..=seq.len() {
+                let lb = length_cost_lower_bound(
+                    &m,
+                    length,
+                    min_instruction_cost,
+                    terminator_cost,
+                );
+                let mut candidate = seq[..length].to_vec();
+                if let Some(t) = terminator {
+                    candidate.push(t);
+                }
+                let real_cost =
+                    <X86_64 as EnumerativeBackend<X86_64>>::sequence_cost(&candidate, &cfg);
+                proptest::prop_assert!(
+                    lb <= real_cost,
+                    "Latency lower bound {lb} exceeded real critical-path cost \
+                     {real_cost} at length {length} (candidate={candidate:?})"
+                );
+            }
+        }
     }
 }

--- a/src/semantics/cost_x86.rs
+++ b/src/semantics/cost_x86.rs
@@ -1,15 +1,73 @@
 //! Cost model for the x86 backend.
 //!
 //! x86 is variable-length, so `CodeSize` is an approximation per variant.
-//! `InstructionCount` and `Latency` mirror the AArch64 module's shape.
+//! `InstructionCount` is a flat per-instruction sum.
 //! Width-aware: x86-32 encodings save one byte per REX prefix.
+//!
+//! # Latency model (issue #622)
+//!
+//! `Latency` is NOT a flat per-instruction sum. It is a **critical-path**
+//! (dependency-aware) sequence cost so that a serial dependency chain costs
+//! more than the same number of independent instructions — which is the whole
+//! point of the metric as a "faster sequence" discriminator for `--auto` (see
+//! `docs/adr/0009-auto-whole-binary-driver.md`).
+//!
+//! Two layers:
+//!
+//! 1. **Per-opcode latency table** ([`instruction_latency`]). Latencies are
+//!    sourced from Agner Fog's "Instruction Tables" (<https://agner.org/optimize/>,
+//!    accessed 2026-06) for the Intel **Skylake** microarchitecture, cross-checked
+//!    against <https://uops.info/>. On Skylake the simple integer ALU ops
+//!    (MOV/ADD/SUB/AND/OR/XOR/INC/DEC/NEG/NOT/CMP/TEST/shift-by-imm/rotate-by-imm
+//!    and CMOV) have **1-cycle** latency, while two-operand/three-operand integer
+//!    multiply (`IMUL r,r` / `IMUL r,r,imm`) has **3-cycle** latency. A
+//!    register-to-register MOV is special-cased to **0** because Skylake (and all
+//!    Sandy-Bridge-and-later cores) eliminate it at rename — it never sits on a
+//!    dependency chain. `MovImm` is a real 1-cycle op (it is not move-elimination
+//!    eligible).
+//!
+//! 2. **Critical-path sequence latency** ([`critical_path_latency`]). The
+//!    sequence cost for `Latency` walks the def-use chains: for each instruction
+//!    its issue time is the max completion time over the last writer of every
+//!    register it reads (plus EFLAGS when it reads flags); its completion time is
+//!    that issue time plus its per-opcode latency. The sequence cost is the
+//!    maximum completion time over all instructions, i.e. the length of the
+//!    longest dependency chain. This is a pure critical path (no port-pressure /
+//!    reciprocal-throughput term) so that the per-instruction lower bound used by
+//!    the enumerative pruner stays provably valid — see "Pruning soundness"
+//!    below. A throughput term is a possible future refinement but is *not* free:
+//!    it would force the pruner's per-instruction lower bound to drop the
+//!    throughput contribution (a single instruction's throughput cost can exceed
+//!    a long independent sequence's marginal throughput), so it is deferred.
+//!
+//! ## Pruning soundness (the critical invariant)
+//!
+//! The enumerative search prunes whole *lengths* using
+//! `length_cost_lower_bound`, which must be a VALID LOWER BOUND on the real cost
+//! of any sequence of that length — a bound that ever *exceeded* the real cost
+//! would prune valid candidates and make the search unsound. Under the
+//! critical-path cost a length-`L` sequence can have a critical path as small as
+//! the latency of its single cheapest independent instruction (e.g. `L`
+//! independent 1-cycle ops cost ~1 on the critical path, NOT `L`). The flat
+//! `min_per_instr_cost * L` bound used for the additive metrics is therefore
+//! INVALID for `Latency`. The search switches to a trivially-valid constant
+//! lower bound for `Latency` — the minimum single-instruction latency in the
+//! candidate pool (which is `<=` every non-empty sequence's critical path). See
+//! `length_cost_lower_bound` in `src/search/enumerative/search.rs`. The symbolic
+//! search prunes per fully-formed candidate against the exact `sequence_cost`, so
+//! it stays sound under any cost function with no change.
 
 #![allow(dead_code)]
 
-use crate::isa::x86::X86Instruction;
+use crate::isa::x86::{X86Instruction, X86Register, x86_reads_flags};
 use crate::semantics::cost::CostMetric;
 
 /// Cost of a single x86 instruction at the given operand width.
+///
+/// For `Latency` this returns the instruction's *isolated* latency (its
+/// per-opcode table value). The sequence-level critical-path combination lives
+/// in [`sequence_cost`] / [`critical_path_latency`]; a single instruction's
+/// critical path equals its own latency, so the two agree on length-1 inputs.
 pub fn instruction_cost(instr: &X86Instruction, metric: &CostMetric, width: u32) -> u64 {
     match metric {
         CostMetric::InstructionCount => 1,
@@ -18,10 +76,25 @@ pub fn instruction_cost(instr: &X86Instruction, metric: &CostMetric, width: u32)
     }
 }
 
-fn instruction_latency(_instr: &X86Instruction) -> u64 {
-    // Every variant in the minimal core set is a single-cycle ALU op on
-    // modern x86 cores. Refine when MUL / IDIV / shifts arrive.
-    1
+/// Isolated per-opcode latency in cycles, sourced from Agner Fog's Skylake
+/// instruction tables (see the module doc-comment).
+///
+/// - Register-to-register `mov` is **0**: Skylake eliminates it at rename, so it
+///   never extends a dependency chain.
+/// - Simple integer ALU ops (everything except multiply) are **1** cycle.
+/// - `IMUL` (two- and three-operand) is **3** cycles on Skylake.
+fn instruction_latency(instr: &X86Instruction) -> u64 {
+    match instr {
+        // Register-rename move elimination: zero-latency on the critical path.
+        X86Instruction::MovReg { .. } => 0,
+        // Two-/three-operand signed multiply: 3-cycle latency on Skylake.
+        X86Instruction::ImulReg { .. } | X86Instruction::ImulRegImm { .. } => 3,
+        // Everything else in the supported set is a 1-cycle integer ALU op:
+        // MovImm, ADD/SUB/AND/OR/XOR (reg and imm), CMP/TEST, NEG/NOT/INC/DEC,
+        // SHL/SHR/SAR/ROL/ROR by immediate, CMOV, and the Jcc terminator
+        // (taken-branch latency; misprediction is not modelled).
+        _ => 1,
+    }
 }
 
 /// Approximate encoded length in bytes. Conservative upper bounds.
@@ -93,8 +166,85 @@ fn instruction_code_size(instr: &X86Instruction, width: u32) -> u64 {
 }
 
 /// Total cost of a sequence at the given width.
+///
+/// `InstructionCount` and `CodeSize` are flat per-instruction sums.
+/// `Latency` is the sequence's **critical path** (see [`critical_path_latency`]),
+/// which is NOT a sum: a serial dependency chain costs more than the same number
+/// of independent instructions. The two agree only on the empty and single-
+/// instruction cases (a single instruction's critical path equals its latency).
 pub fn sequence_cost(seq: &[X86Instruction], metric: &CostMetric, width: u32) -> u64 {
-    seq.iter().map(|i| instruction_cost(i, metric, width)).sum()
+    match metric {
+        CostMetric::Latency => critical_path_latency(seq),
+        CostMetric::InstructionCount | CostMetric::CodeSize => {
+            seq.iter().map(|i| instruction_cost(i, metric, width)).sum()
+        }
+    }
+}
+
+/// EFLAGS is tracked as a synthetic "register" slot beyond the 16 GPRs so that
+/// flag def-use edges (e.g. `cmp` → `cmovCC`, `add` → `jcc`) land on the
+/// dependency graph alongside register edges.
+const FLAGS_SLOT: usize = 16;
+const DEP_SLOTS: usize = 17; // 16 GPRs + EFLAGS.
+
+/// Critical-path latency of a sequence, in cycles (issue #622).
+///
+/// Models an idealized out-of-order core with unbounded execution resources:
+/// the only thing that serializes two instructions is a true data dependency
+/// (a later instruction reading a register or EFLAGS written by an earlier one).
+/// Independent instructions issue in the same cycle, so their latencies overlap
+/// rather than add.
+///
+/// Algorithm (single forward pass, O(n · operands)):
+/// - `ready[slot]` holds the completion cycle of the last writer of each
+///   register slot (and EFLAGS). All slots start ready at cycle 0.
+/// - For instruction `i`: `issue = max(ready[s])` over every source register
+///   `s` it reads, plus `ready[FLAGS_SLOT]` when it reads flags. With no tracked
+///   inputs `issue = 0`.
+/// - `complete = issue + latency(i)`.
+/// - Update `ready[d] = complete` for every register `d` it writes, and
+///   `ready[FLAGS_SLOT] = complete` when it modifies flags.
+/// - The sequence cost is `max(complete)` over all instructions (0 for empty).
+///
+/// This is a valid lower-bound-friendly cost: the critical path of any non-empty
+/// sequence is `>= max_i latency(i) >= min_i latency(i)`, which is what keeps the
+/// enumerative pruner's per-instruction lower bound sound (module doc-comment).
+pub fn critical_path_latency(seq: &[X86Instruction]) -> u64 {
+    let mut ready = [0u64; DEP_SLOTS];
+    let mut max_complete = 0u64;
+
+    for instr in seq {
+        let mut issue = 0u64;
+        for src in instr.source_registers() {
+            if let Some(idx) = reg_slot(src) {
+                issue = issue.max(ready[idx]);
+            }
+        }
+        if x86_reads_flags(instr) {
+            issue = issue.max(ready[FLAGS_SLOT]);
+        }
+
+        let complete = issue.saturating_add(instruction_latency(instr));
+        max_complete = max_complete.max(complete);
+
+        if let Some(dst) = instr.destination()
+            && let Some(idx) = reg_slot(dst)
+        {
+            ready[idx] = complete;
+        }
+        if crate::isa::x86::x86_modifies_flags(instr) {
+            ready[FLAGS_SLOT] = complete;
+        }
+    }
+
+    max_complete
+}
+
+/// Map a register to its dependency-graph slot (0..=15). Returns `None` only if
+/// the register has no architectural index (none do today), defensively keeping
+/// the indexer total.
+fn reg_slot(reg: X86Register) -> Option<usize> {
+    reg.index().map(usize::from)
 }
 
 #[cfg(test)]
@@ -112,25 +262,159 @@ mod tests {
         assert_eq!(instruction_cost(&i, &CostMetric::InstructionCount, 32), 1);
     }
 
+    // --- Layer 1: per-opcode latency table (Agner Fog, Skylake) ---
+
+    /// IMUL has strictly higher isolated latency than ADD on Skylake (3 vs 1),
+    /// per Agner Fog's instruction tables (module doc-comment). This pins the
+    /// documented per-opcode reference value the search relies on.
     #[test]
-    fn latency_is_one_for_minimal_set() {
-        let cases = [
+    fn imul_latency_exceeds_add_latency() {
+        let add = X86Instruction::AddReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+        };
+        let imul = X86Instruction::ImulReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+        };
+        let imul3 = X86Instruction::ImulRegImm {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+            imm: 7,
+        };
+        assert_eq!(instruction_latency(&add), 1);
+        assert_eq!(instruction_latency(&imul), 3);
+        assert_eq!(instruction_latency(&imul3), 3);
+        assert!(instruction_latency(&imul) > instruction_latency(&add));
+        // Register-to-register MOV is move-eliminated (0 cycles); MovImm is a
+        // real 1-cycle op.
+        let mov_reg = X86Instruction::MovReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+        };
+        let mov_imm = X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: 7,
+        };
+        assert_eq!(instruction_latency(&mov_reg), 0);
+        assert_eq!(instruction_latency(&mov_imm), 1);
+    }
+
+    // --- Layer 2: critical-path sequence latency rewards parallelism ---
+
+    /// A serial dependency chain (each op reads the result of the previous one)
+    /// must cost MORE than the same number of fully independent ops, even though
+    /// they have identical length and identical per-instruction latencies. This
+    /// is the whole point of the critical-path model: with the old flat-sum stub
+    /// both sequences cost 3 and this test failed.
+    #[test]
+    fn sequence_latency_rewards_parallelism() {
+        // Serial: rax = rax+rbx; rax = rax+rcx; rax = rax+rdx.
+        // Each instruction reads rax written by the previous one -> chain of 3.
+        let serial = [
+            X86Instruction::AddReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            X86Instruction::AddReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RCX,
+            },
+            X86Instruction::AddReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RDX,
+            },
+        ];
+        // Independent: three distinct destinations, no def-use edge between them.
+        let independent = [
+            X86Instruction::AddReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RSI,
+            },
+            X86Instruction::AddReg {
+                rd: X86Register::RBX,
+                rs: X86Register::RSI,
+            },
+            X86Instruction::AddReg {
+                rd: X86Register::RCX,
+                rs: X86Register::RSI,
+            },
+        ];
+
+        let serial_cost = sequence_cost(&serial, &CostMetric::Latency, 64);
+        let independent_cost = sequence_cost(&independent, &CostMetric::Latency, 64);
+
+        // Serial chain: 1 + 1 + 1 = 3 cycles on the critical path.
+        assert_eq!(serial_cost, 3);
+        // Independent ops all issue at cycle 0, complete at cycle 1.
+        assert_eq!(independent_cost, 1);
+        assert!(
+            serial_cost > independent_cost,
+            "critical-path latency must penalize the serial dependency chain: \
+             serial={serial_cost} independent={independent_cost}"
+        );
+    }
+
+    /// Flag def-use edges serialize too: `cmp` writes EFLAGS, `cmovCC` reads
+    /// them, so the pair forms a 2-cycle chain even though they touch different
+    /// registers.
+    #[test]
+    fn critical_path_tracks_flag_dependencies() {
+        use crate::isa::x86::X86Condition;
+        let seq = [
+            X86Instruction::CmpReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            X86Instruction::Cmov {
+                rd: X86Register::RCX,
+                rs: X86Register::RDX,
+                cond: X86Condition::E,
+            },
+        ];
+        assert_eq!(sequence_cost(&seq, &CostMetric::Latency, 64), 2);
+    }
+
+    /// A register-to-register MOV is eliminated at rename, so it adds 0 to the
+    /// critical path: `mov rax, rbx; add rax, rcx` costs the same as the lone
+    /// `add` (1 cycle), not 2.
+    #[test]
+    fn move_elimination_does_not_extend_critical_path() {
+        let seq = [
             X86Instruction::MovReg {
                 rd: X86Register::RAX,
                 rs: X86Register::RBX,
             },
             X86Instruction::AddReg {
                 rd: X86Register::RAX,
-                rs: X86Register::RBX,
-            },
-            X86Instruction::CmpImm {
-                rn: X86Register::RAX,
-                imm: 0,
+                rs: X86Register::RCX,
             },
         ];
-        for i in cases {
-            assert_eq!(instruction_cost(&i, &CostMetric::Latency, 64), 1);
-        }
+        assert_eq!(sequence_cost(&seq, &CostMetric::Latency, 64), 1);
+    }
+
+    /// IMUL's 3-cycle latency shows up on the critical path: a single IMUL costs
+    /// 3, and chaining it after an ADD that produces its input costs 1 + 3 = 4.
+    #[test]
+    fn imul_latency_lengthens_critical_path() {
+        let single = [X86Instruction::ImulReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+        }];
+        assert_eq!(sequence_cost(&single, &CostMetric::Latency, 64), 3);
+
+        let chain = [
+            X86Instruction::AddReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            // Reads rax produced by the ADD above -> 1 (add) + 3 (imul) = 4.
+            X86Instruction::ImulReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RCX,
+            },
+        ];
+        assert_eq!(sequence_cost(&chain, &CostMetric::Latency, 64), 4);
     }
 
     #[test]


### PR DESCRIPTION
Closes #622.

Replaces the x86 latency stub (every instruction = 1, so `--cost-metric latency` was identical to instruction-count) with a critical-path / dependency-aware sequence latency.

**Critical path** (`critical_path_latency`, cost_x86.rs): single forward pass over a `ready[]` array (16 GPRs + an EFLAGS slot). Each instruction issues at `max(ready[src])` over its `source_registers()` (plus the flags slot when `x86_reads_flags`), completes at `issue + instruction_latency(i)`, and updates `ready[dst]` (and the flags slot when `x86_modifies_flags`). Cost = max completion. Only true RAW deps serialize, so a serial chain `add rax,rbx; add rax,rcx; add rax,rdx` = 3 while three independent adds = 1.

**Per-opcode table** (LAYER 1): Agner Fog *Instruction Tables* (Skylake, cross-checked vs uops.info), cited in the module doc — simple ALU = 1, reg-reg MOV = 0 (move elimination), IMUL (2/3-op) = 3.

**Pruning soundness (the crux)**: the `CostModel::sequence_cost` default `.sum()` is overridden for X86_64/X86_32 so only `Latency` uses the critical path (InstructionCount/CodeSize stay sums). For `Latency`, `length_cost_lower_bound` becomes metric-aware and returns the **constant** `min(min_instruction_cost, terminator_cost)` (each is an isolated single-instruction critical path = its latency). Since any non-empty candidate's critical path ≥ some instruction's completion ≥ its latency ≥ that min, the bound never exceeds the real cost (it's looser — constant in length — but provably valid; the early-break stays sound because a constant is non-decreasing). The symbolic `cost_bound` prune is unchanged (it compares the exact fully-formed candidate cost, valid under any cost function).

**Tests**: `sequence_latency_rewards_parallelism` (serial 3 > independent 1; replaces the stub-pinning `latency_is_one_for_minimal_set`), `imul_latency_exceeds_add_latency` (table vs reference), and the **256-case proptest** `latency_length_lower_bound_never_exceeds_real_cost` guarding the pruning invariant, plus flag-dependency / move-elimination / constant-lower-bound tests. ADR-0009 updated.

Merged latest `main` (resolved the `x86_modifies_flags` doc/visibility overlap with #627 LEA; `Lea` latency falls under the table's `_ => 1`). `./ci_check.sh` + `RUSTFLAGS="-D warnings" cargo build` pass; clippy clean in changed files; tests green.