### PR TITLE
Deepen VerificationTally with a shared fold_into sink; route MCMC through it

### DIFF
--- a/src/search/result.rs
+++ b/src/search/result.rs
@@ -123,10 +123,11 @@ impl From<SearchResultFor<crate::isa::AArch64>> for SearchResult {
 /// [`SearchStatistics`].
 ///
 /// This separates the *policy* — what a verification outcome means for the
-/// counters — from the *sink* it is applied to. The symbolic search path folds
-/// the tally into plain `&mut SearchStatistics` fields; the parallel enumerative
-/// path applies the same tally to its atomic counters. Both share one definition
-/// via [`SearchStatistics::verification_tally`], so the two paths cannot drift.
+/// counters — from the *sink* it is applied to. The symbolic and stochastic
+/// (MCMC) search paths fold the tally into plain `&mut SearchStatistics` fields
+/// via [`VerificationTally::fold_into`]; the parallel enumerative path applies
+/// the same tally to its atomic counters. All three share one definition via
+/// [`SearchStatistics::verification_tally`], so the paths cannot drift.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct VerificationTally {
     /// Wall-clock time this verification spent inside `solver.check()`. Folds
@@ -142,6 +143,34 @@ pub struct VerificationTally {
     /// Whether Z3 proved the candidate equivalent to the target. Folds into
     /// `smt_equivalent`.
     pub proved_equivalent: bool,
+}
+
+impl VerificationTally {
+    /// Fold this tally's SMT-counter deltas into a single-threaded
+    /// [`SearchStatistics`] sink: `smt_elapsed`, `smt_queries` (when the solver
+    /// was reached), and `smt_equivalent` (when equivalence was proven).
+    ///
+    /// This is the shared fold behind every plain-`&mut SearchStatistics`
+    /// verification path — the symbolic search ([`SearchStatistics::record_verification`])
+    /// and the stochastic (MCMC) search both call it, so the SMT accounting
+    /// cannot drift between them. The parallel enumerative path applies the same
+    /// [`SearchStatistics::verification_tally`] to *atomic* counters instead, the
+    /// one genuinely different sink.
+    ///
+    /// It deliberately does **not** touch `candidates_passed_fast`: what counts
+    /// as a fast-validation pass is a per-path policy. The symbolic path ties it
+    /// to `reached_solver` (a candidate that cleared the concrete pre-filter to
+    /// reach Z3); the stochastic path counts it earlier, at the concrete-test
+    /// stage before the cost gate. Each path owns that increment.
+    pub fn fold_into(&self, stats: &mut SearchStatistics) {
+        stats.smt_elapsed += self.smt_elapsed;
+        if self.reached_solver {
+            stats.smt_queries += 1;
+        }
+        if self.proved_equivalent {
+            stats.smt_equivalent += 1;
+        }
+    }
 }
 
 /// Statistics from a search operation
@@ -209,23 +238,24 @@ impl SearchStatistics {
     /// Fold one equivalence verification into the (single-threaded) SMT
     /// counters, returning whether the candidate proved equivalent.
     ///
-    /// Used by the symbolic search path. The parallel enumerative path applies
-    /// the same [`Self::verification_tally`] to its atomic counters instead of
-    /// calling this method, so both paths agree on what each counter means.
+    /// Used by the symbolic search path. The stochastic (MCMC) path shares the
+    /// SMT fold via [`VerificationTally::fold_into`] but owns its own
+    /// `candidates_passed_fast` policy, so it applies the tally directly rather
+    /// than calling this method. The parallel enumerative path applies the same
+    /// [`Self::verification_tally`] to its atomic counters instead. All three
+    /// agree on what each counter means because they share one tally.
     pub fn record_verification(
         &mut self,
         metrics: &EquivalenceMetrics,
         verdict: &EquivalenceResult,
     ) -> bool {
         let tally = Self::verification_tally(metrics, verdict);
-        self.smt_elapsed += tally.smt_elapsed;
         if tally.reached_solver {
-            self.smt_queries += 1;
+            // Symbolic-path policy: reaching Z3 means the candidate cleared the
+            // concrete pre-filter, so it also counts as one fast-validation pass.
             self.candidates_passed_fast += 1;
         }
-        if tally.proved_equivalent {
-            self.smt_equivalent += 1;
-        }
+        tally.fold_into(self);
         tally.proved_equivalent
     }
 
@@ -570,6 +600,50 @@ mod tests {
         assert_eq!(stats.candidates_passed_fast, 2);
         assert_eq!(stats.smt_equivalent, 1);
         assert_eq!(stats.smt_elapsed, Duration::from_millis(4));
+    }
+
+    #[test]
+    fn fold_into_counts_solver_reaching_equivalent_candidate() {
+        // Folding a solver-reaching, proven-equivalent tally into a plain sink
+        // adds its solver time, one SMT query, and one proven equivalence.
+        let tally = SearchStatistics::verification_tally(
+            &reached_solver(7),
+            &EquivalenceResult::Equivalent,
+        );
+        let mut stats = SearchStatistics::default();
+        tally.fold_into(&mut stats);
+        assert_eq!(stats.smt_queries, 1);
+        assert_eq!(stats.smt_equivalent, 1);
+        assert_eq!(stats.smt_elapsed, Duration::from_millis(7));
+    }
+
+    #[test]
+    fn fold_into_leaves_candidates_passed_fast_untouched() {
+        // The fast-pass increment is a per-path policy, not part of the shared
+        // SMT fold: fold_into must never move candidates_passed_fast, even for a
+        // solver-reaching candidate. (The symbolic path adds it separately; the
+        // stochastic path counts it at the concrete-test stage.)
+        let tally = SearchStatistics::verification_tally(
+            &reached_solver(4),
+            &EquivalenceResult::Equivalent,
+        );
+        let mut stats = SearchStatistics::default();
+        tally.fold_into(&mut stats);
+        assert_eq!(stats.candidates_passed_fast, 0);
+    }
+
+    #[test]
+    fn fold_into_ignores_candidates_that_never_reached_the_solver() {
+        // A pre-solver refutation folds in only its (zero) solver time.
+        let tally = SearchStatistics::verification_tally(
+            &refuted_before_solver(),
+            &EquivalenceResult::NotEquivalent,
+        );
+        let mut stats = SearchStatistics::default();
+        tally.fold_into(&mut stats);
+        assert_eq!(stats.smt_queries, 0);
+        assert_eq!(stats.smt_equivalent, 0);
+        assert_eq!(stats.smt_elapsed, Duration::ZERO);
     }
 
     #[test]

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -248,34 +248,35 @@ where
                     width,
                     smt_timeout,
                 );
-                self.statistics.smt_elapsed += metrics.smt_elapsed;
-                if metrics.smt_called {
-                    self.statistics.smt_queries += 1;
-                }
-                match verdict {
-                    EquivalenceResult::Equivalent => {
-                        self.statistics.smt_equivalent += 1;
-                        self.statistics.improvements_found += 1;
+                // Fold the SMT counters through the canonical accounting seam so
+                // this path cannot drift from the symbolic/enumerative ones.
+                // `candidates_passed_fast` is counted separately above (at the
+                // concrete-test stage), which is why we apply the tally directly
+                // rather than calling `record_verification`.
+                let tally = SearchStatistics::verification_tally(&metrics, &verdict);
+                tally.fold_into(&mut self.statistics);
+                if tally.proved_equivalent {
+                    self.statistics.improvements_found += 1;
 
-                        best_equivalent = Some(proposal.clone());
-                        best_cost = proposal_cost;
-                        self.statistics.best_cost_found = best_cost;
+                    best_equivalent = Some(proposal.clone());
+                    best_cost = proposal_cost;
+                    self.statistics.best_cost_found = best_cost;
 
-                        if config.verbose {
-                            println!(
-                                "Found improvement at iteration {}: cost {} -> {}",
-                                iteration, original_cost, best_cost
-                            );
-                        }
+                    if config.verbose {
+                        println!(
+                            "Found improvement at iteration {}: cost {} -> {}",
+                            iteration, original_cost, best_cost
+                        );
                     }
-                    EquivalenceResult::NotEquivalent | EquivalenceResult::NotEquivalentFast(_) => {
-                        smt_refuted = true;
-                    }
-                    // SMT timeout / inconclusive: we cannot prove the proposal
-                    // incorrect, so leave the Metropolis decision below intact
-                    // rather than vetoing exploration.
-                    EquivalenceResult::Unknown(_) => {}
+                } else if matches!(
+                    verdict,
+                    EquivalenceResult::NotEquivalent | EquivalenceResult::NotEquivalentFast(_)
+                ) {
+                    smt_refuted = true;
                 }
+                // SMT timeout / inconclusive (`Unknown`): we cannot prove the
+                // proposal incorrect, so leave the Metropolis decision below
+                // intact rather than vetoing exploration.
             } else {
                 self.statistics.candidates_pruned_by_cost += 1;
             }
@@ -669,6 +670,31 @@ mod tests {
             run_timeout_probe_search_with(config, TIMEOUT_PROBE_EQUIVALENT, true);
         assert_eq!(statistics.smt_queries, 1);
         recorded_timeout
+    }
+
+    #[test]
+    fn stochastic_search_accounts_solver_proven_improvement_through_the_seam() {
+        // The equivalent branch folds its SMT counters through the shared
+        // `VerificationTally` seam: a solver-reaching, proven-equivalent cheaper
+        // proposal counts as one SMT query, one proven equivalence, and one
+        // recorded improvement — the counterpart to the refuted case below.
+        let _guard = set_timeout_probe_result(TIMEOUT_PROBE_EQUIVALENT, true);
+
+        let mut search: StochasticSearch<TimeoutProbeIsa> = StochasticSearch::new();
+        let config = SearchConfig::default().with_stochastic(
+            StochasticConfig::default()
+                .with_iterations(1)
+                .with_test_count(0)
+                .with_seed(1),
+        );
+        let target = [TimeoutProbeInstruction(1), TimeoutProbeInstruction(2)];
+
+        let result = search.search(&target, &(), &config);
+
+        assert_eq!(result.statistics.smt_queries, 1);
+        assert_eq!(result.statistics.smt_equivalent, 1);
+        assert_eq!(result.statistics.improvements_found, 1);
+        assert!(result.found_optimization);
     }
 
     #[test]


### PR DESCRIPTION
## Refactoring goal

Complete the verification-accounting seam introduced in f9554fe so the
"single source of truth" for SMT-counter accounting genuinely covers **all
three** cost-model search algorithms — not just two.

That commit centralised the `(EquivalenceMetrics, EquivalenceResult) → SMT-counter`
policy in `SearchStatistics::verification_tally` and folded it into the
single-threaded counters via `record_verification`, documenting the tally as
"shared by both the symbolic and the parallel enumerative verification paths."
The **stochastic (MCMC)** path was left out: `mcmc.rs` hand-inlined a *third*
copy of the fold

```rust
self.statistics.smt_elapsed += metrics.smt_elapsed;
if metrics.smt_called { self.statistics.smt_queries += 1; }
match verdict { Equivalent => self.statistics.smt_equivalent += 1, ... }
```

so the single-source-of-truth was only two-thirds true, and MCMC's SMT
accounting could silently drift from the documented policy.

## How this was found

This came out of an architecture audit run with the
[`mattpocock/skills` `improve-codebase-architecture`](https://github.com/mattpocock/skills)
methodology (scan for shallow modules / information leakage / poor locality via
the deep-modules "deletion test"), implemented test-first with the companion
`tdd` skill. Three parallel explorers surfaced a ranked candidate list; this one
was chosen as the best **impact-per-risk**: it removes a real, correctness-relevant
policy divergence, is strictly behavior-preserving, and directly continues the
maintainer's most recent commit. (Larger candidates — e.g. unifying the four
duplicated downstream-liveness scanners in `main.rs`, or the three per-ISA search
backend traits — are higher-impact but materially riskier; noted for follow-up.)

## The change

- **`VerificationTally::fold_into(&mut SearchStatistics)`** — new deep seam: the
  one fold shared by both plain-`&mut SearchStatistics` sinks. Folds
  `smt_elapsed`, `smt_queries` (on `reached_solver`) and `smt_equivalent` (on
  `proved_equivalent`). It deliberately does **not** touch `candidates_passed_fast`,
  because what counts as a fast pass is per-path policy.
- **`record_verification`** (symbolic) now folds through `fold_into`, keeping its
  own `candidates_passed_fast += 1` under `reached_solver`. Behavior-preserving.
- **MCMC** applies `verification_tally` + `fold_into`, keeping its own
  `candidates_passed_fast` policy (counted earlier, at the concrete-test stage
  before the cost gate) plus its improvement/refutation bookkeeping.
- The **parallel enumerative** path is unchanged — it keeps applying
  `verification_tally` to its *atomic* counters, the one genuinely different sink.
- The **LLM-assisted** flow is out of scope: it uses a byte-count metric and its
  own `timings`, not an `EquivalenceResult` verdict.

This is a two-adapter seam (symbolic + stochastic), not indirection: it passes
the "one adapter = hypothetical, two = real" test.

## Tests that validate it

TDD, red → green. New unit tests at the seam:

- `fold_into_counts_solver_reaching_equivalent_candidate` — folds solver time, one
  query, one proven equivalence.
- `fold_into_leaves_candidates_passed_fast_untouched` — the linchpin contract that
  lets both paths share the fold without double-counting.
- `fold_into_ignores_candidates_that_never_reached_the_solver` — a pre-solver
  refutation folds only its (zero) solver time.
- `stochastic_search_accounts_solver_proven_improvement_through_the_seam` — pins
  the MCMC equivalent-path accounting through the seam, mirroring the existing
  refuted-path test.

The pre-existing `record_verification_*` and MCMC counter tests
(`stochastic_counts_fast_passing_non_improving_proposal_as_cost_pruned`,
`stochastic_search_does_not_count_pre_smt_refutation_as_smt_query`,
`stochastic_search_does_not_accept_smt_refuted_cheaper_proposal`) guard behavior
preservation.

## Verification

`./ci_check.sh` passes end-to-end (fmt, build, cross-compiled test binaries,
full unit + integration suite, `test_all.sh`). Lib suite: **1433 passed / 0
failed** (baseline 1429 + 4 new tests). `cargo clippy` clean on the touched
files. No ADRs re-litigated.
