### PR TITLE
ci: cache builds, pin toolchain, harden workflow permissions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,11 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs for the same branch/PR to save Actions minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   # Avoid incremental compilation for more reliable coverage data and smaller caches.
@@ -33,6 +38,9 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable --component llvm-tools-preview
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -18,6 +18,11 @@ on:
   schedule:
     - cron: '33 6 * * 1'
 
+# Cancel superseded runs for the same branch/PR to save Actions minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   rust-clippy-analyze:
     name: Run rust-clippy analyzing
@@ -39,6 +44,9 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable --component clippy
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
 
       - name: Install required cargo
         run: cargo install clippy-sarif sarif-fmt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,15 @@ on:
   pull_request:
     branches: [ main ]
 
+# Least-privilege default token: this workflow only needs to read the repo.
+permissions:
+  contents: read
+
+# Cancel superseded runs for the same branch/PR to save Actions minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   # Fail the build on any warning so unused imports / dead code can't slip in.
@@ -28,6 +37,9 @@ jobs:
       run: |
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable --component rustfmt
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+    - name: Cache cargo registry and target
+      uses: Swatinem/rust-cache@v2
 
     - name: Check formatting
       run: cargo fmt -- --check

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,8 @@
+# Pin the toolchain and the components CI + local builds rely on so they
+# resolve identically. rustup reads this file automatically, installing the
+# channel and components on first cargo invocation. Centralizing them here
+# lets the workflow bootstraps drop their ad-hoc `--component` flags over time.
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy", "llvm-tools-preview"]
+profile = "minimal"


### PR DESCRIPTION
## Summary

Implements the **CI efficiency & hardening** slice of the DevX audit in #656 — the lowest-risk, highest-value items that change no Rust behaviour:

- **Build caching** — add `Swatinem/rust-cache@v2` to `test.yml`, `coverage.yml`, and `rust-clippy.yml`. These workflows currently rebuild the whole tree (including the heavy `z3`/`capstone`/`dynasm` FFI crates) from scratch every run; caching `~/.cargo` + `target/` is the biggest Actions-minute win.
- **Toolchain pin** — add `rust-toolchain.toml` (`channel = "stable"`, components `rustfmt`/`clippy`/`llvm-tools-preview`, `profile = "minimal"`) so local and CI builds resolve the same toolchain and rustup auto-installs the needed components.
- **Least-privilege token** — add `permissions: { contents: read }` to `test.yml`, which previously had no `permissions` block and inherited the default token (matching what `coverage.yml` already sets).
- **Concurrency cancellation** — add a `${{ github.workflow }}-${{ github.ref }}` concurrency group with `cancel-in-progress: true` to `test.yml`/`coverage.yml`/`rust-clippy.yml` so superseded PR runs are cancelled.

Part of #656. This is intentionally **not** a closing keyword: #656 is a portfolio-wide audit with ~15 items, and the remaining recommendations (clippy-gating, cargo-deny, SHA-pinning actions, `typos`, issue/PR templates, cargo-fuzz, cargo-nextest, `.claude/` hooks) are left as follow-ups so the tracking issue stays open.

## Test plan

- [x] All three workflow YAMLs parse (`yaml.safe_load`) and introduce no new `yamllint` warnings
- [x] `rust-toolchain.toml` parses; local `rustc`/`cargo` resolve through it without a fresh install; `cargo fmt -- --check` passes
- [ ] This PR's own `Test`, `Coverage`, and `rust-clippy analyze` runs are green (they exercise the cache/concurrency/toolchain changes directly)