### PR TITLE
feat(x86): add SETcc instruction family

### DIFF
--- a/docs/capability.md
+++ b/docs/capability.md
@@ -103,8 +103,11 @@ Rewritable straight-line mnemonic families:
 - Immediate-count rotates: `rol`, `ror`
 - Signed multiply: `imul` (2-operand `imul rd, rs` and 3-operand `imul rd, rs, imm`)
 - Load effective address: `lea` (register-base + displacement only)
-- Conditional byte sets: `set<cond>`
 - Conditional moves: `cmov<cond>`
+
+Synthesizable-only pseudo-instruction families:
+
+- Conditional full-width sets: `set<cond>`
 
 The data-movement/arithmetic/logical/comparison families have register and
 immediate forms where the x86 IR models them. `cmp` and `test` are
@@ -146,27 +149,28 @@ register-base + displacement form, `lea rd, [base + disp]`, computing
 `rd = base + disp` (wrapping at width). It is non-destructive (`base` is read,
 `rd` is purely written, like `mov`) and affects NO flags. The index*scale
 (`[base + index*scale + disp]`) and RIP/EIP-relative addressing forms are
-deferred and rejected as unsupported shapes. `set<cond>` and `cmov<cond>` read
-EFLAGS without modifying them. `cmov<cond>` has two register operands.
-`set<cond>` uses the interim native-width abstraction `rd = zext(condition)`:
-the IR, concrete interpreter, and SMT lowering fully overwrite `rd` with 0 or
-1. Architecturally, the encoded SETcc instruction writes only the low byte and
-preserves the rest of the register. This documented divergence remains until
-sub-register aliasing is represented end to end (#75).
+deferred and rejected as unsupported shapes. `cmov<cond>` reads EFLAGS without
+modifying them and has two register operands. The synthesizable-only
+`set<cond>` pseudo-family also reads EFLAGS without modifying them and uses the
+interim native-width abstraction `rd = zext(condition)`: the IR, concrete
+interpreter, and SMT lowering fully overwrite `rd` with 0 or 1. Candidate
+assembly emits architectural byte `SETcc` followed by same-register `MOVZX`
+into the 32-bit destination; that destination write also clears bits 63:32 in
+x86-64, so the emitted pair matches the full-width IR semantics.
 
 The x86 IR does not yet carry operand width. To avoid rewriting partial-width
 operations as full-width operations, the binary optimization path currently
 accepts only mode-width register aliases: `rax`/`r8`-style 64-bit names for
-x86-64, and `eax`-style 32-bit i386 names for x86-32. The sole exception is
-SETcc, whose architectural low-byte spellings (`al`/`cl`/`dl`/`bl`, plus
-`spl`/`bpl`/`sil`/`dil` and `r8b`–`r15b` in x86-64) are canonicalized to the
-interim full-register `Setcc` destination above. Legacy high-byte aliases
-(`ah`/`ch`/`dh`/`bh`) remain unsupported. In x86-32, only
-`al`/`cl`/`dl`/`bl` are representable SETcc destinations because byte-register
-encoding slots 4–7 name the legacy high-byte registers without a REX prefix.
-Other instructions using x86-64 `eax`/`ax`/`al` forms, x86-32 `ax`/`al`
-forms, or x86-32 extended-register aliases such as `r8d` are rejected until
-operand width is represented end to end.
+x86-64, and `eax`-style 32-bit i386 names for x86-32. Architectural byte SETcc
+from ELF input is rejected until #75 rather than lifted into the full-width
+pseudo-IR. Width-agnostic text accepts only the pseudo-family's canonical
+full-register spelling (`setne rax`, for example), not byte/word/dword aliases.
+In x86-32, synthesized SETcc remains limited to destinations backed by
+`al`/`cl`/`dl`/`bl`, because byte-register encoding slots 4–7 name the legacy
+high-byte registers without a REX prefix. Other instructions using x86-64
+`eax`/`ax`/`al` forms, x86-32 `ax`/`al` forms, or x86-32 extended-register
+aliases such as `r8d` are rejected until operand width is represented end to
+end.
 
 Fixed control-flow terminators:
 

--- a/docs/capability.md
+++ b/docs/capability.md
@@ -103,6 +103,7 @@ Rewritable straight-line mnemonic families:
 - Immediate-count rotates: `rol`, `ror`
 - Signed multiply: `imul` (2-operand `imul rd, rs` and 3-operand `imul rd, rs, imm`)
 - Load effective address: `lea` (register-base + displacement only)
+- Conditional byte sets: `set<cond>`
 - Conditional moves: `cmov<cond>`
 
 The data-movement/arithmetic/logical/comparison families have register and
@@ -145,15 +146,27 @@ register-base + displacement form, `lea rd, [base + disp]`, computing
 `rd = base + disp` (wrapping at width). It is non-destructive (`base` is read,
 `rd` is purely written, like `mov`) and affects NO flags. The index*scale
 (`[base + index*scale + disp]`) and RIP/EIP-relative addressing forms are
-deferred and rejected as unsupported shapes. `cmov<cond>` has register operands
-and reads EFLAGS without modifying them.
+deferred and rejected as unsupported shapes. `set<cond>` and `cmov<cond>` read
+EFLAGS without modifying them. `cmov<cond>` has two register operands.
+`set<cond>` uses the interim native-width abstraction `rd = zext(condition)`:
+the IR, concrete interpreter, and SMT lowering fully overwrite `rd` with 0 or
+1. Architecturally, the encoded SETcc instruction writes only the low byte and
+preserves the rest of the register. This documented divergence remains until
+sub-register aliasing is represented end to end (#75).
 
 The x86 IR does not yet carry operand width. To avoid rewriting partial-width
 operations as full-width operations, the binary optimization path currently
 accepts only mode-width register aliases: `rax`/`r8`-style 64-bit names for
-x86-64, and `eax`-style 32-bit i386 names for x86-32. x86-64 `eax`/`ax`/`al`
-forms, x86-32 `ax`/`al` forms, and x86-32 extended-register aliases such as
-`r8d` are rejected until operand width is represented end to end.
+x86-64, and `eax`-style 32-bit i386 names for x86-32. The sole exception is
+SETcc, whose architectural low-byte spellings (`al`/`cl`/`dl`/`bl`, plus
+`spl`/`bpl`/`sil`/`dil` and `r8b`–`r15b` in x86-64) are canonicalized to the
+interim full-register `Setcc` destination above. Legacy high-byte aliases
+(`ah`/`ch`/`dh`/`bh`) remain unsupported. In x86-32, only
+`al`/`cl`/`dl`/`bl` are representable SETcc destinations because byte-register
+encoding slots 4–7 name the legacy high-byte registers without a REX prefix.
+Other instructions using x86-64 `eax`/`ax`/`al` forms, x86-32 `ax`/`al`
+forms, or x86-32 extended-register aliases such as `r8d` are rejected until
+operand width is represented end to end.
 
 Fixed control-flow terminators:
 

--- a/src/assembler/x86.rs
+++ b/src/assembler/x86.rs
@@ -292,6 +292,28 @@ fn encode_64(ops: &mut dynasmrt::x64::Assembler, instr: &X86Instruction) -> Resu
             }
             Ok(())
         }
+        X86Instruction::Setcc { rd, cond } => {
+            let rd = reg_index(*rd)?;
+            match cond {
+                X86Condition::E => dynasm!(ops ; .arch x64 ; sete Rb(rd)),
+                X86Condition::NE => dynasm!(ops ; .arch x64 ; setne Rb(rd)),
+                X86Condition::B => dynasm!(ops ; .arch x64 ; setb Rb(rd)),
+                X86Condition::AE => dynasm!(ops ; .arch x64 ; setae Rb(rd)),
+                X86Condition::BE => dynasm!(ops ; .arch x64 ; setbe Rb(rd)),
+                X86Condition::A => dynasm!(ops ; .arch x64 ; seta Rb(rd)),
+                X86Condition::L => dynasm!(ops ; .arch x64 ; setl Rb(rd)),
+                X86Condition::GE => dynasm!(ops ; .arch x64 ; setge Rb(rd)),
+                X86Condition::LE => dynasm!(ops ; .arch x64 ; setle Rb(rd)),
+                X86Condition::G => dynasm!(ops ; .arch x64 ; setg Rb(rd)),
+                X86Condition::S => dynasm!(ops ; .arch x64 ; sets Rb(rd)),
+                X86Condition::NS => dynasm!(ops ; .arch x64 ; setns Rb(rd)),
+                X86Condition::O => dynasm!(ops ; .arch x64 ; seto Rb(rd)),
+                X86Condition::NO => dynasm!(ops ; .arch x64 ; setno Rb(rd)),
+                X86Condition::P => dynasm!(ops ; .arch x64 ; setp Rb(rd)),
+                X86Condition::NP => dynasm!(ops ; .arch x64 ; setnp Rb(rd)),
+            }
+            Ok(())
+        }
         X86Instruction::Jcc { cond } => {
             // Short-form Jcc to a 0-byte displacement. The optimizer
             // never patches Jcc bytes into the binary (terminators are
@@ -535,6 +557,34 @@ fn encode_32(ops: &mut dynasmrt::x86::Assembler, instr: &X86Instruction) -> Resu
                 X86Condition::NO => dynasm!(ops ; .arch x86 ; cmovno Rd(rd), Rd(rs)),
                 X86Condition::P => dynasm!(ops ; .arch x86 ; cmovp Rd(rd), Rd(rs)),
                 X86Condition::NP => dynasm!(ops ; .arch x86 ; cmovnp Rd(rd), Rd(rs)),
+            }
+            Ok(())
+        }
+        X86Instruction::Setcc { rd, cond } => {
+            let rd_index = reg_index_32(*rd)?;
+            if rd_index >= 4 {
+                return Err(format!(
+                    "register {:?} has no low-byte encoding in x86-32 mode",
+                    rd
+                ));
+            }
+            match cond {
+                X86Condition::E => dynasm!(ops ; .arch x86 ; sete Rb(rd_index)),
+                X86Condition::NE => dynasm!(ops ; .arch x86 ; setne Rb(rd_index)),
+                X86Condition::B => dynasm!(ops ; .arch x86 ; setb Rb(rd_index)),
+                X86Condition::AE => dynasm!(ops ; .arch x86 ; setae Rb(rd_index)),
+                X86Condition::BE => dynasm!(ops ; .arch x86 ; setbe Rb(rd_index)),
+                X86Condition::A => dynasm!(ops ; .arch x86 ; seta Rb(rd_index)),
+                X86Condition::L => dynasm!(ops ; .arch x86 ; setl Rb(rd_index)),
+                X86Condition::GE => dynasm!(ops ; .arch x86 ; setge Rb(rd_index)),
+                X86Condition::LE => dynasm!(ops ; .arch x86 ; setle Rb(rd_index)),
+                X86Condition::G => dynasm!(ops ; .arch x86 ; setg Rb(rd_index)),
+                X86Condition::S => dynasm!(ops ; .arch x86 ; sets Rb(rd_index)),
+                X86Condition::NS => dynasm!(ops ; .arch x86 ; setns Rb(rd_index)),
+                X86Condition::O => dynasm!(ops ; .arch x86 ; seto Rb(rd_index)),
+                X86Condition::NO => dynasm!(ops ; .arch x86 ; setno Rb(rd_index)),
+                X86Condition::P => dynasm!(ops ; .arch x86 ; setp Rb(rd_index)),
+                X86Condition::NP => dynasm!(ops ; .arch x86 ; setnp Rb(rd_index)),
             }
             Ok(())
         }
@@ -1389,7 +1439,50 @@ mod tests {
         }
     }
 
