### PR TITLE
Deepen SearchStatistics with a verification-accounting seam

### DIFF
--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -266,34 +266,25 @@ where
     };
     let (verdict, metrics) =
         <I as EnumerativeBackend<I>>::check_equivalence(target, candidate, live_out, smt_timeout);
-    let solver_nanos: u64 = metrics
-        .smt_elapsed
-        .as_nanos()
-        .try_into()
-        .unwrap_or(u64::MAX);
+    // The parallel path applies the same canonical policy as the symbolic path
+    // (see `SearchStatistics::verification_tally` for what each counter means:
+    // `reached_solver` marks both an SMT query and a fast pass, including
+    // candidates later disproved by Z3) to its atomic counters.
+    let tally = SearchStatistics::verification_tally(&metrics, &verdict);
+    let solver_nanos: u64 = tally.smt_elapsed.as_nanos().try_into().unwrap_or(u64::MAX);
     shared
         .smt_elapsed_nanos
         .fetch_add(solver_nanos, Ordering::Relaxed);
-    // Count only candidates that actually reached `solver.check()`. The same
-    // metric also marks candidates that passed fast concrete validation,
-    // including ones later disproved by SMT. `smt_called` is the right guard
-    // because every early return that never reaches the solver leaves it
-    // false: the pre-SMT guard (`flag_writers_diverge && flags_live`) returns
-    // `NotEquivalent` and the fast-path returns `NotEquivalentFast`, neither of
-    // which should count as a fast pass (PR #269 review).
-    if metrics.smt_called {
+    if tally.reached_solver {
         shared.smt_queries.fetch_add(1, Ordering::Relaxed);
         shared
             .candidates_passed_fast
             .fetch_add(1, Ordering::Relaxed);
     }
-    match verdict {
-        EquivalenceResult::Equivalent => {
-            shared.smt_equivalent.fetch_add(1, Ordering::Relaxed);
-            true
-        }
-        _ => false,
+    if tally.proved_equivalent {
+        shared.smt_equivalent.fetch_add(1, Ordering::Relaxed);
     }
+    tally.proved_equivalent
 }
 
 struct CachedThreadPool {

--- a/src/search/result.rs
+++ b/src/search/result.rs
@@ -5,6 +5,7 @@
 use crate::ir::Instruction;
 use crate::isa::ISA;
 use crate::search::config::Algorithm;
+use crate::semantics::{EquivalenceMetrics, EquivalenceResult};
 use std::time::Duration;
 
 /// Result of a search operation
@@ -118,6 +119,31 @@ impl From<SearchResultFor<crate::isa::AArch64>> for SearchResult {
     }
 }
 
+/// The counter deltas produced by folding one candidate verification into a
+/// [`SearchStatistics`].
+///
+/// This separates the *policy* — what a verification outcome means for the
+/// counters — from the *sink* it is applied to. The symbolic search path folds
+/// the tally into plain `&mut SearchStatistics` fields; the parallel enumerative
+/// path applies the same tally to its atomic counters. Both share one definition
+/// via [`SearchStatistics::verification_tally`], so the two paths cannot drift.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct VerificationTally {
+    /// Wall-clock time this verification spent inside `solver.check()`. Folds
+    /// into `smt_elapsed`. `Duration::ZERO` when the solver was not invoked.
+    pub smt_elapsed: Duration,
+    /// Whether the verification reached Z3 (`EquivalenceMetrics::smt_called`).
+    ///
+    /// When true the candidate counts as *both* an SMT query and a fast-
+    /// validation pass, even if Z3 later disproved it: reaching the solver means
+    /// it cleared the concrete pre-filter. Fast-path refutations and the pre-SMT
+    /// flag-writer guard leave `smt_called` false, so neither is counted here.
+    pub reached_solver: bool,
+    /// Whether Z3 proved the candidate equivalent to the target. Folds into
+    /// `smt_equivalent`.
+    pub proved_equivalent: bool,
+}
+
 /// Statistics from a search operation
 #[derive(Debug, Clone, Default)]
 pub struct SearchStatistics {
@@ -160,6 +186,47 @@ impl SearchStatistics {
             algorithm,
             ..Default::default()
         }
+    }
+
+    /// The canonical policy mapping one equivalence verification to its counter
+    /// deltas.
+    ///
+    /// This is the single source of truth for how a `(metrics, verdict)` pair
+    /// updates the SMT counters, shared by both the symbolic and the parallel
+    /// enumerative verification paths. See [`VerificationTally`] for what each
+    /// field counts.
+    pub fn verification_tally(
+        metrics: &EquivalenceMetrics,
+        verdict: &EquivalenceResult,
+    ) -> VerificationTally {
+        VerificationTally {
+            smt_elapsed: metrics.smt_elapsed,
+            reached_solver: metrics.smt_called,
+            proved_equivalent: matches!(verdict, EquivalenceResult::Equivalent),
+        }
+    }
+
+    /// Fold one equivalence verification into the (single-threaded) SMT
+    /// counters, returning whether the candidate proved equivalent.
+    ///
+    /// Used by the symbolic search path. The parallel enumerative path applies
+    /// the same [`Self::verification_tally`] to its atomic counters instead of
+    /// calling this method, so both paths agree on what each counter means.
+    pub fn record_verification(
+        &mut self,
+        metrics: &EquivalenceMetrics,
+        verdict: &EquivalenceResult,
+    ) -> bool {
+        let tally = Self::verification_tally(metrics, verdict);
+        self.smt_elapsed += tally.smt_elapsed;
+        if tally.reached_solver {
+            self.smt_queries += 1;
+            self.candidates_passed_fast += 1;
+        }
+        if tally.proved_equivalent {
+            self.smt_equivalent += 1;
+        }
+        tally.proved_equivalent
     }
 
     /// Record the start of timing
