### PR TITLE
Deepen MutationWeights with a mutation-type selection seam

### DIFF
--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -1576,16 +1576,12 @@ impl crate::isa::traits::ISAMutator<X86Instruction> for X86Mutator {
             return sequence.to_vec();
         }
         let mut out = sequence.to_vec();
-        let thresholds = self.weights.cumulative_thresholds();
         let r: f64 = rng.random();
-        if r < thresholds[0] {
-            self.mutate_operand(rng, &mut out);
-        } else if r < thresholds[1] {
-            self.mutate_opcode(rng, &mut out);
-        } else if r < thresholds[2] {
-            self.mutate_swap(rng, &mut out);
-        } else {
-            self.mutate_instruction(rng, &mut out);
+        match self.weights.select_index(r) {
+            0 => self.mutate_operand(rng, &mut out),
+            1 => self.mutate_opcode(rng, &mut out),
+            2 => self.mutate_swap(rng, &mut out),
+            _ => self.mutate_instruction(rng, &mut out),
         }
         out
     }

--- a/src/search/config.rs
+++ b/src/search/config.rs
@@ -165,15 +165,30 @@ impl Default for MutationWeights {
 }
 
 impl MutationWeights {
-    /// Get cumulative thresholds for random selection
-    pub fn cumulative_thresholds(&self) -> [f64; 4] {
+    /// Bucket a uniform draw `r ∈ [0, 1)` into one of the four mutation
+    /// categories, indexed in `MutationType` order: 0 = operand, 1 = opcode,
+    /// 2 = swap, 3 = instruction. A category is chosen with probability
+    /// proportional to its weight.
+    ///
+    /// Degenerate all-zero weights (total ≤ 0) collapse the whole interval
+    /// onto the last bucket instead of dividing by zero into NaN thresholds.
+    pub fn select_index(&self, r: f64) -> usize {
         let total = self.operand + self.opcode + self.swap + self.instruction;
-        [
-            self.operand / total,
-            (self.operand + self.opcode) / total,
-            (self.operand + self.opcode + self.swap) / total,
-            1.0,
-        ]
+        if total <= 0.0 {
+            return 3;
+        }
+        let t0 = self.operand / total;
+        let t1 = (self.operand + self.opcode) / total;
+        let t2 = (self.operand + self.opcode + self.swap) / total;
+        if r < t0 {
+            0
+        } else if r < t1 {
+            1
+        } else if r < t2 {
+            2
+        } else {
+            3
+        }
     }
 }
 
@@ -592,14 +607,74 @@ mod tests {
     }
 
     #[test]
-    fn test_mutation_weights_cumulative() {
-        let weights = MutationWeights::default();
-        let thresholds = weights.cumulative_thresholds();
+    fn select_index_partitions_unit_interval_by_weight() {
+        // Equal weights split [0, 1) into exact quarters (0.25/0.5/0.75 are
+        // all representable in f64), so bucket boundaries are unambiguous.
+        let weights = MutationWeights {
+            operand: 1.0,
+            opcode: 1.0,
+            swap: 1.0,
+            instruction: 1.0,
+        };
+        assert_eq!(weights.select_index(0.0), 0);
+        assert_eq!(weights.select_index(0.24), 0);
+        assert_eq!(weights.select_index(0.25), 1);
+        assert_eq!(weights.select_index(0.49), 1);
+        assert_eq!(weights.select_index(0.50), 2);
+        assert_eq!(weights.select_index(0.74), 2);
+        assert_eq!(weights.select_index(0.75), 3);
+        assert_eq!(weights.select_index(0.999), 3);
+    }
 
-        assert!(thresholds[0] > 0.0);
-        assert!(thresholds[0] < thresholds[1]);
-        assert!(thresholds[1] < thresholds[2]);
-        assert!((thresholds[3] - 1.0).abs() < 1e-10);
+    #[test]
+    fn select_index_default_weights_keep_operand_first() {
+        // Defaults: operand 0.50, opcode 0.16, swap 0.16, instruction 0.18
+        // (sum 1.0), so cutoffs sit at 0.50 / 0.66 / 0.82.
+        let weights = MutationWeights::default();
+        assert_eq!(weights.select_index(0.0), 0);
+        assert_eq!(weights.select_index(0.49), 0);
+        assert_eq!(weights.select_index(0.60), 1);
+        assert_eq!(weights.select_index(0.70), 2);
+        assert_eq!(weights.select_index(0.90), 3);
+    }
+
+    #[test]
+    fn select_index_honours_skewed_weights() {
+        // All mass on operand: every draw in [0, 1) buckets to operand (0).
+        let weights = MutationWeights {
+            operand: 1.0,
+            opcode: 0.0,
+            swap: 0.0,
+            instruction: 0.0,
+        };
+        assert_eq!(weights.select_index(0.0), 0);
+        assert_eq!(weights.select_index(0.5), 0);
+        assert_eq!(weights.select_index(0.999), 0);
+
+        // All mass on swap: every draw buckets to swap (2).
+        let swap_only = MutationWeights {
+            operand: 0.0,
+            opcode: 0.0,
+            swap: 1.0,
+            instruction: 0.0,
+        };
+        assert_eq!(swap_only.select_index(0.0), 2);
+        assert_eq!(swap_only.select_index(0.999), 2);
+    }
+
+    #[test]
+    fn select_index_with_zero_total_is_defined() {
+        // Degenerate all-zero weights must stay well-defined (no NaN from a
+        // divide-by-zero); the whole interval collapses to the last bucket.
+        let weights = MutationWeights {
+            operand: 0.0,
+            opcode: 0.0,
+            swap: 0.0,
+            instruction: 0.0,
+        };
+        assert_eq!(weights.select_index(0.0), 3);
+        assert_eq!(weights.select_index(0.5), 3);
+        assert_eq!(weights.select_index(0.999), 3);
     }
 
     #[test]

--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -156,17 +156,12 @@ impl Mutator {
 
     /// Select a mutation type based on weights
     pub fn select_mutation_type<R: RngExt>(&self, rng: &mut R) -> MutationType {
-        let thresholds = self.weights.cumulative_thresholds();
         let r: f64 = rng.random();
-
-        if r < thresholds[0] {
-            MutationType::Operand
-        } else if r < thresholds[1] {
-            MutationType::Opcode
-        } else if r < thresholds[2] {
-            MutationType::Swap
-        } else {
-            MutationType::Instruction
+        match self.weights.select_index(r) {
+            0 => MutationType::Operand,
+            1 => MutationType::Opcode,
+            2 => MutationType::Swap,
+            _ => MutationType::Instruction,
         }
     }
 
@@ -3496,6 +3491,58 @@ mod tests {
         assert!(opcode_count > 0);
         assert!(swap_count > 0);
         assert!(instr_count > 0);
+    }
+
+    #[test]
+    fn select_mutation_type_maps_each_weight_bucket_to_its_variant() {
+        // Concentrating all weight on one category forces `select_index` to
+        // that bucket for every draw, which pins the bucket-index -> variant
+        // mapping regardless of the RNG stream.
+        let cases = [
+            (
+                MutationWeights {
+                    operand: 1.0,
+                    opcode: 0.0,
+                    swap: 0.0,
+                    instruction: 0.0,
+                },
+                MutationType::Operand,
+            ),
+            (
+                MutationWeights {
+                    operand: 0.0,
+                    opcode: 1.0,
+                    swap: 0.0,
+                    instruction: 0.0,
+                },
+                MutationType::Opcode,
+            ),
+            (
+                MutationWeights {
+                    operand: 0.0,
+                    opcode: 0.0,
+                    swap: 1.0,
+                    instruction: 0.0,
+                },
+                MutationType::Swap,
+            ),
+            (
+                MutationWeights {
+                    operand: 0.0,
+                    opcode: 0.0,
+                    swap: 0.0,
+                    instruction: 1.0,
+                },
+                MutationType::Instruction,
+            ),
+        ];
+        let mut rng = rand::rng();
+        for (weights, expected) in cases {
+            let mutator = Mutator::new(vec![Register::X0], vec![0], weights);
+            for _ in 0..64 {
+                assert_eq!(mutator.select_mutation_type(&mut rng), expected);
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Goal

Architectural refactoring surfaced by the `improve-codebase-architecture` skill: turn a **shallow, leaky** piece of the stochastic search into a **deep** one — concentrate a scattered policy behind a small interface so it has one home and one test surface.

The rule *"map a uniform draw `r ∈ [0, 1)` onto a mutation category by weight"* leaked across **three** sites, none of which owned it:

- `MutationWeights::cumulative_thresholds()` (`src/search/config.rs`) produced a `[f64; 4]` whose **4th slot was always `1.0` and never read** — the consumers' final `else` branch never consults it (dead code).
- The AArch64 mutator `Mutator::select_mutation_type` (`src/search/stochastic/mutation.rs`) and the x86 mutator `X86Mutator::mutate` (`src/isa/x86.rs`) **each re-walked the thresholds** with their own hand-copied `if/else` chain and owned the bucket → action mapping.

Consequences of the leak:
- Adding a mutation category meant editing all three in lockstep.
- All-zero weights divided by zero into **NaN thresholds**, silently collapsing every draw onto the last bucket — an undocumented footgun.

## Change

Lift the bucketing onto `MutationWeights` as one deep method:

```rust
/// Bucket a uniform draw r ∈ [0, 1) into MutationType order:
/// 0 = operand, 1 = opcode, 2 = swap, 3 = instruction.
pub fn select_index(&self, r: f64) -> usize
```

It owns both the threshold walk and the degenerate-weights policy. Both ISA mutators now route through the seam and keep only the trivial index → variant / index → method mapping (a genuine per-ISA concern).

**Behaviour-preserving.** For every real (positive-total) weight set the result is byte-identical: the same threshold arithmetic and the **same single RNG draw**, so stochastic-search reproducibility is unchanged. The dead `[3] = 1.0` slot is removed, and the zero-total case is now NaN-free while returning the same last bucket it always did — now defined by a test rather than an accident.

**Deletion test:** passes — the selection policy becomes one unit-tested surface instead of a threshold producer plus two hand-copied consumers.

## Validating tests (TDD, red → green)

New unit tests, all pure (no RNG/thread/Z3 setup), written before the implementation:

- `select_index_partitions_unit_interval_by_weight` — equal weights split `[0,1)` into exact quarters (`0.25 / 0.5 / 0.75`), boundaries checked exactly.
- `select_index_default_weights_keep_operand_first` — default cutoffs at `0.50 / 0.66 / 0.82`.
- `select_index_honours_skewed_weights` — all mass on one category buckets every draw there.
- `select_index_with_zero_total_is_defined` — pins the degenerate all-zero policy (last bucket, no NaN).
- `select_mutation_type_maps_each_weight_bucket_to_its_variant` — pins the bucket-index → `MutationType` mapping through the public interface.

The existing statistical test `test_mutation_type_selection` and all x86 mutator tests continue to pass.

## Verification

`./ci_check.sh` green: formatting, build, cross-compiled test binaries, unit tests (**1462 passed / 0 failed**), integration tests, and `test_all.sh`. `cargo clippy` clean on the touched files.