### PR TITLE
Deepen SearchConfig with a solver-timeout resolution seam

### DIFF
--- a/src/search/config.rs
+++ b/src/search/config.rs
@@ -487,6 +487,40 @@ impl SearchConfig {
         self.x86_same_count_code_size_allowed = allowed;
         self
     }
+
+    /// Per-query SMT solver timeout, resolving the fallback when unset.
+    ///
+    /// Single home for the fallback used when [`solver_timeout`] is `None`;
+    /// the search backends resolve the timeout here rather than each repeating
+    /// the literal. The fallback is `5s` — the value every backend used before
+    /// this seam existed; note it differs from the `30s` the default config
+    /// ships in the `Some` field, and only applies when a caller explicitly
+    /// clears the timeout.
+    ///
+    /// [`solver_timeout`]: Self::solver_timeout
+    pub fn solver_timeout(&self) -> Duration {
+        self.solver_timeout.unwrap_or(Duration::from_secs(5))
+    }
+
+    /// Per-query SMT solver timeout clamped to the remaining search budget.
+    ///
+    /// `elapsed` is how long the overall search has been running. The result
+    /// is [`solver_timeout`](Self::solver_timeout) capped at the time left
+    /// before [`timeout`](Self::timeout) elapses (unbounded when `timeout` is
+    /// `None`). Returns `None` when the budget is exhausted: Z3 timeouts are
+    /// configured in whole milliseconds, so a sub-millisecond remainder cannot
+    /// be represented usefully and is treated as exhausted.
+    ///
+    /// All SMT-driven backends resolve their per-query timeout here so the
+    /// budget-clamping rule cannot drift between them.
+    pub fn solver_timeout_within_budget(&self, elapsed: Duration) -> Option<Duration> {
+        let solver_timeout = self.solver_timeout();
+        let timeout = match self.timeout {
+            Some(search_timeout) => solver_timeout.min(search_timeout.checked_sub(elapsed)?),
+            None => solver_timeout,
+        };
+        (timeout.as_millis() > 0).then_some(timeout)
+    }
 }
 
 #[cfg(test)]