@@ -425,5 +492,104 @@ mod tests {
         assert!(with_opt_text.contains("Optimization found!"));
         assert!(with_opt_text.contains("Optimized sequence"));
         assert!(with_opt_text.contains("Savings: 1 instructions"));
+    }
+
+    // --- Verification accounting seam (verification_tally / record_verification) ---
+    //
+    // These pin the canonical policy for folding one candidate verification into
+    // the SMT counters, shared by the symbolic and enumerative search paths.
+    use crate::semantics::{EquivalenceMetrics, EquivalenceResult};
+
+    fn reached_solver(elapsed_ms: u64) -> EquivalenceMetrics {
+        EquivalenceMetrics {
+            smt_called: true,
+            smt_elapsed: Duration::from_millis(elapsed_ms),
+            ..Default::default()
+        }
+    }
+
+    fn refuted_before_solver() -> EquivalenceMetrics {
+        EquivalenceMetrics {
+            smt_called: false,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn record_verification_counts_solver_reaching_equivalent_candidate() {
+        // A candidate that reached Z3 and was proven equivalent counts as one SMT
+        // query, one fast-validation pass (it cleared the concrete pre-filter to
+        // reach Z3), and one proven equivalence; its solver time is accumulated.
+        let mut stats = SearchStatistics::default();
+        let proved = stats.record_verification(&reached_solver(7), &EquivalenceResult::Equivalent);
+        assert!(proved);
+        assert_eq!(stats.smt_queries, 1);
+        assert_eq!(stats.candidates_passed_fast, 1);
+        assert_eq!(stats.smt_equivalent, 1);
+        assert_eq!(stats.smt_elapsed, Duration::from_millis(7));
+    }
+
+    #[test]
+    fn record_verification_counts_solver_reaching_but_disproved_candidate() {
+        // Reaching Z3 but being disproved still counts as a fast pass + an SMT
+        // query (the documented meaning of candidates_passed_fast), but NOT an
+        // equivalence.
+        let mut stats = SearchStatistics::default();
+        let proved =
+            stats.record_verification(&reached_solver(3), &EquivalenceResult::NotEquivalent);
+        assert!(!proved);
+        assert_eq!(stats.smt_queries, 1);
+        assert_eq!(stats.candidates_passed_fast, 1);
+        assert_eq!(stats.smt_equivalent, 0);
+        assert_eq!(stats.smt_elapsed, Duration::from_millis(3));
+    }
+
+    #[test]
+    fn record_verification_ignores_candidates_that_never_reached_the_solver() {
+        // A fast-path refutation (smt_called == false) is neither an SMT query
+        // nor a fast pass; only the (zero) solver time is folded in.
+        let mut stats = SearchStatistics::default();
+        let proved = stats.record_verification(
+            &refuted_before_solver(),
+            &EquivalenceResult::Unknown("timeout".into()),
+        );
+        assert!(!proved);
+        assert_eq!(stats.smt_queries, 0);
+        assert_eq!(stats.candidates_passed_fast, 0);
+        assert_eq!(stats.smt_equivalent, 0);
+        assert_eq!(stats.smt_elapsed, Duration::ZERO);
+    }
+
+    #[test]
+    fn record_verification_accumulates_across_calls() {
+        let mut stats = SearchStatistics::default();
+        stats.record_verification(&reached_solver(2), &EquivalenceResult::Equivalent);
+        stats.record_verification(&refuted_before_solver(), &EquivalenceResult::NotEquivalent);
+        stats.record_verification(&reached_solver(2), &EquivalenceResult::NotEquivalent);
+        assert_eq!(stats.smt_queries, 2);
+        assert_eq!(stats.candidates_passed_fast, 2);
+        assert_eq!(stats.smt_equivalent, 1);
+        assert_eq!(stats.smt_elapsed, Duration::from_millis(4));
+    }
+
+    #[test]
+    fn verification_tally_exposes_the_three_counter_decisions() {
+        // The enumerative (parallel) path applies the same tally to its atomic
+        // counters, so the tally must expose exactly the decisions they need.
+        let tally = SearchStatistics::verification_tally(
+            &reached_solver(5),
+            &EquivalenceResult::Equivalent,
+        );
+        assert_eq!(tally.smt_elapsed, Duration::from_millis(5));
+        assert!(tally.reached_solver);
+        assert!(tally.proved_equivalent);
+
+        let refuted = SearchStatistics::verification_tally(
+            &refuted_before_solver(),
+            &EquivalenceResult::NotEquivalent,
+        );
+        assert_eq!(refuted.smt_elapsed, Duration::ZERO);
+        assert!(!refuted.reached_solver);
+        assert!(!refuted.proved_equivalent);
     }
 }

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -15,7 +15,6 @@ use crate::search::config::{SearchConfig, SearchMode};
 use crate::search::result::{SearchResultFor, SearchStatistics};
 use crate::search::symbolic::backend::SymbolicBackend;
 use crate::search::{Algorithm, SearchAlgorithm};
-use crate::semantics::EquivalenceResult;
 use std::marker::PhantomData;
 use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
@@ -337,20 +336,7 @@ where
         let (verdict, metrics) = <I as SymbolicBackend<I>>::check_equivalence(
             target, candidate, live_out, width, timeout,
         );
-        self.statistics.smt_elapsed += metrics.smt_elapsed;
-        // `smt_called` means the candidate survived the fast concrete
-        // pre-filter and reached Z3, regardless of the solver verdict.
-        if metrics.smt_called {
-            self.statistics.smt_queries += 1;
-            self.statistics.candidates_passed_fast += 1;
-        }
-        match verdict {
-            EquivalenceResult::Equivalent => {
-                self.statistics.smt_equivalent += 1;
-                true
-            }
-            _ => false,
-        }
+        self.statistics.record_verification(&metrics, &verdict)
     }
 
     /// Binary search on cost bound (not fully implemented yet)
