### PR TITLE
Extract downstream liveness scanning into a deep library module

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use s11::search::parallel::{ParallelConfig, run_parallel_search};
 use s11::search::{EnumerativeSearch, SearchAlgorithm, StochasticSearch, SymbolicSearch};
 use s11::semantics::LiveOut;
 use s11::semantics::cost::CostMetric;
+use s11::validation::downstream::{ScanStep, scan_flags_live, scan_regs_live};
 #[allow(unused_imports)]
 use s11::{assembler, elf_patcher, ir, isa, parser, search, semantics, validation};
 
@@ -1860,49 +1861,53 @@ fn convert_to_ir(instructions: &capstone::Instructions) -> Result<Vec<Instructio
     Ok(ir_instructions)
 }
 
+/// Resolve the in-section fall-through suffix after an optimization window
+/// ending at `end_addr`. `None` means there is no analyzable suffix — the
+/// window already reaches the section end, or the bytes are unavailable — in
+/// which case downstream liveness is unknown and the caller keeps every
+/// candidate live (the conservative default). The four `*_from_section`
+/// wrappers below all funnel through here rather than repeating the suffix math.
+fn fall_through_suffix(
+    patcher: &ElfPatcher,
+    section: &TextSection,
+    end_addr: u64,
+) -> Option<Vec<u8>> {
+    let section_end = section.virtual_addr + section.size;
+    if end_addr >= section_end {
+        return None;
+    }
+    let suffix_window = AddressWindow {
+        start: end_addr,
+        end: section_end,
+    };
+    patcher.get_instructions_in_window(&suffix_window).ok()
+}
+
+/// Decode one AArch64 Capstone `(mnemonic, op_str)` pair into a downstream scan
+/// step, reusing the shared Capstone→IR bridge so the fall-through scan honors
+/// exactly the same supported-mnemonic set as the optimizer.
+fn aarch64_scan_step(mnemonic: &str, op_str: &str) -> ScanStep<Instruction> {
+    match convert_capstone_op(mnemonic, op_str) {
+        ConvertOutcome::Instruction(instr) => ScanStep::Decoded(instr),
+        ConvertOutcome::Skip => ScanStep::Skipped,
+        ConvertOutcome::Unsupported(_) => ScanStep::Opaque,
+    }
+}
+
 fn aarch64_downstream_flags_live_from_bytes(cs: &Capstone, bytes: &[u8], start_addr: u64) -> bool {
-    if bytes.is_empty() {
-        return true;
-    }
-
-    let mut remaining = bytes;
-    let mut address = start_addr;
-
-    while !remaining.is_empty() {
-        let Ok(instructions) = cs.disasm_count(remaining, address, 1) else {
-            return true;
-        };
-        let Some(instruction) = instructions.iter().next() else {
-            return true;
-        };
-        let instruction_len = instruction.bytes().len();
-        if instruction_len == 0 || instruction_len > remaining.len() {
-            return true;
-        }
-
-        let mnemonic = instruction.mnemonic().unwrap_or("");
-        let op_str = instruction.op_str().unwrap_or("");
-        match convert_capstone_op(mnemonic, op_str) {
-            ConvertOutcome::Instruction(instr) => {
-                if validation::live_out::flags_read_before_overwrite_after_window(&[instr]) {
-                    return true;
-                }
-                if instr.modifies_flags() {
-                    return false;
-                }
-                if instr.is_terminator() {
-                    return true;
-                }
-            }
-            ConvertOutcome::Skip => {}
-            ConvertOutcome::Unsupported(_) => return true,
-        }
-
-        remaining = &remaining[instruction_len..];
-        address += instruction_len as u64;
-    }
-
-    false
+    scan_flags_live(
+        cs,
+        bytes,
+        start_addr,
+        aarch64_scan_step,
+        |instr: &Instruction| {
+            validation::live_out::flags_read_before_overwrite_after_window(std::slice::from_ref(
+                instr,
+            ))
+        },
+        |instr: &Instruction| instr.modifies_flags(),
+        |instr: &Instruction| instr.is_terminator(),
+    )
 }
 
 fn aarch64_downstream_flags_live_from_section(
@@ -1911,20 +1916,10 @@ fn aarch64_downstream_flags_live_from_section(
     end_addr: u64,
     cs: &Capstone,
 ) -> bool {
-    let section_end = section.virtual_addr + section.size;
-    if end_addr >= section_end {
-        return true;
+    match fall_through_suffix(patcher, section, end_addr) {
+        Some(bytes) => aarch64_downstream_flags_live_from_bytes(cs, &bytes, end_addr),
+        None => true,
     }
-
-    let suffix_window = AddressWindow {
-        start: end_addr,
-        end: section_end,
-    };
-    let Ok(bytes) = patcher.get_instructions_in_window(&suffix_window) else {
-        return true;
-    };
-
-    aarch64_downstream_flags_live_from_bytes(cs, &bytes, end_addr)
 }
 
 /// Compute the subset of `candidates` (registers the window writes) that are
@@ -1958,82 +1953,17 @@ fn aarch64_downstream_regs_live_from_bytes(
     start_addr: u64,
     candidates: &semantics::live_out::RegisterSet<Register>,
 ) -> semantics::live_out::RegisterSet<Register> {
-    use semantics::live_out::RegisterSet;
-
-    // Registers not yet proven dead. We start with everything the window wrote
-    // and remove a register only on a provable full overwrite.
-    let mut undecided: Vec<Register> = candidates.iter().copied().collect();
-    let mut live = RegisterSet::<Register>::empty();
-
-    if undecided.is_empty() {
-        return live;
-    }
-
-    // Pins every still-undecided candidate live and clears the worklist.
-    macro_rules! pin_all_remaining_live {
-        () => {{
-            for &reg in &undecided {
-                live.add(reg);
-            }
-            return live;
-        }};
-    }
-
-    if bytes.is_empty() {
-        pin_all_remaining_live!();
-    }
-
-    let mut remaining = bytes;
-    let mut address = start_addr;
-
-    while !remaining.is_empty() && !undecided.is_empty() {
-        let Ok(instructions) = cs.disasm_count(remaining, address, 1) else {
-            pin_all_remaining_live!();
-        };
-        let Some(instruction) = instructions.iter().next() else {
-            pin_all_remaining_live!();
-        };
-        let instruction_len = instruction.bytes().len();
-        if instruction_len == 0 || instruction_len > remaining.len() {
-            pin_all_remaining_live!();
-        }
-
-        let mnemonic = instruction.mnemonic().unwrap_or("");
-        let op_str = instruction.op_str().unwrap_or("");
-        match convert_capstone_op(mnemonic, op_str) {
-            ConvertOutcome::Instruction(instr) => {
-                if instr.is_terminator() {
-                    // Terminators (incl. B/BR/BL/RET) hand control out of the
-                    // window; any window-written register may be observed
-                    // downstream or across the call/ret ABI — pin all live.
-                    pin_all_remaining_live!();
-                }
-                undecided.retain(
-                    |&reg| match validation::live_out::aarch64_reg_downstream_liveness(
-                        reg,
-                        std::slice::from_ref(&instr),
-                    ) {
-                        validation::live_out::DownstreamRegLiveness::Read => {
-                            live.add(reg);
-                            false
-                        }
-                        validation::live_out::DownstreamRegLiveness::Dead => false,
-                        validation::live_out::DownstreamRegLiveness::Uncertain => true,
-                    },
-                );
-            }
-            ConvertOutcome::Skip => {}
-            ConvertOutcome::Unsupported(_) => pin_all_remaining_live!(),
-        }
-
-        remaining = &remaining[instruction_len..];
-        address += instruction_len as u64;
-    }
-
-    // Reached the end of the in-region suffix without resolving these
-    // candidates: control falls through to whatever lies past the analyzed
-    // bytes, so keep them live.
-    pin_all_remaining_live!();
+    scan_regs_live(
+        cs,
+        bytes,
+        start_addr,
+        candidates,
+        aarch64_scan_step,
+        |instr: &Instruction| instr.is_terminator(),
+        |reg: Register, instr: &Instruction| {
+            validation::live_out::aarch64_reg_downstream_liveness(reg, std::slice::from_ref(instr))
+        },
+    )
 }
 
 /// Section wrapper for `aarch64_downstream_regs_live_from_bytes`. Returns all
@@ -2046,69 +1976,42 @@ fn aarch64_downstream_regs_live_from_section(
     cs: &Capstone,
     candidates: &semantics::live_out::RegisterSet<Register>,
 ) -> semantics::live_out::RegisterSet<Register> {
-    let section_end = section.virtual_addr + section.size;
-    if end_addr >= section_end {
-        return candidates.clone();
+    match fall_through_suffix(patcher, section, end_addr) {
+        Some(bytes) => aarch64_downstream_regs_live_from_bytes(cs, &bytes, end_addr, candidates),
+        None => candidates.clone(),
     }
+}
 
-    let suffix_window = AddressWindow {
-        start: end_addr,
-        end: section_end,
-    };
-    let Ok(bytes) = patcher.get_instructions_in_window(&suffix_window) else {
-        return candidates.clone();
-    };
-
-    aarch64_downstream_regs_live_from_bytes(cs, &bytes, end_addr, candidates)
+/// Decode one x86 Capstone `(mnemonic, op_str)` pair into a downstream scan
+/// step. `nop` carries no observable state and is stepped over; anything the
+/// shared x86 IR does not model (including `call`/`ret`) is opaque and pins the
+/// remaining state live.
+fn x86_scan_step(mnemonic: &str, op_str: &str) -> ScanStep<isa::x86::X86Instruction> {
+    match x86_ir_from_mnemonic(mnemonic, op_str) {
+        Ok(Some(instr)) => ScanStep::Decoded(instr),
+        Ok(None) if mnemonic.eq_ignore_ascii_case("nop") => ScanStep::Skipped,
+        Ok(None) => ScanStep::Opaque,
+        Err(_) => ScanStep::Opaque,
+    }
 }
 
 fn x86_downstream_flags_live_from_bytes<I>(cs: &Capstone, bytes: &[u8], start_addr: u64) -> bool
 where
     I: isa::FlagsAnalysis<isa::x86::X86Instruction>,
 {
-    if bytes.is_empty() {
-        return true;
-    }
-
-    let mut remaining = bytes;
-    let mut address = start_addr;
-
-    while !remaining.is_empty() {
-        let Ok(instructions) = cs.disasm_count(remaining, address, 1) else {
-            return true;
-        };
-        let Some(instruction) = instructions.iter().next() else {
-            return true;
-        };
-        let instruction_len = instruction.bytes().len();
-        if instruction_len == 0 || instruction_len > remaining.len() {
-            return true;
-        }
-
-        let mnemonic = instruction.mnemonic().unwrap_or("");
-        let op_str = instruction.op_str().unwrap_or("");
-        match x86_ir_from_mnemonic(mnemonic, op_str) {
-            Ok(Some(instr)) => {
-                if <I as isa::FlagsAnalysis<isa::x86::X86Instruction>>::reads_flags(&instr) {
-                    return true;
-                }
-                if <I as isa::FlagsAnalysis<isa::x86::X86Instruction>>::modifies_flags(&instr) {
-                    return false;
-                }
-                if instr.is_terminator() {
-                    return true;
-                }
-            }
-            Ok(None) if mnemonic.eq_ignore_ascii_case("nop") => {}
-            Ok(None) => return true,
-            Err(_) => return true,
-        }
-
-        remaining = &remaining[instruction_len..];
-        address += instruction_len as u64;
-    }
-
-    false
+    scan_flags_live(
+        cs,
+        bytes,
+        start_addr,
+        x86_scan_step,
+        |instr: &isa::x86::X86Instruction| {
+            <I as isa::FlagsAnalysis<isa::x86::X86Instruction>>::reads_flags(instr)
+        },
+        |instr: &isa::x86::X86Instruction| {
+            <I as isa::FlagsAnalysis<isa::x86::X86Instruction>>::modifies_flags(instr)
+        },
+        |instr: &isa::x86::X86Instruction| instr.is_terminator(),
+    )
 }
 
 fn x86_downstream_flags_live_from_section(
@@ -2118,16 +2021,7 @@ fn x86_downstream_flags_live_from_section(
     end_addr: u64,
     cs: &Capstone,
 ) -> bool {
-    let section_end = section.virtual_addr + section.size;
-    if end_addr >= section_end {
-        return true;
-    }
-
-    let suffix_window = AddressWindow {
-        start: end_addr,
-        end: section_end,
-    };
-    let Ok(bytes) = patcher.get_instructions_in_window(&suffix_window) else {
+    let Some(bytes) = fall_through_suffix(patcher, section, end_addr) else {
         return true;
     };
 
@@ -2168,75 +2062,17 @@ fn x86_downstream_regs_live_from_bytes(
     start_addr: u64,
     candidates: &semantics::live_out::RegisterSet<isa::x86::X86Register>,
 ) -> semantics::live_out::RegisterSet<isa::x86::X86Register> {
-    use semantics::live_out::RegisterSet;
-
-    let mut undecided: Vec<isa::x86::X86Register> = candidates.iter().copied().collect();
-    let mut live = RegisterSet::<isa::x86::X86Register>::empty();
-
-    if undecided.is_empty() {
-        return live;
-    }
-
-    macro_rules! pin_all_remaining_live {
-        () => {{
-            for &reg in &undecided {
-                live.add(reg);
-            }
-            return live;
-        }};
-    }
-
-    if bytes.is_empty() {
-        pin_all_remaining_live!();
-    }
-
-    let mut remaining = bytes;
-    let mut address = start_addr;
-
-    while !remaining.is_empty() && !undecided.is_empty() {
-        let Ok(instructions) = cs.disasm_count(remaining, address, 1) else {
-            pin_all_remaining_live!();
-        };
-        let Some(instruction) = instructions.iter().next() else {
-            pin_all_remaining_live!();
-        };
-        let instruction_len = instruction.bytes().len();
-        if instruction_len == 0 || instruction_len > remaining.len() {
-            pin_all_remaining_live!();
-        }
-
-        let mnemonic = instruction.mnemonic().unwrap_or("");
-        let op_str = instruction.op_str().unwrap_or("");
-        match x86_ir_from_mnemonic(mnemonic, op_str) {
-            Ok(Some(instr)) => {
-                if instr.is_terminator() {
-                    pin_all_remaining_live!();
-                }
-                undecided.retain(|&reg| {
-                    match validation::live_out::x86_reg_downstream_liveness(
-                        reg,
-                        std::slice::from_ref(&instr),
-                    ) {
-                        validation::live_out::DownstreamRegLiveness::Read => {
-                            live.add(reg);
-                            false
-                        }
-                        validation::live_out::DownstreamRegLiveness::Dead => false,
-                        validation::live_out::DownstreamRegLiveness::Uncertain => true,
-                    }
-                });
-            }
-            Ok(None) if mnemonic.eq_ignore_ascii_case("nop") => {}
-            // Unsupported (incl. call/ret) or unparseable → cannot reason; pin live.
-            Ok(None) => pin_all_remaining_live!(),
-            Err(_) => pin_all_remaining_live!(),
-        }
-
-        remaining = &remaining[instruction_len..];
-        address += instruction_len as u64;
-    }
-
-    pin_all_remaining_live!();
+    scan_regs_live(
+        cs,
+        bytes,
+        start_addr,
+        candidates,
+        x86_scan_step,
+        |instr: &isa::x86::X86Instruction| instr.is_terminator(),
+        |reg: isa::x86::X86Register, instr: &isa::x86::X86Instruction| {
+            validation::live_out::x86_reg_downstream_liveness(reg, std::slice::from_ref(instr))
+        },
+    )
 }
 
 /// Section wrapper for `x86_downstream_regs_live_from_bytes`. Returns all
@@ -2250,16 +2086,7 @@ fn x86_downstream_regs_live_from_section(
     cs: &Capstone,
     candidates: &semantics::live_out::RegisterSet<isa::x86::X86Register>,
 ) -> semantics::live_out::RegisterSet<isa::x86::X86Register> {
-    let section_end = section.virtual_addr + section.size;
-    if end_addr >= section_end {
-        return candidates.clone();
-    }
-
-    let suffix_window = AddressWindow {
-        start: end_addr,
-        end: section_end,
-    };
-    let Ok(bytes) = patcher.get_instructions_in_window(&suffix_window) else {
+    let Some(bytes) = fall_through_suffix(patcher, section, end_addr) else {
         return candidates.clone();
     };
 

--- a/src/validation/downstream.rs
+++ b/src/validation/downstream.rs
@@ -1,0 +1,416 @@
+//! Downstream (fall-through) liveness scanning.
+//!
+//! When s11 optimizes a straight-line window inside a `.text` section, the
+//! live-out contract must keep alive any architectural state the *fall-through
+//! successor* can still observe. Computing that means walking the bytes that
+//! follow the window one instruction at a time, converting each to IR, and
+//! applying a per-instruction liveness rule until the answer is settled.
+//!
+//! That walk is identical across AArch64 and x86 and across the two things we
+//! scan for (condition flags, written registers); only two knobs vary:
+//!
+//! * how a Capstone `(mnemonic, op_str)` pair converts to the optimizer IR
+//!   (the AArch64 Capstone bridge vs. `x86_ir_from_mnemonic`), and
+//! * the per-instruction liveness rule applied to a decoded instruction.
+//!
+//! Both knobs are supplied by the caller as closures, so this module owns the
+//! shared scanning discipline once — including the soundness default that an
+//! *un-analyzable* suffix keeps everything live — instead of the four
+//! copy-pasted scanners the CLI used to carry.
+//!
+//! The per-instruction liveness primitives themselves live next door in
+//! [`super::live_out`] (`aarch64_reg_downstream_liveness`,
+//! `x86_reg_downstream_liveness`, `flags_read_before_overwrite_after_window`).
+
+use capstone::prelude::*;
+
+use super::live_out::DownstreamRegLiveness;
+use crate::isa::RegisterType;
+use crate::semantics::live_out::RegisterSet;
+
+/// One decoded step of a downstream suffix scan — the caller's `decode` closure
+/// maps a Capstone `(mnemonic, op_str)` pair into one of these.
+pub enum ScanStep<I> {
+    /// An instruction the optimizer IR can reason about.
+    Decoded(I),
+    /// A no-op with no observable reads or writes; stepped over.
+    Skipped,
+    /// An instruction we cannot reason about (unsupported by the IR, a decode
+    /// failure, or otherwise opaque). Forces the conservative "all live"
+    /// default: the scan can no longer prove anything downstream is dead.
+    Opaque,
+}
+
+/// Scan the fall-through suffix `bytes` (disassembled with `cs`, starting at
+/// `start_addr`) and decide whether the architecture's condition flags are
+/// *live* — i.e. some later instruction may read them before they are
+/// overwritten.
+///
+/// Returns `true` (flags live) conservatively whenever the scan cannot prove
+/// they are dead: an empty/undecodable suffix, an [`ScanStep::Opaque`]
+/// instruction, a terminator, or reaching the end of the analyzable bytes with
+/// no flag-writing instruction seen. Returns `false` only when a decoded
+/// instruction is proven to overwrite the flags before any read.
+///
+/// The three policy closures decode over a decoded instruction `I`:
+/// * `reads_flags` — does it read the flags before overwriting them?
+/// * `modifies_flags` — does it (fully) overwrite the flags?
+/// * `is_terminator` — does it hand control out of the linear suffix?
+pub fn scan_flags_live<I>(
+    cs: &Capstone,
+    bytes: &[u8],
+    start_addr: u64,
+    mut decode: impl FnMut(&str, &str) -> ScanStep<I>,
+    reads_flags: impl Fn(&I) -> bool,
+    modifies_flags: impl Fn(&I) -> bool,
+    is_terminator: impl Fn(&I) -> bool,
+) -> bool {
+    if bytes.is_empty() {
+        return true;
+    }
+
+    let mut remaining = bytes;
+    let mut address = start_addr;
+
+    while !remaining.is_empty() {
+        let Ok(instructions) = cs.disasm_count(remaining, address, 1) else {
+            return true;
+        };
+        let Some(instruction) = instructions.iter().next() else {
+            return true;
+        };
+        let instruction_len = instruction.bytes().len();
+        if instruction_len == 0 || instruction_len > remaining.len() {
+            return true;
+        }
+
+        let mnemonic = instruction.mnemonic().unwrap_or("");
+        let op_str = instruction.op_str().unwrap_or("");
+        match decode(mnemonic, op_str) {
+            ScanStep::Decoded(instr) => {
+                if reads_flags(&instr) {
+                    return true;
+                }
+                if modifies_flags(&instr) {
+                    return false;
+                }
+                if is_terminator(&instr) {
+                    return true;
+                }
+            }
+            ScanStep::Skipped => {}
+            ScanStep::Opaque => return true,
+        }
+
+        remaining = &remaining[instruction_len..];
+        address += instruction_len as u64;
+    }
+
+    false
+}
+
+/// Compute the subset of `candidates` (registers the window writes) that are
+/// provably *live* in the fall-through suffix `bytes`.
+///
+/// **Soundness discipline.** A candidate register stays live unless the scan can
+/// prove it dead. A candidate `R` is dropped only when the first instruction
+/// mentioning it fully overwrites it before reading it
+/// ([`DownstreamRegLiveness::Dead`]). Every other situation keeps `R` live: a
+/// read before overwrite ([`DownstreamRegLiveness::Read`]), a terminator, an
+/// [`ScanStep::Opaque`] instruction, an undecodable byte, or reaching the end
+/// of the analyzable suffix with the candidate still undecided.
+///
+/// [`ScanStep::Skipped`] instructions neither read nor write and are stepped
+/// over.
+pub fn scan_regs_live<R, I>(
+    cs: &Capstone,
+    bytes: &[u8],
+    start_addr: u64,
+    candidates: &RegisterSet<R>,
+    mut decode: impl FnMut(&str, &str) -> ScanStep<I>,
+    is_terminator: impl Fn(&I) -> bool,
+    reg_liveness: impl Fn(R, &I) -> DownstreamRegLiveness,
+) -> RegisterSet<R>
+where
+    R: RegisterType,
+{
+    // Registers not yet proven dead. We start with everything the window wrote
+    // and remove a register only on a provable full overwrite.
+    let mut undecided: Vec<R> = candidates.iter().copied().collect();
+    let mut live = RegisterSet::<R>::empty();
+
+    if undecided.is_empty() {
+        return live;
+    }
+
+    // Pins every still-undecided candidate live and returns.
+    macro_rules! pin_all_remaining_live {
+        () => {{
+            for &reg in &undecided {
+                live.add(reg);
+            }
+            return live;
+        }};
+    }
+
+    if bytes.is_empty() {
+        pin_all_remaining_live!();
+    }
+
+    let mut remaining = bytes;
+    let mut address = start_addr;
+
+    while !remaining.is_empty() && !undecided.is_empty() {
+        let Ok(instructions) = cs.disasm_count(remaining, address, 1) else {
+            pin_all_remaining_live!();
+        };
+        let Some(instruction) = instructions.iter().next() else {
+            pin_all_remaining_live!();
+        };
+        let instruction_len = instruction.bytes().len();
+        if instruction_len == 0 || instruction_len > remaining.len() {
+            pin_all_remaining_live!();
+        }
+
+        let mnemonic = instruction.mnemonic().unwrap_or("");
+        let op_str = instruction.op_str().unwrap_or("");
+        match decode(mnemonic, op_str) {
+            ScanStep::Decoded(instr) => {
+                if is_terminator(&instr) {
+                    // Control leaves the window; any window-written register may
+                    // be observed downstream or across the call/ret ABI.
+                    pin_all_remaining_live!();
+                }
+                undecided.retain(|&reg| match reg_liveness(reg, &instr) {
+                    DownstreamRegLiveness::Read => {
+                        live.add(reg);
+                        false
+                    }
+                    DownstreamRegLiveness::Dead => false,
+                    DownstreamRegLiveness::Uncertain => true,
+                });
+            }
+            ScanStep::Skipped => {}
+            ScanStep::Opaque => pin_all_remaining_live!(),
+        }
+
+        remaining = &remaining[instruction_len..];
+        address += instruction_len as u64;
+    }
+
+    // Reached the end of the analyzable suffix without resolving these
+    // candidates: control falls through to whatever lies past the analyzed
+    // bytes, so keep them live.
+    pin_all_remaining_live!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::Register;
+
+    /// AArch64 `NOP` (`0xD503201F`, little-endian). Decodes to exactly one
+    /// instruction so the scripted `decode` closure is invoked once per copy.
+    const AARCH64_NOP: [u8; 4] = [0x1F, 0x20, 0x03, 0xD5];
+
+    fn aarch64_capstone() -> Capstone {
+        Capstone::new()
+            .arm64()
+            .mode(capstone::arch::arm64::ArchMode::Arm)
+            .build()
+            .expect("test capstone should build")
+    }
+
+    fn nops(count: usize) -> Vec<u8> {
+        AARCH64_NOP.repeat(count)
+    }
+
+    /// A synthetic decoded instruction whose flag/terminator behavior the test
+    /// dictates directly, decoupling the scan's control flow from any real IR
+    /// converter.
+    #[derive(Clone)]
+    struct FakeInsn {
+        reads_flags: bool,
+        modifies_flags: bool,
+        terminator: bool,
+        read_regs: Vec<Register>,
+        dead_regs: Vec<Register>,
+    }
+
+    impl FakeInsn {
+        fn inert() -> Self {
+            FakeInsn {
+                reads_flags: false,
+                modifies_flags: false,
+                terminator: false,
+                read_regs: Vec::new(),
+                dead_regs: Vec::new(),
+            }
+        }
+    }
+
+    /// Turn a fixed script of steps into a `decode` closure that yields one per
+    /// call, in order.
+    fn scripted(steps: Vec<ScanStep<FakeInsn>>) -> impl FnMut(&str, &str) -> ScanStep<FakeInsn> {
+        let mut it = steps.into_iter();
+        move |_mnemonic, _op_str| it.next().expect("decode called more times than scripted")
+    }
+
+    fn flags_scan(bytes: &[u8], steps: Vec<ScanStep<FakeInsn>>) -> bool {
+        let cs = aarch64_capstone();
+        scan_flags_live(
+            &cs,
+            bytes,
+            0x1000,
+            scripted(steps),
+            |i: &FakeInsn| i.reads_flags,
+            |i: &FakeInsn| i.modifies_flags,
+            |i: &FakeInsn| i.terminator,
+        )
+    }
+
+    #[test]
+    fn flags_live_for_empty_suffix() {
+        assert!(flags_scan(&[], vec![]));
+    }
+
+    #[test]
+    fn flags_live_when_instruction_reads_flags() {
+        let step = ScanStep::Decoded(FakeInsn {
+            reads_flags: true,
+            ..FakeInsn::inert()
+        });
+        assert!(flags_scan(&nops(1), vec![step]));
+    }
+
+    #[test]
+    fn flags_dead_when_instruction_modifies_flags_before_read() {
+        let step = ScanStep::Decoded(FakeInsn {
+            modifies_flags: true,
+            ..FakeInsn::inert()
+        });
+        assert!(!flags_scan(&nops(1), vec![step]));
+    }
+
+    #[test]
+    fn flags_live_on_terminator() {
+        let step = ScanStep::Decoded(FakeInsn {
+            terminator: true,
+            ..FakeInsn::inert()
+        });
+        assert!(flags_scan(&nops(1), vec![step]));
+    }
+
+    #[test]
+    fn flags_live_on_opaque_instruction() {
+        assert!(flags_scan(&nops(1), vec![ScanStep::Opaque]));
+    }
+
+    #[test]
+    fn flags_dead_when_suffix_clean_to_end() {
+        // A single non-flag, non-terminator instruction then the suffix ends:
+        // nothing can read the flags, so they are dead.
+        assert!(!flags_scan(
+            &nops(1),
+            vec![ScanStep::Decoded(FakeInsn::inert())]
+        ));
+    }
+
+    #[test]
+    fn flags_scan_steps_over_skipped() {
+        // First step is a NOP (Skipped); the second overwrites the flags.
+        let steps = vec![
+            ScanStep::Skipped,
+            ScanStep::Decoded(FakeInsn {
+                modifies_flags: true,
+                ..FakeInsn::inert()
+            }),
+        ];
+        assert!(!flags_scan(&nops(2), steps));
+    }
+
+    fn regset(regs: &[Register]) -> RegisterSet<Register> {
+        RegisterSet::from_registers(regs.to_vec())
+    }
+
+    fn regs_scan(
+        bytes: &[u8],
+        candidates: &[Register],
+        steps: Vec<ScanStep<FakeInsn>>,
+    ) -> RegisterSet<Register> {
+        let cs = aarch64_capstone();
+        scan_regs_live(
+            &cs,
+            bytes,
+            0x1000,
+            &regset(candidates),
+            scripted(steps),
+            |i: &FakeInsn| i.terminator,
+            |reg: Register, i: &FakeInsn| {
+                if i.read_regs.contains(&reg) {
+                    DownstreamRegLiveness::Read
+                } else if i.dead_regs.contains(&reg) {
+                    DownstreamRegLiveness::Dead
+                } else {
+                    DownstreamRegLiveness::Uncertain
+                }
+            },
+        )
+    }
+
+    fn sorted(set: &RegisterSet<Register>) -> Vec<Register> {
+        let mut regs: Vec<Register> = set.iter().copied().collect();
+        regs.sort_by_key(|r| r.index());
+        regs
+    }
+
+    #[test]
+    fn regs_empty_when_no_candidates() {
+        // Even with a modifying suffix, an empty candidate set stays empty.
+        let out = regs_scan(&nops(1), &[], vec![ScanStep::Opaque]);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn regs_pin_all_on_empty_suffix() {
+        let out = regs_scan(&[], &[Register::X0, Register::X1], vec![]);
+        assert_eq!(sorted(&out), vec![Register::X0, Register::X1]);
+    }
+
+    #[test]
+    fn regs_pin_all_on_terminator() {
+        let step = ScanStep::Decoded(FakeInsn {
+            terminator: true,
+            ..FakeInsn::inert()
+        });
+        let out = regs_scan(&nops(1), &[Register::X0, Register::X1], vec![step]);
+        assert_eq!(sorted(&out), vec![Register::X0, Register::X1]);
+    }
+
+    #[test]
+    fn regs_pin_all_on_opaque() {
+        let out = regs_scan(
+            &nops(1),
+            &[Register::X0, Register::X1],
+            vec![ScanStep::Opaque],
+        );
+        assert_eq!(sorted(&out), vec![Register::X0, Register::X1]);
+    }
+
+    #[test]
+    fn regs_classify_read_dead_and_uncertain() {
+        // X0 read (live), X1 fully overwritten (dead), X2 undecided → pinned
+        // live when the suffix ends.
+        let step = ScanStep::Decoded(FakeInsn {
+            read_regs: vec![Register::X0],
+            dead_regs: vec![Register::X1],
+            ..FakeInsn::inert()
+        });
+        let out = regs_scan(
+            &nops(1),
+            &[Register::X0, Register::X1, Register::X2],
+            vec![step],
+        );
+        assert_eq!(sorted(&out), vec![Register::X0, Register::X2]);
+    }
+}

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -1,5 +1,6 @@
 //! Validation utilities for fast equivalence checking
 
+pub mod downstream;
 pub mod live_out;
 pub mod random;
 


### PR DESCRIPTION
## Refactoring goal

An **improve-codebase-architecture** audit flagged the densest, highest-divergence-risk duplication in the tree: four copy-pasted downstream fall-through liveness scanners in `src/main.rs` (~412 LOC) — one per `{AArch64, x86} × {flags, registers}`. Each paired an identical *disassemble-one-instruction* walk with a near-verbatim "conservatively keep everything live" default, the four `*_from_section` wrappers repeated the same suffix-window math, and the whole cluster — core **live-out contract** logic (see `CONTEXT.md`) — was trapped in the binary crate, testable only through `main.rs`'s private test module.

This is a **deepening** refactor: consolidate a lot of behavior behind a small interface, at a clean seam, testable through that interface.

## What changed

New library module **`validation::downstream`**, placed beside the per-instruction liveness primitives it already leaned on (`aarch64_reg_downstream_liveness`, `x86_reg_downstream_liveness`, `flags_read_before_overwrite_after_window`):

- `scan_flags_live` and `scan_regs_live` own the byte walk **once**, taking the only two things that vary — how a Capstone `(mnemonic, op_str)` pair converts to IR, and the per-instruction liveness rule — as closures via a small `ScanStep<I>` decode result.
- The eight `main.rs` functions become **thin arch adapters** (signatures unchanged), so the existing scanner tests keep exercising them.
- The four section wrappers now funnel through a single `fall_through_suffix` helper instead of repeating the suffix math.

**Net:** `main.rs` loses 173 lines; the scanning discipline lives once behind a small, library-testable interface (`main.rs` −272/+99; new module +416 incl. tests).

## Tests (TDD)

Built test-first at the new seam. Added **12 unit tests** in `validation::downstream` that drive the walk with *scripted decode closures* independent of the real converters, pinning the soundness defaults:

- flags: empty / opaque / terminator / clean-to-end / reads / modifies / steps-over-skipped
- regs: empty candidates / empty suffix / terminator / opaque all pin live; Read→live, Dead→killed, Uncertain→pinned-at-end

The red→green cycle was verified by temporarily breaking the empty-suffix flags default and the `Dead`-kill rule (exactly the corresponding tests failed) then reverting.

## Verification

- `./ci_check.sh` — **all green**: fmt, build, test-binary cross-compile, full unit+integration suite, `test_all.sh`.
- 104 binary unit tests (incl. the 21 pre-existing downstream tests, unchanged — the regression net), 1441 library tests, `cargo clippy` clean.

Behavior is preserved; the eight public scanner signatures are unchanged.