-    // --- CMOV encoding round-trips through Capstone ---
+    // --- SETcc / CMOV encoding round-trips through Capstone ---
+
+    #[test]
+    fn all_setcc_suffixes_round_trip_in_both_x86_modes() {
+        for cond in X86Condition::ALL {
+            let mnemonic = cond.set_mnemonic();
+            check_x86_64(
+                X86Instruction::Setcc {
+                    rd: X86Register::RAX,
+                    cond,
+                },
+                mnemonic,
+                &["al"],
+            );
+            check_x86_32(
+                X86Instruction::Setcc {
+                    rd: X86Register::RAX,
+                    cond,
+                },
+                mnemonic,
+                &["al"],
+            );
+        }
+    }
+
+    #[test]
+    fn setcc_x86_64_encodes_rex_low_byte_registers() {
+        check_x86_64(
+            X86Instruction::Setcc {
+                rd: X86Register::RSP,
+                cond: X86Condition::NE,
+            },
+            "setne",
+            &["spl"],
+        );
+        check_x86_64(
+            X86Instruction::Setcc {
+                rd: X86Register::R8,
+                cond: X86Condition::NE,
+            },
+            "setne",
+            &["r8b"],
+        );
+    }
 
     #[test]
     fn cmove_x86_64_round_trips() {

--- a/src/assembler/x86.rs
+++ b/src/assembler/x86.rs
@@ -68,6 +68,53 @@ fn reg_index_32(reg: X86Register) -> Result<u8, String> {
     Ok(i)
 }
 
+fn setcc_opcode(cond: X86Condition) -> u8 {
+    match cond {
+        X86Condition::E => 0x94,
+        X86Condition::NE => 0x95,
+        X86Condition::B => 0x92,
+        X86Condition::AE => 0x93,
+        X86Condition::BE => 0x96,
+        X86Condition::A => 0x97,
+        X86Condition::L => 0x9c,
+        X86Condition::GE => 0x9d,
+        X86Condition::LE => 0x9e,
+        X86Condition::G => 0x9f,
+        X86Condition::S => 0x98,
+        X86Condition::NS => 0x99,
+        X86Condition::O => 0x90,
+        X86Condition::NO => 0x91,
+        X86Condition::P => 0x9a,
+        X86Condition::NP => 0x9b,
+    }
+}
+
+/// Lower the full-width SETcc pseudo-instruction to an architectural byte
+/// SETcc followed by a same-register MOVZX into the 32-bit destination.
+///
+/// Writing the 32-bit destination produces the intended native-width 0/1 in
+/// both modes: x86-64 zeroes bits 63:32 on every 32-bit register write.
+fn encode_full_width_setcc(ops: &mut impl DynasmApi, rd: u8, cond: X86Condition, mode64: bool) {
+    let low = rd & 7;
+    if mode64 {
+        if rd >= 8 {
+            ops.push(0x41); // REX.B selects R8B..R15B.
+        } else if rd >= 4 {
+            ops.push(0x40); // Bare REX selects SPL/BPL/SIL/DIL.
+        }
+    }
+    ops.extend([0x0f, setcc_opcode(cond), 0xc0 | low]);
+
+    if mode64 {
+        if rd >= 8 {
+            ops.push(0x45); // REX.R + REX.B select the same extended register.
+        } else if rd >= 4 {
+            ops.push(0x40); // Required for the low-byte source.
+        }
+    }
+    ops.extend([0x0f, 0xb6, 0xc0 | (low << 3) | low]);
+}
+
 fn assemble_64(instructions: &[X86Instruction]) -> Result<Vec<u8>, String> {
     let mut ops =
         dynasmrt::x64::Assembler::new().map_err(|e| format!("dynasm x64 init failed: {:?}", e))?;
@@ -294,24 +341,7 @@ fn encode_64(ops: &mut dynasmrt::x64::Assembler, instr: &X86Instruction) -> Resu
         }
         X86Instruction::Setcc { rd, cond } => {
             let rd = reg_index(*rd)?;
-            match cond {
-                X86Condition::E => dynasm!(ops ; .arch x64 ; sete Rb(rd)),
-                X86Condition::NE => dynasm!(ops ; .arch x64 ; setne Rb(rd)),
-                X86Condition::B => dynasm!(ops ; .arch x64 ; setb Rb(rd)),
-                X86Condition::AE => dynasm!(ops ; .arch x64 ; setae Rb(rd)),
-                X86Condition::BE => dynasm!(ops ; .arch x64 ; setbe Rb(rd)),
-                X86Condition::A => dynasm!(ops ; .arch x64 ; seta Rb(rd)),
-                X86Condition::L => dynasm!(ops ; .arch x64 ; setl Rb(rd)),
-                X86Condition::GE => dynasm!(ops ; .arch x64 ; setge Rb(rd)),
-                X86Condition::LE => dynasm!(ops ; .arch x64 ; setle Rb(rd)),
-                X86Condition::G => dynasm!(ops ; .arch x64 ; setg Rb(rd)),
-                X86Condition::S => dynasm!(ops ; .arch x64 ; sets Rb(rd)),
-                X86Condition::NS => dynasm!(ops ; .arch x64 ; setns Rb(rd)),
-                X86Condition::O => dynasm!(ops ; .arch x64 ; seto Rb(rd)),
-                X86Condition::NO => dynasm!(ops ; .arch x64 ; setno Rb(rd)),
-                X86Condition::P => dynasm!(ops ; .arch x64 ; setp Rb(rd)),
-                X86Condition::NP => dynasm!(ops ; .arch x64 ; setnp Rb(rd)),
-            }
+            encode_full_width_setcc(ops, rd, *cond, true);
             Ok(())
         }
         X86Instruction::Jcc { cond } => {
@@ -568,24 +598,7 @@ fn encode_32(ops: &mut dynasmrt::x86::Assembler, instr: &X86Instruction) -> Resu
                     rd
                 ));
             }
-            match cond {
-                X86Condition::E => dynasm!(ops ; .arch x86 ; sete Rb(rd_index)),
-                X86Condition::NE => dynasm!(ops ; .arch x86 ; setne Rb(rd_index)),
-                X86Condition::B => dynasm!(ops ; .arch x86 ; setb Rb(rd_index)),
-                X86Condition::AE => dynasm!(ops ; .arch x86 ; setae Rb(rd_index)),
-                X86Condition::BE => dynasm!(ops ; .arch x86 ; setbe Rb(rd_index)),
-                X86Condition::A => dynasm!(ops ; .arch x86 ; seta Rb(rd_index)),
-                X86Condition::L => dynasm!(ops ; .arch x86 ; setl Rb(rd_index)),
-                X86Condition::GE => dynasm!(ops ; .arch x86 ; setge Rb(rd_index)),
-                X86Condition::LE => dynasm!(ops ; .arch x86 ; setle Rb(rd_index)),
-                X86Condition::G => dynasm!(ops ; .arch x86 ; setg Rb(rd_index)),
-                X86Condition::S => dynasm!(ops ; .arch x86 ; sets Rb(rd_index)),
-                X86Condition::NS => dynasm!(ops ; .arch x86 ; setns Rb(rd_index)),
-                X86Condition::O => dynasm!(ops ; .arch x86 ; seto Rb(rd_index)),
-                X86Condition::NO => dynasm!(ops ; .arch x86 ; setno Rb(rd_index)),
-                X86Condition::P => dynasm!(ops ; .arch x86 ; setp Rb(rd_index)),
-                X86Condition::NP => dynasm!(ops ; .arch x86 ; setnp Rb(rd_index)),
-            }
+            encode_full_width_setcc(ops, rd_index, *cond, false);
             Ok(())
         }
         X86Instruction::Jcc { cond } => {
@@ -1439,49 +1452,102 @@ mod tests {
         }
     }
 
+    #[test]
+    fn setcc_code_size_matches_assembled_length() {
+        use crate::semantics::cost::CostMetric;
+        use crate::semantics::cost_x86::instruction_cost;
+
+        for cond in X86Condition::ALL {
+            for rd in [X86Register::RAX, X86Register::RSP, X86Register::R8] {
+                let instr = X86Instruction::Setcc { rd, cond };
+                let bytes = X86Assembler::new_64()
+                    .assemble_instructions(&[instr])
+                    .expect("x86-64 SETcc lowering");
+                assert_eq!(
+                    instruction_cost(&instr, &CostMetric::CodeSize, 64),
+                    bytes.len() as u64,
+                    "x86-64 SET{} {rd:?} cost must match assembled bytes",
+                    cond.suffix()
+                );
+            }
+
+            let instr = X86Instruction::Setcc {
+                rd: X86Register::RAX,
+                cond,
+            };
+            let bytes = X86Assembler::new_32()
+                .assemble_instructions(&[instr])
+                .expect("x86-32 SETcc lowering");
+            assert_eq!(
+                instruction_cost(&instr, &CostMetric::CodeSize, 32),
+                bytes.len() as u64,
+                "x86-32 SET{} cost must match assembled bytes",
+                cond.suffix()
+            );
+        }
+    }
+
     // --- SETcc / CMOV encoding round-trips through Capstone ---
 
     #[test]
