### PR TITLE
Deepen smt_x86 with states_not_equal_for_live_out_x86 comparator

### DIFF
--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -946,24 +946,15 @@ where
     let final1 = crate::semantics::smt_x86::apply_sequence(initial.clone(), seq1);
     let final2 = crate::semantics::smt_x86::apply_sequence(initial, seq2);
 
-    let mut disjuncts: Vec<z3::ast::Bool> = Vec::new();
-    for reg in config.live_out.iter() {
-        let v1 = final1.get_register(*reg);
-        let v2 = final2.get_register(*reg);
-        disjuncts.push(v1.eq(v2).not());
-    }
-    // When flags are live (caller-declared or forced by a peeled Jcc),
-    // any of the five tracked EFLAGS bits diverging refutes equivalence.
-    if config.live_out.flags_live() {
-        disjuncts.push(crate::semantics::smt_x86::flags_not_equal_x86(
-            &final1, &final2,
-        ));
-    }
-    let any_diff = if disjuncts.is_empty() {
-        z3::ast::Bool::from_bool(false)
-    } else {
-        z3::ast::Bool::or(&disjuncts.iter().collect::<Vec<_>>())
-    };
+    // Delegate the "states differ on the live-out contract" decision (live-out
+    // registers, plus the five EFLAGS bits when flags are live — caller-declared
+    // or forced by a peeled Jcc) to `smt_x86`, mirroring how the AArch64 path
+    // uses `smt::states_not_equal_for_live_out`.
+    let any_diff = crate::semantics::smt_x86::states_not_equal_for_live_out_x86(
+        &final1,
+        &final2,
+        &config.live_out,
+    );
     solver.assert(&any_diff);
     solver
 }

--- a/src/semantics/smt_x86.rs
+++ b/src/semantics/smt_x86.rs
@@ -658,6 +658,37 @@ pub fn flags_not_equal_x86(a: &MachineStateX86, b: &MachineStateX86) -> z3::ast:
     ])
 }
 