@@ -597,6 +631,90 @@ mod tests {
 
         let unset = SearchConfig::default().with_solver_timeout_option(None);
         assert_eq!(unset.solver_timeout, None);
+    }
+
+    #[test]
+    fn solver_timeout_resolves_default_fallback() {
+        // Default config ships an explicit solver timeout.
+        assert_eq!(
+            SearchConfig::default().solver_timeout(),
+            Duration::from_secs(30)
+        );
+        // An explicit value is returned verbatim.
+        assert_eq!(
+            SearchConfig::default()
+                .with_solver_timeout(Duration::from_millis(250))
+                .solver_timeout(),
+            Duration::from_millis(250)
+        );
+        // When unset, the shared fallback is 5s (the value every backend used).
+        assert_eq!(
+            SearchConfig::default()
+                .with_solver_timeout_option(None)
+                .solver_timeout(),
+            Duration::from_secs(5)
+        );
+    }
+
+    #[test]
+    fn solver_timeout_within_budget_clamps_to_remaining_search_time() {
+        // Solver timeout below the remaining budget is used unchanged.
+        let solver_smaller = SearchConfig::default()
+            .with_timeout(Duration::from_secs(10))
+            .with_solver_timeout(Duration::from_millis(250));
+        assert_eq!(
+            solver_smaller.solver_timeout_within_budget(Duration::from_secs(1)),
+            Some(Duration::from_millis(250))
+        );
+
+        // Solver timeout larger than the remaining budget is clamped down.
+        let capped = SearchConfig::default()
+            .with_timeout(Duration::from_millis(100))
+            .with_solver_timeout(Duration::from_secs(1));
+        assert_eq!(
+            capped.solver_timeout_within_budget(Duration::from_millis(40)),
+            Some(Duration::from_millis(60))
+        );
+
+        // Exactly-exhausted budget yields None.
+        assert_eq!(
+            capped.solver_timeout_within_budget(Duration::from_millis(100)),
+            None
+        );
+
+        // A sub-millisecond remainder cannot be represented as a Z3 timeout,
+        // so it is treated as exhausted.
+        assert_eq!(
+            capped.solver_timeout_within_budget(Duration::from_micros(99_500)),
+            None
+        );
+
+        // Over-elapsed (elapsed beyond the deadline) is also exhausted.
+        assert_eq!(
+            capped.solver_timeout_within_budget(Duration::from_millis(250)),
+            None
+        );
+    }
+
+    #[test]
+    fn solver_timeout_within_budget_is_unbounded_without_search_timeout() {
+        // No overall timeout: the resolved solver timeout is returned as-is
+        // regardless of elapsed time, falling back to 5s when unset.
+        let unbounded = SearchConfig::default()
+            .with_timeout_option(None)
+            .with_solver_timeout_option(None);
+        assert_eq!(
+            unbounded.solver_timeout_within_budget(Duration::from_secs(999)),
+            Some(Duration::from_secs(5))
+        );
+
+        let unbounded_explicit = SearchConfig::default()
+            .with_timeout_option(None)
+            .with_solver_timeout(Duration::from_secs(30));
+        assert_eq!(
+            unbounded_explicit.solver_timeout_within_budget(Duration::from_secs(999)),
+            Some(Duration::from_secs(30))
+        );
     }
 
     #[test]

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -258,7 +258,7 @@ fn verify_candidate<I>(
 where
     I: ISA + EnumerativeBackend<I>,
 {
-    let Some(smt_timeout) = candidate_solver_timeout(config, start) else {
+    let Some(smt_timeout) = config.solver_timeout_within_budget(start.elapsed()) else {
         // No millisecond-granularity SMT budget remains for this candidate, so
         // stop the whole parallel enumerative search rather than just this arm.
         shared.stop.store(true, Ordering::Relaxed);
@@ -395,29 +395,6 @@ where
             .expect("candidate pool must be populated")
             .instructions
     }
-}
-
-fn configured_solver_timeout(config: &SearchConfig) -> Duration {
-    config.solver_timeout.unwrap_or(Duration::from_secs(5))
-}
-
-fn candidate_solver_timeout_for_elapsed(
-    config: &SearchConfig,
-    elapsed: Duration,
-) -> Option<Duration> {
-    let solver_timeout = configured_solver_timeout(config);
-    let timeout = match config.timeout {
-        Some(search_timeout) => solver_timeout.min(search_timeout.checked_sub(elapsed)?),
-        None => solver_timeout,
-    };
-
-    // Z3 timeouts are configured in whole milliseconds; a sub-millisecond
-    // remainder cannot be represented usefully, so treat it as exhausted.
-    (timeout.as_millis() > 0).then_some(timeout)
-}
-
-fn candidate_solver_timeout(config: &SearchConfig, start: Instant) -> Option<Duration> {
-    candidate_solver_timeout_for_elapsed(config, start.elapsed())
 }
 
 fn evaluate_candidate<I>(
@@ -1763,56 +1740,6 @@ mod tests {
     }
 
     #[test]
-    fn candidate_solver_timeout_is_bounded_by_search_budget() {
-        let configured_solver = SearchConfig::default()
-            .with_timeout(std::time::Duration::from_secs(10))
-            .with_solver_timeout(std::time::Duration::from_millis(250));
-        assert_eq!(
-            candidate_solver_timeout_for_elapsed(
-                &configured_solver,
-                std::time::Duration::from_secs(1)
-            ),
-            Some(std::time::Duration::from_millis(250))
-        );
-
-        let capped_by_remaining_search = SearchConfig::default()
-            .with_timeout(std::time::Duration::from_millis(100))
-            .with_solver_timeout(std::time::Duration::from_secs(1));
-        assert_eq!(
-            candidate_solver_timeout_for_elapsed(
-                &capped_by_remaining_search,
-                std::time::Duration::from_millis(40)
-            ),
-            Some(std::time::Duration::from_millis(60))
-        );
-        assert_eq!(
-            candidate_solver_timeout_for_elapsed(
-                &capped_by_remaining_search,
-                std::time::Duration::from_millis(100)
-            ),
-            None
-        );
-        assert_eq!(
-            candidate_solver_timeout_for_elapsed(
-                &capped_by_remaining_search,
-                std::time::Duration::from_micros(99_500)
-            ),
-            None
-        );
-
-        let no_search_timeout = SearchConfig::default()
-            .with_timeout_option(None)
-            .with_solver_timeout_option(None);
-        assert_eq!(
-            candidate_solver_timeout_for_elapsed(
-                &no_search_timeout,
-                std::time::Duration::from_secs(999)
-            ),
-            Some(std::time::Duration::from_secs(5))
-        );
-    }
-
-    #[test]
     fn verify_candidate_stops_without_smt_when_search_budget_is_exhausted() {
         let target = vec![Instruction::MovImm {
             rd: Register::X0,
@@ -1998,7 +1925,7 @@ mod tests {
             &target,
             &candidate,
             &live_out,
-            configured_solver_timeout(&SearchConfig::default()),
+            SearchConfig::default().solver_timeout(),
         );
 
         assert_eq!(result.0, EquivalenceResult::Equivalent);
@@ -2007,7 +1934,7 @@ mod tests {
             &target,
             &candidate,
             &live_out.with_flags(true),
-            configured_solver_timeout(&SearchConfig::default()),
+            SearchConfig::default().solver_timeout(),
         );
 
         assert_ne!(flags_live_result.0, EquivalenceResult::Equivalent);

--- a/src/search/llm/mod.rs
+++ b/src/search/llm/mod.rs
@@ -311,7 +311,7 @@ fn verification_timeout_for_remaining(
     config: &SearchConfig,
     remaining: Duration,
 ) -> Option<Duration> {
-    let solver_timeout = config.solver_timeout.unwrap_or(Duration::from_secs(5));
+    let solver_timeout = config.solver_timeout();
     let timeout = remaining.min(solver_timeout);
     (timeout >= MIN_SMT_TIMEOUT).then_some(timeout)
 }

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -31,7 +31,7 @@ use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use std::marker::PhantomData;
 use std::sync::atomic::Ordering;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 /// Stochastic search using MCMC-style proposals and Metropolis cost
 /// acceptance, generic over ISA.
@@ -161,7 +161,6 @@ where
         // tail, so length-change proposals only vary the prefix length.
         let min_length = 1 + terminator_len;
         let max_length = target.len();
-        let smt_timeout = config.solver_timeout.unwrap_or(Duration::from_secs(5));
 
         for iteration in 0..config.stochastic.iterations {
             self.statistics.iterations = iteration + 1;
@@ -241,6 +240,14 @@ where
 
             let mut smt_refuted = false;
             if proposal_cost < best_cost {
+                let Some(smt_timeout) = config.solver_timeout_within_budget(start_time.elapsed())
+                else {
+                    // No millisecond-granularity SMT budget remains, so the
+                    // overall search deadline is effectively reached; stop
+                    // rather than hand Z3 a timeout it cannot honour. Mirrors
+                    // the enumerative path.
+                    break;
+                };
                 let (verdict, metrics) = <I as StochasticBackend<I>>::check_equivalence(
                     target,
                     &proposal,

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -743,6 +743,41 @@ mod tests {
     }
 
     #[test]
+    fn stochastic_smt_timeout_is_clamped_to_remaining_search_budget() {
+        // Solver timeout (30s) vastly exceeds the remaining search budget
+        // (50ms). The timeout handed to Z3 must be clamped to the budget rather
+        // than the full solver timeout — the deadline-respecting behaviour this
+        // seam restores to the MCMC path. Mirrors the symbolic backend's
+        // `symbolic_smt_timeout_is_clamped_to_remaining_search_budget`, using
+        // the deterministic `TimeoutProbeIsa` probe rather than wall-clock
+        // timing.
+        let (statistics, recorded_timeout) = run_timeout_probe_search_with(
+            SearchConfig::default()
+                .with_stochastic(
+                    StochasticConfig::default()
+                        .with_iterations(1)
+                        .with_test_count(0)
+                        .with_seed(1),
+                )
+                .with_timeout(Duration::from_millis(50))
+                .with_solver_timeout(Duration::from_secs(30)),
+            TIMEOUT_PROBE_EQUIVALENT,
+            true,
+        );
+
+        // The cheaper proposal still reaches the solver (the budget is not yet
+        // exhausted at ~0ms elapsed), so exactly one SMT query runs...
+        assert_eq!(statistics.smt_queries, 1);
+        // ...and the timeout it was handed is clamped to the ~50ms budget, not
+        // the 30s solver timeout.
+        let recorded = recorded_timeout.expect("an SMT query should have recorded a timeout");
+        assert!(
+            (1..=50).contains(&recorded),
+            "solver timeout should be clamped to the ~50ms budget, got {recorded}ms",
+        );
+    }
+
+    #[test]
     fn stochastic_search_falls_back_to_five_seconds_when_solver_timeout_unset() {
         let recorded_timeout = run_timeout_probe_search(
             SearchConfig::default()

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -17,7 +17,7 @@ use crate::search::symbolic::backend::SymbolicBackend;
 use crate::search::{Algorithm, SearchAlgorithm};
 use std::marker::PhantomData;
 use std::sync::atomic::Ordering;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 /// Whether the symbolic search loop should exit at the next checkpoint.
 ///
@@ -335,7 +335,7 @@ where
             return CandidateEval::Rejected;
         }
 
-        if self.verify_equivalence(target, &candidate, live_out, config) {
+        if self.verify_equivalence(target, &candidate, live_out, config, start_time) {
             *best_cost = candidate_cost;
             self.statistics.improvements_found += 1;
             CandidateEval::Improved {
@@ -354,8 +354,14 @@ where
         candidate: &[I::Instruction],
         live_out: &<I as SymbolicBackend<I>>::LiveOut,
         config: &SearchConfig,
+        start_time: Instant,
     ) -> bool {
-        let timeout = config.solver_timeout.unwrap_or(Duration::from_secs(5));
+        let Some(timeout) = config.solver_timeout_within_budget(start_time.elapsed()) else {
+            // No millisecond-granularity SMT budget remains: we cannot fund a
+            // query, so treat the candidate as unproven rather than hand Z3 a
+            // timeout it cannot honour.
+            return false;
+        };
         let width = <I as SymbolicBackend<I>>::width();
 
         let (verdict, metrics) = <I as SymbolicBackend<I>>::check_equivalence(
@@ -1354,7 +1360,13 @@ mod tests {
             width: crate::ir::RegisterWidth::X64,
         }];
 
-        assert!(search.verify_equivalence(&target, &candidate, &live_out, &config));
+        assert!(search.verify_equivalence(
+            &target,
+            &candidate,
+            &live_out,
+            &config,
+            std::time::Instant::now()
+        ));
     }
 
     #[test]
@@ -1373,7 +1385,13 @@ mod tests {
             imm: 1,
         }];
 
-        assert!(!search.verify_equivalence(&target, &candidate, &live_out, &config));
+        assert!(!search.verify_equivalence(
+            &target,
+            &candidate,
+            &live_out,
+            &config,
+            std::time::Instant::now()
+        ));
     }
 
     #[test]
@@ -1389,7 +1407,13 @@ mod tests {
         let target = [TestInstruction(1)];
         let candidate = [TestInstruction(2)];
 
-        assert!(!search.verify_equivalence(&target, &candidate, &(), &config));
+        assert!(!search.verify_equivalence(
+            &target,
+            &candidate,
+            &(),
+            &config,
+            std::time::Instant::now()
+        ));
 
         let stats = search.statistics();
         assert_eq!(stats.smt_queries, 1);
@@ -1409,9 +1433,38 @@ mod tests {
         let target = [TestInstruction(1)];
         let candidate = [TestInstruction(2)];
 
-        let _ = search.verify_equivalence(&target, &candidate, &(), &config);
+        let _ =
+            search.verify_equivalence(&target, &candidate, &(), &config, std::time::Instant::now());
 
         assert_eq!(TEST_RECORDED_TIMEOUT_MS.load(Ordering::SeqCst), 31);
+    }
+
+    #[test]
+    fn symbolic_smt_timeout_is_clamped_to_remaining_search_budget() {
+        let _guard = SYMBOLIC_INNER_LOOP_TEST_LOCK
+            .lock()
+            .expect("symbolic inner-loop test lock poisoned");
+        reset_symbolic_inner_loop_test_state();
+
+        // Solver timeout (30s) vastly exceeds the remaining search budget
+        // (50ms). The query handed to Z3 must be clamped to the budget rather
+        // than the full solver timeout — the behaviour this seam restores to
+        // the symbolic path.
+        let mut search: SymbolicSearch<TestIsa> = SymbolicSearch::new();
+        let config = SearchConfig::default()
+            .with_timeout(Duration::from_millis(50))
+            .with_solver_timeout(Duration::from_secs(30));
+        let target = [TestInstruction(1)];
+        let candidate = [TestInstruction(2)];
+
+        let _ =
+            search.verify_equivalence(&target, &candidate, &(), &config, std::time::Instant::now());
+
+        let recorded = TEST_RECORDED_TIMEOUT_MS.load(Ordering::SeqCst);
+        assert!(
+            (1..=50).contains(&recorded),
+            "solver timeout should be clamped to the ~50ms budget, got {recorded}ms",
+        );
     }
 
     #[test]
@@ -1427,12 +1480,24 @@ mod tests {
         reset_symbolic_inner_loop_test_state();
         let explicit_config =
             SearchConfig::default().with_solver_timeout(Duration::from_millis(17));
-        assert!(!search.verify_equivalence(&target, &candidate, &(), &explicit_config));
+        assert!(!search.verify_equivalence(
+            &target,
+            &candidate,
+            &(),
+            &explicit_config,
+            std::time::Instant::now()
+        ));
         assert_eq!(TEST_RECORDED_TIMEOUT_MS.load(Ordering::SeqCst), 17);
 
         reset_symbolic_inner_loop_test_state();
         let defaulted_config = SearchConfig::default().with_solver_timeout_option(None);
-        assert!(!search.verify_equivalence(&target, &candidate, &(), &defaulted_config));
+        assert!(!search.verify_equivalence(
+            &target,
+            &candidate,
+            &(),
+            &defaulted_config,
+            std::time::Instant::now()
+        ));
         assert_eq!(TEST_RECORDED_TIMEOUT_MS.load(Ordering::SeqCst), 5000);
     }
 
@@ -1449,7 +1514,13 @@ mod tests {
         let target = [TestInstruction(1)];
         let candidate = [TestInstruction(2)];
 
-        assert!(!search.verify_equivalence(&target, &candidate, &(), &config));
+        assert!(!search.verify_equivalence(
+            &target,
+            &candidate,
+            &(),
+            &config,
+            std::time::Instant::now()
+        ));
 
         let stats = search.statistics();
         assert_eq!(stats.smt_queries, 0);


### PR DESCRIPTION
## Refactoring goal

Architecture audit (via the `improve-codebase-architecture` skill) surfaced a **shallow, duplicated, and partially-buggy** surface: every SMT-driven search backend re-derived the per-query Z3 solver timeout, and the "clamp it to the remaining search budget" rule was implemented in only half of them.

This deepens that policy into a single tested seam on `SearchConfig`.

### The friction (before)

The rule *"resolve the per-query solver timeout (fall back to 5s when unset), then clamp it to the time left in the overall search budget"* lived in four places:

| Backend | resolves 5s fallback | clamps to remaining budget |
|---|---|---|
| `enumerative` | ✅ | ✅ |
| `llm` | ✅ | ✅ |
| `stochastic` (MCMC) | ✅ | ❌ |
| `symbolic` | ✅ | ❌ |

Consequences:
- **Latent correctness bug.** `stochastic` computed the solver timeout *once* before the loop and reused it every iteration; `symbolic` resolved it per query. Neither clamped to the remaining budget, so a nearly-exhausted `--timeout` could still hand Z3 the full solver timeout (default **30s**) on its final query and overrun the deadline.
- **Duplication.** The `5s` fallback literal was spelled out in all four backends, while the config default ships `30s` — one concept, several spellings.

### The deepening (after)

Two methods on `SearchConfig` (`src/search/config.rs`):

- `solver_timeout() -> Duration` — the fallback resolution; the single home for the `5s` literal.
- `solver_timeout_within_budget(elapsed) -> Option<Duration>` — resolution **+** clamp to the remaining budget **+** sub-millisecond exhaustion (returns `None` when no Z3-representable budget remains).

All four backends now resolve their per-query timeout through this seam:
- `stochastic` and `symbolic` **inherit the budget clamp** (the bug fix).
- `enumerative` and `llm` are **behaviour-preserving** — their sub-ms and 1ms floors already coincided, so routing them through the shared rule changes nothing observable.

**Deletion test:** delete the (formerly enumerative-only) helper and the clamp logic reappears — and was *missing* — across the other backends. It earns its keep at N=4.

## Tests (TDD, red → green)

Written test-first against the new seam's interface, then implemented to pass:

- `solver_timeout_resolves_default_fallback` — default (`30s`), explicit, and `None → 5s` fallback.
- `solver_timeout_within_budget_clamps_to_remaining_search_time` — solver-below-budget passthrough, clamp-to-remaining, exact exhaustion, sub-millisecond exhaustion, over-elapsed.
- `solver_timeout_within_budget_is_unbounded_without_search_timeout` — no overall timeout ⇒ solver timeout returned unclamped.
- `symbolic_smt_timeout_is_clamped_to_remaining_search_budget` — **behavioural proof of the fix**: with a 30s solver timeout and a 50ms search budget, the timeout handed to Z3 (recorded via the `TestIsa` mock) is clamped to ~50ms, not 30s.

The prior enumerative unit test that pinned this logic was migrated onto the new seam (its coverage is fully preserved by the `config.rs` tests).

## Verification

- `./ci_check.sh` passes end to end: `cargo fmt --check`, build, AArch64 test-binary build, full `cargo test` (unit + integration), and `test_all.sh`.
- `cargo clippy --all-targets` introduces no findings in the touched files.
- Full lib suite: 1457 passing.

No public CLI behaviour changes; the only observable change is that stochastic and symbolic search now respect the search deadline when timing out Z3.