-    fn all_setcc_suffixes_round_trip_in_both_x86_modes() {
+    fn all_setcc_suffixes_lower_to_setcc_movzx_in_both_x86_modes() {
         for cond in X86Condition::ALL {
             let mnemonic = cond.set_mnemonic();
-            check_x86_64(
-                X86Instruction::Setcc {
-                    rd: X86Register::RAX,
-                    cond,
-                },
-                mnemonic,
-                &["al"],
+            let instr = X86Instruction::Setcc {
+                rd: X86Register::RAX,
+                cond,
+            };
+
+            let bytes64 = X86Assembler::new_64()
+                .assemble_instructions(&[instr])
+                .expect("x86-64 SETcc lowering");
+            assert_eq!(bytes64.len(), 6, "unexpected x86-64 {mnemonic} size");
+            assert_eq!(
+                disasm_x86_64(&bytes64),
+                vec![
+                    (mnemonic.to_string(), "al".to_string()),
+                    ("movzx".to_string(), "eax, al".to_string()),
+                ],
+                "unexpected x86-64 {mnemonic} lowering"
             );
-            check_x86_32(
-                X86Instruction::Setcc {
-                    rd: X86Register::RAX,
-                    cond,
-                },
-                mnemonic,
-                &["al"],
+
+            let bytes32 = X86Assembler::new_32()
+                .assemble_instructions(&[instr])
+                .expect("x86-32 SETcc lowering");
+            assert_eq!(bytes32.len(), 6, "unexpected x86-32 {mnemonic} size");
+            assert_eq!(
+                disasm_x86_32(&bytes32),
+                vec![
+                    (mnemonic.to_string(), "al".to_string()),
+                    ("movzx".to_string(), "eax, al".to_string()),
+                ],
+                "unexpected x86-32 {mnemonic} lowering"
             );
         }
     }
 
     #[test]
     fn setcc_x86_64_encodes_rex_low_byte_registers() {
-        check_x86_64(
-            X86Instruction::Setcc {
-                rd: X86Register::RSP,
-                cond: X86Condition::NE,
-            },
-            "setne",
-            &["spl"],
-        );
-        check_x86_64(
-            X86Instruction::Setcc {
-                rd: X86Register::R8,
-                cond: X86Condition::NE,
-            },
-            "setne",
-            &["r8b"],
-        );
+        for (rd, byte_name, dword_name) in [
+            (X86Register::RSP, "spl", "esp"),
+            (X86Register::R8, "r8b", "r8d"),
+        ] {
+            let bytes = X86Assembler::new_64()
+                .assemble_instructions(&[X86Instruction::Setcc {
+                    rd,
+                    cond: X86Condition::NE,
+                }])
+                .expect("REX byte-register SETcc lowering");
+            assert_eq!(bytes.len(), 8, "unexpected {rd:?} SETcc lowering size");
+            assert_eq!(
+                disasm_x86_64(&bytes),
+                vec![
+                    ("setne".to_string(), byte_name.to_string()),
+                    ("movzx".to_string(), format!("{dword_name}, {byte_name}"),),
+                ],
+                "SETcc and MOVZX must use the same logical register"
+            );
+        }
     }
 
     #[test]

--- a/src/docs_support.rs
+++ b/src/docs_support.rs
@@ -18,16 +18,11 @@ pub const AARCH64_FIXED_TERMINATORS: &[&str] = &[
     "b", "b.<cond>", "bl", "br", "ret", "cbz", "cbnz", "tbz", "tbnz",
 ];
 
-pub const X86_REWRITABLE_MNEMONICS: &[&str] = &[
-    "mov",
-    "add",
-    "sub",
-    "and",
-    "or",
-    "xor",
-    "cmp",
-    "set<cond>",
-    "cmov<cond>",
-];
+pub const X86_REWRITABLE_MNEMONICS: &[&str] =
+    &["mov", "add", "sub", "and", "or", "xor", "cmp", "cmov<cond>"];
+
+/// Full-width text-IR families available to search but not liftable from
+/// architectural machine code.
+pub const X86_SYNTHESIZABLE_ONLY_MNEMONICS: &[&str] = &["set<cond>"];
 
 pub const X86_FIXED_TERMINATORS: &[&str] = &["j<cond>"];

--- a/src/docs_support.rs
+++ b/src/docs_support.rs
@@ -18,7 +18,16 @@ pub const AARCH64_FIXED_TERMINATORS: &[&str] = &[
     "b", "b.<cond>", "bl", "br", "ret", "cbz", "cbnz", "tbz", "tbnz",
 ];
 
-pub const X86_REWRITABLE_MNEMONICS: &[&str] =
-    &["mov", "add", "sub", "and", "or", "xor", "cmp", "cmov<cond>"];
+pub const X86_REWRITABLE_MNEMONICS: &[&str] = &[
+    "mov",
+    "add",
+    "sub",
+    "and",
+    "or",
+    "xor",
+    "cmp",
+    "set<cond>",
+    "cmov<cond>",
+];
 
 pub const X86_FIXED_TERMINATORS: &[&str] = &["j<cond>"];

--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -5,8 +5,8 @@
 //! `X86_64` and `X86_32` ISA marker structs.
 //!
 //! **Initial instruction set**: MOV, ADD, SUB, AND, OR, XOR, CMP — each with
-//! register and immediate forms — plus rewritable CMOVcc and fixed Jcc
-//! terminators.
+//! register and immediate forms — plus rewritable SETcc / CMOVcc and fixed
+//! Jcc terminators.
 
 // x86 register names are conventionally uppercase (RAX, RBX, ...) in every
 // Intel/AMD manual, Capstone disassembly output, GAS/Intel syntax, and gdb
@@ -19,7 +19,7 @@ use crate::isa::traits::{ISA, InstructionGenerator, InstructionType, OperandType
 use rand::{Rng, RngExt};
 use std::fmt;
 
-/// x86 condition codes consumed by CMOVcc / Jcc.
+/// x86 condition codes consumed by SETcc / CMOVcc / Jcc.
 ///
 /// The 16 canonical codes here cover every short-form jump / cmov GAS
 /// emits. Aliases (`NB` for `AE`, `Z` for `E`, etc.) are normalized to
@@ -108,6 +108,27 @@ impl X86Condition {
             X86Condition::NO => "cmovno",
             X86Condition::P => "cmovp",
             X86Condition::NP => "cmovnp",
+        }
+    }
+
+    pub const fn set_mnemonic(self) -> &'static str {
+        match self {
+            X86Condition::E => "sete",
+            X86Condition::NE => "setne",
+            X86Condition::B => "setb",
+            X86Condition::AE => "setae",
+            X86Condition::BE => "setbe",
+            X86Condition::A => "seta",
+            X86Condition::L => "setl",
+            X86Condition::GE => "setge",
+            X86Condition::LE => "setle",
+            X86Condition::G => "setg",
+            X86Condition::S => "sets",
+            X86Condition::NS => "setns",
+            X86Condition::O => "seto",
+            X86Condition::NO => "setno",
+            X86Condition::P => "setp",
+            X86Condition::NP => "setnp",
         }
     }
 
@@ -404,6 +425,13 @@ pub enum X86Instruction {
         rs: X86Register,
         cond: X86Condition,
     },
+    /// `setCC rd` — materialize an EFLAGS condition as native-width 0 or 1.
+    ///
+    /// This is an interim abstraction until sub-register widths are represented
+    /// by the x86 IR (#75): architectural SETcc writes only the low byte, while
+    /// this variant models a full-register zero-extended result. It reads but
+    /// does not modify EFLAGS.
+    Setcc { rd: X86Register, cond: X86Condition },
     /// `jCC <target>` — conditional branch. Reads EFLAGS;
     /// modelled as an opaque terminator. The branch target is recovered
     /// from the surrounding ELF disassembly and is not carried in the IR
@@ -438,7 +466,8 @@ impl X86Instruction {
             | X86Instruction::ImulReg { rd, .. }
             | X86Instruction::ImulRegImm { rd, .. }
             | X86Instruction::Lea { rd, .. }
-            | X86Instruction::Cmov { rd, .. } => Some(*rd),
+            | X86Instruction::Cmov { rd, .. }
+            | X86Instruction::Setcc { rd, .. } => Some(*rd),
             // CMP and TEST discard their result; only EFLAGS is written.
             X86Instruction::CmpReg { .. }
             | X86Instruction::CmpImm { .. }
@@ -470,6 +499,7 @@ impl X86Instruction {
             X86Instruction::ImulReg { .. } | X86Instruction::ImulRegImm { .. } => "imul",
             X86Instruction::Lea { .. } => "lea",
             X86Instruction::Cmov { cond, .. } => cond.cmov_mnemonic(),
+            X86Instruction::Setcc { cond, .. } => cond.set_mnemonic(),
             X86Instruction::Jcc { cond } => cond.jcc_mnemonic(),
         }
     }
@@ -522,6 +552,8 @@ impl X86Instruction {
             | X86Instruction::Dec { rd } => vec![*rd],
             // Cmov reads both rd (kept on false branch) and rs.
             X86Instruction::Cmov { rd, rs, .. } => vec![*rd, *rs],
+            // SETcc reads only EFLAGS and fully overwrites rd in the interim IR.
+            X86Instruction::Setcc { .. } => vec![],
             X86Instruction::Jcc { .. } => vec![],
         }
     }
@@ -576,11 +608,9 @@ impl InstructionType for X86Instruction {
             X86Instruction::ImulReg { .. } => 25,
             X86Instruction::ImulRegImm { .. } => 26,
             X86Instruction::Lea { .. } => 27,
-            // Cmov MUST stay the last rewritable opcode (COUNT - 1 == 28):
-            // the CMOV distinct-register draw at both generation sites is
-            // gated on `opcode == X86_REWRITABLE_OPCODE_COUNT - 1`.
             X86Instruction::Cmov { .. } => 28,
-            X86Instruction::Jcc { .. } => 29,
+            X86Instruction::Setcc { .. } => 29,
+            X86Instruction::Jcc { .. } => 30,
         }
     }
 
@@ -589,8 +619,9 @@ impl InstructionType for X86Instruction {
     }
 
     fn has_side_effects(&self) -> bool {
-        // MOV / NOT / LEA / CMOV / Jcc do not write EFLAGS (CMOV and Jcc read
-        // them, but reading is not a side effect on observable state; NOT
+        // MOV / NOT / LEA / SETcc / CMOV / Jcc do not write EFLAGS (the
+        // conditional families read them, but reading is not a side effect on
+        // observable state; NOT
         // is bitwise complement and leaves EFLAGS untouched, exactly like
         // MOV; LEA is pure address arithmetic that writes only its destination
         // register). Every other variant — including NEG — sets or clobbers
@@ -602,6 +633,7 @@ impl InstructionType for X86Instruction {
                 | X86Instruction::Not { .. }
                 | X86Instruction::Lea { .. }
                 | X86Instruction::Cmov { .. }
+                | X86Instruction::Setcc { .. }
                 | X86Instruction::Jcc { .. }
         )
     }
@@ -657,6 +689,7 @@ impl fmt::Display for X86Instruction {
             | X86Instruction::Inc { rd }
             | X86Instruction::Dec { rd } => write!(f, "{} {}", mn, rd),
             X86Instruction::Cmov { rd, rs, .. } => write!(f, "{} {}, {}", mn, rd, rs),
+            X86Instruction::Setcc { rd, .. } => write!(f, "{} {}", mn, rd),
             // Target is opaque to the IR; render with a placeholder.
             X86Instruction::Jcc { .. } => write!(f, "{} <target>", mn),
         }
@@ -736,10 +769,10 @@ impl ISA for X86_32 {
 }
 
 /// Helper used by both `FlagsAnalysis<X86Instruction> for X86_64` and
-/// `for X86_32`. MOV / NOT / LEA / CMOV / Jcc do not write EFLAGS — CMOV and
-/// Jcc read them via `x86_reads_flags` but do not modify any flag bit; LEA is
-/// pure address arithmetic. Every other variant in the current set writes
-/// EFLAGS.
+/// `for X86_32`. MOV / NOT / LEA / SETcc / CMOV / Jcc do not write EFLAGS —
+/// the conditional families read them via `x86_reads_flags` but do not modify
+/// any flag bit; LEA is pure address arithmetic. Every other variant in the
+/// current set writes EFLAGS.
 ///
 /// Crate-visible so the cost model's critical-path latency
 /// (`crate::semantics::cost_x86::critical_path_latency`) can route flag
@@ -753,18 +786,18 @@ pub(crate) fn x86_modifies_flags(instr: &X86Instruction) -> bool {
             | X86Instruction::Not { .. }
             | X86Instruction::Lea { .. }
             | X86Instruction::Cmov { .. }
+            | X86Instruction::Setcc { .. }
             | X86Instruction::Jcc { .. }
     )
 }
 
-/// CMOV and Jcc read EFLAGS; every other variant in the current set
-/// is flag-agnostic on the read side. Crate-visible so search and
-/// equivalence callers can route through one authoritative match arm —
-/// adding a future flag-reader like SETcc then updates exactly one place.
+/// SETcc, CMOV, and Jcc read EFLAGS; every other variant in the current set
+/// is flag-agnostic on the read side. Public so search and equivalence callers
+/// can route through one authoritative match arm.
 pub fn x86_reads_flags(instr: &X86Instruction) -> bool {
     matches!(
         instr,
-        X86Instruction::Cmov { .. } | X86Instruction::Jcc { .. }
+        X86Instruction::Cmov { .. } | X86Instruction::Setcc { .. } | X86Instruction::Jcc { .. }
     )
 }
 
@@ -993,6 +1026,7 @@ impl crate::isa::traits::Assembler<X86Instruction> for X86_64 {
             // IMUL rd, rs is `0F AF /r` — always encodable.
             | X86Instruction::ImulReg { .. }
             | X86Instruction::Cmov { .. }
+            | X86Instruction::Setcc { .. }
             | X86Instruction::Jcc { .. } => true,
         }
     }
@@ -1051,6 +1085,11 @@ impl crate::isa::traits::Assembler<X86Instruction> for X86_32 {
             | X86Instruction::Inc { rd }
             | X86Instruction::Dec { rd } => reg_ok_32(*rd),
             X86Instruction::Cmov { rd, rs, .. } => reg_ok_32(*rd) && reg_ok_32(*rs),
+            // Without REX, byte-register encodings 4..=7 name AH..BH rather
+            // than the low byte of ESP..EDI.
+            X86Instruction::Setcc { rd, .. } => {
+                rd.index().is_some_and(|index| index < 4)
+            }
             X86Instruction::Jcc { .. } => true,
         }
     }