+/// Bool predicate asserting that two symbolic x86 states diverge on the given
+/// live-out contract: any live-out register whose value differs, or — when
+/// `live_out.flags_live()` is set — any of the five tracked EFLAGS bits
+/// differing, refutes equivalence.
+///
+/// This is the x86 twin of `smt::states_not_equal_for_live_out`. It keeps the
+/// "how do two states differ on a contract" decision behind the `smt_x86`
+/// interface so the equivalence backend does not have to poke `MachineStateX86`
+/// register-by-register. Unlike the AArch64 twin there is no `memory_live`
+/// disjunct — the x86 IR carries no memory model (see ADR-0007).
+pub fn states_not_equal_for_live_out_x86(
+    state1: &MachineStateX86,
+    state2: &MachineStateX86,
+    live_out: &crate::semantics::live_out::RegisterSet<X86Register>,
+) -> z3::ast::Bool {
+    let mut disjuncts: Vec<z3::ast::Bool> = Vec::new();
+    for reg in live_out.iter() {
+        let v1 = state1.get_register(*reg);
+        let v2 = state2.get_register(*reg);
+        disjuncts.push(v1.eq(v2).not());
+    }
+    if live_out.flags_live() {
+        disjuncts.push(flags_not_equal_x86(state1, state2));
+    }
+    if disjuncts.is_empty() {
+        z3::ast::Bool::from_bool(false)
+    } else {
+        z3::ast::Bool::or(&disjuncts.iter().collect::<Vec<_>>())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2111,6 +2142,123 @@ mod tests {
             solver.check(),
             SatResult::Unsat,
             "CMOV must not write any flag"
+        );
+    }
+
+    // --- states_not_equal_for_live_out_x86: the live-out state comparator ---
+    //
+    // These pin the x86 twin of `smt::states_not_equal_for_live_out`: it must
+    // fold exactly the live-out register slice, and the five EFLAGS bits only
+    // when the contract declares flags live. x86 has no memory model, so there
+    // is no memory disjunct to exercise.
+
+    fn mov_imm(rd: X86Register, imm: i64) -> X86Instruction {
+        X86Instruction::MovImm { rd, imm }
+    }
+
+    #[test]
+    fn states_not_equal_x86_detects_live_out_register_divergence() {
+        // Two sequences leaving RAX at different constants must be refutable on
+        // a contract that includes RAX.
+        let s1 = apply_sequence(
+            MachineStateX86::new_symbolic("init", 64),
+            &[mov_imm(X86Register::RAX, 5)],
+        );
+        let s2 = apply_sequence(
+            MachineStateX86::new_symbolic("init", 64),
+            &[mov_imm(X86Register::RAX, 7)],
+        );
+        let live_out =
+            crate::semantics::live_out::RegisterSet::from_registers(vec![X86Register::RAX]);
+        let solver = Solver::new();
+        let diff = states_not_equal_for_live_out_x86(&s1, &s2, &live_out);
+        solver.assert(&diff);
+        assert_eq!(
+            solver.check(),
+            SatResult::Sat,
+            "diverging live-out register must be satisfiably not-equal"
+        );
+    }
+
+    #[test]
+    fn states_not_equal_x86_agrees_when_live_out_register_matches() {
+        let s1 = apply_sequence(
+            MachineStateX86::new_symbolic("init", 64),
+            &[mov_imm(X86Register::RAX, 5)],
+        );
+        let s2 = apply_sequence(
+            MachineStateX86::new_symbolic("init", 64),
+            &[mov_imm(X86Register::RAX, 5)],
+        );
+        let live_out =
+            crate::semantics::live_out::RegisterSet::from_registers(vec![X86Register::RAX]);
+        let solver = Solver::new();
+        let diff = states_not_equal_for_live_out_x86(&s1, &s2, &live_out);
+        solver.assert(&diff);
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "agreeing live-out register must be provably equal"
+        );
+    }
+
+    #[test]
+    fn states_not_equal_x86_ignores_registers_outside_the_contract() {
+        // RBX differs between the two states but is NOT in the contract; RAX
+        // agrees. Only the live-out slice may be compared.
+        let s1 = apply_sequence(
+            MachineStateX86::new_symbolic("init", 64),
+            &[mov_imm(X86Register::RAX, 5), mov_imm(X86Register::RBX, 1)],
+        );
+        let s2 = apply_sequence(
+            MachineStateX86::new_symbolic("init", 64),
+            &[mov_imm(X86Register::RAX, 5), mov_imm(X86Register::RBX, 2)],
+        );
+        let live_out =
+            crate::semantics::live_out::RegisterSet::from_registers(vec![X86Register::RAX]);
+        let solver = Solver::new();
+        let diff = states_not_equal_for_live_out_x86(&s1, &s2, &live_out);
+        solver.assert(&diff);
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "a register outside the live-out contract must not refute equivalence"
+        );
+    }
+
+    #[test]
+    fn states_not_equal_x86_gates_flags_on_flags_live() {
+        // seq1 writes EFLAGS (add), seq2 leaves them at symbolic init.
+        let s1 = apply_sequence(
+            MachineStateX86::new_symbolic("init", 64),
+            &[X86Instruction::AddReg {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+            }],
+        );
+        let s2 = apply_sequence(MachineStateX86::new_symbolic("init", 64), &[]);
+
+        // Flags dead, no live-out registers: nothing can refute equivalence.
+        let flags_dead = crate::semantics::live_out::RegisterSet::<X86Register>::empty();
+        let solver = Solver::new();
+        let diff_dead = states_not_equal_for_live_out_x86(&s1, &s2, &flags_dead);
+        solver.assert(&diff_dead);
+        assert_eq!(
+            solver.check(),
+            SatResult::Unsat,
+            "an empty flags-dead contract has nothing to refute"
+        );
+
+        // Flags live: the divergent flag effects must be exposed.
+        let flags_live =
+            crate::semantics::live_out::RegisterSet::<X86Register>::empty().with_flags(true);
+        let solver2 = Solver::new();
+        let diff_live = states_not_equal_for_live_out_x86(&s1, &s2, &flags_live);
+        solver2.assert(&diff_live);
+        assert_eq!(
+            solver2.check(),
+            SatResult::Sat,
+            "flags-live contract must fold in the diverging EFLAGS"
         );
     }
 }