@@ -435,10 +421,10 @@ mod tests {
     use crate::ir::{Instruction, Operand, Register};
     use crate::isa::{AArch64, ISA, ISAMutator, InstructionType, OperandType, RegisterType, U64};
     use crate::search::config::SymbolicConfig;
-    use crate::semantics::EquivalenceMetrics;
     use crate::semantics::cost::CostMetric;
     use crate::semantics::live_out::LiveOut;
     use crate::semantics::state::ConcreteMachineState;
+    use crate::semantics::{EquivalenceMetrics, EquivalenceResult};
     use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
     use std::time::Duration;


### PR DESCRIPTION
## Refactoring goal

Surfaced by an `improve-codebase-architecture` audit of the **search** subsystem: the fold from one candidate's equivalence verification into the SMT statistics counters was a **shallow, drift-prone duplication**.

The mapping from `(EquivalenceMetrics, EquivalenceResult)` to the counters (`smt_elapsed`, `smt_queries`, `candidates_passed_fast`, `smt_equivalent`) was hand-written in **two** places with the **definitional comment duplicated verbatim**:

- `src/search/symbolic/synthesis.rs::verify_equivalence` (single-threaded, plain `&mut` fields)
- `src/search/enumerative/search.rs::verify_candidate` (parallel, atomic counters)

There was no single home for the *policy* — "what counts as an SMT query / a fast pass / a proven equivalence" — so the two copies had to be kept in sync by hand (a **locality** failure). The in-code comments themselves admitted the two paths mirror one contract.

## What changed (deepening)

Split **policy** from **sink**:

- New `SearchStatistics::verification_tally(metrics, verdict) -> VerificationTally` — the **one canonical policy** mapping a verification outcome to its counter deltas.
- New `SearchStatistics::record_verification(&mut self, metrics, verdict) -> bool` — folds a tally into the single-threaded counters. The **symbolic** path now calls this.
- The **parallel enumerative** path applies the *same* `verification_tally` to its atomic counters. The atomic-vs-plain sink is the only genuine difference, so it stays per-path while the *decision* is shared — both paths can no longer drift.
- The load-bearing "`smt_called` is the right guard" rationale (why a Z3-disproved candidate still counts as a fast pass) now lives once, on `VerificationTally::reached_solver`.

Behavior-preserving — no counter semantics change. `mcmc` and the LLM flow, which count `candidates_passed_fast` at deliberately different points, are intentionally left untouched.

### Benefits
- **Locality**: each counter's meaning is defined in exactly one place.
- **Leverage**: the coordinator's cross-worker aggregation now sums quantities with a single shared definition.
- **Testability**: the policy is unit-tested directly (below) instead of only through slow full searches.

## Tests that validate it (TDD, red → green)

New unit tests in `src/search/result.rs` pin the canonical policy at the seam:

- `record_verification_counts_solver_reaching_equivalent_candidate` — reached Z3 + proven ⇒ `smt_queries`, `candidates_passed_fast`, `smt_equivalent` each +1, elapsed accumulated, returns `true`.
- `record_verification_counts_solver_reaching_but_disproved_candidate` — reached Z3 but disproved ⇒ query + fast-pass counted, **not** equivalence.
- `record_verification_ignores_candidates_that_never_reached_the_solver` — `smt_called == false` ⇒ no query/fast-pass, only (zero) elapsed folded.
- `record_verification_accumulates_across_calls` — counters and elapsed accumulate correctly.
- `verification_tally_exposes_the_three_counter_decisions` — the tally the atomic path relies on exposes exactly `smt_elapsed` / `reached_solver` / `proved_equivalent`.

The existing enumerative/symbolic statistics tests stay green, confirming the refactor is behavior-preserving.

## Verification
`./ci_check.sh` passes end to end: formatting, build, cross-compiled AArch64/x86 test binaries, full unit + integration suite (1429 lib unit tests), and `test_all.sh`.

---

_Follow-ups the same audit surfaced (out of scope here, higher ceiling/risk): collapse the three per-algorithm `*Backend<I>` traits into one `SearchBackend<I>`; fold the four `main.rs` boundary-liveness scanners into a library module; read x86 width from `I::Width::BITS` instead of hardcoded `64`/`32` literals._