@@ -1192,28 +1231,24 @@ impl X86Mutator {
         if self.registers.is_empty() {
             return None;
         }
-        // Rewritable variants only: 7 reg-reg + 7 reg-imm + CMOVcc.
+        // Rewritable variants only, including CMOVcc and SETcc.
         // The RNG draw order/count MUST stay in lock-step with the shared
         // free helper `generate_random_rewritable_x86_instruction`
         // (opcode → rd → rs → imm → cond, all four drawn unconditionally)
         // so callers that interleave the two stay deterministic. Two
-        // helper behaviours must be mirrored exactly: (1) the trailing
-        // CMOV opcode slot is dropped unless the pool holds a distinct
+        // helper behaviours must be mirrored exactly: (1) the
+        // CMOV opcode slot is skipped unless the pool holds a distinct
         // register pair (a self-CMOV is a no-op), and (2) CMOV draws its
         // source via an extra `pick_register_except` so `rs != rd`. The
         // #593 behaviour change is *which* prefiltered pool the single imm
         // draw indexes: opcode 1 (MOV) uses the MOVABS-capable `mov`
         // pool, every other imm form uses the non-MOV pool.
-        // CMOV with rd == rs is a no-op, so the trailing CMOV opcode slot is
-        // only offered when the pool holds a distinct pair. This MUST mirror
+        // CMOV with rd == rs is a no-op, so its opcode slot is only offered
+        // when the pool holds a distinct pair. This MUST mirror
         // `generate_random_rewritable_x86_instruction` so the two stay in
         // lock-step (stream parity) while both filter self-CMOV.
-        let opcode_count = if has_distinct_register_pair(&self.registers) {
-            X86_REWRITABLE_OPCODE_COUNT
-        } else {
-            X86_REWRITABLE_OPCODE_COUNT - 1
-        };
-        let opcode = rng.random_range(0..u32::from(opcode_count));
+        let opcode =
+            pick_random_rewritable_opcode(rng, has_distinct_register_pair(&self.registers));
         let rd = self.pick_register(rng)?;
         let rs = self.pick_register(rng)?;
         let imm = if opcode == 1 {
@@ -1228,8 +1263,7 @@ impl X86Mutator {
         // opcode to preserve the RNG stream that the parity test
         // `x86_mutator_random_instruction_matches_shared_generator_stream`
         // pins against `generate_random_rewritable_x86_instruction`.
-        let opcode = u8::try_from(opcode).expect("opcode index fits in u8");
-        let final_rs = if opcode == X86_REWRITABLE_OPCODE_COUNT - 1 {
+        let final_rs = if opcode == X86_CMOV_OPCODE {
             pick_register_except(rng, &self.registers, rd)
                 .expect("CMOV opcode requires a distinct register pair")
         } else {
@@ -1282,7 +1316,8 @@ impl X86Mutator {
                 // IMUL rd, rs has no immediate, so it is a no-op with no pool.
                 | X86Instruction::ImulReg { .. }
                 | X86Instruction::Jcc { .. } => {}
-                X86Instruction::Cmov { cond, .. } => *cond = self.pick_condition(rng),
+                X86Instruction::Cmov { cond, .. }
+                | X86Instruction::Setcc { cond, .. } => *cond = self.pick_condition(rng),
             }
             return;
         }
@@ -1382,6 +1417,13 @@ impl X86Mutator {
                     0 => *rd = pick_register_except(rng, &self.registers, *rs).unwrap_or(*rd),
                     1 => *rs = pick_register_except(rng, &self.registers, *rd).unwrap_or(*rs),
                     _ => *cond = self.pick_condition(rng),
+                }
+            }
+            X86Instruction::Setcc { rd, cond } => {
+                if rng.random_bool(0.5) {
+                    *rd = self.pick_register(rng).expect("register pool is non-empty");
+                } else {
+                    *cond = self.pick_condition(rng);
                 }
             }
             // Jcc is a terminator; mutation never reaches it because the
@@ -1526,6 +1568,8 @@ impl X86Mutator {
             // Cmov has a unique shape (rd, rs, cond) with no opcode-shape
             // siblings; keep it unchanged in the opcode-bridge mutator.
             X86Instruction::Cmov { .. } => current,
+            // Setcc has a unique (rd, cond) shape.
+            X86Instruction::Setcc { .. } => current,
             // Jcc is a terminator and should never reach mutation; preserve it.
             X86Instruction::Jcc { .. } => current,
         };
@@ -1595,19 +1639,10 @@ pub struct X86InstructionGenerator;
 
 // One entry per rewritable opcode family: 6 reg-reg + 6 reg-imm + CMP + TEST
 // (each reg/imm) + NEG + NOT + INC + DEC + SHL + SHR + SAR + ROL + ROR +
-// IMUL (2-op) + IMUL (3-op) + CMOVcc. CMOVcc counts as a single family here
-// even though `generate_all` expands it across all 16 `X86Condition::ALL`
-// variants per register pair.
-//
-// CMOV MUST remain the LAST opcode (index COUNT - 1 == 28): both
-// `X86Mutator::random_instruction` and
-// `generate_random_rewritable_x86_instruction` gate the extra distinct-source
-// CMOV draw on `opcode == X86_REWRITABLE_OPCODE_COUNT - 1`. New flag-only
-// families (CMP, TEST), single-operand families (NEG, NOT, INC, DEC), the
-// immediate-count shift families (SHL, SHR, SAR), the immediate-count
-// rotate families (ROL, ROR), the two IMUL forms, and LEA are inserted before
-// CMOV in `build_x86_instruction_by_opcode` to preserve that invariant.
-const X86_REWRITABLE_OPCODE_COUNT: u8 = 29;
+// IMUL (2-op) + IMUL (3-op) + CMOVcc + SETcc. The conditional families each
+// count as one opcode here even though `generate_all` expands all 16 conditions.
+const X86_REWRITABLE_OPCODE_COUNT: u8 = 30;
+const X86_CMOV_OPCODE: u8 = 28;
 
 fn has_distinct_register_pair(registers: &[X86Register]) -> bool {
     let Some(first) = registers.first() else {
@@ -1616,15 +1651,28 @@ fn has_distinct_register_pair(registers: &[X86Register]) -> bool {
     registers.iter().any(|reg| reg != first)
 }
 
+/// Draw a rewritable opcode, omitting CMOV when no distinct register pair can
+/// represent its non-no-op shape. SETcc follows CMOV in the opcode table, so a
+/// degenerate pool skips the CMOV hole rather than dropping the final opcode.
+fn pick_random_rewritable_opcode<R: Rng + ?Sized>(rng: &mut R, cmov_available: bool) -> u8 {
+    if cmov_available {
+        return rng.random_range(0..X86_REWRITABLE_OPCODE_COUNT);
+    }
+    let mut opcode = rng.random_range(0..(X86_REWRITABLE_OPCODE_COUNT - 1));
+    if opcode >= X86_CMOV_OPCODE {
+        opcode += 1;
+    }
+    opcode
+}
+
 /// Maps a rewritable opcode index in `0..X86_REWRITABLE_OPCODE_COUNT` to the
 /// `X86Instruction` variant it denotes, using operands the caller has already
 /// drawn. This is the single source of truth for the opcode → variant table;
 /// `X86Mutator::random_instruction` and
 /// `generate_random_rewritable_x86_instruction` both delegate here so the two
 /// dispatch tables cannot drift (see issue #348). Operand drawing and RNG draw
-/// order stay at the call sites; the CMOV slot (the last index,
-/// `X86_REWRITABLE_OPCODE_COUNT - 1`) consumes the `rs` the caller resolved
-/// via `pick_register_except` so `rs != rd`.
+/// order stay at the call sites; the CMOV slot consumes the `rs` the caller
+/// resolved via `pick_register_except` so `rs != rd`.
 ///
 /// Keep this in lock-step with `X86_REWRITABLE_OPCODE_COUNT` and the
 /// `opcode_dispatch_is_consistent` test, which pins the full mapping.
@@ -1683,9 +1731,8 @@ pub(crate) fn build_x86_instruction_by_opcode(
             base: rs,
             disp: imm,
         },
-        // Cmov stays last (index 28 == X86_REWRITABLE_OPCODE_COUNT - 1) so the
-        // CMOV distinct-register draw at the two generation sites stays correct.
         28 => X86Instruction::Cmov { rd, rs, cond },
+        29 => X86Instruction::Setcc { rd, cond },
         _ => unreachable!("opcode out of range"),
     }
 }
@@ -1721,15 +1768,9 @@ fn generate_random_rewritable_x86_instruction<R: Rng + ?Sized>(
         "x86 random instruction generation requires an immediate pool"
     );
 
-    // CMOVcc with rd == rs is a no-op, so it is only a candidate when the
-    // register pool holds two distinct registers. Drop the trailing CMOV
-    // opcode slot when no distinct pair exists.
-    let opcode_count = if has_distinct_register_pair(registers) {
-        X86_REWRITABLE_OPCODE_COUNT
-    } else {
-        X86_REWRITABLE_OPCODE_COUNT - 1
-    };
-    let opcode = rng.random_range(0..u32::from(opcode_count));
+    // CMOVcc with rd == rs is a no-op, so its opcode is only a candidate when
+    // the register pool holds two distinct registers.
+    let opcode = pick_random_rewritable_opcode(rng, has_distinct_register_pair(registers));
     let rd = registers[rng.random_range(0..registers.len())];
     let rs = registers[rng.random_range(0..registers.len())];
     let imm = immediates[rng.random_range(0..immediates.len())];
@@ -1737,8 +1778,7 @@ fn generate_random_rewritable_x86_instruction<R: Rng + ?Sized>(
     // Mirror `X86Mutator::random_instruction`: the CMOV slot draws a distinct
     // source register; every other opcode reuses `rs`. Keep this draw
     // conditional on the CMOV opcode so both paths share one RNG stream.
-    let opcode = u8::try_from(opcode).expect("opcode index fits in u8");
-    let final_rs = if opcode == X86_REWRITABLE_OPCODE_COUNT - 1 {
+    let final_rs = if opcode == X86_CMOV_OPCODE {
         pick_register_except(rng, registers, rd)
             .expect("CMOV opcode requires a distinct register pair")
     } else {
@@ -1868,9 +1908,15 @@ impl InstructionGenerator<X86Instruction> for X86InstructionGenerator {
                 }
             }
         }
-        // CMOVcc is rewritable and reads flags, so enumerate every
-        // condition for each non-identical register pair. Jcc remains
-        // excluded.
+        // SETcc is rewritable and reads flags, so enumerate every condition
+        // for every destination register.
+        for &rd in registers {
+            for &cond in &X86Condition::ALL {
+                out.push(X86Instruction::Setcc { rd, cond });
+            }
+        }
+        // CMOVcc is rewritable and reads flags, so enumerate every condition
+        // for each non-identical register pair. Jcc remains excluded.
         for &rd in registers {
             for &rs in registers {
                 if rd == rs {
@@ -1987,6 +2033,7 @@ fn with_destination(instr: X86Instruction, new_rd: X86Register) -> X86Instructio
             rs,
             cond,
         },
+        X86Instruction::Setcc { cond, .. } => X86Instruction::Setcc { rd: new_rd, cond },
         // Jcc has no register operand; ignore the requested rd swap.
         X86Instruction::Jcc { cond } => X86Instruction::Jcc { cond },
     }
@@ -2081,6 +2128,7 @@ fn with_sources(instr: X86Instruction, new_rs: X86Register, new_imm: i64) -> X86
             rs: if new_rs == rd { rs } else { new_rs },
             cond,
         },
+        X86Instruction::Setcc { rd, cond } => X86Instruction::Setcc { rd, cond },
         X86Instruction::Jcc { cond } => X86Instruction::Jcc { cond },
     }
 }
@@ -2143,7 +2191,8 @@ mod tests {
         // (NEG, NOT, INC, DEC) + 3 shift families (SHL, SHR, SAR over imm8
         // counts) + 2 rotate families (ROL, ROR over imm8 counts) + IMUL 2-op
         // (every register pair) + IMUL 3-op (every (rd, rs, imm32) triple) +
-        // LEA (every (rd, base, disp32) triple) + CMOVcc over distinct pairs.
+        // LEA (every (rd, base, disp32) triple) + SETcc per register and
+        // condition + CMOVcc over distinct pairs.
         let expected_len = 8 * n * n
             + 8 * n * m
             + 4 * n
@@ -2152,6 +2201,7 @@ mod tests {
             + n * n
             + n * n * imul_m
             + n * n * lea_m
+            + n * X86Condition::ALL.len()
             + n * (n - 1) * X86Condition::ALL.len();
         assert_eq!(
             all.len(),
@@ -2177,6 +2227,24 @@ mod tests {
             }
             for src in instr.source_registers() {
                 assert!(regs.contains(&src));
+            }
+        }
+    }
+
+    #[test]
+    fn x86_generator_enumerates_setcc_for_each_register_and_condition() {
+        use crate::isa::traits::InstructionGenerator;
+
+        let regs = [X86Register::RAX, X86Register::RBX];
+        let all = X86InstructionGenerator.generate_all(&regs, &[0]);
+        for rd in regs {
+            for cond in X86Condition::ALL {
+                assert!(
+                    all.contains(&X86Instruction::Setcc { rd, cond }),
+                    "generator omitted SET{} {}",
+                    cond.suffix(),
+                    rd
+                );
             }
         }
     }
@@ -2352,6 +2420,7 @@ mod tests {
                 | X86Instruction::Dec { .. }
                 | X86Instruction::ImulReg { .. }
                 | X86Instruction::Cmov { .. }
+                | X86Instruction::Setcc { .. }
                 | X86Instruction::Jcc { .. } => {}
             }
         }
@@ -2535,6 +2604,32 @@ mod tests {
                 "{name} should reject extended registers"
             );
         }
+    }
+
+    #[test]
+    fn x86_setcc_encodability_matches_available_low_byte_registers() {
+        use crate::isa::traits::Assembler;
+
+        let setne = |rd| X86Instruction::Setcc {
+            rd,
+            cond: X86Condition::NE,
+        };
+        assert!(<X86_64 as Assembler<X86Instruction>>::can_assemble(
+            &X86_64,
+            &setne(X86Register::R15)
+        ));
+        assert!(<X86_32 as Assembler<X86Instruction>>::can_assemble(
+            &X86_32,
+            &setne(X86Register::RAX)
+        ));
+        assert!(!<X86_32 as Assembler<X86Instruction>>::can_assemble(
+            &X86_32,
+            &setne(X86Register::RSI)
+        ));
+        assert!(!<X86_32 as Assembler<X86Instruction>>::can_assemble(
+            &X86_32,
+            &setne(X86Register::R8)
+        ));
     }
 
     #[test]