### PR DESCRIPTION
## Refactoring goal

Eliminate a **leaky seam** on the soundness-critical SMT verification path and
restore parity between the two SMT lowering modules.

The x86 equivalence backend (`build_smt_solver_x86` in
`src/semantics/equivalence.rs`) hand-rolled the "do these two states differ on
the live-out contract?" disjunction inline — looping over the live-out
registers, poking `MachineStateX86` internals via `get_register` register by
register, and calling `flags_not_equal_x86` directly. The AArch64 path never
does this: it delegates the whole decision to a single comparator behind the
`smt` interface, `smt::states_not_equal_for_live_out`. So the two SMT modules
were asymmetric and the equivalence checker reached across the `smt_x86` seam
to know *how* x86 states are compared.

This is the same "the module should own its invariant" deepening as the recent
`Operand::source_register` / `Instruction::destinations()` work, applied to the
x86 SMT comparator.

## What changed

- **New deep accessor:** `smt_x86::states_not_equal_for_live_out_x86(state1,
  state2, live_out)` — the x86 twin of `smt::states_not_equal_for_live_out`. It
  owns the decision: any live-out register whose value diverges, plus the five
  tracked EFLAGS bits when `live_out.flags_live()` is set, refutes equivalence.
  There is deliberately no `memory_live` disjunct — the x86 IR carries no memory
  model (ADR-0007).
- **Caller deepened:** `build_smt_solver_x86` now delegates to it and no longer
  touches `MachineStateX86` internals. The two `build_smt_solver` functions are
  now structurally symmetric.

Net: **+157 / −18** lines, but the ~18 lines of live-out comparison logic move
from the CLI-adjacent equivalence backend into the `smt_x86` module where their
AArch64 counterpart already lives. The change is behavior-preserving (the moved
logic is byte-for-byte the same disjunction).

## Why this is a deepening (deletion test)

Deleting the new function would force the live-out comparison back into the
equivalence backend, where it can drift from its AArch64 twin — complexity
**concentrates** in the comparator, so it earns its keep. Locality: future
direct-IR callers reuse one comparator instead of re-deriving the disjunction.

## Validating tests (written test-first, TDD)

Four new unit tests in `src/semantics/smt_x86.rs`, added **before** the
implementation (confirmed RED — 5 compile errors for the missing function —
then GREEN):

- `states_not_equal_x86_detects_live_out_register_divergence` — a live-out
  register differing is satisfiably not-equal (SAT).
- `states_not_equal_x86_agrees_when_live_out_register_matches` — an agreeing
  live-out register is provably equal (UNSAT).
- `states_not_equal_x86_ignores_registers_outside_the_contract` — a register
  that differs but is **not** in the contract must not refute equivalence
  (UNSAT). Pins that only the live-out slice is compared.
- `states_not_equal_x86_gates_flags_on_flags_live` — an empty flags-dead
  contract cannot refute (UNSAT); the same states under a flags-live contract
  expose the diverging EFLAGS (SAT).

## Verification

`./ci_check.sh` passes end to end (fmt, build, x86/AArch64 test-binary builds,
`cargo test`, and the `test_all.sh` integration suite). Targeted:
`semantics::smt_x86` 47 passed, `semantics::equivalence` 93 passed.

This refactor was surfaced by the `improve-codebase-architecture` audit and
implemented via the `tdd` skill.
