### PR TITLE
Deepen Operand with source_register accessor (fix dropped shifted rm liveness)

### DIFF
--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -1206,24 +1206,14 @@ impl Instruction {
             | Instruction::Orr { rn, rm, .. }
             | Instruction::Eor { rn, rm, .. } => {
                 let mut regs = vec![*rn];
-                match rm {
-                    Operand::Register(r) => regs.push(*r),
-                    Operand::ShiftedRegister { reg, .. } => regs.push(*reg),
-                    Operand::ExtendedRegister { reg, .. } => regs.push(*reg),
-                    Operand::Immediate(_) => {}
-                }
+                regs.extend(rm.source_register());
                 regs
             }
             Instruction::Lsl { rn, shift, .. }
             | Instruction::Lsr { rn, shift, .. }
             | Instruction::Asr { rn, shift, .. } => {
                 let mut regs = vec![*rn];
-                match shift {
-                    Operand::Register(r) => regs.push(*r),
-                    Operand::ShiftedRegister { reg, .. } => regs.push(*reg),
-                    Operand::ExtendedRegister { reg, .. } => regs.push(*reg),
-                    Operand::Immediate(_) => {}
-                }
+                regs.extend(shift.source_register());
                 regs
             }
             Instruction::Mul { rn, rm, .. }
@@ -1241,12 +1231,7 @@ impl Instruction {
             | Instruction::Cmn { rn, rm }
             | Instruction::Tst { rn, rm, .. } => {
                 let mut regs = vec![*rn];
-                match rm {
-                    Operand::Register(r) => regs.push(*r),
-                    Operand::ShiftedRegister { reg, .. } => regs.push(*reg),
-                    Operand::ExtendedRegister { reg, .. } => regs.push(*reg),
-                    Operand::Immediate(_) => {}
-                }
+                regs.extend(rm.source_register());
                 regs
             }
             // CCMP / CCMN read rn and rm (if register). They also read NZCV
@@ -1254,9 +1239,7 @@ impl Instruction {
             // separately via `reads_flags` and `modifies_flags`.
             Instruction::Ccmp { rn, rm, .. } | Instruction::Ccmn { rn, rm, .. } => {
                 let mut regs = vec![*rn];
-                if let Operand::Register(r) = rm {
-                    regs.push(*r);
-                }
+                regs.extend(rm.source_register());
                 regs
             }
             // Conditional select instructions read rn and rm
@@ -1281,9 +1264,7 @@ impl Instruction {
             | Instruction::Subs { rn, rm, .. }
             | Instruction::Ands { rn, rm, .. } => {
                 let mut regs = vec![*rn];
-                if let Operand::Register(r) = rm {
-                    regs.push(*r);
-                }
+                regs.extend(rm.source_register());
                 regs
             }
             // ADC/ADCS/SBC/SBCS read rn and rm (both plain registers).
@@ -1298,12 +1279,7 @@ impl Instruction {
             // ROR reads rn and shift (if register)
             Instruction::Ror { rn, shift, .. } => {
                 let mut regs = vec![*rn];
-                match shift {
-                    Operand::Register(r) => regs.push(*r),
-                    Operand::ShiftedRegister { reg, .. } => regs.push(*reg),
-                    Operand::ExtendedRegister { reg, .. } => regs.push(*reg),
-                    Operand::Immediate(_) => {}
-                }
+                regs.extend(shift.source_register());
                 regs
             }
             // Single-source bit-manipulation: rn is the only source.
@@ -2989,6 +2965,106 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_source_registers_flag_setting_and_inverted_logical_shifted_register() {
+        use crate::ir::ExtendKind;
+        // Flag-setting arith/logical (ADDS/SUBS/ANDS) and inverted-logical
+        // (BIC/BICS/ORN/EON) must extract the inner register from a
+        // ShiftedRegister / ExtendedRegister rm, exactly like ADD/SUB/AND.
+        // ADDS/SUBS/ANDS are parser-reachable with these operands
+        // (`adds x0, x1, x2, lsl #3`), so dropping the inner register silently
+        // corrupts live-out tracking; the rest are covered for the same
+        // conservative reason as the shift-slot defensive test above.
+        let shifted = Operand::ShiftedRegister {
+            reg: Register::X5,
+            kind: ShiftKind::Lsl,
+            amount: 3,
+        };
+        let extended = Operand::ExtendedRegister {
+            reg: Register::X5,
+            kind: ExtendKind::Uxtb,
+            shift: 0,
+        };
+        for rm in [shifted, extended] {
+            for instr in [
+                Instruction::Adds {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm,
+                },
+                Instruction::Subs {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm,
+                },
+                Instruction::Ands {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm,
+                    width: crate::ir::RegisterWidth::X64,
+                },
+                Instruction::Bic {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm,
+                },
+                Instruction::Bics {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm,
+                },
+                Instruction::Orn {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm,
+                },
+                Instruction::Eon {
+                    rd: Register::X0,
+                    rn: Register::X1,
+                    rm,
+                },
+            ] {
+                assert_eq!(
+                    instr.source_registers(),
+                    vec![Register::X1, Register::X5],
+                    "instr {} must report X1 and the inner rm register X5 as sources",
+                    instr
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_operand_source_register() {
+        use crate::ir::ExtendKind;
+        // The Operand accessor is the single home for "which register does this
+        // operand read": inner register for register/shifted/extended forms,
+        // None for an immediate.
+        assert_eq!(
+            Operand::Register(Register::X7).source_register(),
+            Some(Register::X7)
+        );
+        assert_eq!(
+            Operand::ShiftedRegister {
+                reg: Register::X7,
+                kind: ShiftKind::Lsr,
+                amount: 5,
+            }
+            .source_register(),
+            Some(Register::X7)
+        );
+        assert_eq!(
+            Operand::ExtendedRegister {
+                reg: Register::X7,
+                kind: ExtendKind::Sxtw,
+                shift: 2,
+            }
+            .source_register(),
+            Some(Register::X7)
+        );
+        assert_eq!(Operand::Immediate(42).source_register(), None);
     }
 
     #[test]

--- a/src/ir/types.rs
+++ b/src/ir/types.rs
@@ -286,6 +286,22 @@ pub enum Operand {
 }
 
 impl Operand {
+    /// The register this operand reads, if any: the inner register for the
+    /// `Register`, `ShiftedRegister`, and `ExtendedRegister` forms, and `None`
+    /// for an `Immediate`. This is the single home for "which register does an
+    /// rm/shift operand contribute as a source" — read-set computations such as
+    /// `Instruction::source_registers` route through it so a shifted or extended
+    /// operand never silently drops its inner register from liveness tracking.
+    #[must_use]
+    pub fn source_register(&self) -> Option<Register> {
+        match self {
+            Operand::Register(reg)
+            | Operand::ShiftedRegister { reg, .. }
+            | Operand::ExtendedRegister { reg, .. } => Some(*reg),
+            Operand::Immediate(_) => None,
+        }
+    }
+
     pub fn display_with_width(&self, width: RegisterWidth) -> String {
         match self {
             Operand::Register(reg) => width.register_name(*reg).to_string(),


### PR DESCRIPTION
## Summary

Architecture-review refactoring surfaced by walking the codebase for **deepening opportunities** (deep modules — a lot of behaviour behind a small interface, tested through that interface). The strongest candidate was a **missing mirror**: `Operand` had no accessor for "which register does this operand read", so `Instruction::source_registers()` hand-inlined that destructure in **six** arms — and two of them got it subtly wrong.

## The bug this fixes

`source_registers()` feeds liveness analysis (`validation/live_out.rs`), the equivalence contract (`semantics/equivalence.rs`), the cost model, and every search backend. Its stated invariant (pinned by `test_source_registers_shifted_register` and `test_source_registers_shift_slot_shifted_register_defensive`) is that a `ShiftedRegister`/`ExtendedRegister` `rm` must still report its **inner** register — "otherwise live-out tracking silently drops it."

The `Add/Sub/And/Orr/Eor`, `Cmp/Cmn/Tst`, and shift-slot arms honoured that. But two arms matched only `Operand::Register`:

- the `Bic/Bics/Orn/Eon/Adds/Subs/Ands` arm, and
- the `Ccmp/Ccmn` arm.

`ADDS`/`SUBS`/`ANDS` are **parser-reachable** with a shifted/extended `rm` (`parse_adds`/`parse_subs` route `rm` through `parse_rm_3op`; `parse_ands` through `parse_operand`/`parse_rm_3op`). So a real input like `adds x0, x1, x2, lsl #3` returned `[x1]`, silently dropping `x2` — corrupting the read-set that liveness and equivalence depend on.

## The deepening

- Add `Operand::source_register() -> Option<Register>` in `src/ir/types.rs` — the single home for "the register an rm/shift operand contributes as a source" (inner register for `Register`/`ShiftedRegister`/`ExtendedRegister`, `None` for `Immediate`).
- Route **every** register-bearing arm of `source_registers()` through it. The six copy-pasted destructures collapse to one `regs.extend(rm.source_register())` each, and the narrow/full split disappears **by construction** — no arm can drop a shifted/extended inner register again.

**Deletion test:** delete the accessor and the four-way destructure re-scatters across six arms (today's state, where two had already drifted) — complexity concentrates behind the accessor. It earns its keep.

## Tests (TDD: red → green)

Written test-first at the `Instruction::source_registers()` / `Operand::source_register()` seams:

- `test_source_registers_flag_setting_and_inverted_logical_shifted_register` — **new**, was RED before the fix (`adds x0, x1, x5, lsl #3` returned `[X1]`, asserted `[X1, X5]`). Covers `Adds/Subs/Ands/Bic/Bics/Orn/Eon` × {`ShiftedRegister`, `ExtendedRegister`}.
- `test_operand_source_register` — **new**, pins the accessor directly (register/shifted/extended → inner reg; immediate → `None`).
- Existing `test_source_registers`, `test_source_registers_shifted_register`, `test_source_registers_shift_slot_shifted_register_defensive` remain green (the collapse is behaviour-preserving for the arms that were already correct).

## Verification

`./ci_check.sh` passes end-to-end (fmt, build, cross-compiled test binaries, full unit + integration suite, `test_all.sh`). `cargo clippy --lib` is clean.

## Scope notes

- No public behaviour change for the `Ccmp/Ccmn` arm on real inputs (CCMP/CCMN `rm` is only ever `Register`/`Immediate` through the parser); routing it through the accessor just makes it uniformly conservative for programmatic IR, matching the defensive invariant.
- Independent of open PR #655 (x86 equivalence fast path) — different files, no overlap.