@@ -2814,6 +2909,24 @@ mod tests {
             );
             assert_eq!(instr.to_string(), display);
         }
+    }
+
+    #[test]
+    fn setcc_metadata_models_a_flag_reading_full_register_write() {
+        use crate::isa::traits::InstructionType;
+
+        let setne = X86Instruction::Setcc {
+            rd: X86Register::RAX,
+            cond: X86Condition::NE,
+        };
+        assert_eq!(setne.destination(), Some(X86Register::RAX));
+        assert!(setne.source_registers().is_empty());
+        assert_eq!(setne.mnemonic(), "setne");
+        assert_eq!(setne.to_string(), "setne rax");
+        assert!(!setne.is_terminator());
+        assert!(!setne.has_side_effects());
+        assert!(!x86_modifies_flags(&setne));
+        assert!(x86_reads_flags(&setne));
     }
 
     #[test]
@@ -3476,6 +3589,7 @@ mod tests {
                 | X86Instruction::Dec { .. }
                 | X86Instruction::ImulReg { .. }
                 | X86Instruction::Cmov { .. }
+                | X86Instruction::Setcc { .. }
                 | X86Instruction::Jcc { .. } => {}
             }
         }
@@ -3567,8 +3681,8 @@ mod tests {
                     disp: imm,
                 },
             ),
-            // Cmov stays last at COUNT - 1 == 28.
             (28, X86Instruction::Cmov { rd, rs, cond }),
+            (29, X86Instruction::Setcc { rd, cond }),
         ];
 
         for (opcode, want) in expected {
@@ -3611,6 +3725,7 @@ mod tests {
             (26, "imul"),
             (27, "lea"),
             (28, "cmove"),
+            (29, "sete"),
         ];
         for (opcode, mnem) in mnemonics {
             assert_eq!(
@@ -4085,6 +4200,7 @@ mod tests {
                     | X86Instruction::Dec { .. }
                     | X86Instruction::ImulReg { .. }
                     | X86Instruction::Cmov { .. }
+                    | X86Instruction::Setcc { .. }
                     | X86Instruction::Jcc { .. } => {}
                 }
             }
@@ -4290,11 +4406,15 @@ mod tests {
         assert!(!jcc.has_side_effects());
     }
 
-    // --- FlagsAnalysis::reads_flags wired for Cmov / Jcc ---
+    // --- FlagsAnalysis::reads_flags wired for SETcc / Cmov / Jcc ---
 
     #[test]
-    fn x86_64_reads_flags_returns_true_for_cmov_and_jcc() {
+    fn x86_64_reads_flags_returns_true_for_setcc_cmov_and_jcc() {
         use crate::isa::traits::FlagsAnalysis;
+        let setcc = X86Instruction::Setcc {
+            rd: X86Register::RAX,
+            cond: X86Condition::E,
+        };
         let cmov = X86Instruction::Cmov {
             rd: X86Register::RAX,
             rs: X86Register::RBX,
@@ -4304,14 +4424,21 @@ mod tests {
             cond: X86Condition::NE,
         };
         assert!(<X86_64 as FlagsAnalysis<X86Instruction>>::reads_flags(
+            &setcc
+        ));
+        assert!(<X86_64 as FlagsAnalysis<X86Instruction>>::reads_flags(
             &cmov
         ));
         assert!(<X86_64 as FlagsAnalysis<X86Instruction>>::reads_flags(&jcc));
     }
 
     #[test]
-    fn x86_32_reads_flags_returns_true_for_cmov_and_jcc() {
+    fn x86_32_reads_flags_returns_true_for_setcc_cmov_and_jcc() {
         use crate::isa::traits::FlagsAnalysis;
+        let setcc = X86Instruction::Setcc {
+            rd: X86Register::RAX,
+            cond: X86Condition::E,
+        };
         let cmov = X86Instruction::Cmov {
             rd: X86Register::RAX,
             rs: X86Register::RBX,
@@ -4320,6 +4447,9 @@ mod tests {
         let jcc = X86Instruction::Jcc {
             cond: X86Condition::NE,
         };
+        assert!(<X86_32 as FlagsAnalysis<X86Instruction>>::reads_flags(
+            &setcc
+        ));
         assert!(<X86_32 as FlagsAnalysis<X86Instruction>>::reads_flags(
             &cmov
         ));

--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -425,12 +425,13 @@ pub enum X86Instruction {
         rs: X86Register,
         cond: X86Condition,
     },
-    /// `setCC rd` — materialize an EFLAGS condition as native-width 0 or 1.
+    /// `setCC rd` — full-width pseudo-instruction that materializes an EFLAGS
+    /// condition as native-width 0 or 1.
     ///
-    /// This is an interim abstraction until sub-register widths are represented
-    /// by the x86 IR (#75): architectural SETcc writes only the low byte, while
-    /// this variant models a full-register zero-extended result. It reads but
-    /// does not modify EFLAGS.
+    /// Architectural SETcc writes only the low byte, so binary input is rejected
+    /// until sub-register widths are represented by the x86 IR (#75). Candidate
+    /// assembly lowers this variant to byte SETcc followed by same-register
+    /// MOVZX. It reads but does not modify EFLAGS.
     Setcc { rd: X86Register, cond: X86Condition },
     /// `jCC <target>` — conditional branch. Reads EFLAGS;
     /// modelled as an opaque terminator. The branch target is recovered
@@ -1085,8 +1086,9 @@ impl crate::isa::traits::Assembler<X86Instruction> for X86_32 {
             | X86Instruction::Inc { rd }
             | X86Instruction::Dec { rd } => reg_ok_32(*rd),
             X86Instruction::Cmov { rd, rs, .. } => reg_ok_32(*rd) && reg_ok_32(*rs),
-            // Without REX, byte-register encodings 4..=7 name AH..BH rather
-            // than the low byte of ESP..EDI.
+            // The full-width pseudo-op lowers through the matching byte
+            // register. Without REX, slots 4..=7 name AH..BH rather than the
+            // low byte of ESP..EDI, so only EAX..EBX are available in x86-32.
             X86Instruction::Setcc { rd, .. } => {
                 rd.index().is_some_and(|index| index < 4)
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4468,6 +4468,39 @@ mod cli_helper_tests {
     }
 
     #[test]
+    fn x86_capstone_bridge_accepts_architectural_setcc_byte_destinations() {
+        let expected = vec![X86Instruction::Setcc {
+            rd: X86Register::RAX,
+            cond: isa::x86::X86Condition::NE,
+        }];
+
+        for (mode, parse_mode) in [
+            (
+                capstone::arch::x86::ArchMode::Mode64,
+                parser::x86::X86ParseMode::Mode64,
+            ),
+            (
+                capstone::arch::x86::ArchMode::Mode32,
+                parser::x86::X86ParseMode::Mode32,
+            ),
+        ] {
+            let cs = capstone::Capstone::new()
+                .x86()
+                .mode(mode)
+                .syntax(capstone::arch::x86::ArchSyntax::Intel)
+                .build()
+                .expect("capstone init");
+            let setne_al = cs
+                .disasm_all(&[0x0f, 0x95, 0xc0], 0x1000)
+                .expect("disassemble setne al");
+            let instruction = setne_al.iter().next().expect("one instruction");
+            assert_eq!(instruction.mnemonic(), Some("setne"));
+            assert_eq!(instruction.op_str(), Some("al"));
+            assert_eq!(convert_to_x86_ir(&setne_al, parse_mode).unwrap(), expected);
+        }
+    }
+
+    #[test]
     fn x86_64_optimizer_rejects_narrow_register_alias_before_search() {
         let elf_bytes = build_minimal_elf64(
             &[0x83, 0xc0, 0x00, 0x83, 0xc0, 0x00],

--- a/src/main.rs
+++ b/src/main.rs
@@ -4468,12 +4468,7 @@ mod cli_helper_tests {
     }
 
     #[test]
-    fn x86_capstone_bridge_accepts_architectural_setcc_byte_destinations() {
-        let expected = vec![X86Instruction::Setcc {
-            rd: X86Register::RAX,
-            cond: isa::x86::X86Condition::NE,
-        }];
-
+    fn x86_capstone_bridge_rejects_architectural_setcc_byte_destinations() {
         for (mode, parse_mode) in [
             (
                 capstone::arch::x86::ArchMode::Mode64,
@@ -4496,8 +4491,39 @@ mod cli_helper_tests {
             let instruction = setne_al.iter().next().expect("one instruction");
             assert_eq!(instruction.mnemonic(), Some("setne"));
             assert_eq!(instruction.op_str(), Some("al"));
-            assert_eq!(convert_to_x86_ir(&setne_al, parse_mode).unwrap(), expected);
+            let err = convert_to_x86_ir(&setne_al, parse_mode)
+                .expect_err("architectural byte SETcc must not enter the full-width pseudo-IR");
+            assert!(
+                err.contains("cannot be represented until #75"),
+                "unexpected error: {err}"
+            );
         }
+    }
+
+    #[test]
+    fn x86_64_optimizer_rejects_architectural_setcc_before_search() {
+        let elf_bytes = build_minimal_elf64(
+            &[0x0f, 0x95, 0xc0, 0x0f, 0x95, 0xc0],
+            0x1000,
+            elf::abi::EM_X86_64,
+        );
+        let input = TempFile::new_bytes("s11-x86-64-setcc-byte", "elf", &elf_bytes);
+        let patcher = ElfPatcher::new(input.path()).expect("read synthetic ELF");
+        let mut opts = options_for(Algorithm::Enumerative);
+        opts.timeout = Some(Duration::from_secs(5));
+        opts.cost_metric = CostMetric::CodeSize;
+
+        let err = optimize_elf_binary(&patcher, input.path(), 0x1000, 0x1006, &opts)
+            .expect_err("architectural byte SETcc should be rejected before search");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("failed to parse x86 instruction 'setne al'"),
+            "unexpected error: {msg}"
+        );
+        assert!(
+            msg.contains("cannot be represented until #75"),
+            "unexpected error: {msg}"
+        );
     }
 
     #[test]

--- a/src/parser/x86.rs
+++ b/src/parser/x86.rs
@@ -13,7 +13,7 @@
 use crate::isa::x86::{X86Condition, X86Instruction, X86Operand, X86Register};
 use crate::parser::ParseError;
 
-/// Parse a condition-code suffix from a CMOVcc / Jcc mnemonic. Accepts
+/// Parse a condition-code suffix from a SETcc / CMOVcc / Jcc mnemonic. Accepts
 /// the canonical 16 codes plus the most common GAS aliases
 /// (`z`/`nz`/`nae`/`nb`/`nc`/`pe`/`po`/`nge`/`nl`/`ng`/`nle`).
 /// Returns `Err` on anything unrecognised so callers surface bad input
@@ -250,6 +250,33 @@ fn parse_x86_register_with_mode(
     }
 }
 
+/// Parse SETcc's byte destination. Text input uses the interim IR's canonical
+/// native-width spelling; mode-aware Capstone input must use an architectural
+/// low-byte alias and is canonicalized to the corresponding full register.
+fn parse_x86_setcc_register_with_mode(
+    reg_str: &str,
+    mode: Option<X86ParseMode>,
+) -> Result<X86Register, String> {
+    let Some(mode) = mode else {
+        return parse_x86_register(reg_str);
+    };
+    let (reg, alias_width) = classify_x86_register_alias(reg_str).map_err(|err| err.to_string())?;
+    if alias_width != 8 {
+        return Err(format!(
+            "setcc expects an 8-bit destination from {} binary input, got '{}'",
+            mode.arch_label(),
+            reg_str.trim()
+        ));
+    }
+    if mode == X86ParseMode::Mode32 && reg.index().is_some_and(|index| index >= 4) {
+        return Err(format!(
+            "unsupported x86-32 SETcc low-byte register '{}'",
+            reg_str.trim()
+        ));
+    }
+    Ok(reg)
+}
+
 /// Operand sibling of [`parse_x86_register_with_mode`]: `Some(mode)` enforces
 /// the mode's register width, `None` is the width-agnostic assembly-text path.
 fn parse_x86_operand_with_mode(
@@ -318,6 +345,26 @@ fn x86_ir_from_mnemonic_impl(
     mode: Option<X86ParseMode>,
 ) -> Result<Option<X86Instruction>, String> {
     let mnemonic = mnemonic.trim().to_lowercase();
+
+    // SETcc — one byte-register destination in machine-code input, represented
+    // as a full native-width zero-extended write by the interim IR (#75).
+    if let Some(suffix) = mnemonic.strip_prefix("set") {
+        let cond = parse_x86_condition(suffix)?;
+        let parts: Vec<&str> = op_str.split(',').map(|s| s.trim()).collect();
+        if parts.len() != 1 || parts[0].is_empty() {
+            let operand_count = if op_str.trim().is_empty() {
+                0
+            } else {
+                parts.len()
+            };
+            return Err(format!(
+                "set{} expects 1 operand, got {}",
+                suffix, operand_count
+            ));
+        }
+        let rd = parse_x86_setcc_register_with_mode(parts[0], mode)?;
+        return Ok(Some(X86Instruction::Setcc { rd, cond }));
+    }
 
     // CMOVcc — strip "cmov" prefix, parse suffix, expect
     // two register operands. Unknown suffixes are errors, not Ok(None).
@@ -617,7 +664,7 @@ fn parse_x86_lea_memory_operand(
 /// test, the single-operand neg/not/inc/dec, the immediate-count shifts
 /// shl/sal/shr/sar, the immediate-count rotates rol/ror, the two- and
 /// three-operand signed multiply imul, lea in its register-base +
-/// displacement form, plus the conditional cmovCC and jCC variants).
+/// displacement form, plus the conditional setCC, cmovCC, and jCC variants).
 /// Anything else is a parse error.
 pub fn parse_x86_assembly_string(
     content: &str,
@@ -1498,7 +1545,57 @@ mod tests {
         );
     }
 
-    // --- CMOV / Jcc mnemonic parsing ---
+    // --- SETcc / CMOV / Jcc mnemonic parsing ---
+
+    #[test]
+    fn parses_and_displays_all_canonical_setcc_suffixes() {
+        for cond in X86Condition::ALL {
+            let mnemonic = format!("set{}", cond.suffix());
+            let parsed = x86_ir_from_mnemonic(&mnemonic, "rax").unwrap().unwrap();
+            let expected = X86Instruction::Setcc {
+                rd: X86Register::RAX,
+                cond,
+            };
+            assert_eq!(parsed, expected, "parsing {mnemonic} failed");
+            assert_eq!(parsed.to_string(), format!("{mnemonic} rax"));
+        }
+    }
+
+    #[test]
+    fn mode_aware_setcc_parsing_canonicalizes_architectural_low_byte_aliases() {
+        for (mode, operand, expected_rd) in [
+            (X86ParseMode::Mode64, "al", X86Register::RAX),
+            (X86ParseMode::Mode64, "spl", X86Register::RSP),
+            (X86ParseMode::Mode64, "r8b", X86Register::R8),
+            (X86ParseMode::Mode32, "al", X86Register::RAX),
+            (X86ParseMode::Mode32, "bl", X86Register::RBX),
+        ] {
+            assert_eq!(
+                x86_ir_from_mnemonic_for_mode("setne", operand, mode)
+                    .unwrap()
+                    .unwrap(),
+                X86Instruction::Setcc {
+                    rd: expected_rd,
+                    cond: X86Condition::NE,
+                }
+            );
+        }
+
+        let err = x86_ir_from_mnemonic_for_mode("setne", "sil", X86ParseMode::Mode32)
+            .expect_err("i386 has no SIL byte register");
+        assert!(err.contains("unsupported x86-32 SETcc low-byte register"));
+
+        let err = x86_ir_from_mnemonic_for_mode("setne", "rax", X86ParseMode::Mode64)
+            .expect_err("Capstone SETcc input must name a byte register");
+        assert!(err.contains("expects an 8-bit destination"));
+    }
+
+    #[test]
+    fn setcc_rejects_unknown_conditions_and_wrong_arity() {
+        assert!(x86_ir_from_mnemonic("setxx", "rax").is_err());
+        assert!(x86_ir_from_mnemonic("setne", "").is_err());
+        assert!(x86_ir_from_mnemonic("setne", "rax, rbx").is_err());
+    }
 
     #[test]
     fn parses_cmove_rax_rbx() {

--- a/src/parser/x86.rs
+++ b/src/parser/x86.rs
@@ -250,27 +250,26 @@ fn parse_x86_register_with_mode(
     }
 }
 
-/// Parse SETcc's byte destination. Text input uses the interim IR's canonical
-/// native-width spelling; mode-aware Capstone input must use an architectural
-/// low-byte alias and is canonicalized to the corresponding full register.
+/// Parse the interim full-width SETcc pseudo-instruction's destination.
+///
+/// Width-agnostic text accepts only the canonical register spelling emitted by
+/// `Display`. Mode-aware input comes from real machine code, where SETcc is a
+/// partial byte write that the current IR cannot soundly represent (#75).
 fn parse_x86_setcc_register_with_mode(
     reg_str: &str,
     mode: Option<X86ParseMode>,
 ) -> Result<X86Register, String> {
-    let Some(mode) = mode else {
-        return parse_x86_register(reg_str);
-    };
-    let (reg, alias_width) = classify_x86_register_alias(reg_str).map_err(|err| err.to_string())?;
-    if alias_width != 8 {
+    if let Some(mode) = mode {
         return Err(format!(
-            "setcc expects an 8-bit destination from {} binary input, got '{}'",
-            mode.arch_label(),
-            reg_str.trim()
+            "architectural byte SETcc from {} binary input cannot be represented until #75",
+            mode.arch_label()
         ));
     }
-    if mode == X86ParseMode::Mode32 && reg.index().is_some_and(|index| index >= 4) {
+    let (reg, alias_width) = classify_x86_register_alias(reg_str).map_err(|err| err.to_string())?;
+    if alias_width != 64 {
         return Err(format!(
-            "unsupported x86-32 SETcc low-byte register '{}'",
+            "SETcc full-width pseudo-instruction requires a canonical 64-bit register spelling, \
+             got '{}'",
             reg_str.trim()
         ));
     }
@@ -346,8 +345,9 @@ fn x86_ir_from_mnemonic_impl(
 ) -> Result<Option<X86Instruction>, String> {
     let mnemonic = mnemonic.trim().to_lowercase();
 
-    // SETcc — one byte-register destination in machine-code input, represented
-    // as a full native-width zero-extended write by the interim IR (#75).
+    // SETcc — one canonical full-register destination in text pseudo-syntax.
+    // Mode-aware binary input is rejected because real SETcc is a byte write
+    // that cannot be represented soundly until #75.
     if let Some(suffix) = mnemonic.strip_prefix("set") {
         let cond = parse_x86_condition(suffix)?;
         let parts: Vec<&str> = op_str.split(',').map(|s| s.trim()).collect();
@@ -1558,36 +1558,43 @@ mod tests {
             };
             assert_eq!(parsed, expected, "parsing {mnemonic} failed");
             assert_eq!(parsed.to_string(), format!("{mnemonic} rax"));
+            assert_eq!(
+                parse_x86_assembly_string(&parsed.to_string(), "setcc-round-trip".to_string())
+                    .unwrap(),
+                vec![parsed],
+                "canonical {mnemonic} display must parse back to the same IR"
+            );
+        }
+
+        for partial_width in ["al", "ax", "eax"] {
+            let err = x86_ir_from_mnemonic("setne", partial_width)
+                .expect_err("partial-width SETcc text must not enter the full-width pseudo-IR");
+            assert!(
+                err.contains("full-width pseudo-instruction"),
+                "unexpected error for {partial_width}: {err}"
+            );
         }
     }
 
     #[test]
-    fn mode_aware_setcc_parsing_canonicalizes_architectural_low_byte_aliases() {
-        for (mode, operand, expected_rd) in [
-            (X86ParseMode::Mode64, "al", X86Register::RAX),
-            (X86ParseMode::Mode64, "spl", X86Register::RSP),
-            (X86ParseMode::Mode64, "r8b", X86Register::R8),
-            (X86ParseMode::Mode32, "al", X86Register::RAX),
-            (X86ParseMode::Mode32, "bl", X86Register::RBX),
+    fn mode_aware_setcc_parsing_rejects_architectural_byte_instructions_until_issue_75() {
+        for (mode, operand) in [
+            (X86ParseMode::Mode64, "al"),
+            (X86ParseMode::Mode64, "spl"),
+            (X86ParseMode::Mode64, "r8b"),
+            (X86ParseMode::Mode64, "ah"),
+            (X86ParseMode::Mode64, "byte ptr [rax]"),
+            (X86ParseMode::Mode32, "al"),
+            (X86ParseMode::Mode32, "bl"),
         ] {
-            assert_eq!(
-                x86_ir_from_mnemonic_for_mode("setne", operand, mode)
-                    .unwrap()
-                    .unwrap(),
-                X86Instruction::Setcc {
-                    rd: expected_rd,
-                    cond: X86Condition::NE,
-                }
+            let err = x86_ir_from_mnemonic_for_mode("setne", operand, mode)
+                .expect_err("architectural byte SETcc must not enter the full-width pseudo-IR");
+            assert!(
+                err.contains("cannot be represented until #75"),
+                "unexpected error for {} {operand}: {err}",
+                mode.arch_label()
             );
         }
-
-        let err = x86_ir_from_mnemonic_for_mode("setne", "sil", X86ParseMode::Mode32)
-            .expect_err("i386 has no SIL byte register");
-        assert!(err.contains("unsupported x86-32 SETcc low-byte register"));
-
-        let err = x86_ir_from_mnemonic_for_mode("setne", "rax", X86ParseMode::Mode64)
-            .expect_err("Capstone SETcc input must name a byte register");
-        assert!(err.contains("expects an 8-bit destination"));
     }
 
     #[test]

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -12,7 +12,7 @@ use std::time::{Duration, Instant};
 
 use rayon::prelude::*;
 
-use crate::isa::{AArch64, CostModel, ISA, InstructionGenerator};
+use crate::isa::{AArch64, Assembler, CostModel, ISA, InstructionGenerator};
 use crate::search::SearchAlgorithm;
 use crate::search::candidate::generate_all_encodable_instructions;
 use crate::search::config::{Algorithm, SearchConfig};
@@ -211,7 +211,11 @@ impl EnumerativeBackend<crate::isa::X86_32> for crate::isa::X86_32 {
         regs: &[crate::isa::x86::X86Register],
         imms: &[i64],
     ) -> Vec<crate::isa::x86::X86Instruction> {
-        crate::isa::x86::X86InstructionGenerator.generate_all(regs, imms)
+        crate::isa::x86::X86InstructionGenerator
+            .generate_all(regs, imms)
+            .into_iter()
+            .filter(|instruction| crate::isa::X86_32.can_assemble(instruction))
+            .collect()
     }
 
     fn sequence_cost(seq: &[crate::isa::x86::X86Instruction], config: &SearchConfig) -> u64 {
@@ -2601,6 +2605,47 @@ mod tests {
         );
         assert!(result.statistics.smt_queries > 0);
         assert!(result.statistics.smt_equivalent > 0);
+    }
+
+    #[test]
+    fn x86_32_enumerative_only_generates_assemblable_setcc_candidates() {
+        use crate::isa::x86::{X86Instruction, X86Register};
+        use crate::isa::{Assembler, X86_32};
+
+        let regs = [
+            X86Register::RAX,
+            X86Register::RSP,
+            X86Register::RBP,
+            X86Register::RSI,
+            X86Register::RDI,
+        ];
+        let candidates = <X86_32 as EnumerativeBackend<X86_32>>::enumerate_all(&regs, &[0]);
+        let setcc_count = candidates
+            .iter()
+            .filter(|instruction| matches!(instruction, X86Instruction::Setcc { .. }))
+            .count();
+
+        assert!(
+            candidates
+                .iter()
+                .all(|instruction| X86_32.can_assemble(instruction)),
+            "x86-32 enumerative search generated an unassemblable candidate"
+        );
+        assert_eq!(
+            setcc_count,
+            crate::isa::x86::X86Condition::ALL.len(),
+            "enumerative search must retain every SETcc condition for EAX"
+        );
+        assert!(
+            candidates.iter().any(|instruction| matches!(
+                instruction,
+                X86Instruction::MovImm {
+                    rd: X86Register::RSI,
+                    ..
+                }
+            )),
+            "mode-specific SETcc filtering must not remove encodable ESI candidates"
+        );
     }
 
     // --- Latency pruning-soundness (issue #622) ---

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -1096,11 +1096,10 @@ mod tests {
         let mut search: StochasticSearch<X86_64> = StochasticSearch::new();
         let config = SearchConfig::default()
             .with_stochastic(
-                // Seed retuned to 2 when LEA raised the rewritable opcode count
-                // to 29, shifting the seeded mutation trajectory. A 0..64 seed
-                // sweep confirms seed 2 reaches `mov rax, rbx` within 500 iters
-                // (many other seeds also work; 2 was picked as the lowest
-                // passing value).
+                // Adding rewritable families shifts the seeded mutation
+                // trajectory. With SETcc raising the opcode count to 30, seed 2
+                // reaches the equally valid `imul rax, rbx, 1` collapse within
+                // 500 iterations (flags are dead in this test).
                 StochasticConfig::default()
                     .with_iterations(500)
                     .with_seed(2),
@@ -1131,9 +1130,10 @@ mod tests {
         assert_eq!(result.cost_savings(), 1);
         assert_eq!(
             result.optimized_sequence,
-            Some(vec![X86Instruction::MovReg {
+            Some(vec![X86Instruction::ImulRegImm {
                 rd: X86Register::RAX,
                 rs: X86Register::RBX,
+                imm: 1,
             }])
         );
     }

--- a/src/search/symbolic/backend.rs
+++ b/src/search/symbolic/backend.rs
@@ -8,7 +8,7 @@
 //! Both AArch64 and x86 implement this trait by delegating to the
 //! existing free helpers and the generic equivalence checker.
 
-use crate::isa::{CostModel, ISA, InstructionGenerator};
+use crate::isa::{Assembler, CostModel, ISA, InstructionGenerator};
 use crate::search::config::SearchConfig;
 use crate::semantics::cost::CostMetric;
 use crate::semantics::{EquivalenceMetrics, EquivalenceResult};
@@ -215,7 +215,11 @@ impl SymbolicBackend<crate::isa::X86_32> for crate::isa::X86_32 {
         regs: &[crate::isa::x86::X86Register],
         imms: &[i64],
     ) -> Vec<crate::isa::x86::X86Instruction> {
-        crate::isa::x86::X86InstructionGenerator.generate_all(regs, imms)
+        crate::isa::x86::X86InstructionGenerator
+            .generate_all(regs, imms)
+            .into_iter()
+            .filter(|instruction| crate::isa::X86_32.can_assemble(instruction))
+            .collect()
     }
 
     fn target_terminator(
@@ -328,6 +332,47 @@ mod tests {
         assert_eq!(
             <crate::isa::AArch64 as SymbolicBackend<crate::isa::AArch64>>::width(),
             64
+        );
+    }
+
+    #[test]
+    fn x86_32_symbolic_only_generates_assemblable_setcc_candidates() {
+        use crate::isa::x86::{X86Instruction, X86Register};
+        use crate::isa::{Assembler, X86_32};
+
+        let regs = [
+            X86Register::RAX,
+            X86Register::RSP,
+            X86Register::RBP,
+            X86Register::RSI,
+            X86Register::RDI,
+        ];
+        let candidates = <X86_32 as SymbolicBackend<X86_32>>::enumerate_all(&regs, &[0]);
+        let setcc_count = candidates
+            .iter()
+            .filter(|instruction| matches!(instruction, X86Instruction::Setcc { .. }))
+            .count();
+
+        assert!(
+            candidates
+                .iter()
+                .all(|instruction| X86_32.can_assemble(instruction)),
+            "x86-32 symbolic search generated an unassemblable candidate"
+        );
+        assert_eq!(
+            setcc_count,
+            crate::isa::x86::X86Condition::ALL.len(),
+            "symbolic search must retain every SETcc condition for EAX"
+        );
+        assert!(
+            candidates.iter().any(|instruction| matches!(
+                instruction,
+                X86Instruction::MovImm {
+                    rd: X86Register::RSI,
+                    ..
+                }
+            )),
+            "mode-specific SETcc filtering must not remove encodable ESI candidates"
         );
     }
 }

--- a/src/semantics/concrete_x86.rs
+++ b/src/semantics/concrete_x86.rs
@@ -75,6 +75,10 @@ pub fn apply_instruction_concrete_x86(
             }
             // CMOV does not write EFLAGS regardless of the branch taken.
         }
+        X86Instruction::Setcc { rd, cond } => {
+            let value = u64::from(state.get_flags().evaluate(*cond));
+            state.set_register(*rd, ConcreteValue::new(value));
+        }
         // Jcc transfers control; PC is unmodelled and the search peels
         // it off via `split_terminator_x86`. Treat as a no-op for
         // safety if a stray Jcc reaches the concrete executor.
@@ -1471,6 +1475,135 @@ mod tests {
     }
 
     // --- CMOVcc concrete semantics ---
+
+    #[test]
+    fn setcc_materializes_every_condition_and_preserves_flags() {
+        use crate::isa::x86::X86Condition;
+
+        fn flags(cf: bool, pf: bool, zf: bool, sf: bool, of: bool) -> Eflags {
+            Eflags {
+                cf,
+                pf,
+                af: false,
+                zf,
+                sf,
+                of,
+            }
+        }
+
+        let cases = [
+            (
+                X86Condition::E,
+                flags(false, false, true, false, false),
+                flags(false, false, false, false, false),
+            ),
+            (
+                X86Condition::NE,
+                flags(false, false, false, false, false),
+                flags(false, false, true, false, false),
+            ),
+            (
+                X86Condition::B,
+                flags(true, false, false, false, false),
+                flags(false, false, false, false, false),
+            ),
+            (
+                X86Condition::AE,
+                flags(false, false, false, false, false),
+                flags(true, false, false, false, false),
+            ),
+            (
+                X86Condition::BE,
+                flags(true, false, false, false, false),
+                flags(false, false, false, false, false),
+            ),
+            (
+                X86Condition::A,
+                flags(false, false, false, false, false),
+                flags(true, false, false, false, false),
+            ),
+            (
+                X86Condition::L,
+                flags(false, false, false, true, false),
+                flags(false, false, false, false, false),
+            ),
+            (
+                X86Condition::GE,
+                flags(false, false, false, true, true),
+                flags(false, false, false, true, false),
+            ),
+            (
+                X86Condition::LE,
+                flags(false, false, true, false, false),
+                flags(false, false, false, false, false),
+            ),
+            (
+                X86Condition::G,
+                flags(false, false, false, true, true),
+                flags(false, false, true, false, false),
+            ),
+            (
+                X86Condition::S,
+                flags(false, false, false, true, false),
+                flags(false, false, false, false, false),
+            ),
+            (
+                X86Condition::NS,
+                flags(false, false, false, false, false),
+                flags(false, false, false, true, false),
+            ),
+            (
+                X86Condition::O,
+                flags(false, false, false, false, true),
+                flags(false, false, false, false, false),
+            ),
+            (
+                X86Condition::NO,
+                flags(false, false, false, false, false),
+                flags(false, false, false, false, true),
+            ),
+            (
+                X86Condition::P,
+                flags(false, true, false, false, false),
+                flags(false, false, false, false, false),
+            ),
+            (
+                X86Condition::NP,
+                flags(false, false, false, false, false),
+                flags(false, true, false, false, false),
+            ),
+        ];
+
+        for width in [32, 64] {
+            for (cond, true_flags, false_flags) in cases {
+                for (input_flags, expected) in [(true_flags, 1), (false_flags, 0)] {
+                    let mut state = X86ConcreteMachineState::new_zeroed(width);
+                    state.set_register(X86Register::RAX, ConcreteValue::new(u64::MAX));
+                    state.set_flags(input_flags);
+
+                    let after = apply_instruction_concrete_x86(
+                        state,
+                        &X86Instruction::Setcc {
+                            rd: X86Register::RAX,
+                            cond,
+                        },
+                    );
+                    assert_eq!(
+                        after.get_register(X86Register::RAX).as_u64(),
+                        expected,
+                        "x86-{width} SET{} result",
+                        cond.suffix()
+                    );
+                    assert_eq!(
+                        after.get_flags(),
+                        input_flags,
+                        "x86-{width} SET{} modified EFLAGS",
+                        cond.suffix()
+                    );
+                }
+            }
+        }
+    }
 
     #[test]
     fn cmov_when_condition_true_writes_source() {

--- a/src/semantics/cost_x86.rs
+++ b/src/semantics/cost_x86.rs
@@ -160,6 +160,12 @@ fn instruction_code_size(instr: &X86Instruction, width: u32) -> u64 {
         | X86Instruction::TestImm { .. } => 6 + rex,
         // CMOV is `0F 4x ModR/M` = 3 bytes plus REX.W on 64-bit.
         X86Instruction::Cmov { .. } => 3 + rex,
+        // SETcc is `0F 9x ModR/M` = 3 bytes. In x86-64, low-byte registers
+        // SPL..DIL and R8B..R15B (indices 4..15) need a REX prefix; AL..BL do
+        // not. x86-32 only admits indices 0..3 for this family.
+        X86Instruction::Setcc { rd, .. } => {
+            3 + u64::from(width == 64 && rd.index().is_some_and(|index| index >= 4))
+        }
         // Short-form Jcc is `7x rel8` = 2 bytes (no REX). Long-form
         // `0F 8x rel32` = 6 bytes is used when the displacement doesn't
         // fit. The optimizer never emits Jcc bytes (terminators stay
@@ -512,7 +518,25 @@ mod tests {
         assert_eq!(instruction_cost(&small, &CostMetric::CodeSize, 32), 5);
     }
 
-    // --- CMOV / Jcc cost ---
+    // --- SETcc / CMOV / Jcc cost ---
+
+    #[test]
+    fn setcc_code_size_accounts_for_optional_rex_prefix() {
+        use crate::isa::x86::X86Condition;
+
+        let setne_rax = X86Instruction::Setcc {
+            rd: X86Register::RAX,
+            cond: X86Condition::NE,
+        };
+        let setne_rsp = X86Instruction::Setcc {
+            rd: X86Register::RSP,
+            cond: X86Condition::NE,
+        };
+        assert_eq!(instruction_cost(&setne_rax, &CostMetric::CodeSize, 64), 3);
+        assert_eq!(instruction_cost(&setne_rsp, &CostMetric::CodeSize, 64), 4);
+        assert_eq!(instruction_cost(&setne_rax, &CostMetric::CodeSize, 32), 3);
+        assert_eq!(instruction_cost(&setne_rax, &CostMetric::Latency, 64), 1);
+    }
 
     #[test]
     fn cmov_code_size_includes_rex_on_64_bit() {

--- a/src/semantics/cost_x86.rs
+++ b/src/semantics/cost_x86.rs
@@ -1,7 +1,8 @@
 //! Cost model for the x86 backend.
 //!
 //! x86 is variable-length, so `CodeSize` is an approximation per variant.
-//! `InstructionCount` is a flat per-instruction sum.
+//! `InstructionCount` counts emitted machine instructions; the full-width
+//! SETcc pseudo-instruction counts as its SETcc + MOVZX lowering.
 //! Width-aware: x86-32 encodings save one byte per REX prefix.
 //!
 //! # Latency model (issue #622)
@@ -19,7 +20,8 @@
 //!    accessed 2026-06) for the Intel **Skylake** microarchitecture, cross-checked
 //!    against <https://uops.info/>. On Skylake the simple integer ALU ops
 //!    (MOV/ADD/SUB/AND/OR/XOR/INC/DEC/NEG/NOT/CMP/TEST/shift-by-imm/rotate-by-imm
-//!    and CMOV) have **1-cycle** latency, while two-operand/three-operand integer
+//!    and CMOV) have **1-cycle** latency, SETcc's two-operation lowering has
+//!    **2-cycle** dependent latency, and two-operand/three-operand integer
 //!    multiply (`IMUL r,r` / `IMUL r,r,imm`) has **3-cycle** latency. A
 //!    register-to-register MOV is special-cased to **0** because Skylake (and all
 //!    Sandy-Bridge-and-later cores) eliminate it at rename — it never sits on a
@@ -70,7 +72,10 @@ use crate::semantics::cost::CostMetric;
 /// critical path equals its own latency, so the two agree on length-1 inputs.
 pub fn instruction_cost(instr: &X86Instruction, metric: &CostMetric, width: u32) -> u64 {
     match metric {
-        CostMetric::InstructionCount => 1,
+        CostMetric::InstructionCount => match instr {
+            X86Instruction::Setcc { .. } => 2,
+            _ => 1,
+        },
         CostMetric::Latency => instruction_latency(instr),
         CostMetric::CodeSize => instruction_code_size(instr, width),
     }
@@ -87,6 +92,8 @@ fn instruction_latency(instr: &X86Instruction) -> u64 {
     match instr {
         // Register-rename move elimination: zero-latency on the critical path.
         X86Instruction::MovReg { .. } => 0,
+        // Full-width SETcc lowers to a byte SETcc followed by a dependent MOVZX.
+        X86Instruction::Setcc { .. } => 2,
         // Two-/three-operand signed multiply: 3-cycle latency on Skylake.
         X86Instruction::ImulReg { .. } | X86Instruction::ImulRegImm { .. } => 3,
         // Everything else in the supported set is a 1-cycle integer ALU op:
@@ -160,11 +167,12 @@ fn instruction_code_size(instr: &X86Instruction, width: u32) -> u64 {
         | X86Instruction::TestImm { .. } => 6 + rex,
         // CMOV is `0F 4x ModR/M` = 3 bytes plus REX.W on 64-bit.
         X86Instruction::Cmov { .. } => 3 + rex,
-        // SETcc is `0F 9x ModR/M` = 3 bytes. In x86-64, low-byte registers
-        // SPL..DIL and R8B..R15B (indices 4..15) need a REX prefix; AL..BL do
-        // not. x86-32 only admits indices 0..3 for this family.
+        // Full-width SETcc lowers to `0F 9x ModR/M` plus
+        // `0F B6 ModR/M` (MOVZX), 6 bytes total. In x86-64, SPL..DIL and
+        // R8B..R15B (indices 4..15) need a REX prefix on both instructions.
+        // x86-32 only admits indices 0..3 for this family.
         X86Instruction::Setcc { rd, .. } => {
-            3 + u64::from(width == 64 && rd.index().is_some_and(|index| index >= 4))
+            6 + 2 * u64::from(width == 64 && rd.index().is_some_and(|index| index >= 4))
         }
         // Short-form Jcc is `7x rel8` = 2 bytes (no REX). Long-form
         // `0F 8x rel32` = 6 bytes is used when the displacement doesn't
@@ -385,6 +393,28 @@ mod tests {
         assert_eq!(sequence_cost(&seq, &CostMetric::Latency, 64), 2);
     }
 
+    /// SETcc's two-instruction lowering contributes its internal dependency:
+    /// CMP (1) -> SETcc+MOVZX (2) -> consumer (1) is a 4-cycle chain.
+    #[test]
+    fn critical_path_accounts_for_setcc_macro_lowering() {
+        use crate::isa::x86::X86Condition;
+        let seq = [
+            X86Instruction::CmpReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            X86Instruction::Setcc {
+                rd: X86Register::RCX,
+                cond: X86Condition::NE,
+            },
+            X86Instruction::AddReg {
+                rd: X86Register::RDX,
+                rs: X86Register::RCX,
+            },
+        ];
+        assert_eq!(sequence_cost(&seq, &CostMetric::Latency, 64), 4);
+    }
+
     /// A register-to-register MOV is eliminated at rename, so it adds 0 to the
     /// critical path: `mov rax, rbx; add rax, rcx` costs the same as the lone
     /// `add` (1 cycle), not 2.
@@ -521,7 +551,7 @@ mod tests {
     // --- SETcc / CMOV / Jcc cost ---
 
     #[test]
-    fn setcc_code_size_accounts_for_optional_rex_prefix() {
+    fn setcc_cost_accounts_for_two_instruction_lowering() {
         use crate::isa::x86::X86Condition;
 
         let setne_rax = X86Instruction::Setcc {
@@ -532,10 +562,19 @@ mod tests {
             rd: X86Register::RSP,
             cond: X86Condition::NE,
         };
-        assert_eq!(instruction_cost(&setne_rax, &CostMetric::CodeSize, 64), 3);
-        assert_eq!(instruction_cost(&setne_rsp, &CostMetric::CodeSize, 64), 4);
-        assert_eq!(instruction_cost(&setne_rax, &CostMetric::CodeSize, 32), 3);
-        assert_eq!(instruction_cost(&setne_rax, &CostMetric::Latency, 64), 1);
+        let setne_r8 = X86Instruction::Setcc {
+            rd: X86Register::R8,
+            cond: X86Condition::NE,
+        };
+        assert_eq!(instruction_cost(&setne_rax, &CostMetric::CodeSize, 64), 6);
+        assert_eq!(instruction_cost(&setne_rsp, &CostMetric::CodeSize, 64), 8);
+        assert_eq!(instruction_cost(&setne_r8, &CostMetric::CodeSize, 64), 8);
+        assert_eq!(instruction_cost(&setne_rax, &CostMetric::CodeSize, 32), 6);
+        assert_eq!(
+            instruction_cost(&setne_rax, &CostMetric::InstructionCount, 64),
+            2
+        );
+        assert_eq!(instruction_cost(&setne_rax, &CostMetric::Latency, 64), 2);
     }
 
     #[test]

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -1531,6 +1531,53 @@ mod tests {
         assert!(metrics.smt_elapsed > Duration::ZERO);
     }
 
+    #[test]
+    fn x86_smt_proves_each_setcc_matches_mov_cmov_construction() {
+        use crate::isa::x86::X86Condition;
+
+        for cond in X86Condition::ALL {
+            let setcc = vec![X86Instruction::Setcc {
+                rd: X86Register::RAX,
+                cond,
+            }];
+            let mov_cmov = vec![
+                X86Instruction::MovImm {
+                    rd: X86Register::RAX,
+                    imm: 0,
+                },
+                X86Instruction::MovImm {
+                    rd: X86Register::RBX,
+                    imm: 1,
+                },
+                X86Instruction::Cmov {
+                    rd: X86Register::RAX,
+                    rs: X86Register::RBX,
+                    cond,
+                },
+            ];
+
+            let mut cfg64 = EquivalenceConfigFor::<crate::isa::X86_64>::default()
+                .live_out(X86LiveOut::from_registers(vec![X86Register::RAX]).with_flags(true));
+            cfg64.random_test_count = 0;
+            assert_eq!(
+                check_equivalence_for::<crate::isa::X86_64>(&setcc, &mov_cmov, &cfg64),
+                EquivalenceResult::Equivalent,
+                "x86-64 SET{} did not match MOV/CMOV construction",
+                cond.suffix()
+            );
+
+            let mut cfg32 = EquivalenceConfigFor::<crate::isa::X86_32>::default()
+                .live_out(X86LiveOut::from_registers(vec![X86Register::RAX]).with_flags(true));
+            cfg32.random_test_count = 0;
+            assert_eq!(
+                check_equivalence_for::<crate::isa::X86_32>(&setcc, &mov_cmov, &cfg32),
+                EquivalenceResult::Equivalent,
+                "x86-32 SET{} did not match MOV/CMOV construction",
+                cond.suffix()
+            );
+        }
+    }
+
     // --- SMT path catches flag-only divergence when flags_live ---
 
     #[test]

--- a/src/semantics/smt_x86.rs
+++ b/src/semantics/smt_x86.rs
@@ -624,6 +624,12 @@ pub fn apply_instruction(
             let rd_old = state.get_register(*rd).clone();
             state.set_register(*rd, pred.ite(&rs_val, &rd_old));
         }
+        X86Instruction::Setcc { rd, cond } => {
+            let pred = x86_condition_to_smt(*cond, state.get_flags());
+            let one = BV::from_u64(1, state.width());
+            let zero = BV::from_u64(0, state.width());
+            state.set_register(*rd, pred.ite(&one, &zero));
+        }
         // Jcc reads EFLAGS but transfers control; nothing is observable
         // in the data-state machine modelled here. Cycle 10 peels Jccs
         // off the sequence before applying it symbolically.

--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -398,12 +398,12 @@ pub fn compute_live_in_registers(instructions: &[Instruction]) -> RegisterSet<Re
 /// Build an x86 `RegisterSet` from a target sequence by treating every
 /// written register as live-out and declaring EFLAGS live whenever the
 /// target contains any instruction with observable side effects (i.e.
-/// any non-MOV / non-CMOV / non-Jcc variant — see
+/// any non-MOV / non-SETcc / non-CMOV / non-Jcc variant — see
 /// `InstructionType::has_side_effects` for the contract).
 ///
-/// **Asymmetry:** CMOV and Jcc READ EFLAGS but report
-/// `has_side_effects=false` (they don't write flags), so a CMOV-only or
-/// Jcc-only target gets `flags_live=false` from this helper.
+/// **Asymmetry:** SETcc, CMOV, and Jcc READ EFLAGS but report
+/// `has_side_effects=false` (they don't write flags), so a target containing
+/// only these families gets `flags_live=false` from this helper.
 /// x86 equivalence compensates for a fixed trailing Jcc by forcing flags into
 /// the effective live-out contract before comparing prefixes. Direct callers
 /// that bypass the generic equivalence entry point must apply their own

--- a/tests/integration/docs_capability.rs
+++ b/tests/integration/docs_capability.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use s11::docs_support::{
     AARCH64_FIXED_TERMINATORS, AARCH64_REWRITABLE_MNEMONICS, X86_FIXED_TERMINATORS,
-    X86_REWRITABLE_MNEMONICS,
+    X86_REWRITABLE_MNEMONICS, X86_SYNTHESIZABLE_ONLY_MNEMONICS,
 };
 
 fn repo_file(relative: &str) -> PathBuf {
@@ -315,6 +315,12 @@ fn x86_support_is_visible_in_public_docs() {
             "docs/capability.md must list x86 fixed terminator `{terminator}`"
         );
     }
+    for pseudo in X86_SYNTHESIZABLE_ONLY_MNEMONICS {
+        assert!(
+            matrix.contains(&format!("`{pseudo}`")),
+            "docs/capability.md must list x86 synthesizable-only pseudo-family `{pseudo}`"
+        );
+    }
 
     for family in ["set<cond>", "cmov<cond>", "j<cond>"] {
         assert!(
@@ -327,8 +333,26 @@ fn x86_support_is_visible_in_public_docs() {
         "docs/capability.md must describe CMOVcc as rewritable"
     );
     assert!(
-        matrix.contains("rewritable") && matrix.contains("`set<cond>`"),
-        "docs/capability.md must describe SETcc as rewritable"
+        !X86_REWRITABLE_MNEMONICS.contains(&"set<cond>"),
+        "architectural byte SETcc must not be classified as binary-rewritable"
+    );
+    assert!(
+        X86_SYNTHESIZABLE_ONLY_MNEMONICS.contains(&"set<cond>"),
+        "full-width SETcc must be classified as synthesizable-only"
+    );
+    assert!(
+        matrix.contains("synthesizable-only") && matrix.contains("`set<cond>`"),
+        "docs/capability.md must describe SETcc as a synthesizable-only pseudo-family"
+    );
+    assert!(
+        matrix.contains("architectural byte setcc")
+            && matrix.contains("elf")
+            && matrix.contains("rejected until #75"),
+        "docs/capability.md must document architectural byte SETcc ELF rejection"
+    );
+    assert!(
+        matrix.contains("setcc") && matrix.contains("followed by") && matrix.contains("movzx"),
+        "docs/capability.md must document the SETcc followed by MOVZX lowering"
     );
     assert!(
         matrix.contains("fixed") && matrix.contains("terminator") && matrix.contains("`j<cond>`"),

--- a/tests/integration/docs_capability.rs
+++ b/tests/integration/docs_capability.rs
@@ -316,7 +316,7 @@ fn x86_support_is_visible_in_public_docs() {
         );
     }
 
-    for family in ["cmov<cond>", "j<cond>"] {
+    for family in ["set<cond>", "cmov<cond>", "j<cond>"] {
         assert!(
             matrix.contains(&format!("`{family}`")),
             "docs/capability.md must list x86 family `{family}`"
@@ -325,6 +325,10 @@ fn x86_support_is_visible_in_public_docs() {
     assert!(
         matrix.contains("rewritable") && matrix.contains("`cmov<cond>`"),
         "docs/capability.md must describe CMOVcc as rewritable"
+    );
+    assert!(
+        matrix.contains("rewritable") && matrix.contains("`set<cond>`"),
+        "docs/capability.md must describe SETcc as rewritable"
     );
     assert!(
         matrix.contains("fixed") && matrix.contains("terminator") && matrix.contains("`j<cond>`"),


### PR DESCRIPTION
## Summary

- add all 16 SETcc conditions to the x86 IR, text parser, concrete and SMT semantics, flag analysis, and search generation
- model SETcc as a synthesizable full-width pseudo-instruction that reads and preserves EFLAGS, while rejecting architectural byte SETcc from ELF/Capstone input until #75
- lower candidates to flag-preserving byte SETcc followed by same-register MOVZX, with exact x86-64/x86-32 encodability and cost accounting
- document SETcc as synthesis-only and test parser, optimizer, assembler, concrete, SMT, cost, and capability boundaries

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`
- `./ci_check.sh`

Closes #631

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**