### PR TITLE
feat(x86): model sub-register aliasing

### DIFF
--- a/docs/adr/0004-isa-trait-collapse.md
+++ b/docs/adr/0004-isa-trait-collapse.md
@@ -7,7 +7,7 @@ Date: 2026-05-16
 
 The x86 `Assembler::can_assemble` implementations in `src/isa/x86.rs` intentionally duplicate the assembler-side immediate constraints from `src/assembler/x86.rs`. The prefilter helpers `x86_signed_imm32_ok` and `x86_imm32_bitpattern_ok` keep generic search helpers such as `src/search/candidate.rs::is_sequence_encodable_for` from sending obviously unencodable candidates into the heavier dynasm path. The assembler helpers `signed_imm_i32` and `imm32_bitpattern_i32` remain the final encoding authority and own the emitted error text.
 
-This is an accepted cost of the trait/assembler boundary, not a request to collapse the helper pairs into shared code. Future x86 immediate-encoding changes must update both sides: the ISA prefilter should stay conservative, and the assembler should stay authoritative. In particular, x86-64 non-`MOV` immediate forms are limited to signed imm32 encodings, x86-64 `MovImm` may still use `movabs` for full-width immediates, and x86-32 immediate forms accept canonical 32-bit bit patterns while continuing to reject R8-R15 register operands.
+This is an accepted cost of the trait/assembler boundary, not a request to collapse the helper pairs into shared code. Future x86 immediate-encoding changes must update both sides: the ISA prefilter should stay conservative, and the assembler should stay authoritative. In particular, native 64-bit x86-64 non-`MOV` forms require a sign-extendable imm32, while dword x86-64 forms and effective-32-bit x86-32 forms accept either signed values or canonical unsigned imm32 bit patterns. Native x86-64 `MovImm` may still use `movabs` for full-width immediates, and x86-32 continues to reject R8-R15 register operands.
 
 ## Context
 

--- a/docs/adr/0010-x86-register-views.md
+++ b/docs/adr/0010-x86-register-views.md
@@ -1,0 +1,81 @@
+# ADR-0010: Represent x86 sub-register operands as register views
+
+## Status
+
+Accepted for issue #75.
+
+## Context
+
+The x86 IR historically stored only a canonical GPR such as `RAX`. Parsing
+`rax`, `eax`, `ax`, and `al` therefore produced the same value, even though the
+operands select different architectural bits and have different write
+semantics. Legacy high-byte operands such as `ah` were rejected entirely.
+
+Operand width affects every correctness boundary: concrete and SMT execution,
+flag computation, liveness, code size, assembly, and search. A 32-bit write in
+x86-64 clears bits 63:32, while 8/16-bit writes preserve all bits outside their
+selected slice. High-byte writes select bits 15:8 rather than bits 7:0.
+
+## Decision
+
+`X86Register` represents an operand view consisting of:
+
+- a canonical architectural GPR identity;
+- one of native, dword, word, low-byte, or high-byte access.
+
+The existing native constants (`RAX` through `R15`) remain the default for
+programmatically constructed IR. Alias constants and parser results retain
+explicit narrower views.
+
+Architectural machine state, live-in sets, and live-out sets are always keyed
+by the canonical GPR. Instruction operands retain their views until execution
+or encoding. Reads extract the selected slice. Writes:
+
+- replace the whole mode-width value for native operands;
+- zero-extend dword results to the whole GPR in x86-64 and replace the whole
+  GPR in x86-32;
+- preserve surrounding bits for word and byte results;
+- replace bits 15:8 for a high-byte result.
+
+Instructions validate operand-view compatibility at the parser and assembler
+boundaries. The legacy high-byte views are restricted to AX/BX/CX/DX and to
+encodings that do not require a REX prefix.
+
+Search carries views in its operand register pool but canonicalizes them for
+state generation and liveness. Candidate generation and mutation are filtered
+through the architecture's encodability check, which rejects incompatible
+views before equivalence checking.
+
+## Alternatives considered
+
+### Separate instruction variants for every width
+
+Variants such as `MovReg32`, `MovReg16`, `MovReg8L`, and `MovReg8H` make width
+explicit but multiply every supported opcode family and every match site.
+Mixed-width operations would require a combinatorial set of additional
+variants. This was rejected as disproportionate and difficult to extend.
+
+### One width field on every instruction
+
+An instruction-wide field avoids variant multiplication for current
+same-width operations. It does not naturally represent instructions whose
+source and destination widths differ, notably MOVZX/MOVSX, and it still needs
+an extra high-byte lane marker. This was rejected in favor of a composable
+per-operand view.
+
+### Independent architectural registers for each alias
+
+Treating `RAX`, `EAX`, `AX`, `AL`, and `AH` as independent state keys makes
+ordinary maps simple but loses architectural aliasing and would require
+cross-register synchronization after every write. This was rejected as
+error-prone in both concrete and SMT state.
+
+## Consequences
+
+The IR can round-trip sub-register spellings and model their semantics without
+new opcode variants. Future mixed-width instructions can reuse the same
+operand representation.
+
+Every state and liveness boundary must canonicalize register views. Missing
+that step would split one architectural GPR into several independent values,
+so canonicalization and partial-store behavior require dedicated regressions.

--- a/docs/capability.md
+++ b/docs/capability.md
@@ -148,12 +148,16 @@ register-base + displacement form, `lea rd, [base + disp]`, computing
 deferred and rejected as unsupported shapes. `cmov<cond>` has register operands
 and reads EFLAGS without modifying them.
 
-The x86 IR does not yet carry operand width. To avoid rewriting partial-width
-operations as full-width operations, the binary optimization path currently
-accepts only mode-width register aliases: `rax`/`r8`-style 64-bit names for
-x86-64, and `eax`-style 32-bit i386 names for x86-32. x86-64 `eax`/`ax`/`al`
-forms, x86-32 `ax`/`al` forms, and x86-32 extended-register aliases such as
-`r8d` are rejected until operand width is represented end to end.
+The x86 IR retains each GPR operand's native, dword, word, low-byte, or
+legacy high-byte view. Reads select the corresponding slice of the canonical
+architectural register. Native writes replace the mode-width register, dword
+writes zero-extend into the full GPR on x86-64, and word/byte writes preserve
+the surrounding bits. Thus `rax`/`eax`/`ax`/`al`/`ah` (and their corresponding
+GPR aliases) are distinct operands throughout parsing, search, concrete and
+SMT execution, liveness, costing, and assembly. Legacy high-byte operands are
+limited to `ah`/`bh`/`ch`/`dh` and cannot be combined with an encoding that
+requires a REX prefix. x86-32 continues to reject the x86-64-only extended
+register family (`r8` through `r15` and their aliases).
 
 Fixed control-flow terminators:
 

--- a/docs/capability.md
+++ b/docs/capability.md
@@ -117,7 +117,11 @@ the source alias and zero- or sign-extend them into the native-width destination
 high-byte sources (`ah`/`bh`/`ch`/`dh`) are not modelled. The 32-to-64 signed
 form is the distinct `movsxd` family and remains unsupported; x86 has no
 `movzx r64, r32` encoding because a 32-bit GPR write already provides that zero
-extension. `cmp` and `test` are
+extension. For the same reason, the x86-64 parser normalizes a 32-bit
+destination spelling such as `movzx eax, bl` to the native-width zero-extension
+IR. It rejects `movsx eax, bl`, whose sign extension into EAX followed by
+architectural zero-extension is not equivalent to native-width sign extension.
+`cmp` and `test` are
 flag-setting: each discards its result and writes only EFLAGS (`cmp` from a
 subtraction, `test` from a bitwise AND that clears CF/OF). `neg` and `not`
 are single-operand: `neg` computes `rd = -rd` and sets EFLAGS as if from

--- a/src/assembler/x86.rs
+++ b/src/assembler/x86.rs
@@ -1840,31 +1840,101 @@ mod tests {
     }
 
     #[test]
-    fn imul_dword_accepts_canonical_high_bit_imm32() {
-        // Regression (PR #675): the 3-operand IMUL immediate is a 32-bit
-        // field, so a canonical bit pattern like 0xffffffff (== -1) is a legal
-        // dword / native-32 encoding. `x86_can_assemble_instruction` already
-        // admits it, so the encoder must agree instead of aborting through the
-        // signed-only helper reserved for the sign-extended 64-bit form.
-        let mut a64 = X86Assembler::new_64();
-        let bytes = a64
-            .assemble_instructions(&[X86Instruction::ImulRegImm {
-                rd: X86Register::EAX,
-                rs: X86Register::ECX,
-                imm: i64::from(u32::MAX),
-            }])
-            .expect("dword IMUL should encode a canonical imm32 bit pattern");
-        assert_eq!(disasm_x86_64(&bytes)[0].0, "imul");
+    fn imul_32_bit_operands_accept_canonical_imm32_bitpatterns() {
+        let can_assemble =
+            |mode, instruction: &X86Instruction| match mode {
+                X86Mode::Mode64 => <crate::isa::x86::X86_64 as crate::isa::Assembler<
+                    X86Instruction,
+                >>::can_assemble(
+                    &crate::isa::x86::X86_64, instruction
+                ),
+                X86Mode::Mode32 => <crate::isa::x86::X86_32 as crate::isa::Assembler<
+                    X86Instruction,
+                >>::can_assemble(
+                    &crate::isa::x86::X86_32, instruction
+                ),
+            };
+        let assemble = |mode, instruction| {
+            match mode {
+                X86Mode::Mode64 => X86Assembler::new_64(),
+                X86Mode::Mode32 => X86Assembler::new_32(),
+            }
+            .assemble_instructions(&[instruction])
+        };
 
-        let mut a32 = X86Assembler::new_32();
-        let bytes = a32
-            .assemble_instructions(&[X86Instruction::ImulRegImm {
-                rd: X86Register::RCX,
-                rs: X86Register::RDX,
-                imm: i64::from(u32::MAX),
-            }])
-            .expect("x86-32 IMUL should encode a canonical imm32 bit pattern");
-        assert_eq!(disasm_x86_32(&bytes)[0].0, "imul");
+        let canonical_u32_max = i64::from(u32::MAX);
+        let accepted = [
+            (
+                "x86-64 dword",
+                X86Mode::Mode64,
+                X86Register::EAX,
+                X86Register::EBX,
+            ),
+            (
+                "x86-32 native",
+                X86Mode::Mode32,
+                X86Register::RAX,
+                X86Register::RBX,
+            ),
+        ];
+        for (description, mode, rd, rs) in accepted {
+            let unsigned = X86Instruction::ImulRegImm {
+                rd,
+                rs,
+                imm: canonical_u32_max,
+            };
+            assert!(
+                can_assemble(mode, &unsigned),
+                "{description}: prefilter rejected a canonical imm32 bit pattern"
+            );
+            let unsigned_bytes = assemble(mode, unsigned)
+                .unwrap_or_else(|error| panic!("{description}: encoding failed: {error}"));
+            let signed_bytes = assemble(mode, X86Instruction::ImulRegImm { rd, rs, imm: -1 })
+                .unwrap_or_else(|error| panic!("{description}: signed encoding failed: {error}"));
+            assert_eq!(
+                unsigned_bytes, signed_bytes,
+                "{description}: equivalent imm32 spellings encoded differently"
+            );
+        }
+
+        let above_u32_max = canonical_u32_max + 1;
+        let rejected = [
+            (
+                "x86-64 native IMUL cannot encode positive u32::MAX",
+                X86Mode::Mode64,
+                X86Instruction::ImulRegImm {
+                    rd: X86Register::RAX,
+                    rs: X86Register::RBX,
+                    imm: canonical_u32_max,
+                },
+            ),
+            (
+                "x86-64 dword IMUL rejects values above u32::MAX",
+                X86Mode::Mode64,
+                X86Instruction::ImulRegImm {
+                    rd: X86Register::EAX,
+                    rs: X86Register::EBX,
+                    imm: above_u32_max,
+                },
+            ),
+            (
+                "x86-32 native IMUL rejects values above u32::MAX",
+                X86Mode::Mode32,
+                X86Instruction::ImulRegImm {
+                    rd: X86Register::RAX,
+                    rs: X86Register::RBX,
+                    imm: above_u32_max,
+                },
+            ),
+        ];
+        for (description, mode, instruction) in rejected {
+            assert!(
+                !can_assemble(mode, &instruction),
+                "{description}: prefilter accepted it"
+            );
+            let encoded = assemble(mode, instruction);
+            assert!(encoded.is_err(), "{description}: encoder accepted it");
+        }
     }
 
     #[test]

--- a/src/assembler/x86.rs
+++ b/src/assembler/x86.rs
@@ -611,7 +611,12 @@ fn encode_64(ops: &mut dynasmrt::x64::Assembler, instr: &X86Instruction) -> Resu
                     dynasm!(ops ; .arch x64 ; imul Rq(rd), Rq(rs), imm);
                 }
                 X86RegisterView::Dword => {
-                    let imm = signed_imm_i32(*imm)?;
+                    // The 3-operand IMUL immediate is a 32-bit field, so a
+                    // canonical bit pattern (e.g. 0xffffffff == -1) is a legal
+                    // dword encoding; match the encodability filter and the
+                    // sibling dword arithmetic encoders rather than the
+                    // signed-only helper used by the sign-extended 64-bit form.
+                    let imm = imm32_bitpattern_i32(*imm)?;
                     dynasm!(ops ; .arch x64 ; imul Rd(rd), Rd(rs), imm);
                 }
                 X86RegisterView::Word => {
@@ -869,7 +874,10 @@ fn encode_32(ops: &mut dynasmrt::x86::Assembler, instr: &X86Instruction) -> Resu
             let rs = reg_index_32(*rs)?;
             match view {
                 X86RegisterView::Native | X86RegisterView::Dword => {
-                    let imm = signed_imm_i32(*imm)?;
+                    // x86-32 operands are 32-bit, so the IMUL immediate is a
+                    // 32-bit field that admits any canonical bit pattern
+                    // (0xffffffff == -1), matching the encodability filter.
+                    let imm = imm32_bitpattern_i32(*imm)?;
                     dynasm!(ops ; .arch x86 ; imul Rd(rd), Rd(rs), imm);
                 }
                 X86RegisterView::Word => {
@@ -1829,6 +1837,34 @@ mod tests {
             "cmp",
             &["eax", "0xffffffff"],
         );
+    }
+
+    #[test]
+    fn imul_dword_accepts_canonical_high_bit_imm32() {
+        // Regression (PR #675): the 3-operand IMUL immediate is a 32-bit
+        // field, so a canonical bit pattern like 0xffffffff (== -1) is a legal
+        // dword / native-32 encoding. `x86_can_assemble_instruction` already
+        // admits it, so the encoder must agree instead of aborting through the
+        // signed-only helper reserved for the sign-extended 64-bit form.
+        let mut a64 = X86Assembler::new_64();
+        let bytes = a64
+            .assemble_instructions(&[X86Instruction::ImulRegImm {
+                rd: X86Register::EAX,
+                rs: X86Register::ECX,
+                imm: i64::from(u32::MAX),
+            }])
+            .expect("dword IMUL should encode a canonical imm32 bit pattern");
+        assert_eq!(disasm_x86_64(&bytes)[0].0, "imul");
+
+        let mut a32 = X86Assembler::new_32();
+        let bytes = a32
+            .assemble_instructions(&[X86Instruction::ImulRegImm {
+                rd: X86Register::RCX,
+                rs: X86Register::RDX,
+                imm: i64::from(u32::MAX),
+            }])
+            .expect("x86-32 IMUL should encode a canonical imm32 bit pattern");
+        assert_eq!(disasm_x86_32(&bytes)[0].0, "imul");
     }
 
     #[test]

--- a/src/assembler/x86.rs
+++ b/src/assembler/x86.rs
@@ -17,7 +17,7 @@
 // disfiguring the macro invocations. Allow at module scope.
 #![allow(clippy::useless_conversion)]
 
-use crate::isa::x86::{X86Condition, X86Instruction, X86Register};
+use crate::isa::x86::{X86Condition, X86Instruction, X86Register, X86RegisterView};
 use dynasm::dynasm;
 use dynasmrt::DynasmApi;
 
@@ -68,6 +68,337 @@ fn reg_index_32(reg: X86Register) -> Result<u8, String> {
     Ok(i)
 }
 
+fn validate_register_pair(
+    lhs: X86Register,
+    rhs: X86Register,
+    mode_width: u32,
+) -> Result<(), String> {
+    validate_single_register(lhs, mode_width)?;
+    validate_single_register(rhs, mode_width)?;
+    if lhs.effective_width(mode_width) != rhs.effective_width(mode_width) {
+        return Err(format!("register widths do not match: {} and {}", lhs, rhs));
+    }
+    if (lhs.is_high_byte() || rhs.is_high_byte())
+        && (lhs.index().is_some_and(|index| index >= 4)
+            || rhs.index().is_some_and(|index| index >= 4))
+    {
+        return Err(format!(
+            "high-byte register cannot be encoded when a REX prefix is required: {}, {}",
+            lhs, rhs
+        ));
+    }
+    Ok(())
+}
+
+fn validate_single_register(reg: X86Register, mode_width: u32) -> Result<(), String> {
+    if reg.effective_width(mode_width) > mode_width {
+        return Err(format!(
+            "register {} is not available in x86-{}",
+            reg, mode_width
+        ));
+    }
+    if mode_width == 32
+        && reg.view() == X86RegisterView::LowByte
+        && reg.index().is_some_and(|index| index >= 4)
+    {
+        return Err(format!(
+            "register {} requires a REX prefix and is not available in x86-32",
+            reg
+        ));
+    }
+    Ok(())
+}
+
+macro_rules! legacy_byte_reg_reg_opcode {
+    (mov) => {
+        0x88u8
+    };
+    (add) => {
+        0x00u8
+    };
+    (sub) => {
+        0x28u8
+    };
+    (and) => {
+        0x20u8
+    };
+    (or) => {
+        0x08u8
+    };
+    (xor) => {
+        0x30u8
+    };
+    (cmp) => {
+        0x38u8
+    };
+    (test) => {
+        0x84u8
+    };
+}
+
+macro_rules! emit_legacy_byte_reg_reg {
+    ($ops:expr, $op:ident, $dst:expr, $src:expr) => {{
+        $ops.push(legacy_byte_reg_reg_opcode!($op));
+        $ops.push(0xc0u8 | (($src & 7) << 3) | ($dst & 7));
+    }};
+}
+
+macro_rules! emit_reg_reg_64 {
+    ($ops:expr, $op:ident, $lhs:expr, $rhs:expr) => {{
+        let lhs_reg = $lhs;
+        let rhs_reg = $rhs;
+        validate_register_pair(lhs_reg, rhs_reg, 64)?;
+        let lhs = reg_index(lhs_reg)?;
+        let rhs = reg_index(rhs_reg)?;
+        match (lhs_reg.view(), rhs_reg.view()) {
+            (X86RegisterView::Native, X86RegisterView::Native) => {
+                dynasm!($ops ; .arch x64 ; $op Rq(lhs), Rq(rhs))
+            }
+            (X86RegisterView::Dword, X86RegisterView::Dword) => {
+                dynasm!($ops ; .arch x64 ; $op Rd(lhs), Rd(rhs))
+            }
+            (X86RegisterView::Word, X86RegisterView::Word) => {
+                dynasm!($ops ; .arch x64 ; $op Rw(lhs), Rw(rhs))
+            }
+            (X86RegisterView::LowByte, X86RegisterView::LowByte) => {
+                dynasm!($ops ; .arch x64 ; $op Rb(lhs), Rb(rhs))
+            }
+            (X86RegisterView::HighByte, X86RegisterView::HighByte) => {
+                let lhs = lhs + 4;
+                let rhs = rhs + 4;
+                dynasm!($ops ; .arch x64 ; $op Rh(lhs), Rh(rhs))
+            }
+            (X86RegisterView::LowByte, X86RegisterView::HighByte) => {
+                let rhs = rhs + 4;
+                emit_legacy_byte_reg_reg!($ops, $op, lhs, rhs)
+            }
+            (X86RegisterView::HighByte, X86RegisterView::LowByte) => {
+                let lhs = lhs + 4;
+                emit_legacy_byte_reg_reg!($ops, $op, lhs, rhs)
+            }
+            _ => unreachable!("validated register widths select one encoding family"),
+        }
+    }};
+}
+
+macro_rules! emit_reg_imm_64 {
+    ($ops:expr, $op:ident, $reg:expr, $imm:expr) => {{
+        let register = $reg;
+        validate_single_register(register, 64)?;
+        let index = reg_index(register)?;
+        match register.view() {
+            X86RegisterView::Native => {
+                let imm = signed_imm_i32($imm)?;
+                dynasm!($ops ; .arch x64 ; $op Rq(index), imm);
+            }
+            X86RegisterView::Dword => {
+                let imm = imm32_bitpattern_i32($imm)?;
+                dynasm!($ops ; .arch x64 ; $op Rd(index), imm);
+            }
+            X86RegisterView::Word => {
+                let imm = imm16_bitpattern_i16($imm)?;
+                dynasm!($ops ; .arch x64 ; $op Rw(index), WORD imm);
+            }
+            X86RegisterView::LowByte => {
+                let imm = imm8_bitpattern_i8($imm)?;
+                dynasm!($ops ; .arch x64 ; $op Rb(index), BYTE imm);
+            }
+            X86RegisterView::HighByte => {
+                let imm = imm8_bitpattern_i8($imm)?;
+                let index = index + 4;
+                dynasm!($ops ; .arch x64 ; $op Rh(index), BYTE imm);
+            }
+        }
+    }};
+}
+
+macro_rules! emit_unary_64 {
+    ($ops:expr, $op:ident, $reg:expr) => {{
+        let register = $reg;
+        validate_single_register(register, 64)?;
+        let index = reg_index(register)?;
+        match register.view() {
+            X86RegisterView::Native => dynasm!($ops ; .arch x64 ; $op Rq(index)),
+            X86RegisterView::Dword => dynasm!($ops ; .arch x64 ; $op Rd(index)),
+            X86RegisterView::Word => dynasm!($ops ; .arch x64 ; $op Rw(index)),
+            X86RegisterView::LowByte => dynasm!($ops ; .arch x64 ; $op Rb(index)),
+            X86RegisterView::HighByte => {
+                let index = index + 4;
+                dynasm!($ops ; .arch x64 ; $op Rh(index))
+            }
+        }
+    }};
+}
+
+macro_rules! emit_shift_64 {
+    ($ops:expr, $op:ident, $reg:expr, $count:expr) => {{
+        let register = $reg;
+        validate_single_register(register, 64)?;
+        let index = reg_index(register)?;
+        let count = shift_count_imm8($count)?;
+        match register.view() {
+            X86RegisterView::Native => dynasm!($ops ; .arch x64 ; $op Rq(index), BYTE count),
+            X86RegisterView::Dword => dynasm!($ops ; .arch x64 ; $op Rd(index), BYTE count),
+            X86RegisterView::Word => dynasm!($ops ; .arch x64 ; $op Rw(index), BYTE count),
+            X86RegisterView::LowByte => dynasm!($ops ; .arch x64 ; $op Rb(index), BYTE count),
+            X86RegisterView::HighByte => {
+                let index = index + 4;
+                dynasm!($ops ; .arch x64 ; $op Rh(index), BYTE count)
+            }
+        }
+    }};
+}
+
+macro_rules! emit_reg_reg_32 {
+    ($ops:expr, $op:ident, $lhs:expr, $rhs:expr) => {{
+        let lhs_reg = $lhs;
+        let rhs_reg = $rhs;
+        validate_register_pair(lhs_reg, rhs_reg, 32)?;
+        let lhs = reg_index_32(lhs_reg)?;
+        let rhs = reg_index_32(rhs_reg)?;
+        match (lhs_reg.view(), rhs_reg.view()) {
+            (
+                X86RegisterView::Native | X86RegisterView::Dword,
+                X86RegisterView::Native | X86RegisterView::Dword,
+            ) => {
+                dynasm!($ops ; .arch x86 ; $op Rd(lhs), Rd(rhs))
+            }
+            (X86RegisterView::Word, X86RegisterView::Word) => {
+                dynasm!($ops ; .arch x86 ; $op Rw(lhs), Rw(rhs))
+            }
+            (X86RegisterView::LowByte, X86RegisterView::LowByte) => {
+                dynasm!($ops ; .arch x86 ; $op Rb(lhs), Rb(rhs))
+            }
+            (X86RegisterView::HighByte, X86RegisterView::HighByte) => {
+                let lhs = lhs + 4;
+                let rhs = rhs + 4;
+                dynasm!($ops ; .arch x86 ; $op Rh(lhs), Rh(rhs))
+            }
+            (X86RegisterView::LowByte, X86RegisterView::HighByte) => {
+                let rhs = rhs + 4;
+                emit_legacy_byte_reg_reg!($ops, $op, lhs, rhs)
+            }
+            (X86RegisterView::HighByte, X86RegisterView::LowByte) => {
+                let lhs = lhs + 4;
+                emit_legacy_byte_reg_reg!($ops, $op, lhs, rhs)
+            }
+            _ => unreachable!("validated register widths select one encoding family"),
+        }
+    }};
+}
+
+macro_rules! emit_reg_imm_32 {
+    ($ops:expr, $op:ident, $reg:expr, $imm:expr) => {{
+        let register = $reg;
+        validate_single_register(register, 32)?;
+        let index = reg_index_32(register)?;
+        match register.view() {
+            X86RegisterView::Native | X86RegisterView::Dword => {
+                let imm = imm32_bitpattern_i32($imm)?;
+                dynasm!($ops ; .arch x86 ; $op Rd(index), imm);
+            }
+            X86RegisterView::Word => {
+                let imm = imm16_bitpattern_i16($imm)?;
+                dynasm!($ops ; .arch x86 ; $op Rw(index), WORD imm);
+            }
+            X86RegisterView::LowByte => {
+                let imm = imm8_bitpattern_i8($imm)?;
+                dynasm!($ops ; .arch x86 ; $op Rb(index), BYTE imm);
+            }
+            X86RegisterView::HighByte => {
+                let imm = imm8_bitpattern_i8($imm)?;
+                let index = index + 4;
+                dynasm!($ops ; .arch x86 ; $op Rh(index), BYTE imm);
+            }
+        }
+    }};
+}
+
+macro_rules! emit_unary_32 {
+    ($ops:expr, $op:ident, $reg:expr) => {{
+        let register = $reg;
+        validate_single_register(register, 32)?;
+        let index = reg_index_32(register)?;
+        match register.view() {
+            X86RegisterView::Native | X86RegisterView::Dword => {
+                dynasm!($ops ; .arch x86 ; $op Rd(index))
+            }
+            X86RegisterView::Word => dynasm!($ops ; .arch x86 ; $op Rw(index)),
+            X86RegisterView::LowByte => dynasm!($ops ; .arch x86 ; $op Rb(index)),
+            X86RegisterView::HighByte => {
+                let index = index + 4;
+                dynasm!($ops ; .arch x86 ; $op Rh(index))
+            }
+        }
+    }};
+}
+
+macro_rules! emit_shift_32 {
+    ($ops:expr, $op:ident, $reg:expr, $count:expr) => {{
+        let register = $reg;
+        validate_single_register(register, 32)?;
+        let index = reg_index_32(register)?;
+        let count = shift_count_imm8($count)?;
+        match register.view() {
+            X86RegisterView::Native | X86RegisterView::Dword => {
+                dynasm!($ops ; .arch x86 ; $op Rd(index), BYTE count)
+            }
+            X86RegisterView::Word => dynasm!($ops ; .arch x86 ; $op Rw(index), BYTE count),
+            X86RegisterView::LowByte => dynasm!($ops ; .arch x86 ; $op Rb(index), BYTE count),
+            X86RegisterView::HighByte => {
+                let index = index + 4;
+                dynasm!($ops ; .arch x86 ; $op Rh(index), BYTE count)
+            }
+        }
+    }};
+}
+
+macro_rules! emit_cmov_64_for_family {
+    ($ops:expr, $cond:expr, $family:ident, $rd:expr, $rs:expr) => {
+        match $cond {
+            X86Condition::E => dynasm!($ops ; .arch x64 ; cmove $family($rd), $family($rs)),
+            X86Condition::NE => dynasm!($ops ; .arch x64 ; cmovne $family($rd), $family($rs)),
+            X86Condition::B => dynasm!($ops ; .arch x64 ; cmovb $family($rd), $family($rs)),
+            X86Condition::AE => dynasm!($ops ; .arch x64 ; cmovae $family($rd), $family($rs)),
+            X86Condition::BE => dynasm!($ops ; .arch x64 ; cmovbe $family($rd), $family($rs)),
+            X86Condition::A => dynasm!($ops ; .arch x64 ; cmova $family($rd), $family($rs)),
+            X86Condition::L => dynasm!($ops ; .arch x64 ; cmovl $family($rd), $family($rs)),
+            X86Condition::GE => dynasm!($ops ; .arch x64 ; cmovge $family($rd), $family($rs)),
+            X86Condition::LE => dynasm!($ops ; .arch x64 ; cmovle $family($rd), $family($rs)),
+            X86Condition::G => dynasm!($ops ; .arch x64 ; cmovg $family($rd), $family($rs)),
+            X86Condition::S => dynasm!($ops ; .arch x64 ; cmovs $family($rd), $family($rs)),
+            X86Condition::NS => dynasm!($ops ; .arch x64 ; cmovns $family($rd), $family($rs)),
+            X86Condition::O => dynasm!($ops ; .arch x64 ; cmovo $family($rd), $family($rs)),
+            X86Condition::NO => dynasm!($ops ; .arch x64 ; cmovno $family($rd), $family($rs)),
+            X86Condition::P => dynasm!($ops ; .arch x64 ; cmovp $family($rd), $family($rs)),
+            X86Condition::NP => dynasm!($ops ; .arch x64 ; cmovnp $family($rd), $family($rs)),
+        }
+    };
+}
+
+macro_rules! emit_cmov_32_for_family {
+    ($ops:expr, $cond:expr, $family:ident, $rd:expr, $rs:expr) => {
+        match $cond {
+            X86Condition::E => dynasm!($ops ; .arch x86 ; cmove $family($rd), $family($rs)),
+            X86Condition::NE => dynasm!($ops ; .arch x86 ; cmovne $family($rd), $family($rs)),
+            X86Condition::B => dynasm!($ops ; .arch x86 ; cmovb $family($rd), $family($rs)),
+            X86Condition::AE => dynasm!($ops ; .arch x86 ; cmovae $family($rd), $family($rs)),
+            X86Condition::BE => dynasm!($ops ; .arch x86 ; cmovbe $family($rd), $family($rs)),
+            X86Condition::A => dynasm!($ops ; .arch x86 ; cmova $family($rd), $family($rs)),
+            X86Condition::L => dynasm!($ops ; .arch x86 ; cmovl $family($rd), $family($rs)),
+            X86Condition::GE => dynasm!($ops ; .arch x86 ; cmovge $family($rd), $family($rs)),
+            X86Condition::LE => dynasm!($ops ; .arch x86 ; cmovle $family($rd), $family($rs)),
+            X86Condition::G => dynasm!($ops ; .arch x86 ; cmovg $family($rd), $family($rs)),
+            X86Condition::S => dynasm!($ops ; .arch x86 ; cmovs $family($rd), $family($rs)),
+            X86Condition::NS => dynasm!($ops ; .arch x86 ; cmovns $family($rd), $family($rs)),
+            X86Condition::O => dynasm!($ops ; .arch x86 ; cmovo $family($rd), $family($rs)),
+            X86Condition::NO => dynasm!($ops ; .arch x86 ; cmovno $family($rd), $family($rs)),
+            X86Condition::P => dynasm!($ops ; .arch x86 ; cmovp $family($rd), $family($rs)),
+            X86Condition::NP => dynasm!($ops ; .arch x86 ; cmovnp $family($rd), $family($rs)),
+        }
+    };
+}
+
 fn assemble_64(instructions: &[X86Instruction]) -> Result<Vec<u8>, String> {
     let mut ops =
         dynasmrt::x64::Assembler::new().map_err(|e| format!("dynasm x64 init failed: {:?}", e))?;
@@ -95,200 +426,202 @@ fn assemble_32(instructions: &[X86Instruction]) -> Result<Vec<u8>, String> {
 fn encode_64(ops: &mut dynasmrt::x64::Assembler, instr: &X86Instruction) -> Result<(), String> {
     match instr {
         X86Instruction::MovReg { rd, rs } => {
-            let rd = reg_index(*rd)?;
-            let rs = reg_index(*rs)?;
-            dynasm!(ops ; .arch x64 ; mov Rq(rd), Rq(rs));
+            emit_reg_reg_64!(ops, mov, *rd, *rs);
             Ok(())
         }
         X86Instruction::MovImm { rd, imm } => {
-            let rd = reg_index(*rd)?;
-            // Prefer the imm32 sign-extended encoding (`REX.W C7 /0 id`,
-            // 7 bytes) when the immediate fits — Capstone shows this as
-            // canonical "mov rax, 0x...". Fall back to MOVABS
-            // (`REX.W B8+rd io`, 10 bytes) for the full 64-bit immediate
-            // case. The CodeSize cost model mirrors these lengths (issue #225).
-            if let Ok(i32_imm) = i32::try_from(*imm) {
-                dynasm!(ops ; .arch x64 ; mov Rq(rd), i32_imm);
+            if rd.view() == X86RegisterView::Native {
+                let rd = reg_index(*rd)?;
+                // Prefer the imm32 sign-extended encoding (`REX.W C7 /0 id`,
+                // 7 bytes) when the immediate fits. Fall back to MOVABS for a
+                // full 64-bit immediate.
+                if let Ok(i32_imm) = i32::try_from(*imm) {
+                    dynasm!(ops ; .arch x64 ; mov Rq(rd), i32_imm);
+                } else {
+                    let imm = *imm;
+                    dynasm!(ops ; .arch x64 ; mov Rq(rd), QWORD imm);
+                }
             } else {
-                let imm = *imm;
-                dynasm!(ops ; .arch x64 ; mov Rq(rd), QWORD imm);
+                emit_reg_imm_64!(ops, mov, *rd, *imm);
             }
             Ok(())
         }
         X86Instruction::AddReg { rd, rs } => {
-            let rd = reg_index(*rd)?;
-            let rs = reg_index(*rs)?;
-            dynasm!(ops ; .arch x64 ; add Rq(rd), Rq(rs));
+            emit_reg_reg_64!(ops, add, *rd, *rs);
             Ok(())
         }
         X86Instruction::AddImm { rd, imm } => {
-            let rd = reg_index(*rd)?;
-            let imm = signed_imm_i32(*imm)?;
-            dynasm!(ops ; .arch x64 ; add Rq(rd), imm);
+            emit_reg_imm_64!(ops, add, *rd, *imm);
             Ok(())
         }
         X86Instruction::SubReg { rd, rs } => {
-            let rd = reg_index(*rd)?;
-            let rs = reg_index(*rs)?;
-            dynasm!(ops ; .arch x64 ; sub Rq(rd), Rq(rs));
+            emit_reg_reg_64!(ops, sub, *rd, *rs);
             Ok(())
         }
         X86Instruction::SubImm { rd, imm } => {
-            let rd = reg_index(*rd)?;
-            let imm = signed_imm_i32(*imm)?;
-            dynasm!(ops ; .arch x64 ; sub Rq(rd), imm);
+            emit_reg_imm_64!(ops, sub, *rd, *imm);
             Ok(())
         }
         X86Instruction::AndReg { rd, rs } => {
-            let rd = reg_index(*rd)?;
-            let rs = reg_index(*rs)?;
-            dynasm!(ops ; .arch x64 ; and Rq(rd), Rq(rs));
+            emit_reg_reg_64!(ops, and, *rd, *rs);
             Ok(())
         }
         X86Instruction::AndImm { rd, imm } => {
-            let rd = reg_index(*rd)?;
-            let imm = signed_imm_i32(*imm)?;
-            dynasm!(ops ; .arch x64 ; and Rq(rd), imm);
+            emit_reg_imm_64!(ops, and, *rd, *imm);
             Ok(())
         }
         X86Instruction::OrReg { rd, rs } => {
-            let rd = reg_index(*rd)?;
-            let rs = reg_index(*rs)?;
-            dynasm!(ops ; .arch x64 ; or Rq(rd), Rq(rs));
+            emit_reg_reg_64!(ops, or, *rd, *rs);
             Ok(())
         }
         X86Instruction::OrImm { rd, imm } => {
-            let rd = reg_index(*rd)?;
-            let imm = signed_imm_i32(*imm)?;
-            dynasm!(ops ; .arch x64 ; or Rq(rd), imm);
+            emit_reg_imm_64!(ops, or, *rd, *imm);
             Ok(())
         }
         X86Instruction::XorReg { rd, rs } => {
-            let rd = reg_index(*rd)?;
-            let rs = reg_index(*rs)?;
-            dynasm!(ops ; .arch x64 ; xor Rq(rd), Rq(rs));
+            emit_reg_reg_64!(ops, xor, *rd, *rs);
             Ok(())
         }
         X86Instruction::XorImm { rd, imm } => {
-            let rd = reg_index(*rd)?;
-            let imm = signed_imm_i32(*imm)?;
-            dynasm!(ops ; .arch x64 ; xor Rq(rd), imm);
+            emit_reg_imm_64!(ops, xor, *rd, *imm);
             Ok(())
         }
         X86Instruction::CmpReg { rn, rs } => {
-            let rn = reg_index(*rn)?;
-            let rs = reg_index(*rs)?;
-            dynasm!(ops ; .arch x64 ; cmp Rq(rn), Rq(rs));
+            emit_reg_reg_64!(ops, cmp, *rn, *rs);
             Ok(())
         }
         X86Instruction::CmpImm { rn, imm } => {
-            let rn = reg_index(*rn)?;
-            let imm = signed_imm_i32(*imm)?;
-            dynasm!(ops ; .arch x64 ; cmp Rq(rn), imm);
+            emit_reg_imm_64!(ops, cmp, *rn, *imm);
             Ok(())
         }
         X86Instruction::TestReg { rn, rs } => {
-            let rn = reg_index(*rn)?;
-            let rs = reg_index(*rs)?;
-            dynasm!(ops ; .arch x64 ; test Rq(rn), Rq(rs));
+            emit_reg_reg_64!(ops, test, *rn, *rs);
             Ok(())
         }
         X86Instruction::TestImm { rn, imm } => {
-            let rn = reg_index(*rn)?;
-            let imm = signed_imm_i32(*imm)?;
-            dynasm!(ops ; .arch x64 ; test Rq(rn), imm);
+            emit_reg_imm_64!(ops, test, *rn, *imm);
             Ok(())
         }
         X86Instruction::Neg { rd } => {
-            let rd = reg_index(*rd)?;
-            dynasm!(ops ; .arch x64 ; neg Rq(rd));
+            emit_unary_64!(ops, neg, *rd);
             Ok(())
         }
         X86Instruction::Not { rd } => {
-            let rd = reg_index(*rd)?;
-            dynasm!(ops ; .arch x64 ; not Rq(rd));
+            emit_unary_64!(ops, not, *rd);
             Ok(())
         }
         X86Instruction::Inc { rd } => {
-            let rd = reg_index(*rd)?;
-            dynasm!(ops ; .arch x64 ; inc Rq(rd));
+            emit_unary_64!(ops, inc, *rd);
             Ok(())
         }
         X86Instruction::Dec { rd } => {
-            let rd = reg_index(*rd)?;
-            dynasm!(ops ; .arch x64 ; dec Rq(rd));
+            emit_unary_64!(ops, dec, *rd);
             Ok(())
         }
         X86Instruction::Shl { rd, imm } => {
-            let rd = reg_index(*rd)?;
-            let count = shift_count_imm8(*imm)?;
-            dynasm!(ops ; .arch x64 ; shl Rq(rd), BYTE count);
+            emit_shift_64!(ops, shl, *rd, *imm);
             Ok(())
         }
         X86Instruction::Shr { rd, imm } => {
-            let rd = reg_index(*rd)?;
-            let count = shift_count_imm8(*imm)?;
-            dynasm!(ops ; .arch x64 ; shr Rq(rd), BYTE count);
+            emit_shift_64!(ops, shr, *rd, *imm);
             Ok(())
         }
         X86Instruction::Sar { rd, imm } => {
-            let rd = reg_index(*rd)?;
-            let count = shift_count_imm8(*imm)?;
-            dynasm!(ops ; .arch x64 ; sar Rq(rd), BYTE count);
+            emit_shift_64!(ops, sar, *rd, *imm);
             Ok(())
         }
         X86Instruction::Rol { rd, imm } => {
-            let rd = reg_index(*rd)?;
-            let count = shift_count_imm8(*imm)?;
-            dynasm!(ops ; .arch x64 ; rol Rq(rd), BYTE count);
+            emit_shift_64!(ops, rol, *rd, *imm);
             Ok(())
         }
         X86Instruction::Ror { rd, imm } => {
-            let rd = reg_index(*rd)?;
-            let count = shift_count_imm8(*imm)?;
-            dynasm!(ops ; .arch x64 ; ror Rq(rd), BYTE count);
+            emit_shift_64!(ops, ror, *rd, *imm);
             Ok(())
         }
         X86Instruction::ImulReg { rd, rs } => {
+            validate_register_pair(*rd, *rs, 64)?;
+            let view = rd.view();
             let rd = reg_index(*rd)?;
             let rs = reg_index(*rs)?;
-            dynasm!(ops ; .arch x64 ; imul Rq(rd), Rq(rs));
+            match view {
+                X86RegisterView::Native => dynasm!(ops ; .arch x64 ; imul Rq(rd), Rq(rs)),
+                X86RegisterView::Dword => dynasm!(ops ; .arch x64 ; imul Rd(rd), Rd(rs)),
+                X86RegisterView::Word => dynasm!(ops ; .arch x64 ; imul Rw(rd), Rw(rs)),
+                X86RegisterView::LowByte | X86RegisterView::HighByte => {
+                    return Err("IMUL has no byte-register form".to_string());
+                }
+            }
             Ok(())
         }
         X86Instruction::ImulRegImm { rd, rs, imm } => {
+            validate_register_pair(*rd, *rs, 64)?;
+            let view = rd.view();
             let rd = reg_index(*rd)?;
             let rs = reg_index(*rs)?;
-            let imm = signed_imm_i32(*imm)?;
-            dynasm!(ops ; .arch x64 ; imul Rq(rd), Rq(rs), imm);
+            match view {
+                X86RegisterView::Native => {
+                    let imm = signed_imm_i32(*imm)?;
+                    dynasm!(ops ; .arch x64 ; imul Rq(rd), Rq(rs), imm);
+                }
+                X86RegisterView::Dword => {
+                    let imm = signed_imm_i32(*imm)?;
+                    dynasm!(ops ; .arch x64 ; imul Rd(rd), Rd(rs), imm);
+                }
+                X86RegisterView::Word => {
+                    let imm = imm16_bitpattern_i16(*imm)?;
+                    dynasm!(ops ; .arch x64 ; imul Rw(rd), Rw(rs), WORD imm);
+                }
+                X86RegisterView::LowByte | X86RegisterView::HighByte => {
+                    return Err("IMUL has no byte-register form".to_string());
+                }
+            }
             Ok(())
         }
         X86Instruction::Lea { rd, base, disp } => {
+            if base.view() != X86RegisterView::Native {
+                return Err(format!(
+                    "64-bit LEA address base must be a native register, got {}",
+                    base
+                ));
+            }
+            let view = rd.view();
             let rd = reg_index(*rd)?;
             let base = reg_index(*base)?;
             let disp = signed_imm_i32(*disp)?;
-            dynasm!(ops ; .arch x64 ; lea Rq(rd), [Rq(base) + disp]);
+            match view {
+                X86RegisterView::Native => {
+                    dynasm!(ops ; .arch x64 ; lea Rq(rd), [Rq(base) + disp])
+                }
+                X86RegisterView::Dword => {
+                    dynasm!(ops ; .arch x64 ; lea Rd(rd), [Rq(base) + disp])
+                }
+                X86RegisterView::Word => {
+                    dynasm!(ops ; .arch x64 ; lea Rw(rd), [Rq(base) + disp])
+                }
+                X86RegisterView::LowByte | X86RegisterView::HighByte => {
+                    return Err("LEA has no byte-register destination".to_string());
+                }
+            }
             Ok(())
         }
         X86Instruction::Cmov { rd, rs, cond } => {
+            validate_register_pair(*rd, *rs, 64)?;
+            let view = rd.view();
             let rd = reg_index(*rd)?;
             let rs = reg_index(*rs)?;
-            match cond {
-                X86Condition::E => dynasm!(ops ; .arch x64 ; cmove Rq(rd), Rq(rs)),
-                X86Condition::NE => dynasm!(ops ; .arch x64 ; cmovne Rq(rd), Rq(rs)),
-                X86Condition::B => dynasm!(ops ; .arch x64 ; cmovb Rq(rd), Rq(rs)),
-                X86Condition::AE => dynasm!(ops ; .arch x64 ; cmovae Rq(rd), Rq(rs)),
-                X86Condition::BE => dynasm!(ops ; .arch x64 ; cmovbe Rq(rd), Rq(rs)),
-                X86Condition::A => dynasm!(ops ; .arch x64 ; cmova Rq(rd), Rq(rs)),
-                X86Condition::L => dynasm!(ops ; .arch x64 ; cmovl Rq(rd), Rq(rs)),
-                X86Condition::GE => dynasm!(ops ; .arch x64 ; cmovge Rq(rd), Rq(rs)),
-                X86Condition::LE => dynasm!(ops ; .arch x64 ; cmovle Rq(rd), Rq(rs)),
-                X86Condition::G => dynasm!(ops ; .arch x64 ; cmovg Rq(rd), Rq(rs)),
-                X86Condition::S => dynasm!(ops ; .arch x64 ; cmovs Rq(rd), Rq(rs)),
-                X86Condition::NS => dynasm!(ops ; .arch x64 ; cmovns Rq(rd), Rq(rs)),
-                X86Condition::O => dynasm!(ops ; .arch x64 ; cmovo Rq(rd), Rq(rs)),
-                X86Condition::NO => dynasm!(ops ; .arch x64 ; cmovno Rq(rd), Rq(rs)),
-                X86Condition::P => dynasm!(ops ; .arch x64 ; cmovp Rq(rd), Rq(rs)),
-                X86Condition::NP => dynasm!(ops ; .arch x64 ; cmovnp Rq(rd), Rq(rs)),
+            match view {
+                X86RegisterView::Native => {
+                    emit_cmov_64_for_family!(ops, cond, Rq, rd, rs)
+                }
+                X86RegisterView::Dword => {
+                    emit_cmov_64_for_family!(ops, cond, Rd, rd, rs)
+                }
+                X86RegisterView::Word => {
+                    emit_cmov_64_for_family!(ops, cond, Rw, rd, rs)
+                }
+                X86RegisterView::LowByte | X86RegisterView::HighByte => {
+                    return Err("CMOV has no byte-register form".to_string());
+                }
             }
             Ok(())
         }
@@ -347,194 +680,195 @@ fn imm32_bitpattern_i32(imm: i64) -> Result<i32, String> {
         .map_err(|_| format!("immediate {} does not fit in 32 bits", imm))
 }
 
+fn imm16_bitpattern_i16(imm: i64) -> Result<i16, String> {
+    i16::try_from(imm)
+        .or_else(|_| u16::try_from(imm).map(|imm| imm as i16))
+        .map_err(|_| format!("immediate {} does not fit in 16 bits", imm))
+}
+
+fn imm8_bitpattern_i8(imm: i64) -> Result<i8, String> {
+    i8::try_from(imm)
+        .or_else(|_| u8::try_from(imm).map(|imm| imm as i8))
+        .map_err(|_| format!("immediate {} does not fit in 8 bits", imm))
+}
+
 fn encode_32(ops: &mut dynasmrt::x86::Assembler, instr: &X86Instruction) -> Result<(), String> {
     match instr {
         X86Instruction::MovReg { rd, rs } => {
-            let rd = reg_index_32(*rd)?;
-            let rs = reg_index_32(*rs)?;
-            dynasm!(ops ; .arch x86 ; mov Rd(rd), Rd(rs));
+            emit_reg_reg_32!(ops, mov, *rd, *rs);
             Ok(())
         }
         X86Instruction::MovImm { rd, imm } => {
-            let rd = reg_index_32(*rd)?;
-            let imm = imm32_bitpattern_i32(*imm)?;
-            dynasm!(ops ; .arch x86 ; mov Rd(rd), imm);
+            emit_reg_imm_32!(ops, mov, *rd, *imm);
             Ok(())
         }
         X86Instruction::AddReg { rd, rs } => {
-            let rd = reg_index_32(*rd)?;
-            let rs = reg_index_32(*rs)?;
-            dynasm!(ops ; .arch x86 ; add Rd(rd), Rd(rs));
+            emit_reg_reg_32!(ops, add, *rd, *rs);
             Ok(())
         }
         X86Instruction::AddImm { rd, imm } => {
-            let rd = reg_index_32(*rd)?;
-            let imm = imm32_bitpattern_i32(*imm)?;
-            dynasm!(ops ; .arch x86 ; add Rd(rd), imm);
+            emit_reg_imm_32!(ops, add, *rd, *imm);
             Ok(())
         }
         X86Instruction::SubReg { rd, rs } => {
-            let rd = reg_index_32(*rd)?;
-            let rs = reg_index_32(*rs)?;
-            dynasm!(ops ; .arch x86 ; sub Rd(rd), Rd(rs));
+            emit_reg_reg_32!(ops, sub, *rd, *rs);
             Ok(())
         }
         X86Instruction::SubImm { rd, imm } => {
-            let rd = reg_index_32(*rd)?;
-            let imm = imm32_bitpattern_i32(*imm)?;
-            dynasm!(ops ; .arch x86 ; sub Rd(rd), imm);
+            emit_reg_imm_32!(ops, sub, *rd, *imm);
             Ok(())
         }
         X86Instruction::AndReg { rd, rs } => {
-            let rd = reg_index_32(*rd)?;
-            let rs = reg_index_32(*rs)?;
-            dynasm!(ops ; .arch x86 ; and Rd(rd), Rd(rs));
+            emit_reg_reg_32!(ops, and, *rd, *rs);
             Ok(())
         }
         X86Instruction::AndImm { rd, imm } => {
-            let rd = reg_index_32(*rd)?;
-            let imm = imm32_bitpattern_i32(*imm)?;
-            dynasm!(ops ; .arch x86 ; and Rd(rd), imm);
+            emit_reg_imm_32!(ops, and, *rd, *imm);
             Ok(())
         }
         X86Instruction::OrReg { rd, rs } => {
-            let rd = reg_index_32(*rd)?;
-            let rs = reg_index_32(*rs)?;
-            dynasm!(ops ; .arch x86 ; or Rd(rd), Rd(rs));
+            emit_reg_reg_32!(ops, or, *rd, *rs);
             Ok(())
         }
         X86Instruction::OrImm { rd, imm } => {
-            let rd = reg_index_32(*rd)?;
-            let imm = imm32_bitpattern_i32(*imm)?;
-            dynasm!(ops ; .arch x86 ; or Rd(rd), imm);
+            emit_reg_imm_32!(ops, or, *rd, *imm);
             Ok(())
         }
         X86Instruction::XorReg { rd, rs } => {
-            let rd = reg_index_32(*rd)?;
-            let rs = reg_index_32(*rs)?;
-            dynasm!(ops ; .arch x86 ; xor Rd(rd), Rd(rs));
+            emit_reg_reg_32!(ops, xor, *rd, *rs);
             Ok(())
         }
         X86Instruction::XorImm { rd, imm } => {
-            let rd = reg_index_32(*rd)?;
-            let imm = imm32_bitpattern_i32(*imm)?;
-            dynasm!(ops ; .arch x86 ; xor Rd(rd), imm);
+            emit_reg_imm_32!(ops, xor, *rd, *imm);
             Ok(())
         }
         X86Instruction::CmpReg { rn, rs } => {
-            let rn = reg_index_32(*rn)?;
-            let rs = reg_index_32(*rs)?;
-            dynasm!(ops ; .arch x86 ; cmp Rd(rn), Rd(rs));
+            emit_reg_reg_32!(ops, cmp, *rn, *rs);
             Ok(())
         }
         X86Instruction::CmpImm { rn, imm } => {
-            let rn = reg_index_32(*rn)?;
-            let imm = imm32_bitpattern_i32(*imm)?;
-            dynasm!(ops ; .arch x86 ; cmp Rd(rn), imm);
+            emit_reg_imm_32!(ops, cmp, *rn, *imm);
             Ok(())
         }
         X86Instruction::TestReg { rn, rs } => {
-            let rn = reg_index_32(*rn)?;
-            let rs = reg_index_32(*rs)?;
-            dynasm!(ops ; .arch x86 ; test Rd(rn), Rd(rs));
+            emit_reg_reg_32!(ops, test, *rn, *rs);
             Ok(())
         }
         X86Instruction::TestImm { rn, imm } => {
-            let rn = reg_index_32(*rn)?;
-            let imm = imm32_bitpattern_i32(*imm)?;
-            dynasm!(ops ; .arch x86 ; test Rd(rn), imm);
+            emit_reg_imm_32!(ops, test, *rn, *imm);
             Ok(())
         }
         X86Instruction::Neg { rd } => {
-            let rd = reg_index_32(*rd)?;
-            dynasm!(ops ; .arch x86 ; neg Rd(rd));
+            emit_unary_32!(ops, neg, *rd);
             Ok(())
         }
         X86Instruction::Not { rd } => {
-            let rd = reg_index_32(*rd)?;
-            dynasm!(ops ; .arch x86 ; not Rd(rd));
+            emit_unary_32!(ops, not, *rd);
             Ok(())
         }
         X86Instruction::Inc { rd } => {
-            let rd = reg_index_32(*rd)?;
-            dynasm!(ops ; .arch x86 ; inc Rd(rd));
+            emit_unary_32!(ops, inc, *rd);
             Ok(())
         }
         X86Instruction::Dec { rd } => {
-            let rd = reg_index_32(*rd)?;
-            dynasm!(ops ; .arch x86 ; dec Rd(rd));
+            emit_unary_32!(ops, dec, *rd);
             Ok(())
         }
         X86Instruction::Shl { rd, imm } => {
-            let rd = reg_index_32(*rd)?;
-            let count = shift_count_imm8(*imm)?;
-            dynasm!(ops ; .arch x86 ; shl Rd(rd), BYTE count);
+            emit_shift_32!(ops, shl, *rd, *imm);
             Ok(())
         }
         X86Instruction::Shr { rd, imm } => {
-            let rd = reg_index_32(*rd)?;
-            let count = shift_count_imm8(*imm)?;
-            dynasm!(ops ; .arch x86 ; shr Rd(rd), BYTE count);
+            emit_shift_32!(ops, shr, *rd, *imm);
             Ok(())
         }
         X86Instruction::Sar { rd, imm } => {
-            let rd = reg_index_32(*rd)?;
-            let count = shift_count_imm8(*imm)?;
-            dynasm!(ops ; .arch x86 ; sar Rd(rd), BYTE count);
+            emit_shift_32!(ops, sar, *rd, *imm);
             Ok(())
         }
         X86Instruction::Rol { rd, imm } => {
-            let rd = reg_index_32(*rd)?;
-            let count = shift_count_imm8(*imm)?;
-            dynasm!(ops ; .arch x86 ; rol Rd(rd), BYTE count);
+            emit_shift_32!(ops, rol, *rd, *imm);
             Ok(())
         }
         X86Instruction::Ror { rd, imm } => {
-            let rd = reg_index_32(*rd)?;
-            let count = shift_count_imm8(*imm)?;
-            dynasm!(ops ; .arch x86 ; ror Rd(rd), BYTE count);
+            emit_shift_32!(ops, ror, *rd, *imm);
             Ok(())
         }
         X86Instruction::ImulReg { rd, rs } => {
+            validate_register_pair(*rd, *rs, 32)?;
+            let view = rd.view();
             let rd = reg_index_32(*rd)?;
             let rs = reg_index_32(*rs)?;
-            dynasm!(ops ; .arch x86 ; imul Rd(rd), Rd(rs));
+            match view {
+                X86RegisterView::Native | X86RegisterView::Dword => {
+                    dynasm!(ops ; .arch x86 ; imul Rd(rd), Rd(rs))
+                }
+                X86RegisterView::Word => dynasm!(ops ; .arch x86 ; imul Rw(rd), Rw(rs)),
+                X86RegisterView::LowByte | X86RegisterView::HighByte => {
+                    return Err("IMUL has no byte-register form".to_string());
+                }
+            }
             Ok(())
         }
         X86Instruction::ImulRegImm { rd, rs, imm } => {
+            validate_register_pair(*rd, *rs, 32)?;
+            let view = rd.view();
             let rd = reg_index_32(*rd)?;
             let rs = reg_index_32(*rs)?;
-            let imm = signed_imm_i32(*imm)?;
-            dynasm!(ops ; .arch x86 ; imul Rd(rd), Rd(rs), imm);
+            match view {
+                X86RegisterView::Native | X86RegisterView::Dword => {
+                    let imm = signed_imm_i32(*imm)?;
+                    dynasm!(ops ; .arch x86 ; imul Rd(rd), Rd(rs), imm);
+                }
+                X86RegisterView::Word => {
+                    let imm = imm16_bitpattern_i16(*imm)?;
+                    dynasm!(ops ; .arch x86 ; imul Rw(rd), Rw(rs), WORD imm);
+                }
+                X86RegisterView::LowByte | X86RegisterView::HighByte => {
+                    return Err("IMUL has no byte-register form".to_string());
+                }
+            }
             Ok(())
         }
         X86Instruction::Lea { rd, base, disp } => {
+            if base.effective_width(32) != 32 {
+                return Err(format!(
+                    "32-bit LEA address base must be a 32-bit register, got {}",
+                    base
+                ));
+            }
+            let view = rd.view();
             let rd = reg_index_32(*rd)?;
             let base = reg_index_32(*base)?;
             let disp = signed_imm_i32(*disp)?;
-            dynasm!(ops ; .arch x86 ; lea Rd(rd), [Rd(base) + disp]);
+            match view {
+                X86RegisterView::Native | X86RegisterView::Dword => {
+                    dynasm!(ops ; .arch x86 ; lea Rd(rd), [Rd(base) + disp])
+                }
+                X86RegisterView::Word => {
+                    dynasm!(ops ; .arch x86 ; lea Rw(rd), [Rd(base) + disp])
+                }
+                X86RegisterView::LowByte | X86RegisterView::HighByte => {
+                    return Err("LEA has no byte-register destination".to_string());
+                }
+            }
             Ok(())
         }
         X86Instruction::Cmov { rd, rs, cond } => {
+            validate_register_pair(*rd, *rs, 32)?;
+            let view = rd.view();
             let rd = reg_index_32(*rd)?;
             let rs = reg_index_32(*rs)?;
-            match cond {
-                X86Condition::E => dynasm!(ops ; .arch x86 ; cmove Rd(rd), Rd(rs)),
-                X86Condition::NE => dynasm!(ops ; .arch x86 ; cmovne Rd(rd), Rd(rs)),
-                X86Condition::B => dynasm!(ops ; .arch x86 ; cmovb Rd(rd), Rd(rs)),
-                X86Condition::AE => dynasm!(ops ; .arch x86 ; cmovae Rd(rd), Rd(rs)),
-                X86Condition::BE => dynasm!(ops ; .arch x86 ; cmovbe Rd(rd), Rd(rs)),
-                X86Condition::A => dynasm!(ops ; .arch x86 ; cmova Rd(rd), Rd(rs)),
-                X86Condition::L => dynasm!(ops ; .arch x86 ; cmovl Rd(rd), Rd(rs)),
-                X86Condition::GE => dynasm!(ops ; .arch x86 ; cmovge Rd(rd), Rd(rs)),
-                X86Condition::LE => dynasm!(ops ; .arch x86 ; cmovle Rd(rd), Rd(rs)),
-                X86Condition::G => dynasm!(ops ; .arch x86 ; cmovg Rd(rd), Rd(rs)),
-                X86Condition::S => dynasm!(ops ; .arch x86 ; cmovs Rd(rd), Rd(rs)),
-                X86Condition::NS => dynasm!(ops ; .arch x86 ; cmovns Rd(rd), Rd(rs)),
-                X86Condition::O => dynasm!(ops ; .arch x86 ; cmovo Rd(rd), Rd(rs)),
-                X86Condition::NO => dynasm!(ops ; .arch x86 ; cmovno Rd(rd), Rd(rs)),
-                X86Condition::P => dynasm!(ops ; .arch x86 ; cmovp Rd(rd), Rd(rs)),
-                X86Condition::NP => dynasm!(ops ; .arch x86 ; cmovnp Rd(rd), Rd(rs)),
+            match view {
+                X86RegisterView::Native | X86RegisterView::Dword => {
+                    emit_cmov_32_for_family!(ops, cond, Rd, rd, rs)
+                }
+                X86RegisterView::Word => {
+                    emit_cmov_32_for_family!(ops, cond, Rw, rd, rs)
+                }
+                X86RegisterView::LowByte | X86RegisterView::HighByte => {
+                    return Err("CMOV has no byte-register form".to_string());
+                }
             }
             Ok(())
         }
@@ -687,6 +1021,129 @@ mod tests {
                 disasm[0].1
             );
         }
+    }
+
+    #[test]
+    fn x86_64_emits_each_rax_register_view() {
+        for (reg, spelling) in [
+            (X86Register::EAX, "eax"),
+            (X86Register::AX, "ax"),
+            (X86Register::AL, "al"),
+            (X86Register::AH, "ah"),
+        ] {
+            check_x86_64(
+                X86Instruction::MovImm { rd: reg, imm: 1 },
+                "mov",
+                &[spelling, "1"],
+            );
+        }
+        check_x86_64(
+            X86Instruction::XorReg {
+                rd: X86Register::EAX,
+                rs: X86Register::EBX,
+            },
+            "xor",
+            &["eax", "ebx"],
+        );
+    }
+
+    #[test]
+    fn x86_64_round_trips_mixed_legacy_byte_views() {
+        for (instruction, mnemonic) in [
+            (
+                X86Instruction::MovReg {
+                    rd: X86Register::AH,
+                    rs: X86Register::BL,
+                },
+                "mov",
+            ),
+            (
+                X86Instruction::AddReg {
+                    rd: X86Register::AH,
+                    rs: X86Register::BL,
+                },
+                "add",
+            ),
+            (
+                X86Instruction::SubReg {
+                    rd: X86Register::AH,
+                    rs: X86Register::BL,
+                },
+                "sub",
+            ),
+            (
+                X86Instruction::AndReg {
+                    rd: X86Register::AH,
+                    rs: X86Register::BL,
+                },
+                "and",
+            ),
+            (
+                X86Instruction::OrReg {
+                    rd: X86Register::AH,
+                    rs: X86Register::BL,
+                },
+                "or",
+            ),
+            (
+                X86Instruction::XorReg {
+                    rd: X86Register::AH,
+                    rs: X86Register::BL,
+                },
+                "xor",
+            ),
+            (
+                X86Instruction::CmpReg {
+                    rn: X86Register::AH,
+                    rs: X86Register::BL,
+                },
+                "cmp",
+            ),
+            (
+                X86Instruction::TestReg {
+                    rn: X86Register::AH,
+                    rs: X86Register::BL,
+                },
+                "test",
+            ),
+        ] {
+            check_x86_64(instruction, mnemonic, &["ah", "bl"]);
+        }
+        check_x86_64(
+            X86Instruction::MovReg {
+                rd: X86Register::AL,
+                rs: X86Register::BH,
+            },
+            "mov",
+            &["al", "bh"],
+        );
+    }
+
+    #[test]
+    fn x86_32_emits_word_and_byte_register_views() {
+        for (reg, spelling) in [
+            (X86Register::AX, "ax"),
+            (X86Register::AL, "al"),
+            (X86Register::AH, "ah"),
+        ] {
+            check_x86_32(
+                X86Instruction::MovImm { rd: reg, imm: 1 },
+                "mov",
+                &[spelling, "1"],
+            );
+        }
+    }
+
+    #[test]
+    fn x86_64_rejects_high_byte_when_rex_is_required() {
+        let mut asm = X86Assembler::new_64();
+        let err = asm
+            .assemble_instructions(&[X86Instruction::MovReg {
+                rd: X86Register::AH,
+                rs: X86Register::SPL,
+            }])
+            .expect_err("AH cannot be encoded in an instruction requiring REX");
+        assert!(err.contains("high-byte"), "unexpected error: {err}");
     }
 
     #[test]

--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -440,9 +440,12 @@ impl fmt::Display for X86Operand {
 /// the destination) would silently regress liveness for x86.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum X86Instruction {
-    /// `mov rd, rs` — non-destructive register copy; no EFLAGS effect.
+    /// `mov rd, rs` — register copy; no EFLAGS effect. Word and byte
+    /// destinations implicitly read `rd` because their writes preserve the
+    /// surrounding bits of its canonical register.
     MovReg { rd: X86Register, rs: X86Register },
-    /// `mov rd, imm` — load immediate; no EFLAGS effect.
+    /// `mov rd, imm` — load immediate; no EFLAGS effect. Word and byte
+    /// destinations implicitly read `rd` to preserve surrounding bits.
     MovImm { rd: X86Register, imm: i64 },
     /// `movzx rd, rs_sub` — zero-extend the low `src_width` bits of `rs`
     /// into the mode-width destination. The supported source widths are 8 and
@@ -555,9 +558,10 @@ pub enum X86Instruction {
     ImulReg { rd: X86Register, rs: X86Register },
     /// `imul rd, rs, imm` — three-operand signed multiply: `rd = rs * imm`
     /// (low `width` bits). The project's FIRST 3-operand x86 variant. `rd` is
-    /// purely WRITTEN (not read), so `source_registers()` is just `[rs]`. Same
-    /// flag model as `ImulReg`: CF/OF on signed overflow, SF/ZF/PF
-    /// Intel-undefined and modelled deterministically.
+    /// purely WRITTEN at native/dword width, so `source_registers()` is just
+    /// `[rs]` there. A word destination also reads `rd` to preserve its
+    /// surrounding bits. Same flag model as `ImulReg`: CF/OF on signed
+    /// overflow, SF/ZF/PF Intel-undefined and modelled deterministically.
     ImulRegImm {
         rd: X86Register,
         rs: X86Register,
@@ -565,10 +569,11 @@ pub enum X86Instruction {
     },
     /// `lea rd, [base + disp]` — load effective address in its minimal
     /// register-base + displacement form: `rd = base + disp` (wrapping at
-    /// width). NON-destructive: `base` is read, `rd` is purely WRITTEN (not
-    /// read), exactly like `MovReg`. Affects NO flags. The `index*scale` and
-    /// RIP-relative addressing forms are deferred; the parser rejects them as
-    /// unsupported shapes.
+    /// width). NON-destructive at native/dword width: `base` is read and `rd`
+    /// is purely written. A word destination also reads `rd` to preserve its
+    /// surrounding bits. Affects NO flags. The `index*scale` and RIP-relative
+    /// addressing forms are deferred; the parser rejects them as unsupported
+    /// shapes.
     Lea {
         rd: X86Register,
         base: X86Register,
@@ -679,12 +684,21 @@ impl X86Instruction {
     ///
     /// **x86 destructive-form divergence**: for `AddReg/SubReg/AndReg/OrReg/XorReg`
     /// and their immediate forms, `rd` is BOTH source and destination, so it
-    /// appears here. `MovReg`/`MovImm` are non-destructive (rd is purely
-    /// written), so rd is NOT in the source list. See the enum doc-comment.
+    /// appears here. Nominally pure writes also include `rd` when a word or
+    /// byte destination preserves surrounding bits of the canonical register.
+    /// Native and dword destinations fully overwrite it. See the enum
+    /// doc-comment.
     pub fn source_registers(&self) -> Vec<X86Register> {
+        let pure_write_sources = |rd: X86Register, sources: Vec<X86Register>| -> Vec<X86Register> {
+            if rd.fully_overwrites_architectural_register() {
+                sources
+            } else {
+                std::iter::once(rd).chain(sources).collect()
+            }
+        };
         let operands = match self {
-            X86Instruction::MovReg { rs, .. } => vec![*rs],
-            X86Instruction::MovImm { .. } => vec![],
+            X86Instruction::MovReg { rd, rs } => pure_write_sources(*rd, vec![*rs]),
+            X86Instruction::MovImm { rd, .. } => pure_write_sources(*rd, vec![]),
             X86Instruction::Movzx { rs, .. } | X86Instruction::Movsx { rs, .. } => vec![*rs],
             X86Instruction::AddReg { rd, rs }
             | X86Instruction::SubReg { rd, rs }
@@ -693,11 +707,13 @@ impl X86Instruction {
             // IMUL rd, rs is destructive (`rd = rd * rs`), so rd is read too.
             | X86Instruction::ImulReg { rd, rs }
             | X86Instruction::XorReg { rd, rs } => vec![*rd, *rs],
-            // IMUL rd, rs, imm writes rd purely from `rs * imm`; rd is NOT read.
-            X86Instruction::ImulRegImm { rs, .. } => vec![*rs],
-            // LEA writes rd purely from `base + disp`; rd is NOT read (it is
-            // non-destructive, like MovReg). Only `base` is a source.
-            X86Instruction::Lea { base, .. } => vec![*base],
+            // At native/dword width these write rd purely from the explicit
+            // sources. A word destination also reads rd to preserve the
+            // surrounding canonical-register bits.
+            X86Instruction::ImulRegImm { rd, rs, .. } => {
+                pure_write_sources(*rd, vec![*rs])
+            }
+            X86Instruction::Lea { rd, base, .. } => pure_write_sources(*rd, vec![*base]),
             X86Instruction::AddImm { rd, .. }
             | X86Instruction::SubImm { rd, .. }
             | X86Instruction::AndImm { rd, .. }
@@ -3494,6 +3510,59 @@ mod tests {
         // NEG / NOT are single-operand: each reads its own destination.
         assert_eq!(X86Instruction::Neg { rd }.source_registers(), vec![rd]);
         assert_eq!(X86Instruction::Not { rd }.source_registers(), vec![rd]);
+    }
+
+    #[test]
+    fn partial_pure_writes_read_the_preserved_canonical_destination() {
+        let cases = [
+            (
+                X86Instruction::MovReg {
+                    rd: X86Register::AL,
+                    rs: X86Register::BL,
+                },
+                vec![X86Register::RAX, X86Register::RBX],
+            ),
+            (
+                X86Instruction::MovImm {
+                    rd: X86Register::AH,
+                    imm: 1,
+                },
+                vec![X86Register::RAX],
+            ),
+            (
+                X86Instruction::ImulRegImm {
+                    rd: X86Register::AX,
+                    rs: X86Register::BX,
+                    imm: 3,
+                },
+                vec![X86Register::RAX, X86Register::RBX],
+            ),
+            (
+                X86Instruction::Lea {
+                    rd: X86Register::AX,
+                    base: X86Register::RBX,
+                    disp: 1,
+                },
+                vec![X86Register::RAX, X86Register::RBX],
+            ),
+        ];
+
+        for (instruction, expected) in cases {
+            assert_eq!(
+                instruction.source_registers(),
+                expected,
+                "{instruction} must read the canonical destination bits it preserves"
+            );
+        }
+
+        for rd in [X86Register::RAX, X86Register::EAX] {
+            assert!(
+                X86Instruction::MovImm { rd, imm: 1 }
+                    .source_registers()
+                    .is_empty(),
+                "{rd} fully overwrites the architectural register"
+            );
+        }
     }
 
     #[test]

--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -1,8 +1,8 @@
 //! x86 ISA backend (x86-64 primary, x86-32 secondary).
 //!
-//! Mirrors the dual-variant pattern of `src/isa/riscv.rs`: a single set of
-//! `X86Register` / `X86Operand` / `X86Instruction` enums shared by the
-//! `X86_64` and `X86_32` ISA marker structs.
+//! Mirrors the dual-variant pattern of `src/isa/riscv.rs`: a single
+//! `X86Register` view type plus shared `X86Operand` / `X86Instruction` enums
+//! serve the `X86_64` and `X86_32` ISA marker structs.
 //!
 //! **Initial instruction set**: MOV, ADD, SUB, AND, OR, XOR, CMP — each with
 //! register and immediate forms — plus rewritable CMOVcc and fixed Jcc
@@ -139,89 +139,198 @@ impl fmt::Display for X86Condition {
     }
 }
 
+/// The bit slice selected by an x86 register operand.
+///
+/// `Native` preserves the historical programmatic IR convention: it means the
+/// machine mode's full GPR width (64 bits for [`X86_64`], 32 for [`X86_32`]).
+/// Parsed aliases retain an explicit narrower view. The high-byte view is the
+/// legacy AH/CH/DH/BH slice at bits 15:8, not the low byte.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum X86Register {
-    RAX,
-    RCX,
-    RDX,
-    RBX,
-    RSP,
-    RBP,
-    RSI,
-    RDI,
-    R8,
-    R9,
-    R10,
-    R11,
-    R12,
-    R13,
-    R14,
-    R15,
+pub enum X86RegisterView {
+    Native,
+    Dword,
+    Word,
+    LowByte,
+    HighByte,
+}
+
+impl X86RegisterView {
+    pub const fn bit_width(self, mode_width: u32) -> u32 {
+        match self {
+            X86RegisterView::Native => mode_width,
+            X86RegisterView::Dword => 32,
+            X86RegisterView::Word => 16,
+            X86RegisterView::LowByte | X86RegisterView::HighByte => 8,
+        }
+    }
+}
+
+/// An x86 GPR operand: canonical architectural register plus selected view.
+///
+/// Machine state and liveness key on [`Self::canonical`], while instruction
+/// operands retain the view so execution and assembly can distinguish RAX,
+/// EAX, AX, AL, and AH without multiplying instruction variants.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct X86Register {
+    index: u8,
+    view: X86RegisterView,
 }
 
 impl X86Register {
+    const fn new(index: u8, view: X86RegisterView) -> Self {
+        Self { index, view }
+    }
+
+    pub const RAX: Self = Self::new(0, X86RegisterView::Native);
+    pub const RCX: Self = Self::new(1, X86RegisterView::Native);
+    pub const RDX: Self = Self::new(2, X86RegisterView::Native);
+    pub const RBX: Self = Self::new(3, X86RegisterView::Native);
+    pub const RSP: Self = Self::new(4, X86RegisterView::Native);
+    pub const RBP: Self = Self::new(5, X86RegisterView::Native);
+    pub const RSI: Self = Self::new(6, X86RegisterView::Native);
+    pub const RDI: Self = Self::new(7, X86RegisterView::Native);
+    pub const R8: Self = Self::new(8, X86RegisterView::Native);
+    pub const R9: Self = Self::new(9, X86RegisterView::Native);
+    pub const R10: Self = Self::new(10, X86RegisterView::Native);
+    pub const R11: Self = Self::new(11, X86RegisterView::Native);
+    pub const R12: Self = Self::new(12, X86RegisterView::Native);
+    pub const R13: Self = Self::new(13, X86RegisterView::Native);
+    pub const R14: Self = Self::new(14, X86RegisterView::Native);
+    pub const R15: Self = Self::new(15, X86RegisterView::Native);
+
+    pub const EAX: Self = Self::new(0, X86RegisterView::Dword);
+    pub const ECX: Self = Self::new(1, X86RegisterView::Dword);
+    pub const EDX: Self = Self::new(2, X86RegisterView::Dword);
+    pub const EBX: Self = Self::new(3, X86RegisterView::Dword);
+    pub const ESP: Self = Self::new(4, X86RegisterView::Dword);
+    pub const EBP: Self = Self::new(5, X86RegisterView::Dword);
+    pub const ESI: Self = Self::new(6, X86RegisterView::Dword);
+    pub const EDI: Self = Self::new(7, X86RegisterView::Dword);
+    pub const R8D: Self = Self::new(8, X86RegisterView::Dword);
+    pub const R9D: Self = Self::new(9, X86RegisterView::Dword);
+    pub const R10D: Self = Self::new(10, X86RegisterView::Dword);
+    pub const R11D: Self = Self::new(11, X86RegisterView::Dword);
+    pub const R12D: Self = Self::new(12, X86RegisterView::Dword);
+    pub const R13D: Self = Self::new(13, X86RegisterView::Dword);
+    pub const R14D: Self = Self::new(14, X86RegisterView::Dword);
+    pub const R15D: Self = Self::new(15, X86RegisterView::Dword);
+
+    pub const AX: Self = Self::new(0, X86RegisterView::Word);
+    pub const CX: Self = Self::new(1, X86RegisterView::Word);
+    pub const DX: Self = Self::new(2, X86RegisterView::Word);
+    pub const BX: Self = Self::new(3, X86RegisterView::Word);
+    pub const SP: Self = Self::new(4, X86RegisterView::Word);
+    pub const BP: Self = Self::new(5, X86RegisterView::Word);
+    pub const SI: Self = Self::new(6, X86RegisterView::Word);
+    pub const DI: Self = Self::new(7, X86RegisterView::Word);
+    pub const R8W: Self = Self::new(8, X86RegisterView::Word);
+    pub const R9W: Self = Self::new(9, X86RegisterView::Word);
+    pub const R10W: Self = Self::new(10, X86RegisterView::Word);
+    pub const R11W: Self = Self::new(11, X86RegisterView::Word);
+    pub const R12W: Self = Self::new(12, X86RegisterView::Word);
+    pub const R13W: Self = Self::new(13, X86RegisterView::Word);
+    pub const R14W: Self = Self::new(14, X86RegisterView::Word);
+    pub const R15W: Self = Self::new(15, X86RegisterView::Word);
+
+    pub const AL: Self = Self::new(0, X86RegisterView::LowByte);
+    pub const CL: Self = Self::new(1, X86RegisterView::LowByte);
+    pub const DL: Self = Self::new(2, X86RegisterView::LowByte);
+    pub const BL: Self = Self::new(3, X86RegisterView::LowByte);
+    pub const SPL: Self = Self::new(4, X86RegisterView::LowByte);
+    pub const BPL: Self = Self::new(5, X86RegisterView::LowByte);
+    pub const SIL: Self = Self::new(6, X86RegisterView::LowByte);
+    pub const DIL: Self = Self::new(7, X86RegisterView::LowByte);
+    pub const R8B: Self = Self::new(8, X86RegisterView::LowByte);
+    pub const R9B: Self = Self::new(9, X86RegisterView::LowByte);
+    pub const R10B: Self = Self::new(10, X86RegisterView::LowByte);
+    pub const R11B: Self = Self::new(11, X86RegisterView::LowByte);
+    pub const R12B: Self = Self::new(12, X86RegisterView::LowByte);
+    pub const R13B: Self = Self::new(13, X86RegisterView::LowByte);
+    pub const R14B: Self = Self::new(14, X86RegisterView::LowByte);
+    pub const R15B: Self = Self::new(15, X86RegisterView::LowByte);
+
+    pub const AH: Self = Self::new(0, X86RegisterView::HighByte);
+    pub const CH: Self = Self::new(1, X86RegisterView::HighByte);
+    pub const DH: Self = Self::new(2, X86RegisterView::HighByte);
+    pub const BH: Self = Self::new(3, X86RegisterView::HighByte);
+
     pub fn index(&self) -> Option<u8> {
-        Some(match self {
-            X86Register::RAX => 0,
-            X86Register::RCX => 1,
-            X86Register::RDX => 2,
-            X86Register::RBX => 3,
-            X86Register::RSP => 4,
-            X86Register::RBP => 5,
-            X86Register::RSI => 6,
-            X86Register::RDI => 7,
-            X86Register::R8 => 8,
-            X86Register::R9 => 9,
-            X86Register::R10 => 10,
-            X86Register::R11 => 11,
-            X86Register::R12 => 12,
-            X86Register::R13 => 13,
-            X86Register::R14 => 14,
-            X86Register::R15 => 15,
-        })
+        Some(self.index)
     }
 
     pub fn mnemonic(&self) -> &'static str {
-        match self {
-            X86Register::RAX => "rax",
-            X86Register::RCX => "rcx",
-            X86Register::RDX => "rdx",
-            X86Register::RBX => "rbx",
-            X86Register::RSP => "rsp",
-            X86Register::RBP => "rbp",
-            X86Register::RSI => "rsi",
-            X86Register::RDI => "rdi",
-            X86Register::R8 => "r8",
-            X86Register::R9 => "r9",
-            X86Register::R10 => "r10",
-            X86Register::R11 => "r11",
-            X86Register::R12 => "r12",
-            X86Register::R13 => "r13",
-            X86Register::R14 => "r14",
-            X86Register::R15 => "r15",
+        const NATIVE: [&str; 16] = [
+            "rax", "rcx", "rdx", "rbx", "rsp", "rbp", "rsi", "rdi", "r8", "r9", "r10", "r11",
+            "r12", "r13", "r14", "r15",
+        ];
+        const DWORD: [&str; 16] = [
+            "eax", "ecx", "edx", "ebx", "esp", "ebp", "esi", "edi", "r8d", "r9d", "r10d", "r11d",
+            "r12d", "r13d", "r14d", "r15d",
+        ];
+        const WORD: [&str; 16] = [
+            "ax", "cx", "dx", "bx", "sp", "bp", "si", "di", "r8w", "r9w", "r10w", "r11w", "r12w",
+            "r13w", "r14w", "r15w",
+        ];
+        const LOW_BYTE: [&str; 16] = [
+            "al", "cl", "dl", "bl", "spl", "bpl", "sil", "dil", "r8b", "r9b", "r10b", "r11b",
+            "r12b", "r13b", "r14b", "r15b",
+        ];
+        const HIGH_BYTE: [&str; 4] = ["ah", "ch", "dh", "bh"];
+
+        match self.view {
+            X86RegisterView::Native => NATIVE[self.index as usize],
+            X86RegisterView::Dword => DWORD[self.index as usize],
+            X86RegisterView::Word => WORD[self.index as usize],
+            X86RegisterView::LowByte => LOW_BYTE[self.index as usize],
+            X86RegisterView::HighByte => HIGH_BYTE[self.index as usize],
         }
     }
 
     pub fn from_index(i: u8) -> Option<Self> {
-        Some(match i {
-            0 => X86Register::RAX,
-            1 => X86Register::RCX,
-            2 => X86Register::RDX,
-            3 => X86Register::RBX,
-            4 => X86Register::RSP,
-            5 => X86Register::RBP,
-            6 => X86Register::RSI,
-            7 => X86Register::RDI,
-            8 => X86Register::R8,
-            9 => X86Register::R9,
-            10 => X86Register::R10,
-            11 => X86Register::R11,
-            12 => X86Register::R12,
-            13 => X86Register::R13,
-            14 => X86Register::R14,
-            15 => X86Register::R15,
-            _ => return None,
-        })
+        (i < 16).then_some(Self::new(i, X86RegisterView::Native))
+    }
+
+    pub const fn view(self) -> X86RegisterView {
+        self.view
+    }
+
+    pub fn canonical(self) -> Self {
+        Self::from_index(self.index).expect("x86 register index is always valid")
+    }
+
+    pub const fn effective_width(self, mode_width: u32) -> u32 {
+        self.view.bit_width(mode_width)
+    }
+
+    pub const fn is_high_byte(self) -> bool {
+        matches!(self.view, X86RegisterView::HighByte)
+    }
+
+    pub const fn is_byte(self) -> bool {
+        matches!(
+            self.view,
+            X86RegisterView::LowByte | X86RegisterView::HighByte
+        )
+    }
+
+    pub const fn is_native(self) -> bool {
+        matches!(self.view, X86RegisterView::Native)
+    }
+
+    pub const fn fully_overwrites_architectural_register(self) -> bool {
+        matches!(self.view, X86RegisterView::Native | X86RegisterView::Dword)
+    }
+
+    pub fn with_view(self, view: X86RegisterView) -> Option<Self> {
+        if view == X86RegisterView::HighByte && self.index >= 4 {
+            None
+        } else {
+            Some(Self::new(self.index, view))
+        }
+    }
+
+    pub fn with_base(self, base: X86Register) -> Option<Self> {
+        base.canonical().with_view(self.view)
     }
 }
 
@@ -248,7 +357,7 @@ impl RegisterType for X86Register {
         // Only RSP. RBP is not special — modern x86-64 ABIs do not require
         // a frame pointer, so excluding it would bias the search away from
         // valid scratch-register uses.
-        matches!(self, X86Register::RSP)
+        self.canonical() == X86Register::RSP
     }
 }
 
@@ -412,7 +521,16 @@ pub enum X86Instruction {
 }
 
 impl X86Instruction {
+    /// Canonical architectural destination used by liveness and machine-state
+    /// interfaces. The encoded operand view remains available through
+    /// [`Self::destination_operand`].
     pub fn destination(&self) -> Option<X86Register> {
+        self.destination_operand().map(X86Register::canonical)
+    }
+
+    /// Destination exactly as encoded by this instruction, including its
+    /// dword/word/byte view.
+    pub fn destination_operand(&self) -> Option<X86Register> {
         match self {
             X86Instruction::MovReg { rd, .. }
             | X86Instruction::MovImm { rd, .. }
@@ -481,7 +599,7 @@ impl X86Instruction {
     /// appears here. `MovReg`/`MovImm` are non-destructive (rd is purely
     /// written), so rd is NOT in the source list. See the enum doc-comment.
     pub fn source_registers(&self) -> Vec<X86Register> {
-        match self {
+        let operands = match self {
             X86Instruction::MovReg { rs, .. } => vec![*rs],
             X86Instruction::MovImm { .. } => vec![],
             X86Instruction::AddReg { rd, rs }
@@ -523,7 +641,8 @@ impl X86Instruction {
             // Cmov reads both rd (kept on false branch) and rs.
             X86Instruction::Cmov { rd, rs, .. } => vec![*rd, *rs],
             X86Instruction::Jcc { .. } => vec![],
-        }
+        };
+        operands.into_iter().map(X86Register::canonical).collect()
     }
 
     /// Whether this instruction transfers control out of the
@@ -784,6 +903,50 @@ fn x86_imm32_bitpattern_ok(imm: i64) -> bool {
     x86_signed_imm32_ok(imm) || u32::try_from(imm).is_ok()
 }
 
+fn x86_imm16_bitpattern_ok(imm: i64) -> bool {
+    i16::try_from(imm).is_ok() || u16::try_from(imm).is_ok()
+}
+
+fn x86_imm8_bitpattern_ok(imm: i64) -> bool {
+    i8::try_from(imm).is_ok() || u8::try_from(imm).is_ok()
+}
+
+fn x86_register_ok(reg: X86Register, mode_width: u32) -> bool {
+    reg.index().is_some_and(|index| {
+        index < if mode_width == 32 { 8 } else { 16 }
+            && !(mode_width == 32 && reg.view() == X86RegisterView::LowByte && index >= 4)
+    })
+}
+
+fn x86_register_pair_ok(lhs: X86Register, rhs: X86Register, mode_width: u32) -> bool {
+    x86_register_ok(lhs, mode_width)
+        && x86_register_ok(rhs, mode_width)
+        && lhs.effective_width(mode_width) == rhs.effective_width(mode_width)
+        && (!(lhs.is_high_byte() || rhs.is_high_byte())
+            || (lhs.index().is_some_and(|index| index < 4)
+                && rhs.index().is_some_and(|index| index < 4)))
+}
+
+fn x86_operand_immediate_ok(reg: X86Register, imm: i64, mode_width: u32) -> bool {
+    match reg.effective_width(mode_width) {
+        64 => x86_signed_imm32_ok(imm),
+        32 => x86_imm32_bitpattern_ok(imm),
+        16 => x86_imm16_bitpattern_ok(imm),
+        8 => x86_imm8_bitpattern_ok(imm),
+        _ => false,
+    }
+}
+
+fn x86_mov_operand_immediate_ok(reg: X86Register, imm: i64, mode_width: u32) -> bool {
+    match reg.effective_width(mode_width) {
+        64 => true,
+        32 => x86_imm32_bitpattern_ok(imm),
+        16 => x86_imm16_bitpattern_ok(imm),
+        8 => x86_imm8_bitpattern_ok(imm),
+        _ => false,
+    }
+}
+
 fn x86_mov_imm_ok(mode: crate::assembler::x86::X86Mode, imm: i64) -> bool {
     match mode {
         crate::assembler::x86::X86Mode::Mode64 => true,
@@ -951,50 +1114,70 @@ impl crate::isa::traits::CostModel<X86Instruction> for X86_32 {
     }
 }
 
+fn x86_can_assemble_instruction(instruction: &X86Instruction, mode_width: u32) -> bool {
+    match instruction {
+        X86Instruction::MovReg { rd, rs }
+        | X86Instruction::AddReg { rd, rs }
+        | X86Instruction::SubReg { rd, rs }
+        | X86Instruction::AndReg { rd, rs }
+        | X86Instruction::OrReg { rd, rs }
+        | X86Instruction::XorReg { rd, rs } => x86_register_pair_ok(*rd, *rs, mode_width),
+        X86Instruction::CmpReg { rn, rs } | X86Instruction::TestReg { rn, rs } => {
+            x86_register_pair_ok(*rn, *rs, mode_width)
+        }
+        X86Instruction::ImulReg { rd, rs } => {
+            x86_register_pair_ok(*rd, *rs, mode_width) && !rd.is_byte()
+        }
+        X86Instruction::ImulRegImm { rd, rs, imm } => {
+            x86_register_pair_ok(*rd, *rs, mode_width)
+                && !rd.is_byte()
+                && x86_operand_immediate_ok(*rd, *imm, mode_width)
+        }
+        X86Instruction::Lea { rd, base, disp } => {
+            x86_register_ok(*rd, mode_width)
+                && !rd.is_byte()
+                && x86_register_ok(*base, mode_width)
+                && base.effective_width(mode_width) == mode_width
+                && x86_signed_imm32_ok(*disp)
+        }
+        X86Instruction::MovImm { rd, imm } => {
+            x86_register_ok(*rd, mode_width) && x86_mov_operand_immediate_ok(*rd, *imm, mode_width)
+        }
+        X86Instruction::AddImm { rd, imm }
+        | X86Instruction::SubImm { rd, imm }
+        | X86Instruction::AndImm { rd, imm }
+        | X86Instruction::OrImm { rd, imm }
+        | X86Instruction::XorImm { rd, imm } => {
+            x86_register_ok(*rd, mode_width) && x86_operand_immediate_ok(*rd, *imm, mode_width)
+        }
+        X86Instruction::CmpImm { rn, imm } | X86Instruction::TestImm { rn, imm } => {
+            x86_register_ok(*rn, mode_width) && x86_operand_immediate_ok(*rn, *imm, mode_width)
+        }
+        X86Instruction::Shl { rd, imm }
+        | X86Instruction::Shr { rd, imm }
+        | X86Instruction::Sar { rd, imm }
+        | X86Instruction::Rol { rd, imm }
+        | X86Instruction::Ror { rd, imm } => {
+            x86_register_ok(*rd, mode_width) && x86_shift_count_imm8_ok(*imm)
+        }
+        X86Instruction::Neg { rd }
+        | X86Instruction::Not { rd }
+        | X86Instruction::Inc { rd }
+        | X86Instruction::Dec { rd } => x86_register_ok(*rd, mode_width),
+        X86Instruction::Cmov { rd, rs, .. } => {
+            x86_register_pair_ok(*rd, *rs, mode_width) && !rd.is_byte()
+        }
+        X86Instruction::Jcc { .. } => true,
+    }
+}
+
 impl crate::isa::traits::Assembler<X86Instruction> for X86_64 {
     fn assemble(&mut self, instructions: &[X86Instruction]) -> Result<Vec<u8>, String> {
         crate::assembler::x86::X86Assembler::new_64().assemble_instructions(instructions)
     }
 
     fn can_assemble(&self, instruction: &X86Instruction) -> bool {
-        match instruction {
-            X86Instruction::AddImm { imm, .. }
-            | X86Instruction::SubImm { imm, .. }
-            | X86Instruction::AndImm { imm, .. }
-            | X86Instruction::OrImm { imm, .. }
-            | X86Instruction::XorImm { imm, .. }
-            | X86Instruction::CmpImm { imm, .. }
-            // The 3-operand IMUL immediate encodes as imm32 (`69 /r id`).
-            | X86Instruction::ImulRegImm { imm, .. }
-            // LEA's displacement encodes as a signed disp32 in the ModRM/SIB.
-            | X86Instruction::Lea { disp: imm, .. }
-            | X86Instruction::TestImm { imm, .. } => x86_signed_imm32_ok(*imm),
-            // SHL / SHR / SAR / ROL / ROR encode their count as imm8: reject any
-            // count that does not fit a single byte so the search never proposes
-            // an unencodable shift or rotate.
-            X86Instruction::Shl { imm, .. }
-            | X86Instruction::Shr { imm, .. }
-            | X86Instruction::Sar { imm, .. }
-            | X86Instruction::Rol { imm, .. }
-            | X86Instruction::Ror { imm, .. } => x86_shift_count_imm8_ok(*imm),
-            X86Instruction::MovReg { .. }
-            | X86Instruction::MovImm { .. }
-            | X86Instruction::AddReg { .. }
-            | X86Instruction::SubReg { .. }
-            | X86Instruction::AndReg { .. }
-            | X86Instruction::OrReg { .. }
-            | X86Instruction::XorReg { .. }
-            | X86Instruction::CmpReg { .. }
-            | X86Instruction::TestReg { .. }
-            | X86Instruction::Neg { .. }
-            | X86Instruction::Not { .. }
-            | X86Instruction::Inc { .. }
-            | X86Instruction::Dec { .. }
-            // IMUL rd, rs is `0F AF /r` — always encodable.
-            | X86Instruction::ImulReg { .. }
-            | X86Instruction::Cmov { .. }
-            | X86Instruction::Jcc { .. } => true,
-        }
+        x86_can_assemble_instruction(instruction, 64)
     }
 }
 
@@ -1004,55 +1187,7 @@ impl crate::isa::traits::Assembler<X86Instruction> for X86_32 {
     }
 
     fn can_assemble(&self, instruction: &X86Instruction) -> bool {
-        // In 32-bit mode, R8..R15 are illegal. The x86 assembler's reg_index_32
-        // rejects them; reproduce the same check here so trait dispatch can
-        // pre-filter sequences before invoking the heavier assemble path.
-        fn reg_ok_32(r: X86Register) -> bool {
-            r.index().is_some_and(|i| i < 8)
-        }
-        match instruction {
-            X86Instruction::MovReg { rd, rs }
-            | X86Instruction::AddReg { rd, rs }
-            | X86Instruction::SubReg { rd, rs }
-            | X86Instruction::AndReg { rd, rs }
-            | X86Instruction::OrReg { rd, rs }
-            // IMUL rd, rs: both registers must be low-8 in 32-bit mode.
-            | X86Instruction::ImulReg { rd, rs }
-            | X86Instruction::XorReg { rd, rs } => reg_ok_32(*rd) && reg_ok_32(*rs),
-            // IMUL rd, rs, imm: low-8 registers plus an imm32 immediate.
-            X86Instruction::ImulRegImm { rd, rs, imm } => {
-                reg_ok_32(*rd) && reg_ok_32(*rs) && x86_signed_imm32_ok(*imm)
-            }
-            // LEA rd, [base + disp]: low-8 registers plus a signed disp32.
-            X86Instruction::Lea { rd, base, disp } => {
-                reg_ok_32(*rd) && reg_ok_32(*base) && x86_signed_imm32_ok(*disp)
-            }
-            X86Instruction::MovImm { rd, imm }
-            | X86Instruction::AddImm { rd, imm }
-            | X86Instruction::SubImm { rd, imm }
-            | X86Instruction::AndImm { rd, imm }
-            | X86Instruction::OrImm { rd, imm }
-            | X86Instruction::XorImm { rd, imm } => reg_ok_32(*rd) && x86_imm32_bitpattern_ok(*imm),
-            X86Instruction::CmpReg { rn, rs } | X86Instruction::TestReg { rn, rs } => {
-                reg_ok_32(*rn) && reg_ok_32(*rs)
-            }
-            X86Instruction::CmpImm { rn, imm } | X86Instruction::TestImm { rn, imm } => {
-                reg_ok_32(*rn) && x86_imm32_bitpattern_ok(*imm)
-            }
-            // SHL / SHR / SAR / ROL / ROR: legal 32-bit register plus an imm8
-            // count.
-            X86Instruction::Shl { rd, imm }
-            | X86Instruction::Shr { rd, imm }
-            | X86Instruction::Sar { rd, imm }
-            | X86Instruction::Rol { rd, imm }
-            | X86Instruction::Ror { rd, imm } => reg_ok_32(*rd) && x86_shift_count_imm8_ok(*imm),
-            X86Instruction::Neg { rd }
-            | X86Instruction::Not { rd }
-            | X86Instruction::Inc { rd }
-            | X86Instruction::Dec { rd } => reg_ok_32(*rd),
-            X86Instruction::Cmov { rd, rs, .. } => reg_ok_32(*rd) && reg_ok_32(*rs),
-            X86Instruction::Jcc { .. } => true,
-        }
+        x86_can_assemble_instruction(instruction, 32)
     }
 }
 
@@ -1778,6 +1913,9 @@ impl InstructionGenerator<X86Instruction> for X86InstructionGenerator {
         // Register-register variants (8 data mnemonics).
         for &rd in registers {
             for &rs in registers {
+                if !x86_register_pair_ok(rd, rs, 64) {
+                    continue;
+                }
                 out.push(X86Instruction::MovReg { rd, rs });
                 out.push(X86Instruction::AddReg { rd, rs });
                 out.push(X86Instruction::SubReg { rd, rs });
@@ -1791,14 +1929,18 @@ impl InstructionGenerator<X86Instruction> for X86InstructionGenerator {
         // Register-immediate variants (8 data mnemonics).
         for &rd in registers {
             for &imm in immediates {
-                out.push(X86Instruction::MovImm { rd, imm });
-                out.push(X86Instruction::AddImm { rd, imm });
-                out.push(X86Instruction::SubImm { rd, imm });
-                out.push(X86Instruction::AndImm { rd, imm });
-                out.push(X86Instruction::OrImm { rd, imm });
-                out.push(X86Instruction::XorImm { rd, imm });
-                out.push(X86Instruction::CmpImm { rn: rd, imm });
-                out.push(X86Instruction::TestImm { rn: rd, imm });
+                if x86_mov_operand_immediate_ok(rd, imm, 64) {
+                    out.push(X86Instruction::MovImm { rd, imm });
+                }
+                if x86_operand_immediate_ok(rd, imm, 64) {
+                    out.push(X86Instruction::AddImm { rd, imm });
+                    out.push(X86Instruction::SubImm { rd, imm });
+                    out.push(X86Instruction::AndImm { rd, imm });
+                    out.push(X86Instruction::OrImm { rd, imm });
+                    out.push(X86Instruction::XorImm { rd, imm });
+                    out.push(X86Instruction::CmpImm { rn: rd, imm });
+                    out.push(X86Instruction::TestImm { rn: rd, imm });
+                }
             }
         }
         // Single-operand variants (NEG, NOT, INC, DEC): one per register.
@@ -1837,6 +1979,9 @@ impl InstructionGenerator<X86Instruction> for X86InstructionGenerator {
         // including rd == rs (self-multiply is meaningful, unlike self-CMOV).
         for &rd in registers {
             for &rs in registers {
+                if !x86_register_pair_ok(rd, rs, 64) || rd.is_byte() {
+                    continue;
+                }
                 out.push(X86Instruction::ImulReg { rd, rs });
             }
         }
@@ -1845,8 +1990,11 @@ impl InstructionGenerator<X86Instruction> for X86InstructionGenerator {
         // here rather than emitted and later rejected by `can_assemble`.
         for &rd in registers {
             for &rs in registers {
+                if !x86_register_pair_ok(rd, rs, 64) || rd.is_byte() {
+                    continue;
+                }
                 for &imm in immediates {
-                    if i32::try_from(imm).is_err() {
+                    if !x86_operand_immediate_ok(rd, imm, 64) {
                         continue;
                     }
                     out.push(X86Instruction::ImulRegImm { rd, rs, imm });
@@ -1860,6 +2008,15 @@ impl InstructionGenerator<X86Instruction> for X86InstructionGenerator {
         // `can_assemble`.
         for &rd in registers {
             for &base in registers {
+                if rd.is_byte()
+                    || !matches!(
+                        base.view(),
+                        X86RegisterView::Native | X86RegisterView::Dword
+                    )
+                    || !x86_register_ok(rd, 64)
+                {
+                    continue;
+                }
                 for &disp in immediates {
                     if i32::try_from(disp).is_err() {
                         continue;
@@ -1873,7 +2030,7 @@ impl InstructionGenerator<X86Instruction> for X86InstructionGenerator {
         // excluded.
         for &rd in registers {
             for &rs in registers {
-                if rd == rs {
+                if rd == rs || !x86_register_pair_ok(rd, rs, 64) || rd.is_byte() {
                     continue;
                 }
                 for &cond in &X86Condition::ALL {

--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -1201,11 +1201,12 @@ fn x86_can_assemble_instruction(instruction: &X86Instruction, mode_width: u32) -
         X86Instruction::Cmov { rd, rs, .. } => {
             x86_register_pair_ok(*rd, *rs, mode_width) && !rd.is_byte()
         }
-        // SETcc materializes a boolean byte result and is always encodable in
-        // 64-bit mode. In x86-32 only EAX..EBX (slots 0..=3) name a low byte
-        // without a REX prefix, so restrict the destination there.
+        // SETcc is a full-width pseudo-op. In x86-32 only EAX..EBX
+        // (slots 0..=3) name a low byte without a REX prefix, so restrict the
+        // native destination there.
         X86Instruction::Setcc { rd, .. } => {
-            mode_width == 64 || rd.index().is_some_and(|index| index < 4)
+            rd.view() == X86RegisterView::Native
+                && (mode_width == 64 || rd.index().is_some_and(|index| index < 4))
         }
         X86Instruction::Jcc { .. } => true,
     }
@@ -2765,7 +2766,7 @@ mod tests {
     }
 
     #[test]
-    fn x86_setcc_encodability_matches_available_low_byte_registers() {
+    fn x86_setcc_encodability_requires_native_view_and_available_low_byte_register() {
         use crate::isa::traits::Assembler;
 
         let setne = |rd| X86Instruction::Setcc {
@@ -2776,10 +2777,34 @@ mod tests {
             &X86_64,
             &setne(X86Register::R15)
         ));
+        for rd in [
+            X86Register::EAX,
+            X86Register::AX,
+            X86Register::AL,
+            X86Register::AH,
+            X86Register::R15D,
+            X86Register::R15B,
+        ] {
+            assert!(
+                !<X86_64 as Assembler<X86Instruction>>::can_assemble(&X86_64, &setne(rd)),
+                "x86-64 SETcc pseudo-op should reject non-native destination {rd}"
+            );
+        }
         assert!(<X86_32 as Assembler<X86Instruction>>::can_assemble(
             &X86_32,
             &setne(X86Register::RAX)
         ));
+        for rd in [
+            X86Register::EAX,
+            X86Register::AX,
+            X86Register::AL,
+            X86Register::AH,
+        ] {
+            assert!(
+                !<X86_32 as Assembler<X86Instruction>>::can_assemble(&X86_32, &setne(rd)),
+                "x86-32 SETcc pseudo-op should reject non-native destination {rd}"
+            );
+        }
         assert!(!<X86_32 as Assembler<X86Instruction>>::can_assemble(
             &X86_32,
             &setne(X86Register::RSI)

--- a/src/main.rs
+++ b/src/main.rs
@@ -4972,6 +4972,24 @@ mod cli_helper_tests {
                 src_width: 8,
             }]
         );
+        let movzx_eax = cs64
+            .disasm_all(&[0x0f, 0xb6, 0xc3], 0x1000)
+            .expect("disassemble movzx eax, bl");
+        assert_eq!(
+            convert_to_x86_ir(&movzx_eax, parser::x86::X86ParseMode::Mode64).unwrap(),
+            vec![X86Instruction::Movzx {
+                rd: X86Register::RAX,
+                rs: X86Register::RBX,
+                src_width: 8,
+            }]
+        );
+        let movsx_eax = cs64
+            .disasm_all(&[0x0f, 0xbe, 0xc3], 0x1000)
+            .expect("disassemble movsx eax, bl");
+        assert!(
+            convert_to_x86_ir(&movsx_eax, parser::x86::X86ParseMode::Mode64).is_err(),
+            "MOVSX through EAX is not representable by the native-width extension IR"
+        );
 
         let cs32 = capstone::Capstone::new()
             .x86()

--- a/src/main.rs
+++ b/src/main.rs
@@ -645,13 +645,13 @@ trait ElfOptimizationBackend {
         optimization_context_for_backend(self.arch(), patcher, section, end_addr, cs)
     }
 
-    /// Run the selected search. `capstone_instructions` preserves source
-    /// operand spelling for backends whose IR collapses aliases; backends
-    /// that do not need that syntax metadata can ignore it.
+    /// Run the selected search. `capstone_instructions` preserves the original
+    /// instruction bytes for backends that need encoding metadata; backends
+    /// that do not need it can ignore the argument.
     fn run_search(
         &self,
         ir: &[Self::Instruction],
-        capstone_instructions: &capstone::Instructions,
+        _capstone_instructions: &capstone::Instructions,
         options: &OptimizationOptions,
         context: OptimizationContext,
     ) -> Result<Option<Vec<Self::Instruction>>, Box<dyn std::error::Error>>;
@@ -886,9 +886,6 @@ impl ElfOptimizationBackend for X86OptimizationBackend {
         // the linear fall-through successor, so a held-fixed terminator (the
         // trailing Jcc, with its unscanned branch-taken target) vetoes
         // narrowing. We leave `downstream_live_regs` Unknown in that case.
-        // x86 narrowing is additionally inert today (#75 — no operand width),
-        // but the gate is applied for consistency and future-safety once #75
-        // turns the kill rule on.
         let has_terminator = ir.last().is_some_and(|i| i.is_terminator());
         let downstream_live_regs = if has_terminator {
             DownstreamLiveRegs::Unknown
@@ -920,7 +917,7 @@ impl ElfOptimizationBackend for X86OptimizationBackend {
     fn run_search(
         &self,
         ir: &[Self::Instruction],
-        capstone_instructions: &capstone::Instructions,
+        _capstone_instructions: &capstone::Instructions,
         options: &OptimizationOptions,
         context: OptimizationContext,
     ) -> Result<Option<Vec<Self::Instruction>>, Box<dyn std::error::Error>> {
@@ -950,10 +947,7 @@ impl ElfOptimizationBackend for X86OptimizationBackend {
                 options,
                 context.downstream_flags_live,
                 downstream_live.as_ref(),
-                x86_capstone_window_uses_only_full_width_register_operands(
-                    capstone_instructions,
-                    width,
-                ),
+                true,
             ),
             Algorithm::Hybrid | Algorithm::Llm => {
                 // Rejected upstream at the CLI layer; defensive check here
@@ -1407,9 +1401,9 @@ fn build_x86_stochastic_search_config(
 fn build_x86_symbolic_search_config(
     target: &[isa::x86::X86Instruction],
     options: &OptimizationOptions,
-    // Binary-patching guard: direct IR callers can allow same-count CodeSize
-    // search, but the ELF frontend disables it when Capstone exposed
-    // partial-register operands that the x86 IR cannot model.
+    // Kept as a search-policy input for callers that intentionally disable
+    // same-count rewrites. The ELF frontend passes true because register views
+    // are represented precisely throughout the x86 pipeline.
     same_count_code_size_allowed: bool,
 ) -> SearchConfig {
     let symbolic_config = SymbolicConfig::default().with_search_mode(options.search_mode);
@@ -2143,19 +2137,13 @@ fn x86_downstream_flags_live_from_section(
 /// Compute the subset of `candidates` (registers an x86 window writes) that are
 /// provably *live* downstream, given the fall-through bytes that follow.
 ///
-/// Structurally identical to the AArch64 register scan, but the kill rule is
-/// intentionally weaker to stay sound under issue #75 (the x86 IR has no
-/// operand width). `x86_reg_downstream_liveness` therefore *never* reports a
-/// write as a full overwrite, so the only way a candidate leaves the live set
-/// is — there is no such way today. In practice every candidate stays live:
-/// either an instruction reads it (`Read`), or the scan reaches an
-/// uncertainty (unsupported instruction — which includes `call`/`ret`, since
-/// neither is modelled in the x86 IR and `x86_ir_from_mnemonic` returns
-/// `Ok(None)` for them — a terminator, a disasm failure, or the end of the
-/// in-region suffix), all of which pin the remaining candidates live. This is
-/// the vacuously-safe behaviour the issue calls for; when #75 lands and
-/// `x86_destination_fully_kills` learns real widths, the narrowing turns on
-/// without weakening the contract.
+/// Structurally identical to the AArch64 register scan. The x86 kill rule
+/// distinguishes full architectural writes (native or dword) from word and
+/// byte writes that preserve surrounding bits. An instruction that reads a
+/// candidate first keeps it live; an unsupported instruction — including
+/// `call`/`ret`, since neither is modelled in the x86 IR — a terminator, a
+/// disassembly failure, or the end of the in-region suffix conservatively
+/// pins every unresolved candidate live.
 ///
 /// Unlike the flags scan, this needs no ISA-marker type parameter: register
 /// reads/kills are width-independent in the shared x86 IR, and the `cs`
@@ -2266,10 +2254,7 @@ fn validate_basic_block(ir: &[Instruction]) -> Result<(), String> {
 // (`convert_to_x86_ir`) and the length-1 enumerator used by the
 // enumerative x86 pipeline.
 
-use parser::x86::{
-    X86ParseMode, parse_x86_register_with_width, x86_ir_from_mnemonic,
-    x86_ir_from_mnemonic_for_mode,
-};
+use parser::x86::{X86ParseMode, x86_ir_from_mnemonic, x86_ir_from_mnemonic_for_mode};
 
 /// Reject any non-terminal Jcc in an x86 optimization window. The
 /// optimizer only special-cases a trailing Jcc (peeled by
@@ -2292,29 +2277,6 @@ fn validate_x86_window_terminator_placement(ir: &[isa::x86::X86Instruction]) -> 
         }
     }
     Ok(())
-}
-
-fn x86_capstone_window_uses_only_full_width_register_operands(
-    instructions: &capstone::Instructions,
-    width: u32,
-) -> bool {
-    instructions.iter().all(|instruction| {
-        instruction
-            .op_str()
-            .unwrap_or("")
-            .split(',')
-            .all(
-                |operand| match parse_x86_register_with_width(operand.trim()) {
-                    Ok((_reg, alias_width)) => alias_width == width,
-                    // Non-register syntax (immediates, memory operands,
-                    // unsupported forms) does not participate in this direct
-                    // register-width guard. Supported instructions naming an
-                    // unknown register such as `ah` are rejected by
-                    // `convert_to_x86_ir` before this helper is used.
-                    Err(_) => true,
-                },
-            )
-    })
 }
 
 fn convert_to_x86_ir(
@@ -2367,9 +2329,14 @@ fn convert_to_x86_ir(
 /// introduce unrelated writable registers.
 fn x86_registers_from_target(target: &[isa::x86::X86Instruction]) -> Vec<isa::x86::X86Register> {
     let mut pool: Vec<isa::x86::X86Register> = Vec::new();
-    let referenced = target.iter().filter_map(|instr| instr.destination());
+    let referenced = target
+        .iter()
+        .filter_map(|instr| instr.destination_operand());
     for reg in referenced {
-        if matches!(reg, isa::x86::X86Register::RSP | isa::x86::X86Register::RBP) {
+        if matches!(
+            reg.canonical(),
+            isa::x86::X86Register::RSP | isa::x86::X86Register::RBP
+        ) {
             continue;
         }
         if !pool.contains(&reg) {
@@ -2413,11 +2380,6 @@ fn x86_enumerative_immediates_from_target(target: &[isa::x86::X86Instruction]) -
 /// registers (issue #621): when `downstream_live` is `Some(set)`, the
 /// window-written live-out set is narrowed to that proven-live subset;
 /// when `None` every written register stays live (the pre-#621 default).
-///
-/// Because the x86 register kill rule is intentionally inert under #75 (no
-/// operand width — see `validation::live_out::x86_reg_downstream_liveness`),
-/// the proven-live subset is, today, always the full window-written set. The
-/// narrowing wiring is in place so that #75 enables it with no further change.
 ///
 /// **Conditional/branch soundness gate (defense in depth).** Like the AArch64
 /// builder, register narrowing applies only when the window has no terminator:
@@ -4093,10 +4055,8 @@ mod cli_helper_tests {
 
     #[test]
     fn downstream_regs_live_scan_marks_dead_when_later_full_overwrite_precedes_any_read() {
-        // Window wrote RAX. Suffix `mov rax, rbx` fully overwrites rax before
-        // any read — RAX is dead/optimizable. (Driven via AArch64 because the
-        // x86 IR cannot prove a full overwrite under #75; see the x86 partial
-        // test below.)
+        // Window wrote X0. Suffix `mov x0, x1` fully overwrites x0 before any
+        // read, so X0 is dead/optimizable.
         let bytes = assemble_aarch64_test_bytes(&[Instruction::MovReg {
             rd: Register::X0,
             rn: Register::X1,
@@ -4182,15 +4142,11 @@ mod cli_helper_tests {
 
     #[test]
     fn x86_partial_write_does_not_kill() {
-        // Window wrote RAX. Suffix `mov rax, rbx` *looks* like a full
-        // overwrite, but the x86 IR carries no operand width (#75): it could be
-        // `mov eax/al, ...`, a partial write that leaves RAX's upper bits live.
-        // The scan must therefore NOT treat it as a kill — RAX stays live.
-        // This guard keeps the path sound when #75 lands and the kill rule is
-        // turned on for genuinely full-width forms.
-        let bytes = assemble_x86_64_test_bytes(&[X86Instruction::MovReg {
-            rd: X86Register::RAX,
-            rs: X86Register::RBX,
+        // Window wrote RAX. Suffix `mov al, 0` leaves the rest of RAX intact,
+        // so the downstream scan must not treat it as a full-register kill.
+        let bytes = assemble_x86_64_test_bytes(&[X86Instruction::MovImm {
+            rd: X86Register::AL,
+            imm: 0,
         }]);
         let cs = x86_64_test_capstone();
         let live = x86_downstream_regs_live_from_bytes(
@@ -4201,7 +4157,7 @@ mod cli_helper_tests {
         );
         assert!(
             live.contains(X86Register::RAX),
-            "x86 write must not be trusted as a full overwrite (#75) — RAX stays live"
+            "an AL write preserves upper RAX bits, so RAX stays live"
         );
     }
 
@@ -4336,60 +4292,21 @@ mod cli_helper_tests {
         ];
         for (aliases, reg) in cases {
             for alias in aliases {
-                assert_eq!(parse_x86_register(alias).unwrap(), reg);
+                assert_eq!(parse_x86_register(alias).unwrap().canonical(), reg);
             }
+        }
+        for (alias, expected) in [
+            ("ah", X86Register::AH),
+            ("ch", X86Register::CH),
+            ("dh", X86Register::DH),
+            ("bh", X86Register::BH),
+        ] {
+            assert_eq!(parse_x86_register(alias).unwrap(), expected);
         }
     }
 
-    fn x86_disassembled_operands_are_full_width_for_test(
-        bytes: &[u8],
-        mode: capstone::arch::x86::ArchMode,
-        width: u32,
-    ) -> bool {
-        let cs = Capstone::new()
-            .x86()
-            .mode(mode)
-            .syntax(capstone::arch::x86::ArchSyntax::Intel)
-            .build()
-            .unwrap();
-        let instructions = cs.disasm_all(bytes, 0x1000).unwrap();
-        x86_capstone_window_uses_only_full_width_register_operands(&instructions, width)
-    }
-
     #[test]
-    fn x86_full_width_operand_detector() {
-        let mode64 = capstone::arch::x86::ArchMode::Mode64;
-        let mode32 = capstone::arch::x86::ArchMode::Mode32;
-
-        assert!(!x86_disassembled_operands_are_full_width_for_test(
-            &[0x66, 0xb8, 0x00, 0x00],
-            mode64,
-            64
-        ));
-        assert!(!x86_disassembled_operands_are_full_width_for_test(
-            &[0xb0, 0x00],
-            mode64,
-            64
-        ));
-        assert!(!x86_disassembled_operands_are_full_width_for_test(
-            &[0xb8, 0x00, 0x00, 0x00, 0x00],
-            mode64,
-            64
-        ));
-        assert!(x86_disassembled_operands_are_full_width_for_test(
-            &[0x48, 0xc7, 0xc0, 0x00, 0x00, 0x00, 0x00],
-            mode64,
-            64
-        ));
-        assert!(x86_disassembled_operands_are_full_width_for_test(
-            &[0xb8, 0x00, 0x00, 0x00, 0x00],
-            mode32,
-            32
-        ));
-    }
-
-    #[test]
-    fn x86_64_capstone_bridge_rejects_non_mode_width_register_aliases() {
+    fn x86_64_capstone_bridge_retains_sub_register_aliases() {
         let cs = capstone::Capstone::new()
             .x86()
             .mode(capstone::arch::x86::ArchMode::Mode64)
@@ -4403,11 +4320,12 @@ mod cli_helper_tests {
         let insn = add_eax.iter().next().expect("one instruction");
         assert_eq!(insn.mnemonic(), Some("add"));
         assert_eq!(insn.op_str(), Some("eax, 0"));
-        let err = convert_to_x86_ir(&add_eax, parser::x86::X86ParseMode::Mode64)
-            .expect_err("x86-64 add eax, 0 must be rejected until width is modeled");
-        assert!(
-            err.contains("unsupported x86-64 register alias width"),
-            "unexpected error: {err}"
+        assert_eq!(
+            convert_to_x86_ir(&add_eax, parser::x86::X86ParseMode::Mode64).unwrap(),
+            vec![X86Instruction::AddImm {
+                rd: X86Register::EAX,
+                imm: 0,
+            }]
         );
 
         let mov_al = cs
@@ -4416,11 +4334,12 @@ mod cli_helper_tests {
         let insn = mov_al.iter().next().expect("one instruction");
         assert_eq!(insn.mnemonic(), Some("mov"));
         assert_eq!(insn.op_str(), Some("al, 0x7f"));
-        let err = convert_to_x86_ir(&mov_al, parser::x86::X86ParseMode::Mode64)
-            .expect_err("x86-64 mov al, imm must be rejected until width is modeled");
-        assert!(
-            err.contains("unsupported x86-64 register alias width"),
-            "unexpected error: {err}"
+        assert_eq!(
+            convert_to_x86_ir(&mov_al, parser::x86::X86ParseMode::Mode64).unwrap(),
+            vec![X86Instruction::MovImm {
+                rd: X86Register::AL,
+                imm: 0x7f,
+            }]
         );
     }
 
@@ -4461,14 +4380,14 @@ mod cli_helper_tests {
         assert_eq!(
             convert_to_x86_ir(&add_eax, parser::x86::X86ParseMode::Mode32).unwrap(),
             vec![X86Instruction::AddImm {
-                rd: X86Register::RAX,
+                rd: X86Register::EAX,
                 imm: 0,
             }]
         );
     }
 
     #[test]
-    fn x86_64_optimizer_rejects_narrow_register_alias_before_search() {
+    fn x86_64_optimizer_accepts_narrow_register_aliases() {
         let elf_bytes = build_minimal_elf64(
             &[0x83, 0xc0, 0x00, 0x83, 0xc0, 0x00],
             0x1000,
@@ -4480,17 +4399,8 @@ mod cli_helper_tests {
         opts.timeout = Some(Duration::from_secs(5));
         opts.cost_metric = CostMetric::CodeSize;
 
-        let err = optimize_elf_binary(&patcher, input.path(), 0x1000, 0x1006, &opts)
-            .expect_err("narrow register aliases should be rejected before search");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("failed to parse x86 instruction 'add eax, 0'"),
-            "unexpected error: {msg}"
-        );
-        assert!(
-            msg.contains("unsupported x86-64 register alias width"),
-            "unexpected error: {msg}"
-        );
+        optimize_elf_binary(&patcher, input.path(), 0x1000, 0x1006, &opts)
+            .expect("narrow register aliases should reach search");
     }
 
     #[test]
@@ -4498,7 +4408,13 @@ mod cli_helper_tests {
         assert!(parse_x86_operand("not-an-operand").is_err());
         assert!(x86_ir_from_mnemonic("add", "rax").unwrap().is_none());
         assert!(x86_ir_from_mnemonic("add", "rax, nope").is_err());
-        assert!(x86_ir_from_mnemonic("mov", "ah, 0").is_err());
+        assert_eq!(
+            x86_ir_from_mnemonic("mov", "ah, 0").unwrap(),
+            Some(X86Instruction::MovImm {
+                rd: X86Register::AH,
+                imm: 0,
+            })
+        );
 
         let mut opts = options_for(Algorithm::Enumerative);
         opts.timeout = Some(Duration::from_secs(5));
@@ -4665,10 +4581,9 @@ mod cli_helper_tests {
         );
     }
 
-    /// x86 sibling of the conditional-terminator soundness gate. The x86 path
-    /// is inert under #75 today, but the gate must still hold so it stays sound
-    /// when #75 turns the kill rule on: a target ending in a Jcc must NOT narrow
-    /// even if the (future) proven-live set excludes a written register.
+    /// x86 sibling of the conditional-terminator soundness gate: a target
+    /// ending in a Jcc must not narrow even if the proven-live set excludes a
+    /// written register.
     #[test]
     fn x86_live_out_for_optimization_does_not_narrow_with_trailing_jcc() {
         use isa::x86::X86Condition;
@@ -4735,7 +4650,7 @@ mod cli_helper_tests {
 
         assert!(
             run_x86_symbolic(&target, 64, &opts, false, None, false).is_none(),
-            "the ELF frontend can disable same-count symbolic code-size rewrites when source operand widths are unsafe"
+            "a caller can explicitly disable same-count symbolic code-size rewrites"
         );
 
         assert!(
@@ -4745,7 +4660,7 @@ mod cli_helper_tests {
     }
 
     #[test]
-    fn x86_symbolic_backend_gates_same_count_code_size_from_capstone_operands() {
+    fn x86_symbolic_backend_preserves_capstone_register_views() {
         let backend = X86OptimizationBackend::new(X86Arch::X86_64);
         let cs = backend.disassembler().unwrap();
         let mut opts = options_for(Algorithm::Symbolic);
@@ -4757,25 +4672,32 @@ mod cli_helper_tests {
             downstream_live_regs: DownstreamLiveRegs::Unknown,
         };
 
-        // 66 b8 00 00 = mov ax, 0. The Capstone bridge now rejects
-        // partial-width register aliases outright, so a window whose
-        // source operands are not mode-width never reaches search and the
-        // binary-patching hazard the same-count gate guards against cannot
-        // occur through the ELF frontend.
+        // 66 b8 00 00 = mov ax, 0. The register view survives conversion.
         let partial_instructions = cs.disasm_all(&[0x66, 0xb8, 0x00, 0x00], 0x1000).unwrap();
-        assert!(
-            backend.convert_ir(&partial_instructions).is_err(),
-            "x86-64 conversion must reject a partial-width source operand"
+        assert_eq!(
+            backend.convert_ir(&partial_instructions).unwrap(),
+            vec![X86Instruction::MovImm {
+                rd: X86Register::AX,
+                imm: 0,
+            }]
         );
 
         // 66 83 e0 00 = and ax, 0; 74 00 = je +0. The partial-width AND in
-        // the rewritable prefix is likewise rejected before search.
+        // the rewritable prefix also remains precise before a pinned Jcc.
         let partial_with_jcc_instructions = cs
             .disasm_all(&[0x66, 0x83, 0xe0, 0x00, 0x74, 0x00], 0x1000)
             .unwrap();
-        assert!(
-            backend.convert_ir(&partial_with_jcc_instructions).is_err(),
-            "x86-64 conversion must reject a partial-width prefix before a pinned Jcc"
+        assert_eq!(
+            backend.convert_ir(&partial_with_jcc_instructions).unwrap(),
+            vec![
+                X86Instruction::AndImm {
+                    rd: X86Register::AX,
+                    imm: 0,
+                },
+                X86Instruction::Jcc {
+                    cond: isa::x86::X86Condition::E,
+                },
+            ]
         );
 
         // 48 c7 c0 00 00 00 00 = mov rax, 0

--- a/src/main.rs
+++ b/src/main.rs
@@ -4389,7 +4389,10 @@ mod cli_helper_tests {
     #[test]
     fn x86_64_optimizer_accepts_narrow_register_aliases() {
         let elf_bytes = build_minimal_elf64(
-            &[0x83, 0xc0, 0x00, 0x83, 0xc0, 0x00],
+            // Use the five-byte accumulator form so the two-instruction
+            // window has room for any cheaper one-instruction dword-immediate
+            // encoding that dynasm may choose.
+            &[0x05, 0x00, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00],
             0x1000,
             elf::abi::EM_X86_64,
         );
@@ -4399,7 +4402,7 @@ mod cli_helper_tests {
         opts.timeout = Some(Duration::from_secs(5));
         opts.cost_metric = CostMetric::CodeSize;
 
-        optimize_elf_binary(&patcher, input.path(), 0x1000, 0x1006, &opts)
+        optimize_elf_binary(&patcher, input.path(), 0x1000, 0x100a, &opts)
             .expect("narrow register aliases should reach search");
     }
 

--- a/src/parser/x86.rs
+++ b/src/parser/x86.rs
@@ -533,8 +533,16 @@ fn x86_ir_from_mnemonic_impl(
                 mnemonic, parts[0]
             ));
         }
+        // Writing a 32-bit MOVZX destination in x86-64 clears the upper half
+        // of the canonical GPR, so it is exactly representable by the
+        // native-width zero-extension IR. MOVSX is not: sign extension into
+        // EAX followed by architectural zero-extension differs from sign
+        // extension directly into RAX.
+        let mode64_movzx_dword =
+            mnemonic == "movzx" && mode == Some(X86ParseMode::Mode64) && destination_width == 32;
         if let Some(mode) = mode
             && destination_width != mode.mode_width()
+            && !mode64_movzx_dword
         {
             return Err(format!(
                 "{} destination '{}' must match the {}-bit execution mode",
@@ -543,8 +551,8 @@ fn x86_ir_from_mnemonic_impl(
                 mode.mode_width()
             ));
         }
-        // MOVZX to 32 bits and then architectural zero-extension is equivalent
-        // to the widthless IR's full-width zero-extension; MOVSX is not.
+        // The same MOVZX equivalence makes a 32-bit destination sound for the
+        // widthless parser; MOVSX remains unrepresentable there.
         if mode.is_none() && mnemonic == "movsx" && destination_width == 32 {
             return Err(format!(
                 "widthless x86 parser cannot represent a 32-bit destination for movsx: '{}'",
@@ -1041,7 +1049,7 @@ mod tests {
     }
 
     #[test]
-    fn movzx_movsx_mode_parser_requires_native_destination_and_encodable_narrow_source() {
+    fn movzx_movsx_mode_parser_normalizes_sound_destinations_and_rejects_other_widths() {
         assert_eq!(
             x86_ir_from_mnemonic_for_mode("movzx", "rax, bl", X86ParseMode::Mode64)
                 .unwrap()
@@ -1062,9 +1070,22 @@ mod tests {
                 src_width: 16,
             }
         );
+        for (operands, src_width) in [("eax, bl", 8), ("eax, bx", 16)] {
+            assert_eq!(
+                x86_ir_from_mnemonic_for_mode("movzx", operands, X86ParseMode::Mode64)
+                    .unwrap()
+                    .unwrap(),
+                X86Instruction::Movzx {
+                    rd: X86Register::RAX,
+                    rs: X86Register::RBX,
+                    src_width,
+                },
+                "x86-64 MOVZX through EAX must canonicalize its zero-extending write"
+            );
+        }
 
         for (mode, operands) in [
-            (X86ParseMode::Mode64, "eax, bl"),
+            (X86ParseMode::Mode64, "ax, bl"),
             (X86ParseMode::Mode64, "rax, ebx"),
             (X86ParseMode::Mode32, "ax, bl"),
             (X86ParseMode::Mode32, "eax, ebx"),
@@ -1076,6 +1097,10 @@ mod tests {
                 "unsupported extension shape should fail: {mode:?} {operands}"
             );
         }
+        assert!(
+            x86_ir_from_mnemonic_for_mode("movsx", "eax, bl", X86ParseMode::Mode64).is_err(),
+            "MOVSX through EAX is not equivalent to native-width sign extension"
+        );
         assert!(x86_ir_from_mnemonic("movsx", "rax, 1").is_err());
         assert!(x86_ir_from_mnemonic("movzx", "rax, ah").is_err());
     }

--- a/src/parser/x86.rs
+++ b/src/parser/x86.rs
@@ -82,69 +82,73 @@ impl std::fmt::Display for X86RegisterParseError {
 fn classify_x86_register_alias(reg_str: &str) -> Result<(X86Register, u32), X86RegisterParseError> {
     match reg_str.trim().to_lowercase().as_str() {
         "rax" => Ok((X86Register::RAX, 64)),
-        "eax" => Ok((X86Register::RAX, 32)),
-        "ax" => Ok((X86Register::RAX, 16)),
-        "al" => Ok((X86Register::RAX, 8)),
+        "eax" => Ok((X86Register::EAX, 32)),
+        "ax" => Ok((X86Register::AX, 16)),
+        "al" => Ok((X86Register::AL, 8)),
+        "ah" => Ok((X86Register::AH, 8)),
         "rcx" => Ok((X86Register::RCX, 64)),
-        "ecx" => Ok((X86Register::RCX, 32)),
-        "cx" => Ok((X86Register::RCX, 16)),
-        "cl" => Ok((X86Register::RCX, 8)),
+        "ecx" => Ok((X86Register::ECX, 32)),
+        "cx" => Ok((X86Register::CX, 16)),
+        "cl" => Ok((X86Register::CL, 8)),
+        "ch" => Ok((X86Register::CH, 8)),
         "rdx" => Ok((X86Register::RDX, 64)),
-        "edx" => Ok((X86Register::RDX, 32)),
-        "dx" => Ok((X86Register::RDX, 16)),
-        "dl" => Ok((X86Register::RDX, 8)),
+        "edx" => Ok((X86Register::EDX, 32)),
+        "dx" => Ok((X86Register::DX, 16)),
+        "dl" => Ok((X86Register::DL, 8)),
+        "dh" => Ok((X86Register::DH, 8)),
         "rbx" => Ok((X86Register::RBX, 64)),
-        "ebx" => Ok((X86Register::RBX, 32)),
-        "bx" => Ok((X86Register::RBX, 16)),
-        "bl" => Ok((X86Register::RBX, 8)),
+        "ebx" => Ok((X86Register::EBX, 32)),
+        "bx" => Ok((X86Register::BX, 16)),
+        "bl" => Ok((X86Register::BL, 8)),
+        "bh" => Ok((X86Register::BH, 8)),
         "rsp" => Ok((X86Register::RSP, 64)),
-        "esp" => Ok((X86Register::RSP, 32)),
-        "sp" => Ok((X86Register::RSP, 16)),
-        "spl" => Ok((X86Register::RSP, 8)),
+        "esp" => Ok((X86Register::ESP, 32)),
+        "sp" => Ok((X86Register::SP, 16)),
+        "spl" => Ok((X86Register::SPL, 8)),
         "rbp" => Ok((X86Register::RBP, 64)),
-        "ebp" => Ok((X86Register::RBP, 32)),
-        "bp" => Ok((X86Register::RBP, 16)),
-        "bpl" => Ok((X86Register::RBP, 8)),
+        "ebp" => Ok((X86Register::EBP, 32)),
+        "bp" => Ok((X86Register::BP, 16)),
+        "bpl" => Ok((X86Register::BPL, 8)),
         "rsi" => Ok((X86Register::RSI, 64)),
-        "esi" => Ok((X86Register::RSI, 32)),
-        "si" => Ok((X86Register::RSI, 16)),
-        "sil" => Ok((X86Register::RSI, 8)),
+        "esi" => Ok((X86Register::ESI, 32)),
+        "si" => Ok((X86Register::SI, 16)),
+        "sil" => Ok((X86Register::SIL, 8)),
         "rdi" => Ok((X86Register::RDI, 64)),
-        "edi" => Ok((X86Register::RDI, 32)),
-        "di" => Ok((X86Register::RDI, 16)),
-        "dil" => Ok((X86Register::RDI, 8)),
+        "edi" => Ok((X86Register::EDI, 32)),
+        "di" => Ok((X86Register::DI, 16)),
+        "dil" => Ok((X86Register::DIL, 8)),
         "r8" => Ok((X86Register::R8, 64)),
-        "r8d" => Ok((X86Register::R8, 32)),
-        "r8w" => Ok((X86Register::R8, 16)),
-        "r8b" => Ok((X86Register::R8, 8)),
+        "r8d" => Ok((X86Register::R8D, 32)),
+        "r8w" => Ok((X86Register::R8W, 16)),
+        "r8b" => Ok((X86Register::R8B, 8)),
         "r9" => Ok((X86Register::R9, 64)),
-        "r9d" => Ok((X86Register::R9, 32)),
-        "r9w" => Ok((X86Register::R9, 16)),
-        "r9b" => Ok((X86Register::R9, 8)),
+        "r9d" => Ok((X86Register::R9D, 32)),
+        "r9w" => Ok((X86Register::R9W, 16)),
+        "r9b" => Ok((X86Register::R9B, 8)),
         "r10" => Ok((X86Register::R10, 64)),
-        "r10d" => Ok((X86Register::R10, 32)),
-        "r10w" => Ok((X86Register::R10, 16)),
-        "r10b" => Ok((X86Register::R10, 8)),
+        "r10d" => Ok((X86Register::R10D, 32)),
+        "r10w" => Ok((X86Register::R10W, 16)),
+        "r10b" => Ok((X86Register::R10B, 8)),
         "r11" => Ok((X86Register::R11, 64)),
-        "r11d" => Ok((X86Register::R11, 32)),
-        "r11w" => Ok((X86Register::R11, 16)),
-        "r11b" => Ok((X86Register::R11, 8)),
+        "r11d" => Ok((X86Register::R11D, 32)),
+        "r11w" => Ok((X86Register::R11W, 16)),
+        "r11b" => Ok((X86Register::R11B, 8)),
         "r12" => Ok((X86Register::R12, 64)),
-        "r12d" => Ok((X86Register::R12, 32)),
-        "r12w" => Ok((X86Register::R12, 16)),
-        "r12b" => Ok((X86Register::R12, 8)),
+        "r12d" => Ok((X86Register::R12D, 32)),
+        "r12w" => Ok((X86Register::R12W, 16)),
+        "r12b" => Ok((X86Register::R12B, 8)),
         "r13" => Ok((X86Register::R13, 64)),
-        "r13d" => Ok((X86Register::R13, 32)),
-        "r13w" => Ok((X86Register::R13, 16)),
-        "r13b" => Ok((X86Register::R13, 8)),
+        "r13d" => Ok((X86Register::R13D, 32)),
+        "r13w" => Ok((X86Register::R13W, 16)),
+        "r13b" => Ok((X86Register::R13B, 8)),
         "r14" => Ok((X86Register::R14, 64)),
-        "r14d" => Ok((X86Register::R14, 32)),
-        "r14w" => Ok((X86Register::R14, 16)),
-        "r14b" => Ok((X86Register::R14, 8)),
+        "r14d" => Ok((X86Register::R14D, 32)),
+        "r14w" => Ok((X86Register::R14W, 16)),
+        "r14b" => Ok((X86Register::R14B, 8)),
         "r15" => Ok((X86Register::R15, 64)),
-        "r15d" => Ok((X86Register::R15, 32)),
-        "r15w" => Ok((X86Register::R15, 16)),
-        "r15b" => Ok((X86Register::R15, 8)),
+        "r15d" => Ok((X86Register::R15D, 32)),
+        "r15w" => Ok((X86Register::R15W, 16)),
+        "r15b" => Ok((X86Register::R15B, 8)),
         _ => Err(X86RegisterParseError::Unknown(format!(
             "Unknown x86 register: {}",
             reg_str
@@ -154,10 +158,8 @@ fn classify_x86_register_alias(reg_str: &str) -> Result<(X86Register, u32), X86R
 
 /// Parse a single x86 register name (case-insensitive).
 ///
-/// Width aliases (`eax`, `ax`, `al`) collapse to the canonical 64-bit
-/// variant. Legacy high-byte aliases (`ah`, `bh`, `ch`, `dh`) are
-/// intentionally excluded because the minimal x86 IR models the
-/// low-byte/REX alias set.
+/// The result retains the named register view; call [`X86Register::canonical`]
+/// at architectural state or liveness boundaries.
 pub fn parse_x86_register(reg_str: &str) -> Result<X86Register, String> {
     classify_x86_register_alias(reg_str)
         .map(|(reg, _width)| reg)
@@ -165,10 +167,6 @@ pub fn parse_x86_register(reg_str: &str) -> Result<X86Register, String> {
 }
 
 /// Parse a single x86 register name and report the textual alias width.
-///
-/// This is syntax metadata only: the returned register is still the
-/// canonical minimal-IR register, while the width preserves whether the
-/// source text named `rax`, `eax`, `ax`, or `al`.
 pub fn parse_x86_register_with_width(reg_str: &str) -> Result<(X86Register, u32), String> {
     classify_x86_register_alias(reg_str).map_err(|err| err.to_string())
 }
@@ -176,7 +174,7 @@ pub fn parse_x86_register_with_width(reg_str: &str) -> Result<(X86Register, u32)
 /// Parse an Intel-syntax operand string ("rax" or "42" or "0x2a").
 pub fn parse_x86_operand(op_str: &str) -> Result<X86Operand, String> {
     let s = op_str.trim();
-    if let Ok(reg) = parse_x86_register(s) {
+    if let Ok((reg, _width)) = classify_x86_register_alias(s) {
         return Ok(X86Operand::Register(reg));
     }
     let imm = parse_x86_immediate(s)?;
@@ -189,19 +187,7 @@ fn parse_x86_register_for_mode(
 ) -> Result<X86Register, X86RegisterParseError> {
     let (reg, alias_width) = classify_x86_register_alias(reg_str)?;
     let trimmed = reg_str.trim();
-    if mode == X86ParseMode::Mode32
-        && matches!(
-            reg,
-            X86Register::R8
-                | X86Register::R9
-                | X86Register::R10
-                | X86Register::R11
-                | X86Register::R12
-                | X86Register::R13
-                | X86Register::R14
-                | X86Register::R15
-        )
-    {
+    if mode == X86ParseMode::Mode32 && reg.index().is_some_and(|index| index >= 8) {
         return Err(X86RegisterParseError::UnsupportedAlias(format!(
             "unsupported {} register alias: '{}' names an extended register, \
              which is not encodable in x86-32",
@@ -209,14 +195,17 @@ fn parse_x86_register_for_mode(
             trimmed
         )));
     }
-    if alias_width != mode.mode_width() {
+    if mode == X86ParseMode::Mode32
+        && (alias_width == 64
+            || matches!(
+                reg,
+                X86Register::SPL | X86Register::BPL | X86Register::SIL | X86Register::DIL
+            ))
+    {
         return Err(X86RegisterParseError::UnsupportedAlias(format!(
-            "unsupported {} register alias width: '{}' is {}-bit, but the \
-             current x86 IR only models {}-bit operands from binary input",
+            "unsupported {} register alias: '{}' is not encodable in this mode",
             mode.arch_label(),
             trimmed,
-            alias_width,
-            mode.mode_width()
         )));
     }
     Ok(reg)
@@ -236,17 +225,17 @@ fn parse_x86_operand_for_mode(op_str: &str, mode: X86ParseMode) -> Result<X86Ope
 
 /// Parse a register, dispatching on whether an operand width is known.
 ///
-/// `Some(mode)` is the binary/Capstone path: it width-checks the alias and
-/// rejects spellings that are not the mode's native width (see
-/// `parse_x86_register_for_mode`). `None` is the assembly-text path, which
-/// is width-agnostic (`parse_x86_register`).
+/// `Some(mode)` is the binary/Capstone path and rejects aliases unavailable in
+/// that execution mode. `None` is the mode-neutral assembly-text path.
 fn parse_x86_register_with_mode(
     reg_str: &str,
     mode: Option<X86ParseMode>,
 ) -> Result<X86Register, String> {
     match mode {
         Some(mode) => parse_x86_register_for_mode(reg_str, mode).map_err(|err| err.to_string()),
-        None => parse_x86_register(reg_str),
+        None => classify_x86_register_alias(reg_str)
+            .map(|(reg, _width)| reg)
+            .map_err(|err| err.to_string()),
     }
 }
 
@@ -260,6 +249,32 @@ fn parse_x86_operand_with_mode(
         Some(mode) => parse_x86_operand_for_mode(op_str, mode),
         None => parse_x86_operand(op_str),
     }
+}
+
+fn validate_same_register_width(
+    lhs: X86Register,
+    rhs: X86Register,
+    mode: Option<X86ParseMode>,
+) -> Result<(), String> {
+    let mode_width = mode.map_or(64, X86ParseMode::mode_width);
+    if lhs.effective_width(mode_width) != rhs.effective_width(mode_width) {
+        return Err(format!(
+            "x86 register operands must have matching widths: '{}' and '{}'",
+            lhs, rhs
+        ));
+    }
+
+    // AH/CH/DH/BH are unavailable in any encoding that needs a REX prefix.
+    // A low-byte register numbered 4+ (SPL/BPL/SIL/DIL/R8B-R15B) requires REX.
+    if (lhs.is_high_byte() && rhs.index().is_some_and(|index| index >= 4))
+        || (rhs.is_high_byte() && lhs.index().is_some_and(|index| index >= 4))
+    {
+        return Err(format!(
+            "legacy high-byte register cannot be encoded with REX-byte operand: '{}' and '{}'",
+            lhs, rhs
+        ));
+    }
+    Ok(())
 }
 
 pub fn parse_x86_immediate(s: &str) -> Result<i64, String> {
@@ -302,8 +317,8 @@ pub fn x86_ir_from_mnemonic(
 }
 
 /// Convert a `(mnemonic, op_str)` pair into x86 IR for binary input
-/// disassembled in a known mode. Until x86 IR carries operand width
-/// end-to-end, only mode-width register aliases are accepted.
+/// disassembled in a known mode. The mode rejects unavailable register
+/// families while preserving each legal operand's register view.
 pub fn x86_ir_from_mnemonic_for_mode(
     mnemonic: &str,
     op_str: &str,
@@ -333,6 +348,10 @@ fn x86_ir_from_mnemonic_impl(
         }
         let rd = parse_x86_register_with_mode(parts[0], mode)?;
         let rs = parse_x86_register_with_mode(parts[1], mode)?;
+        validate_same_register_width(rd, rs, mode)?;
+        if rd.is_byte() {
+            return Err("cmov does not support 8-bit register operands".to_string());
+        }
         return Ok(Some(X86Instruction::Cmov { rd, rs, cond }));
     }
 
@@ -397,11 +416,19 @@ fn x86_ir_from_mnemonic_impl(
             2 => {
                 let rd = parse_x86_register_with_mode(parts[0], mode)?;
                 let rs = parse_x86_register_with_mode(parts[1], mode)?;
+                validate_same_register_width(rd, rs, mode)?;
+                if rd.is_byte() {
+                    return Err("imul does not support 8-bit register operands".to_string());
+                }
                 return Ok(Some(X86Instruction::ImulReg { rd, rs }));
             }
             3 => {
                 let rd = parse_x86_register_with_mode(parts[0], mode)?;
                 let rs = parse_x86_register_with_mode(parts[1], mode)?;
+                validate_same_register_width(rd, rs, mode)?;
+                if rd.is_byte() {
+                    return Err("imul does not support 8-bit register operands".to_string());
+                }
                 let imm = parse_x86_immediate(parts[2])?;
                 return Ok(Some(X86Instruction::ImulRegImm { rd, rs, imm }));
             }
@@ -425,6 +452,9 @@ fn x86_ir_from_mnemonic_impl(
             return Ok(None);
         }
         let rd = parse_x86_register_with_mode(parts[0], mode)?;
+        if rd.is_byte() {
+            return Err("lea does not support 8-bit destinations".to_string());
+        }
         let Some((base, disp)) = parse_x86_lea_memory_operand(parts[1], mode)? else {
             return Ok(None);
         };
@@ -464,6 +494,9 @@ fn x86_ir_from_mnemonic_impl(
     }
     let rd = parse_x86_register_with_mode(parts[0], mode)?;
     let src_op = parse_x86_operand_with_mode(parts[1], mode)?;
+    if let X86Operand::Register(rs) = src_op {
+        validate_same_register_width(rd, rs, mode)?;
+    }
     let make = |reg_form: fn(X86Register, X86Register) -> X86Instruction,
                 imm_form: fn(X86Register, i64) -> X86Instruction|
      -> Result<Option<X86Instruction>, String> {
@@ -693,10 +726,10 @@ mod tests {
     #[test]
     fn parse_register_handles_aliased_names() {
         assert_eq!(parse_x86_register("rax").unwrap(), X86Register::RAX);
-        assert_eq!(parse_x86_register("eax").unwrap(), X86Register::RAX);
+        assert_eq!(parse_x86_register("eax").unwrap(), X86Register::EAX);
         assert_eq!(parse_x86_register("RAX").unwrap(), X86Register::RAX);
         assert_eq!(parse_x86_register("r10").unwrap(), X86Register::R10);
-        assert_eq!(parse_x86_register("r10d").unwrap(), X86Register::R10);
+        assert_eq!(parse_x86_register("r10d").unwrap(), X86Register::R10D);
         assert!(parse_x86_register("zmm0").is_err());
     }
 
@@ -705,12 +738,12 @@ mod tests {
         let cases = [
             ("rax", X86Register::RAX, 64),
             ("r8", X86Register::R8, 64),
-            ("eax", X86Register::RAX, 32),
-            ("r8d", X86Register::R8, 32),
-            ("ax", X86Register::RAX, 16),
-            ("r8w", X86Register::R8, 16),
-            ("al", X86Register::RAX, 8),
-            ("r8b", X86Register::R8, 8),
+            ("eax", X86Register::EAX, 32),
+            ("r8d", X86Register::R8D, 32),
+            ("ax", X86Register::AX, 16),
+            ("r8w", X86Register::R8W, 16),
+            ("al", X86Register::AL, 8),
+            ("r8b", X86Register::R8B, 8),
         ];
 
         for (alias, expected_register, expected_width) in cases {
@@ -721,6 +754,58 @@ mod tests {
             );
         }
         assert!(parse_x86_register_with_width("zmm0").is_err());
+    }
+
+    #[test]
+    fn instruction_parser_retains_sub_register_views() {
+        let cases = [
+            ("mov", "rax, rbx", X86Register::RAX, X86Register::RBX),
+            ("mov", "eax, ebx", X86Register::EAX, X86Register::EBX),
+            ("mov", "ax, bx", X86Register::AX, X86Register::BX),
+            ("mov", "al, bl", X86Register::AL, X86Register::BL),
+            ("mov", "ah, bh", X86Register::AH, X86Register::BH),
+        ];
+
+        for (mnemonic, operands, expected_rd, expected_rs) in cases {
+            assert_eq!(
+                x86_ir_from_mnemonic_for_mode(mnemonic, operands, X86ParseMode::Mode64).unwrap(),
+                Some(X86Instruction::MovReg {
+                    rd: expected_rd,
+                    rs: expected_rs,
+                }),
+                "{mnemonic} {operands}"
+            );
+        }
+
+        assert_eq!(X86Register::EAX.canonical(), X86Register::RAX);
+        assert_eq!(X86Register::AX.canonical(), X86Register::RAX);
+        assert_eq!(X86Register::AL.canonical(), X86Register::RAX);
+        assert_eq!(X86Register::AH.canonical(), X86Register::RAX);
+        assert_eq!(X86Register::EAX.to_string(), "eax");
+        assert_eq!(X86Register::AH.to_string(), "ah");
+    }
+
+    #[test]
+    fn mode_aware_parser_accepts_legal_narrow_aliases_and_rejects_mixed_widths() {
+        assert!(
+            x86_ir_from_mnemonic_for_mode("cmp", "al, 0", X86ParseMode::Mode64)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            x86_ir_from_mnemonic_for_mode("xor", "eax, eax", X86ParseMode::Mode64)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            x86_ir_from_mnemonic_for_mode("mov", "ah, bl", X86ParseMode::Mode32)
+                .unwrap()
+                .is_some()
+        );
+
+        let err =
+            x86_ir_from_mnemonic_for_mode("mov", "eax, bx", X86ParseMode::Mode64).unwrap_err();
+        assert!(err.contains("matching widths"), "{err}");
     }
 
     #[test]
@@ -862,7 +947,7 @@ mod tests {
     }
 
     #[test]
-    fn x86_ir_for_mode64_accepts_mode_width_and_rejects_narrow_aliases() {
+    fn x86_ir_for_mode64_retains_every_supported_register_view() {
         assert_eq!(
             x86_ir_from_mnemonic_for_mode("add", "rax, 0", X86ParseMode::Mode64)
                 .unwrap()
@@ -883,29 +968,57 @@ mod tests {
             }
         );
 
-        for (mnemonic, operands) in [
-            ("add", "eax, 0"),
-            ("mov", "ax, 1"),
-            ("mov", "al, 1"),
-            ("cmove", "eax, ebx"),
+        for (mnemonic, operands, expected) in [
+            (
+                "add",
+                "eax, 0",
+                X86Instruction::AddImm {
+                    rd: X86Register::EAX,
+                    imm: 0,
+                },
+            ),
+            (
+                "mov",
+                "ax, 1",
+                X86Instruction::MovImm {
+                    rd: X86Register::AX,
+                    imm: 1,
+                },
+            ),
+            (
+                "mov",
+                "al, 1",
+                X86Instruction::MovImm {
+                    rd: X86Register::AL,
+                    imm: 1,
+                },
+            ),
+            (
+                "cmove",
+                "eax, ebx",
+                X86Instruction::Cmov {
+                    rd: X86Register::EAX,
+                    rs: X86Register::EBX,
+                    cond: X86Condition::E,
+                },
+            ),
         ] {
-            let err = x86_ir_from_mnemonic_for_mode(mnemonic, operands, X86ParseMode::Mode64)
-                .expect_err("narrow alias should be rejected in x86-64 binary parsing");
-            assert!(
-                err.contains("unsupported x86-64 register alias width"),
-                "unexpected error for {mnemonic} {operands}: {err}"
+            assert_eq!(
+                x86_ir_from_mnemonic_for_mode(mnemonic, operands, X86ParseMode::Mode64).unwrap(),
+                Some(expected),
+                "{mnemonic} {operands}"
             );
         }
     }
 
     #[test]
-    fn x86_ir_for_mode32_accepts_only_i386_width_register_aliases() {
+    fn x86_ir_for_mode32_retains_i386_register_views() {
         assert_eq!(
             x86_ir_from_mnemonic_for_mode("add", "eax, 0", X86ParseMode::Mode32)
                 .unwrap()
                 .unwrap(),
             X86Instruction::AddImm {
-                rd: X86Register::RAX,
+                rd: X86Register::EAX,
                 imm: 0,
             }
         );
@@ -914,8 +1027,8 @@ mod tests {
                 .unwrap()
                 .unwrap(),
             X86Instruction::MovReg {
-                rd: X86Register::RCX,
-                rs: X86Register::RDX,
+                rd: X86Register::ECX,
+                rs: X86Register::EDX,
             }
         );
         assert_eq!(
@@ -923,20 +1036,25 @@ mod tests {
                 .unwrap()
                 .unwrap(),
             X86Instruction::Cmov {
-                rd: X86Register::RAX,
-                rs: X86Register::RBX,
+                rd: X86Register::EAX,
+                rs: X86Register::EBX,
                 cond: X86Condition::E,
             }
         );
 
-        for (mnemonic, operands) in [("mov", "ax, 1"), ("mov", "al, 1"), ("mov", "rax, 1")] {
-            let err = x86_ir_from_mnemonic_for_mode(mnemonic, operands, X86ParseMode::Mode32)
-                .expect_err("non-32-bit alias should be rejected in x86-32 binary parsing");
-            assert!(
-                err.contains("unsupported x86-32 register alias width"),
-                "unexpected error for {mnemonic} {operands}: {err}"
+        for (operands, expected_rd) in [("ax, 1", X86Register::AX), ("al, 1", X86Register::AL)] {
+            assert_eq!(
+                x86_ir_from_mnemonic_for_mode("mov", operands, X86ParseMode::Mode32).unwrap(),
+                Some(X86Instruction::MovImm {
+                    rd: expected_rd,
+                    imm: 1,
+                })
             );
         }
+
+        let err = x86_ir_from_mnemonic_for_mode("mov", "rax, 1", X86ParseMode::Mode32)
+            .expect_err("64-bit alias should be rejected in x86-32 binary parsing");
+        assert!(err.contains("not encodable in this mode"), "{err}");
 
         let err = x86_ir_from_mnemonic_for_mode("mov", "r8d, 1", X86ParseMode::Mode32)
             .expect_err("x86-32 must reject extended registers");
@@ -1001,7 +1119,7 @@ mod tests {
                 .unwrap()
                 .unwrap(),
             X86Instruction::TestImm {
-                rn: X86Register::RAX,
+                rn: X86Register::EAX,
                 imm: 5,
             }
         );
@@ -1104,7 +1222,7 @@ mod tests {
                 .unwrap()
                 .unwrap(),
             X86Instruction::Dec {
-                rd: X86Register::RAX
+                rd: X86Register::EAX
             }
         );
     }
@@ -1191,7 +1309,7 @@ mod tests {
                 .unwrap()
                 .unwrap(),
             X86Instruction::Sar {
-                rd: X86Register::RAX,
+                rd: X86Register::EAX,
                 imm: 4
             }
         );
@@ -1259,7 +1377,7 @@ mod tests {
                 .unwrap()
                 .unwrap(),
             X86Instruction::Ror {
-                rd: X86Register::RAX,
+                rd: X86Register::EAX,
                 imm: 4
             }
         );
@@ -1332,8 +1450,8 @@ mod tests {
                 .unwrap()
                 .unwrap(),
             X86Instruction::ImulRegImm {
-                rd: X86Register::RAX,
-                rs: X86Register::RBX,
+                rd: X86Register::EAX,
+                rs: X86Register::EBX,
                 imm: 4,
             }
         );
@@ -1354,7 +1472,7 @@ mod tests {
                 .unwrap()
                 .unwrap(),
             X86Instruction::Not {
-                rd: X86Register::RAX
+                rd: X86Register::EAX
             }
         );
     }
@@ -1478,21 +1596,19 @@ mod tests {
 
     #[test]
     fn assembly_string_accepts_width_suffixed_register_aliases() {
-        // Intel-syntax disassemblers sometimes render 32-bit operations
-        // using EAX-style aliases even when the underlying instruction
-        // is 64-bit-wide for our purposes. Ensure aliases collapse.
+        // Width-suffixed aliases retain their selected sub-register view.
         let result =
             parse_x86_assembly_string("mov eax, ebx\nxor r10d, r10d", "t".to_string()).unwrap();
         assert_eq!(
             result,
             vec![
                 X86Instruction::MovReg {
-                    rd: X86Register::RAX,
-                    rs: X86Register::RBX
+                    rd: X86Register::EAX,
+                    rs: X86Register::EBX
                 },
                 X86Instruction::XorReg {
-                    rd: X86Register::R10,
-                    rs: X86Register::R10
+                    rd: X86Register::R10D,
+                    rs: X86Register::R10D
                 },
             ]
         );
@@ -1768,8 +1884,8 @@ mod tests {
                 .unwrap()
                 .unwrap(),
             X86Instruction::Lea {
-                rd: X86Register::RAX,
-                base: X86Register::RBX,
+                rd: X86Register::EAX,
+                base: X86Register::EBX,
                 disp: -0x10,
             }
         );

--- a/src/search/config.rs
+++ b/src/search/config.rs
@@ -354,9 +354,8 @@ pub struct SearchConfig {
     /// AArch64 pool ships at the same cardinality.
     pub x86_available_registers: Vec<crate::isa::x86::X86Register>,
     /// Whether x86 symbolic code-size search may consider same-instruction-count
-    /// candidates. Direct IR callers default to true; the ELF frontend can
-    /// disable this when source operands used partial-register aliases that the
-    /// current x86 IR collapses to full-width registers.
+    /// candidates. Defaults to true; callers may disable it as an additional
+    /// conservative policy gate.
     pub x86_same_count_code_size_allowed: bool,
     /// Stochastic-specific configuration
     pub stochastic: StochasticConfig,

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -158,7 +158,16 @@ impl EnumerativeBackend<crate::isa::X86_64> for crate::isa::X86_64 {
         regs: &[crate::isa::x86::X86Register],
         imms: &[i64],
     ) -> Vec<crate::isa::x86::X86Instruction> {
-        crate::isa::x86::X86InstructionGenerator.generate_all(regs, imms)
+        crate::isa::x86::X86InstructionGenerator
+            .generate_all(regs, imms)
+            .into_iter()
+            .filter(|instruction| {
+                crate::search::candidate::is_sequence_encodable_for(
+                    std::slice::from_ref(instruction),
+                    &crate::isa::X86_64,
+                )
+            })
+            .collect()
     }
 
     fn sequence_cost(seq: &[crate::isa::x86::X86Instruction], config: &SearchConfig) -> u64 {
@@ -211,7 +220,16 @@ impl EnumerativeBackend<crate::isa::X86_32> for crate::isa::X86_32 {
         regs: &[crate::isa::x86::X86Register],
         imms: &[i64],
     ) -> Vec<crate::isa::x86::X86Instruction> {
-        crate::isa::x86::X86InstructionGenerator.generate_all(regs, imms)
+        crate::isa::x86::X86InstructionGenerator
+            .generate_all(regs, imms)
+            .into_iter()
+            .filter(|instruction| {
+                crate::search::candidate::is_sequence_encodable_for(
+                    std::slice::from_ref(instruction),
+                    &crate::isa::X86_32,
+                )
+            })
+            .collect()
     }
 
     fn sequence_cost(seq: &[crate::isa::x86::X86Instruction], config: &SearchConfig) -> u64 {

--- a/src/search/symbolic/backend.rs
+++ b/src/search/symbolic/backend.rs
@@ -40,10 +40,8 @@ pub trait SymbolicBackend<I: ISA>: Sized {
     /// Whether this backend may find a strict metric improvement without
     /// reducing the number of rewritable instructions for this target/config.
     ///
-    /// For x86 code-size search, the config flag is a binary-patching guard:
-    /// the current x86 IR collapses partial-register aliases to full-width
-    /// registers, so the ELF frontend disables same-count rewrites when the
-    /// original Capstone operands were not full-width for the binary mode.
+    /// For x86 code-size search, the config flag lets callers conservatively
+    /// disable same-count rewrites independently of the metric comparison.
     fn can_improve_at_same_instruction_count(
         _target: &[I::Instruction],
         _config: &SearchConfig,
@@ -137,7 +135,16 @@ impl SymbolicBackend<crate::isa::X86_64> for crate::isa::X86_64 {
         regs: &[crate::isa::x86::X86Register],
         imms: &[i64],
     ) -> Vec<crate::isa::x86::X86Instruction> {
-        crate::isa::x86::X86InstructionGenerator.generate_all(regs, imms)
+        crate::isa::x86::X86InstructionGenerator
+            .generate_all(regs, imms)
+            .into_iter()
+            .filter(|instruction| {
+                crate::search::candidate::is_sequence_encodable_for(
+                    std::slice::from_ref(instruction),
+                    &crate::isa::X86_64,
+                )
+            })
+            .collect()
     }
 
     fn target_terminator(
@@ -215,7 +222,16 @@ impl SymbolicBackend<crate::isa::X86_32> for crate::isa::X86_32 {
         regs: &[crate::isa::x86::X86Register],
         imms: &[i64],
     ) -> Vec<crate::isa::x86::X86Instruction> {
-        crate::isa::x86::X86InstructionGenerator.generate_all(regs, imms)
+        crate::isa::x86::X86InstructionGenerator
+            .generate_all(regs, imms)
+            .into_iter()
+            .filter(|instruction| {
+                crate::search::candidate::is_sequence_encodable_for(
+                    std::slice::from_ref(instruction),
+                    &crate::isa::X86_32,
+                )
+            })
+            .collect()
     }
 
     fn target_terminator(

--- a/src/semantics/concrete_x86.rs
+++ b/src/semantics/concrete_x86.rs
@@ -6,11 +6,11 @@
 //! Issue #77 keeps this file as the x86 instruction interpreter while the
 //! public search/equivalence callers route through the ISA trait surface.
 //!
-//! `X86Instruction` and `X86ConcreteMachineState`. Operand widths follow
-//! `state.width()` — writes to registers are already masked by the
-//! state, and flag computation receives the correct width.
+//! `X86Instruction` and `X86ConcreteMachineState`. Each register operand
+//! carries its architectural view, so reads, writes, and flags use the encoded
+//! operand width rather than assuming every access has the machine width.
 
-use crate::isa::x86::X86Instruction;
+use crate::isa::x86::{X86Instruction, X86Register};
 use crate::semantics::live_out::X86LiveOut;
 use crate::semantics::state::{ConcreteValue, Eflags, X86ConcreteMachineState};
 
@@ -21,11 +21,11 @@ pub fn apply_instruction_concrete_x86(
 ) -> X86ConcreteMachineState {
     match instruction {
         X86Instruction::MovReg { rd, rs } => {
-            let value = state.get_register(*rs);
-            state.set_register(*rd, value);
+            let value = state.read_operand(*rs);
+            state.write_operand(*rd, value);
         }
         X86Instruction::MovImm { rd, imm } => {
-            state.set_register(*rd, ConcreteValue::from_i64(*imm));
+            state.write_operand(*rd, ConcreteValue::from_i64(*imm));
         }
         X86Instruction::AddReg { rd, rs } => apply_binop_reg(&mut state, *rd, *rs, Binop::Add),
         X86Instruction::AddImm { rd, imm } => apply_binop_imm(&mut state, *rd, *imm, Binop::Add),
@@ -51,27 +51,27 @@ pub fn apply_instruction_concrete_x86(
         X86Instruction::Rol { rd, imm } => apply_rotate(&mut state, *rd, *imm, RotateKind::Rol),
         X86Instruction::Ror { rd, imm } => apply_rotate(&mut state, *rd, *imm, RotateKind::Ror),
         X86Instruction::ImulReg { rd, rs } => {
-            let lhs = state.get_register(*rd).as_u64();
-            let rhs = state.get_register(*rs).as_u64();
+            let lhs = state.read_operand(*rd).as_u64();
+            let rhs = state.read_operand(*rs).as_u64();
             apply_imul(&mut state, *rd, lhs, rhs);
         }
         X86Instruction::ImulRegImm { rd, rs, imm } => {
-            let lhs = state.get_register(*rs).as_u64();
+            let lhs = state.read_operand(*rs).as_u64();
             let rhs = *imm as u64;
             apply_imul(&mut state, *rd, lhs, rhs);
         }
         // LEA computes `rd = base + disp` (wrapping at width) and writes NO
-        // flags — pure address arithmetic, like MovReg. `set_register` masks
-        // the result to the state width.
+        // flags — pure address arithmetic, like MovReg. `write_operand` applies
+        // the destination view's truncation and partial-write behavior.
         X86Instruction::Lea { rd, base, disp } => {
-            let base = state.get_register(*base).as_u64();
+            let base = state.read_operand(*base).as_u64();
             let result = base.wrapping_add(*disp as u64);
-            state.set_register(*rd, ConcreteValue::new(result));
+            state.write_operand(*rd, ConcreteValue::new(result));
         }
         X86Instruction::Cmov { rd, rs, cond } => {
             if state.get_flags().evaluate(*cond) {
-                let v = state.get_register(*rs);
-                state.set_register(*rd, v);
+                let v = state.read_operand(*rs);
+                state.write_operand(*rd, v);
             }
             // CMOV does not write EFLAGS regardless of the branch taken.
         }
@@ -83,73 +83,71 @@ pub fn apply_instruction_concrete_x86(
     state
 }
 
-fn apply_cmp_reg(
-    state: &mut X86ConcreteMachineState,
-    rn: crate::isa::x86::X86Register,
-    rs: crate::isa::x86::X86Register,
-) {
-    let lhs = state.get_register(rn).as_u64();
-    let rhs = state.get_register(rs).as_u64();
+fn apply_cmp_reg(state: &mut X86ConcreteMachineState, rn: X86Register, rs: X86Register) {
+    let width = rn.effective_width(state.width());
+    let lhs = state.read_operand(rn).as_u64();
+    let rhs = state.read_operand(rs).as_u64();
     let result = lhs.wrapping_sub(rhs);
-    state.set_flags(Eflags::from_sub(lhs, rhs, result, state.width()));
+    state.set_flags(Eflags::from_sub(lhs, rhs, result, width));
 }
 
-fn apply_cmp_imm(state: &mut X86ConcreteMachineState, rn: crate::isa::x86::X86Register, imm: i64) {
-    let lhs = state.get_register(rn).as_u64();
+fn apply_cmp_imm(state: &mut X86ConcreteMachineState, rn: X86Register, imm: i64) {
+    let width = rn.effective_width(state.width());
+    let lhs = state.read_operand(rn).as_u64();
     let rhs = imm as u64;
     let result = lhs.wrapping_sub(rhs);
-    state.set_flags(Eflags::from_sub(lhs, rhs, result, state.width()));
+    state.set_flags(Eflags::from_sub(lhs, rhs, result, width));
 }
 
 // TEST is the non-destructive sibling of AND: it computes `rn & rhs`, sets
 // flags from the result via the logical path (CF=OF=0, SF/ZF/PF from result),
 // and writes no register — just as CMP discards a SUB result.
-fn apply_test_reg(
-    state: &mut X86ConcreteMachineState,
-    rn: crate::isa::x86::X86Register,
-    rs: crate::isa::x86::X86Register,
-) {
-    let lhs = state.get_register(rn).as_u64();
-    let rhs = state.get_register(rs).as_u64();
+fn apply_test_reg(state: &mut X86ConcreteMachineState, rn: X86Register, rs: X86Register) {
+    let width = rn.effective_width(state.width());
+    let lhs = state.read_operand(rn).as_u64();
+    let rhs = state.read_operand(rs).as_u64();
     let result = lhs & rhs;
-    state.set_flags(Eflags::from_logical(result, state.width()));
+    state.set_flags(Eflags::from_logical(result, width));
 }
 
-fn apply_test_imm(state: &mut X86ConcreteMachineState, rn: crate::isa::x86::X86Register, imm: i64) {
-    let lhs = state.get_register(rn).as_u64();
+fn apply_test_imm(state: &mut X86ConcreteMachineState, rn: X86Register, imm: i64) {
+    let width = rn.effective_width(state.width());
+    let lhs = state.read_operand(rn).as_u64();
     let rhs = imm as u64;
     let result = lhs & rhs;
-    state.set_flags(Eflags::from_logical(result, state.width()));
+    state.set_flags(Eflags::from_logical(result, width));
 }
 
 // NEG computes `rd = -rd` (two's complement) and sets EFLAGS as if computing
 // `0 - rd`: CF = (rd != 0), with OF/SF/ZF/PF from the SUB result. We reuse the
 // SUB flag path with lhs = 0, rhs = old_rd so the carry/overflow semantics
 // match `sub` exactly.
-fn apply_neg(state: &mut X86ConcreteMachineState, rd: crate::isa::x86::X86Register) {
-    let old = state.get_register(rd).as_u64();
+fn apply_neg(state: &mut X86ConcreteMachineState, rd: X86Register) {
+    let width = rd.effective_width(state.width());
+    let old = state.read_operand(rd).as_u64();
     let result = 0u64.wrapping_sub(old);
-    state.set_register(rd, ConcreteValue::new(result));
-    state.set_flags(Eflags::from_sub(0, old, result, state.width()));
+    state.write_operand(rd, ConcreteValue::new(result));
+    state.set_flags(Eflags::from_sub(0, old, result, width));
 }
 
 // NOT computes `rd = !rd` (bitwise complement). It affects NO flags — EFLAGS
 // is left exactly as it was, like MOV.
-fn apply_not(state: &mut X86ConcreteMachineState, rd: crate::isa::x86::X86Register) {
-    let old = state.get_register(rd).as_u64();
-    state.set_register(rd, ConcreteValue::new(!old));
+fn apply_not(state: &mut X86ConcreteMachineState, rd: X86Register) {
+    let old = state.read_operand(rd).as_u64();
+    state.write_operand(rd, ConcreteValue::new(!old));
 }
 
 // INC computes `rd = rd + 1`. It sets OF/SF/ZF/PF exactly as `add rd, 1` would,
 // but — the load-bearing subtlety — it leaves CF UNCHANGED (the incoming carry
 // flows through untouched). We capture the prior CF FIRST, compute the ADD flag
 // path for `rd + 1`, then override CF back to the captured value.
-fn apply_inc(state: &mut X86ConcreteMachineState, rd: crate::isa::x86::X86Register) {
+fn apply_inc(state: &mut X86ConcreteMachineState, rd: X86Register) {
     let prev_cf = state.get_flags().cf;
-    let old = state.get_register(rd).as_u64();
+    let width = rd.effective_width(state.width());
+    let old = state.read_operand(rd).as_u64();
     let result = old.wrapping_add(1);
-    state.set_register(rd, ConcreteValue::new(result));
-    let mut flags = Eflags::from_add(old, 1, result, state.width());
+    state.write_operand(rd, ConcreteValue::new(result));
+    let mut flags = Eflags::from_add(old, 1, result, width);
     flags.cf = prev_cf;
     state.set_flags(flags);
 }
@@ -157,12 +155,13 @@ fn apply_inc(state: &mut X86ConcreteMachineState, rd: crate::isa::x86::X86Regist
 // DEC computes `rd = rd - 1`. Like INC it sets OF/SF/ZF/PF as `sub rd, 1` would
 // while leaving CF UNCHANGED. Capture the prior CF first, derive flags from the
 // SUB path for `rd - 1`, then restore CF.
-fn apply_dec(state: &mut X86ConcreteMachineState, rd: crate::isa::x86::X86Register) {
+fn apply_dec(state: &mut X86ConcreteMachineState, rd: X86Register) {
     let prev_cf = state.get_flags().cf;
-    let old = state.get_register(rd).as_u64();
+    let width = rd.effective_width(state.width());
+    let old = state.read_operand(rd).as_u64();
     let result = old.wrapping_sub(1);
-    state.set_register(rd, ConcreteValue::new(result));
-    let mut flags = Eflags::from_sub(old, 1, result, state.width());
+    state.write_operand(rd, ConcreteValue::new(result));
+    let mut flags = Eflags::from_sub(old, 1, result, width);
     flags.cf = prev_cf;
     state.set_flags(flags);
 }
@@ -193,13 +192,8 @@ fn sign_extend_to_i128(value: u64, width: u32) -> i128 {
 // equivalence checking stays internally consistent and conservative — it never
 // accepts a rewrite that changes a flag a legitimate program could rely on,
 // since legitimate programs do not read IMUL's undefined flags.
-fn apply_imul(
-    state: &mut X86ConcreteMachineState,
-    rd: crate::isa::x86::X86Register,
-    lhs: u64,
-    rhs: u64,
-) {
-    let width = state.width();
+fn apply_imul(state: &mut X86ConcreteMachineState, rd: X86Register, lhs: u64, rhs: u64) {
+    let width = rd.effective_width(state.width());
     let full = sign_extend_to_i128(lhs, width) * sign_extend_to_i128(rhs, width);
     let result = mask_width(full as u64, width);
 
@@ -207,7 +201,7 @@ fn apply_imul(
     // sign-extension of the truncated result.
     let overflow = full != sign_extend_to_i128(result, width);
 
-    state.set_register(rd, ConcreteValue::new(result));
+    state.write_operand(rd, ConcreteValue::new(result));
     // SF/ZF/PF from the truncated result (Intel-undefined; modelled
     // deterministically — see the function comment). CF/OF then overridden.
     let mut flags = Eflags::from_logical(result, width);
@@ -254,16 +248,11 @@ fn msb(value: u64, width: u32) -> bool {
 // equivalence checking stays internally consistent; downstream consumers must
 // not rely on OF after a count > 1 shift because the architecture leaves it
 // undefined.
-fn apply_shift(
-    state: &mut X86ConcreteMachineState,
-    rd: crate::isa::x86::X86Register,
-    imm: i64,
-    kind: ShiftKind,
-) {
-    let width = state.width();
-    let mask = u64::from(width - 1);
+fn apply_shift(state: &mut X86ConcreteMachineState, rd: X86Register, imm: i64, kind: ShiftKind) {
+    let width = rd.effective_width(state.width());
+    let mask = if width == 64 { 0x3f } else { 0x1f };
     let eff = (imm as u64) & mask;
-    let old = mask_width(state.get_register(rd).as_u64(), width);
+    let old = state.read_operand(rd).as_u64();
 
     // Count masks to 0: leave rd and every flag untouched.
     if eff == 0 {
@@ -271,15 +260,35 @@ fn apply_shift(
     }
 
     let result = match kind {
-        ShiftKind::Shl => old << eff,
-        ShiftKind::Shr => old >> eff,
+        ShiftKind::Shl => {
+            if eff >= u64::from(width) {
+                0
+            } else {
+                old << eff
+            }
+        }
+        ShiftKind::Shr => {
+            if eff >= u64::from(width) {
+                0
+            } else {
+                old >> eff
+            }
+        }
         // Arithmetic right shift: sign-extend within the operand width.
         ShiftKind::Sar => {
             let sign = msb(old, width);
-            let logical = old >> eff;
+            let logical = if eff >= u64::from(width) {
+                0
+            } else {
+                old >> eff
+            };
             if sign {
                 // Set the top `eff` bits that the logical shift cleared.
-                let fill = mask_width(!0u64 << (width as u64 - eff), width);
+                let fill = if eff >= u64::from(width) {
+                    mask_width(!0, width)
+                } else {
+                    mask_width(!0u64 << (width as u64 - eff), width)
+                };
                 logical | fill
             } else {
                 logical
@@ -291,9 +300,11 @@ fn apply_shift(
     // CF is the last bit shifted out of the source.
     let cf = match kind {
         // SHL: the bit at index `width - eff` of the original operand.
-        ShiftKind::Shl => (old >> (width as u64 - eff)) & 1 == 1,
+        ShiftKind::Shl if eff <= u64::from(width) => (old >> (width as u64 - eff)) & 1 == 1,
+        ShiftKind::Shl => false,
         // SHR / SAR: the bit at index `eff - 1` of the original operand.
-        ShiftKind::Shr | ShiftKind::Sar => (old >> (eff - 1)) & 1 == 1,
+        ShiftKind::Shr | ShiftKind::Sar if eff <= u64::from(width) => (old >> (eff - 1)) & 1 == 1,
+        ShiftKind::Shr | ShiftKind::Sar => false,
     };
 
     // OF: defined for count == 1 only; we reuse the count-1 formula for all
@@ -304,7 +315,7 @@ fn apply_shift(
         ShiftKind::Sar => false,
     };
 
-    state.set_register(rd, ConcreteValue::new(result));
+    state.write_operand(rd, ConcreteValue::new(result));
     let mut flags = Eflags::from_logical(result, width);
     flags.cf = cf;
     flags.of = of;
@@ -335,22 +346,17 @@ enum RotateKind {
 //   - For count != 1 OF is architecturally UNDEFINED, so we PRESERVE the
 //     incoming OF (deterministic and internally consistent: target and candidate
 //     share this lowering).
-fn apply_rotate(
-    state: &mut X86ConcreteMachineState,
-    rd: crate::isa::x86::X86Register,
-    imm: i64,
-    kind: RotateKind,
-) {
-    let width = state.width();
-    let mask = u64::from(width - 1);
-    let eff = (imm as u64) & mask;
+fn apply_rotate(state: &mut X86ConcreteMachineState, rd: X86Register, imm: i64, kind: RotateKind) {
+    let width = rd.effective_width(state.width());
+    let mask = if width == 64 { 0x3f } else { 0x1f };
+    let eff = ((imm as u64) & mask) % u64::from(width);
 
     // Count masks to 0: leave rd and every flag untouched.
     if eff == 0 {
         return;
     }
 
-    let old = mask_width(state.get_register(rd).as_u64(), width);
+    let old = state.read_operand(rd).as_u64();
     let eff_u32 = eff as u32;
 
     // `(old << eff) | (old >>u (width - eff))` for ROL (and the mirror for ROR),
@@ -381,7 +387,7 @@ fn apply_rotate(
         };
     }
 
-    state.set_register(rd, ConcreteValue::new(result));
+    state.write_operand(rd, ConcreteValue::new(result));
     state.set_flags(flags);
 }
 
@@ -396,34 +402,29 @@ enum Binop {
 
 fn apply_binop_reg(
     state: &mut X86ConcreteMachineState,
-    rd: crate::isa::x86::X86Register,
-    rs: crate::isa::x86::X86Register,
+    rd: X86Register,
+    rs: X86Register,
     op: Binop,
 ) {
-    let lhs = state.get_register(rd).as_u64();
-    let rhs = state.get_register(rs).as_u64();
+    let lhs = state.read_operand(rd).as_u64();
+    let rhs = state.read_operand(rs).as_u64();
     apply_binop(state, rd, lhs, rhs, op);
 }
 
-fn apply_binop_imm(
-    state: &mut X86ConcreteMachineState,
-    rd: crate::isa::x86::X86Register,
-    imm: i64,
-    op: Binop,
-) {
-    let lhs = state.get_register(rd).as_u64();
+fn apply_binop_imm(state: &mut X86ConcreteMachineState, rd: X86Register, imm: i64, op: Binop) {
+    let lhs = state.read_operand(rd).as_u64();
     let rhs = imm as u64;
     apply_binop(state, rd, lhs, rhs, op);
 }
 
 fn apply_binop(
     state: &mut X86ConcreteMachineState,
-    rd: crate::isa::x86::X86Register,
+    rd: X86Register,
     lhs: u64,
     rhs: u64,
     op: Binop,
 ) {
-    let width = state.width();
+    let width = rd.effective_width(state.width());
     let (result, flags) = match op {
         Binop::Add => {
             let r = lhs.wrapping_add(rhs);
@@ -446,7 +447,7 @@ fn apply_binop(
             (r, Eflags::from_logical(r, width))
         }
     };
-    state.set_register(rd, ConcreteValue::new(result));
+    state.write_operand(rd, ConcreteValue::new(result));
     state.set_flags(flags);
 }
 
@@ -487,6 +488,48 @@ pub fn states_equal_for_live_out_x86(
 mod tests {
     use super::*;
     use crate::isa::x86::X86Register;
+
+    #[test]
+    fn mov_uses_register_view_write_semantics() {
+        let cases = [
+            (X86Register::AL, 0xaa, 0x1122_3344_5566_77aa),
+            (X86Register::AH, 0xbb, 0x1122_3344_5566_bb88),
+            (X86Register::AX, 0xccdd, 0x1122_3344_5566_ccdd),
+            (X86Register::EAX, 0xdead_beef, 0x0000_0000_dead_beef),
+        ];
+
+        for (rd, imm, expected) in cases {
+            let mut state = X86ConcreteMachineState::new_zeroed(64);
+            state.set_register(X86Register::RAX, ConcreteValue::new(0x1122_3344_5566_7788));
+            let after = apply_instruction_concrete_x86(state, &X86Instruction::MovImm { rd, imm });
+            assert_eq!(
+                after.get_register(X86Register::RAX).as_u64(),
+                expected,
+                "wrong result for {rd}"
+            );
+        }
+    }
+
+    #[test]
+    fn byte_operations_compute_flags_at_byte_width() {
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(0x1122_3344_5566_77ff));
+        let after = apply_instruction_concrete_x86(
+            state,
+            &X86Instruction::AddImm {
+                rd: X86Register::AL,
+                imm: 1,
+            },
+        );
+
+        assert_eq!(
+            after.get_register(X86Register::RAX).as_u64(),
+            0x1122_3344_5566_7700
+        );
+        assert!(after.get_flags().cf, "0xff + 1 carries at width 8");
+        assert!(after.get_flags().zf, "the byte result is zero");
+        assert!(!after.get_flags().sf);
+    }
 
     #[test]
     fn cmpreg_sets_eflags_without_writing_register() {

--- a/src/semantics/concrete_x86.rs
+++ b/src/semantics/concrete_x86.rs
@@ -64,8 +64,9 @@ pub fn apply_instruction_concrete_x86(
         // flags — pure address arithmetic, like MovReg. `write_operand` applies
         // the destination view's truncation and partial-write behavior.
         X86Instruction::Lea { rd, base, disp } => {
+            let address_width = base.effective_width(state.width());
             let base = state.read_operand(*base).as_u64();
-            let result = base.wrapping_add(*disp as u64);
+            let result = mask_width(base.wrapping_add(*disp as u64), address_width);
             state.write_operand(*rd, ConcreteValue::new(result));
         }
         X86Instruction::Cmov { rd, rs, cond } => {
@@ -1752,5 +1753,34 @@ mod tests {
         );
         // 0xffff_fff8 + 0x10 = 0x1_0000_0008, masked to 32 bits = 0x8.
         assert_eq!(after.get_register(X86Register::RAX).as_u64(), 0x8);
+    }
+
+    #[test]
+    fn x86_64_lea_wraps_at_address_override_width() {
+        use crate::parser::x86::{X86ParseMode, x86_ir_from_mnemonic_for_mode};
+
+        // Capstone preserves the 32-bit base on an address-size-overridden
+        // x86-64 LEA. Exercise that binary-input parse path: its effective
+        // address wraps at 32 bits before the native RAX destination is
+        // written.
+        let instruction =
+            x86_ir_from_mnemonic_for_mode("lea", "rax, [ebx - 1]", X86ParseMode::Mode64)
+                .expect("address-size-overridden LEA should parse")
+                .expect("LEA should be supported");
+        assert_eq!(
+            instruction,
+            X86Instruction::Lea {
+                rd: X86Register::RAX,
+                base: X86Register::EBX,
+                disp: -1,
+            }
+        );
+
+        let state = X86ConcreteMachineState::new_zeroed(64);
+        let after = apply_instruction_concrete_x86(state, &instruction);
+        assert_eq!(
+            after.get_register(X86Register::RAX).as_u64(),
+            u64::from(u32::MAX)
+        );
     }
 }

--- a/src/semantics/cost_x86.rs
+++ b/src/semantics/cost_x86.rs
@@ -109,17 +109,65 @@ fn instruction_latency(instr: &X86Instruction) -> u64 {
 ///   immediate fits in i32, else the 10-byte `REX.W B8+rd io` movabs. These
 ///   match the assembler exactly (a flat cost previously underestimated
 ///   movabs, which is unsound for length-based pruning).
+fn encoding_prefix_bytes(registers: &[X86Register], machine_width: u32) -> u64 {
+    let Some(first) = registers.first() else {
+        return 0;
+    };
+    let operand_width = first.effective_width(machine_width);
+    let operand_size_prefix = u64::from(operand_width == 16);
+    let rex = u64::from(
+        machine_width == 64
+            && (operand_width == 64
+                || registers
+                    .iter()
+                    .any(|reg| reg.index().is_some_and(|index| index >= 8))
+                || registers
+                    .iter()
+                    .any(|reg| reg.is_byte() && !reg.is_high_byte() && reg.index() >= Some(4))),
+    );
+    operand_size_prefix + rex
+}
+
 fn instruction_code_size(instr: &X86Instruction, width: u32) -> u64 {
-    let rex = if width == 64 { 1 } else { 0 };
+    let operand = instr.destination_operand().or(match instr {
+        X86Instruction::CmpReg { rn, .. }
+        | X86Instruction::CmpImm { rn, .. }
+        | X86Instruction::TestReg { rn, .. }
+        | X86Instruction::TestImm { rn, .. } => Some(*rn),
+        _ => None,
+    });
+    let operands: Vec<X86Register> = match instr {
+        X86Instruction::MovReg { rd, rs }
+        | X86Instruction::AddReg { rd, rs }
+        | X86Instruction::SubReg { rd, rs }
+        | X86Instruction::AndReg { rd, rs }
+        | X86Instruction::OrReg { rd, rs }
+        | X86Instruction::XorReg { rd, rs }
+        | X86Instruction::ImulReg { rd, rs }
+        | X86Instruction::Cmov { rd, rs, .. } => vec![*rd, *rs],
+        X86Instruction::CmpReg { rn, rs } | X86Instruction::TestReg { rn, rs } => {
+            vec![*rn, *rs]
+        }
+        X86Instruction::ImulRegImm { rd, rs, .. } => vec![*rd, *rs],
+        X86Instruction::Lea { rd, base, .. } => vec![*rd, *base],
+        _ => operand.into_iter().collect(),
+    };
+    let prefixes = encoding_prefix_bytes(&operands, width);
+    let operand_width = operand.map_or(width, |reg| reg.effective_width(width));
     match instr {
-        X86Instruction::MovReg { .. } => 2 + rex,
+        X86Instruction::MovReg { .. } => 2 + prefixes,
         // See the module doc-comment: immediate-dependent to stay a valid
         // upper bound on the assembler's MovImm encoding (issue #225).
         X86Instruction::MovImm { imm, .. } => {
-            if width == 64 {
+            if operand_width == 64 {
                 if i32::try_from(*imm).is_ok() { 7 } else { 10 }
             } else {
-                5
+                match operand_width {
+                    32 => 5 + prefixes,
+                    16 => 3 + prefixes,
+                    8 => 2 + prefixes,
+                    _ => unreachable!("unsupported x86 operand width"),
+                }
             }
         }
         X86Instruction::AddReg { .. }
@@ -134,7 +182,7 @@ fn instruction_code_size(instr: &X86Instruction, width: u32) -> u64 {
         | X86Instruction::Not { .. }
         // INC / DEC are single-operand `FF /0` / `FF /1` = 2 bytes (+REX.W).
         | X86Instruction::Inc { .. }
-        | X86Instruction::Dec { .. } => 2 + rex,
+        | X86Instruction::Dec { .. } => 2 + prefixes,
         // SHL / SHR / SAR / ROL / ROR by imm8 are `C1 /n ib` = opcode + ModR/M
         // + imm8 = 3 bytes (+REX.W).
         X86Instruction::Shl { .. }
@@ -143,23 +191,34 @@ fn instruction_code_size(instr: &X86Instruction, width: u32) -> u64 {
         | X86Instruction::Rol { .. }
         // IMUL rd, rs is `0F AF /r` = opcode (2) + ModR/M = 3 bytes (+REX.W).
         | X86Instruction::ImulReg { .. }
-        | X86Instruction::Ror { .. } => 3 + rex,
+        | X86Instruction::Ror { .. } => 3 + prefixes,
         // IMUL rd, rs, imm is `69 /r id` = opcode + ModR/M + 4-byte imm
         // = 6 bytes (+REX.W), mirroring the reg-imm arithmetic sizing.
-        X86Instruction::ImulRegImm { .. } => 6 + rex,
+        X86Instruction::ImulRegImm { .. } => {
+            if operand_width == 16 {
+                4 + prefixes
+            } else {
+                6 + prefixes
+            }
+        }
         // LEA rd, [base + disp] is `8D /r` = opcode + ModR/M, plus a possible
         // SIB byte (when base is RSP/R12) and a 4-byte disp32 = up to 7 bytes
         // (+REX.W). A conservative upper bound for length-based pruning.
-        X86Instruction::Lea { .. } => 7 + rex,
+        X86Instruction::Lea { .. } => 7 + prefixes,
         X86Instruction::AddImm { .. }
         | X86Instruction::SubImm { .. }
         | X86Instruction::AndImm { .. }
         | X86Instruction::OrImm { .. }
         | X86Instruction::XorImm { .. }
         | X86Instruction::CmpImm { .. }
-        | X86Instruction::TestImm { .. } => 6 + rex,
+        | X86Instruction::TestImm { .. } => match operand_width {
+            64 | 32 => 6 + prefixes,
+            16 => 4 + prefixes,
+            8 => 3 + prefixes,
+            _ => unreachable!("unsupported x86 operand width"),
+        },
         // CMOV is `0F 4x ModR/M` = 3 bytes plus REX.W on 64-bit.
-        X86Instruction::Cmov { .. } => 3 + rex,
+        X86Instruction::Cmov { .. } => 3 + prefixes,
         // Short-form Jcc is `7x rel8` = 2 bytes (no REX). Long-form
         // `0F 8x rel32` = 6 bytes is used when the displacement doesn't
         // fit. The optimizer never emits Jcc bytes (terminators stay
@@ -447,6 +506,62 @@ mod tests {
         };
         assert_eq!(instruction_cost(&rr, &CostMetric::CodeSize, 32), 2);
         assert_eq!(instruction_cost(&ri, &CostMetric::CodeSize, 32), 6);
+    }
+
+    #[test]
+    fn code_size_tracks_sub_register_prefixes_and_immediates() {
+        let cases = [
+            (
+                X86Instruction::MovImm {
+                    rd: X86Register::EAX,
+                    imm: 1,
+                },
+                5,
+            ),
+            (
+                X86Instruction::MovImm {
+                    rd: X86Register::AX,
+                    imm: 1,
+                },
+                4,
+            ),
+            (
+                X86Instruction::MovImm {
+                    rd: X86Register::AL,
+                    imm: 1,
+                },
+                2,
+            ),
+            (
+                X86Instruction::MovImm {
+                    rd: X86Register::AH,
+                    imm: 1,
+                },
+                2,
+            ),
+            (
+                X86Instruction::XorReg {
+                    rd: X86Register::EAX,
+                    rs: X86Register::EAX,
+                },
+                2,
+            ),
+            (
+                X86Instruction::XorReg {
+                    rd: X86Register::AX,
+                    rs: X86Register::AX,
+                },
+                3,
+            ),
+        ];
+
+        for (instruction, expected) in cases {
+            assert_eq!(
+                instruction_cost(&instruction, &CostMetric::CodeSize, 64),
+                expected,
+                "{instruction}"
+            );
+        }
     }
 
     #[test]

--- a/src/semantics/cost_x86.rs
+++ b/src/semantics/cost_x86.rs
@@ -62,7 +62,7 @@
 
 #![allow(dead_code)]
 
-use crate::isa::x86::{X86Instruction, X86Register, x86_reads_flags};
+use crate::isa::x86::{X86Instruction, X86Register, X86RegisterView, x86_reads_flags};
 use crate::semantics::cost::CostMetric;
 
 /// Cost of a single x86 instruction at the given operand width.
@@ -85,14 +85,20 @@ pub fn instruction_cost(instr: &X86Instruction, metric: &CostMetric, width: u32)
 /// Isolated per-opcode latency in cycles, sourced from Agner Fog's Skylake
 /// instruction tables (see the module doc-comment).
 ///
-/// - Register-to-register `mov` is **0**: Skylake eliminates it at rename, so it
-///   never extends a dependency chain.
+/// - A full-width (native/dword) register-to-register `mov` is **0**: Skylake
+///   eliminates it at rename, so it never extends a dependency chain. A narrower
+///   `mov` (word or byte) is NOT move-eliminated — it needs an executed merge —
+///   so it costs **1** cycle like any ALU op.
 /// - Simple integer ALU ops (everything except multiply) are **1** cycle.
 /// - `IMUL` (two- and three-operand) is **3** cycles on Skylake.
 fn instruction_latency(instr: &X86Instruction) -> u64 {
     match instr {
-        // Register-rename move elimination: zero-latency on the critical path.
-        X86Instruction::MovReg { .. } => 0,
+        // Register-rename move elimination applies only to full-width copies;
+        // word/byte moves need an executed merge µop and cost a cycle.
+        X86Instruction::MovReg { rd, .. } => match rd.view() {
+            X86RegisterView::Native | X86RegisterView::Dword => 0,
+            X86RegisterView::Word | X86RegisterView::LowByte | X86RegisterView::HighByte => 1,
+        },
         // Full-width SETcc lowers to a byte SETcc followed by a dependent MOVZX.
         X86Instruction::Setcc { .. } => 2,
         // Two-/three-operand signed multiply: 3-cycle latency on Skylake.
@@ -494,6 +500,27 @@ mod tests {
             },
         ];
         assert_eq!(sequence_cost(&seq, &CostMetric::Latency, 64), 1);
+    }
+
+    #[test]
+    fn partial_register_moves_are_not_move_eliminated() {
+        // Skylake move elimination only applies to full-width (native/dword)
+        // reg-reg moves; word and byte MovReg forms need an executed merge and
+        // cost a cycle, so the latency model must not report them as free.
+        for (rd, rs, expected, label) in [
+            (X86Register::RAX, X86Register::RCX, 0u64, "native"),
+            (X86Register::EAX, X86Register::ECX, 0, "dword"),
+            (X86Register::AX, X86Register::CX, 1, "word"),
+            (X86Register::AL, X86Register::CL, 1, "low byte"),
+            (X86Register::AH, X86Register::CH, 1, "high byte"),
+        ] {
+            let seq = [X86Instruction::MovReg { rd, rs }];
+            assert_eq!(
+                sequence_cost(&seq, &CostMetric::Latency, 64),
+                expected,
+                "{label} MovReg latency"
+            );
+        }
     }
 
     #[test]

--- a/src/semantics/cost_x86.rs
+++ b/src/semantics/cost_x86.rs
@@ -107,7 +107,9 @@ fn instruction_latency(instr: &X86Instruction) -> u64 {
 
 /// Approximate encoded length in bytes. Conservative upper bounds.
 ///
-/// - REX prefix adds 1 byte to x86-64 ops touching r0..r15 with REX.W.
+/// - REX prefix adds 1 byte to every x86-64 register op except one naming a
+///   legacy high-byte register (dynasm emits REX.W for native operands and a
+///   bare 0x40 for dword/word/low-byte operands via its dynamic-register path).
 /// - Register-register: opcode + ModR/M = 2 bytes, plus REX for x86-64
 ///   = 3 bytes.
 /// - Register-immediate (32-bit imm): opcode + ModR/M + 4-byte imm
@@ -123,16 +125,14 @@ fn encoding_prefix_bytes(registers: &[X86Register], machine_width: u32) -> u64 {
     };
     let operand_width = first.effective_width(machine_width);
     let operand_size_prefix = u64::from(operand_width == 16);
-    let rex = u64::from(
-        machine_width == 64
-            && (operand_width == 64
-                || registers
-                    .iter()
-                    .any(|reg| reg.index().is_some_and(|index| index >= 8))
-                || registers
-                    .iter()
-                    .any(|reg| reg.is_byte() && !reg.is_high_byte() && reg.index() >= Some(4))),
-    );
+    // In 64-bit mode the assembler encodes register operands through dynasm's
+    // dynamic-register path, which always emits a REX byte — REX.W for a native
+    // operand, otherwise a bare 0x40 for a dword/word/low-byte operand (with the
+    // REX.R/REX.B extension bits added for r8..r15 / spl..dil). The sole
+    // exception is a legacy high-byte register (AH/BH/CH/DH), which is
+    // REX-incompatible and forces a REX-free legacy encoding. So an x86-64
+    // instruction carries a REX byte unless it names a high-byte register.
+    let rex = u64::from(machine_width == 64 && !registers.iter().any(|reg| reg.is_high_byte()));
     operand_size_prefix + rex
 }
 
@@ -591,21 +591,21 @@ mod tests {
                     rd: X86Register::EAX,
                     imm: 1,
                 },
-                5,
+                6,
             ),
             (
                 X86Instruction::MovImm {
                     rd: X86Register::AX,
                     imm: 1,
                 },
-                4,
+                5,
             ),
             (
                 X86Instruction::MovImm {
                     rd: X86Register::AL,
                     imm: 1,
                 },
-                2,
+                3,
             ),
             (
                 X86Instruction::MovImm {
@@ -619,14 +619,14 @@ mod tests {
                     rd: X86Register::EAX,
                     rs: X86Register::EAX,
                 },
-                2,
+                3,
             ),
             (
                 X86Instruction::XorReg {
                     rd: X86Register::AX,
                     rs: X86Register::AX,
                 },
-                3,
+                4,
             ),
         ];
 

--- a/src/semantics/cost_x86.rs
+++ b/src/semantics/cost_x86.rs
@@ -496,6 +496,41 @@ mod tests {
         assert_eq!(sequence_cost(&seq, &CostMetric::Latency, 64), 1);
     }
 
+    #[test]
+    fn partial_write_keeps_old_destination_on_the_critical_path() {
+        let producer = X86Instruction::AddReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RCX,
+        };
+        let consumer = X86Instruction::AddReg {
+            rd: X86Register::RDX,
+            rs: X86Register::RAX,
+        };
+        let partial = [
+            producer,
+            X86Instruction::MovImm {
+                rd: X86Register::AL,
+                imm: 1,
+            },
+            consumer,
+        ];
+        let dword = [
+            producer,
+            X86Instruction::MovImm {
+                rd: X86Register::EAX,
+                imm: 1,
+            },
+            consumer,
+        ];
+
+        assert_eq!(sequence_cost(&partial, &CostMetric::Latency, 64), 3);
+        assert_eq!(
+            sequence_cost(&dword, &CostMetric::Latency, 64),
+            2,
+            "an EAX write replaces the old RAX value and breaks its dependency"
+        );
+    }
+
     /// IMUL's 3-cycle latency shows up on the critical path: a single IMUL costs
     /// 3, and chaining it after an ADD that produces its input costs 1 + 3 = 4.
     #[test]

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -1207,6 +1207,57 @@ mod tests {
     }
 
     #[test]
+    fn x86_64_smt_models_partial_byte_writes() {
+        let seq_mov_al = vec![X86Instruction::MovImm {
+            rd: X86Register::AL,
+            imm: 0,
+        }];
+        let seq_clear_low_byte = vec![X86Instruction::AndImm {
+            rd: X86Register::RAX,
+            imm: !0xffu64 as i64,
+        }];
+        let cfg = EquivalenceConfigFor::<crate::isa::X86_64>::default()
+            .live_out(X86LiveOut::from_registers(vec![X86Register::RAX]))
+            .random_tests(0);
+
+        assert_eq!(
+            check_equivalence_for::<crate::isa::X86_64>(&seq_mov_al, &seq_clear_low_byte, &cfg),
+            EquivalenceResult::Equivalent
+        );
+        assert!(matches!(
+            check_equivalence_for::<crate::isa::X86_64>(
+                &seq_mov_al,
+                &[X86Instruction::MovImm {
+                    rd: X86Register::RAX,
+                    imm: 0,
+                }],
+                &cfg
+            ),
+            EquivalenceResult::NotEquivalent
+        ));
+    }
+
+    #[test]
+    fn x86_64_smt_models_dword_writes_as_zero_extending() {
+        let seq_xor_eax = vec![X86Instruction::XorReg {
+            rd: X86Register::EAX,
+            rs: X86Register::EAX,
+        }];
+        let seq_xor_rax = vec![X86Instruction::XorReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RAX,
+        }];
+        let cfg = EquivalenceConfigFor::<crate::isa::X86_64>::default()
+            .live_out(X86LiveOut::from_registers(vec![X86Register::RAX]).with_flags(true))
+            .random_tests(0);
+
+        assert_eq!(
+            check_equivalence_for::<crate::isa::X86_64>(&seq_xor_eax, &seq_xor_rax, &cfg),
+            EquivalenceResult::Equivalent
+        );
+    }
+
+    #[test]
     fn x86_mov_zero_not_equivalent_to_xor_self_when_flags_live() {
         // XOR sets EFLAGS; MOV does not. So with flags_live=true, the two
         // sequences must NOT be considered equivalent.

--- a/src/semantics/smt_x86.rs
+++ b/src/semantics/smt_x86.rs
@@ -12,7 +12,7 @@
 
 #![allow(dead_code)]
 
-use crate::isa::x86::{X86Instruction, X86Register};
+use crate::isa::x86::{X86Instruction, X86Register, X86RegisterView};
 use std::collections::HashMap;
 use z3::ast::BV;
 
@@ -72,12 +72,51 @@ impl MachineStateX86 {
 
     pub fn get_register(&self, reg: X86Register) -> &BV {
         self.registers
-            .get(&reg)
+            .get(&reg.canonical())
             .expect("register absent from x86 state")
     }
 
     pub fn set_register(&mut self, reg: X86Register, value: BV) {
-        self.registers.insert(reg, value);
+        self.registers.insert(reg.canonical(), value);
+    }
+
+    /// Read the bitvector denoted by an instruction register operand.
+    pub fn read_operand(&self, reg: X86Register) -> BV {
+        let full = self.get_register(reg);
+        match reg.view() {
+            X86RegisterView::Native => full.clone(),
+            X86RegisterView::Dword => full.extract(31, 0),
+            X86RegisterView::Word => full.extract(15, 0),
+            X86RegisterView::LowByte => full.extract(7, 0),
+            X86RegisterView::HighByte => full.extract(15, 8),
+        }
+    }
+
+    /// Write an operand-sized value back into its architectural register.
+    pub fn write_operand(&mut self, reg: X86Register, value: BV) {
+        let full = self.operand_write_value(reg, &value);
+        self.set_register(reg.canonical(), full);
+    }
+
+    fn operand_write_value(&self, reg: X86Register, value: &BV) -> BV {
+        let old = self.get_register(reg).clone();
+        let operand_width = reg.effective_width(self.width);
+        let value = match value.get_size().cmp(&operand_width) {
+            std::cmp::Ordering::Greater => value.extract(operand_width - 1, 0),
+            std::cmp::Ordering::Less => value.zero_ext(operand_width - value.get_size()),
+            std::cmp::Ordering::Equal => value.clone(),
+        };
+        match reg.view() {
+            X86RegisterView::Native => value,
+            X86RegisterView::Dword if self.width == 64 => value.zero_ext(32),
+            X86RegisterView::Dword => value,
+            X86RegisterView::Word => old.extract(self.width - 1, 16).concat(&value),
+            X86RegisterView::LowByte => old.extract(self.width - 1, 8).concat(&value),
+            X86RegisterView::HighByte => old
+                .extract(self.width - 1, 16)
+                .concat(&value)
+                .concat(old.extract(7, 0)),
+        }
     }
 
     /// Return the five tracked flag BVs.
@@ -96,8 +135,8 @@ impl MachineStateX86 {
         self.flags = flags;
     }
 
-    fn imm_bv(&self, imm: i64) -> BV {
-        BV::from_i64(imm, self.width)
+    fn imm_bv(&self, imm: i64, width: u32) -> BV {
+        BV::from_i64(imm, width)
     }
 }
 
@@ -246,14 +285,9 @@ enum ShiftKind {
 ///   with the SAME formula as count 1 (a deterministic value). Target and
 ///   candidate share this lowering, so equivalence stays internally
 ///   consistent; downstream code must not rely on OF after a count > 1 shift.
-fn apply_shift_smt(
-    state: &mut MachineStateX86,
-    rd: crate::isa::x86::X86Register,
-    imm: i64,
-    kind: ShiftKind,
-) {
-    let width = state.width();
-    let mask = u64::from(width - 1);
+fn apply_shift_smt(state: &mut MachineStateX86, rd: X86Register, imm: i64, kind: ShiftKind) {
+    let width = rd.effective_width(state.width());
+    let mask = if width == 64 { 0x3f } else { 0x1f };
     let eff = (imm as u64) & mask;
 
     // Count masks to 0: no register or flag change.
@@ -261,7 +295,7 @@ fn apply_shift_smt(
         return;
     }
 
-    let old = state.get_register(rd).clone();
+    let old = state.read_operand(rd);
     let amount = BV::from_u64(eff, width);
     let result = match kind {
         ShiftKind::Shl => old.bvshl(&amount),
@@ -273,15 +307,17 @@ fn apply_shift_smt(
     // concrete we extract the exact bit index.
     let cf = match kind {
         // SHL: original bit at index `width - eff`.
-        ShiftKind::Shl => {
+        ShiftKind::Shl if eff <= u64::from(width) => {
             let bit = width - eff as u32;
             old.extract(bit, bit)
         }
+        ShiftKind::Shl => bv_zero(),
         // SHR / SAR: original bit at index `eff - 1`.
-        ShiftKind::Shr | ShiftKind::Sar => {
+        ShiftKind::Shr | ShiftKind::Sar if eff <= u64::from(width) => {
             let bit = eff as u32 - 1;
             old.extract(bit, bit)
         }
+        ShiftKind::Shr | ShiftKind::Sar => bv_zero(),
     };
 
     // OF: count-1 formula, reused for all nonzero counts (see doc comment).
@@ -294,7 +330,7 @@ fn apply_shift_smt(
     let mut flags = compute_eflags_logical(&result, width);
     flags.cf = cf;
     flags.of = of;
-    state.set_register(rd, result);
+    state.write_operand(rd, result);
     state.set_flags(flags);
 }
 
@@ -320,22 +356,17 @@ enum RotateKind {
 ///   - ROR: `result = bvrotr(rd, eff)`; CF = the MSB (bit `width-1`) of the
 ///     result. OF (count 1 only) = XOR of the result's two most-significant bits.
 ///   - For count != 1 OF is UNDEFINED on hardware; we preserve the incoming OF.
-fn apply_rotate_smt(
-    state: &mut MachineStateX86,
-    rd: crate::isa::x86::X86Register,
-    imm: i64,
-    kind: RotateKind,
-) {
-    let width = state.width();
-    let mask = u64::from(width - 1);
-    let eff = (imm as u64) & mask;
+fn apply_rotate_smt(state: &mut MachineStateX86, rd: X86Register, imm: i64, kind: RotateKind) {
+    let width = rd.effective_width(state.width());
+    let mask = if width == 64 { 0x3f } else { 0x1f };
+    let eff = ((imm as u64) & mask) % u64::from(width);
 
     // Count masks to 0: no register or flag change.
     if eff == 0 {
         return;
     }
 
-    let old = state.get_register(rd).clone();
+    let old = state.read_operand(rd);
     let amount = BV::from_u64(eff, width);
     let result = match kind {
         RotateKind::Rol => old.bvrotl(&amount),
@@ -368,7 +399,7 @@ fn apply_rotate_smt(
         };
     }
 
-    state.set_register(rd, result);
+    state.write_operand(rd, result);
     state.set_flags(flags);
 }
 
@@ -388,13 +419,8 @@ fn apply_rotate_smt(
 /// PF = low-byte parity). Both target and candidate share this lowering, so
 /// equivalence stays internally consistent and conservative. AF is not modelled
 /// (see module docs).
-fn apply_imul_smt(
-    state: &mut MachineStateX86,
-    rd: crate::isa::x86::X86Register,
-    lhs: &BV,
-    rhs: &BV,
-) {
-    let width = state.width();
+fn apply_imul_smt(state: &mut MachineStateX86, rd: X86Register, lhs: &BV, rhs: &BV) {
+    let width = rd.effective_width(state.width());
     // `sign_ext(width)` adds `width` bits, giving a 2*width-bit BV.
     let wide = lhs.sign_ext(width).bvmul(rhs.sign_ext(width));
     let result = lhs.bvmul(rhs);
@@ -409,224 +435,177 @@ fn apply_imul_smt(
     let mut flags = compute_eflags_logical(&result, width);
     flags.cf = overflow.clone();
     flags.of = overflow;
-    state.set_register(rd, result);
+    state.write_operand(rd, result);
     state.set_flags(flags);
 }
 
-/// Apply a single x86 instruction symbolically. Arithmetic / logic /
-/// CMP arms bind the five tracked flag BVs via `compute_eflags_*`;
-/// CMOV reads them via `x86_condition_to_smt`.
+#[derive(Clone, Copy)]
+enum Binop {
+    Add,
+    Sub,
+    And,
+    Or,
+    Xor,
+}
+
+fn apply_binop_smt(state: &mut MachineStateX86, rd: X86Register, rhs: BV, op: Binop) {
+    let width = rd.effective_width(state.width());
+    let lhs = state.read_operand(rd);
+    let result = match op {
+        Binop::Add => lhs.bvadd(&rhs),
+        Binop::Sub => lhs.bvsub(&rhs),
+        Binop::And => lhs.bvand(&rhs),
+        Binop::Or => lhs.bvor(&rhs),
+        Binop::Xor => lhs.bvxor(&rhs),
+    };
+    let flags = match op {
+        Binop::Add => compute_eflags_add(&lhs, &rhs, width),
+        Binop::Sub => compute_eflags_sub(&lhs, &rhs, width),
+        Binop::And | Binop::Or | Binop::Xor => compute_eflags_logical(&result, width),
+    };
+    state.write_operand(rd, result);
+    state.set_flags(flags);
+}
+
+fn apply_cmp_smt(state: &mut MachineStateX86, rn: X86Register, rhs: BV) {
+    let width = rn.effective_width(state.width());
+    let lhs = state.read_operand(rn);
+    state.set_flags(compute_eflags_sub(&lhs, &rhs, width));
+}
+
+fn apply_test_smt(state: &mut MachineStateX86, rn: X86Register, rhs: BV) {
+    let width = rn.effective_width(state.width());
+    let result = state.read_operand(rn).bvand(&rhs);
+    state.set_flags(compute_eflags_logical(&result, width));
+}
+
+/// Apply a single x86 instruction symbolically. Register views determine the
+/// bitvector width of every read, write, and flag computation.
 pub fn apply_instruction(
     mut state: MachineStateX86,
     instruction: &X86Instruction,
 ) -> MachineStateX86 {
     match instruction {
         X86Instruction::MovReg { rd, rs } => {
-            let value = state.get_register(*rs).clone();
-            state.set_register(*rd, value);
+            let value = state.read_operand(*rs);
+            state.write_operand(*rd, value);
         }
         X86Instruction::MovImm { rd, imm } => {
-            let value = state.imm_bv(*imm);
-            state.set_register(*rd, value);
+            let width = rd.effective_width(state.width());
+            let value = state.imm_bv(*imm, width);
+            state.write_operand(*rd, value);
         }
         X86Instruction::AddReg { rd, rs } => {
-            let lhs = state.get_register(*rd).clone();
-            let rhs = state.get_register(*rs).clone();
-            let result = lhs.bvadd(&rhs);
-            let flags = compute_eflags_add(&lhs, &rhs, state.width());
-            state.set_register(*rd, result);
-            state.set_flags(flags);
+            let rhs = state.read_operand(*rs);
+            apply_binop_smt(&mut state, *rd, rhs, Binop::Add);
         }
         X86Instruction::AddImm { rd, imm } => {
-            let lhs = state.get_register(*rd).clone();
-            let rhs = state.imm_bv(*imm);
-            let result = lhs.bvadd(&rhs);
-            let flags = compute_eflags_add(&lhs, &rhs, state.width());
-            state.set_register(*rd, result);
-            state.set_flags(flags);
+            let rhs = state.imm_bv(*imm, rd.effective_width(state.width()));
+            apply_binop_smt(&mut state, *rd, rhs, Binop::Add);
         }
         X86Instruction::SubReg { rd, rs } => {
-            let lhs = state.get_register(*rd).clone();
-            let rhs = state.get_register(*rs).clone();
-            let result = lhs.bvsub(&rhs);
-            let flags = compute_eflags_sub(&lhs, &rhs, state.width());
-            state.set_register(*rd, result);
-            state.set_flags(flags);
+            let rhs = state.read_operand(*rs);
+            apply_binop_smt(&mut state, *rd, rhs, Binop::Sub);
         }
         X86Instruction::SubImm { rd, imm } => {
-            let lhs = state.get_register(*rd).clone();
-            let rhs = state.imm_bv(*imm);
-            let result = lhs.bvsub(&rhs);
-            let flags = compute_eflags_sub(&lhs, &rhs, state.width());
-            state.set_register(*rd, result);
-            state.set_flags(flags);
+            let rhs = state.imm_bv(*imm, rd.effective_width(state.width()));
+            apply_binop_smt(&mut state, *rd, rhs, Binop::Sub);
         }
         X86Instruction::AndReg { rd, rs } => {
-            let lhs = state.get_register(*rd).clone();
-            let rhs = state.get_register(*rs).clone();
-            let result = lhs.bvand(&rhs);
-            let flags = compute_eflags_logical(&result, state.width());
-            state.set_register(*rd, result);
-            state.set_flags(flags);
+            let rhs = state.read_operand(*rs);
+            apply_binop_smt(&mut state, *rd, rhs, Binop::And);
         }
         X86Instruction::AndImm { rd, imm } => {
-            let lhs = state.get_register(*rd).clone();
-            let rhs = state.imm_bv(*imm);
-            let result = lhs.bvand(&rhs);
-            let flags = compute_eflags_logical(&result, state.width());
-            state.set_register(*rd, result);
-            state.set_flags(flags);
+            let rhs = state.imm_bv(*imm, rd.effective_width(state.width()));
+            apply_binop_smt(&mut state, *rd, rhs, Binop::And);
         }
         X86Instruction::OrReg { rd, rs } => {
-            let lhs = state.get_register(*rd).clone();
-            let rhs = state.get_register(*rs).clone();
-            let result = lhs.bvor(&rhs);
-            let flags = compute_eflags_logical(&result, state.width());
-            state.set_register(*rd, result);
-            state.set_flags(flags);
+            let rhs = state.read_operand(*rs);
+            apply_binop_smt(&mut state, *rd, rhs, Binop::Or);
         }
         X86Instruction::OrImm { rd, imm } => {
-            let lhs = state.get_register(*rd).clone();
-            let rhs = state.imm_bv(*imm);
-            let result = lhs.bvor(&rhs);
-            let flags = compute_eflags_logical(&result, state.width());
-            state.set_register(*rd, result);
-            state.set_flags(flags);
+            let rhs = state.imm_bv(*imm, rd.effective_width(state.width()));
+            apply_binop_smt(&mut state, *rd, rhs, Binop::Or);
         }
         X86Instruction::XorReg { rd, rs } => {
-            let lhs = state.get_register(*rd).clone();
-            let rhs = state.get_register(*rs).clone();
-            let result = lhs.bvxor(&rhs);
-            let flags = compute_eflags_logical(&result, state.width());
-            state.set_register(*rd, result);
-            state.set_flags(flags);
+            let rhs = state.read_operand(*rs);
+            apply_binop_smt(&mut state, *rd, rhs, Binop::Xor);
         }
         X86Instruction::XorImm { rd, imm } => {
-            let lhs = state.get_register(*rd).clone();
-            let rhs = state.imm_bv(*imm);
-            let result = lhs.bvxor(&rhs);
-            let flags = compute_eflags_logical(&result, state.width());
-            state.set_register(*rd, result);
-            state.set_flags(flags);
+            let rhs = state.imm_bv(*imm, rd.effective_width(state.width()));
+            apply_binop_smt(&mut state, *rd, rhs, Binop::Xor);
         }
-        // CMP sets EFLAGS without writing a register.
         X86Instruction::CmpReg { rn, rs } => {
-            let lhs = state.get_register(*rn).clone();
-            let rhs = state.get_register(*rs).clone();
-            let flags = compute_eflags_sub(&lhs, &rhs, state.width());
-            state.set_flags(flags);
+            let rhs = state.read_operand(*rs);
+            apply_cmp_smt(&mut state, *rn, rhs);
         }
         X86Instruction::CmpImm { rn, imm } => {
-            let lhs = state.get_register(*rn).clone();
-            let rhs = state.imm_bv(*imm);
-            let flags = compute_eflags_sub(&lhs, &rhs, state.width());
-            state.set_flags(flags);
+            let rhs = state.imm_bv(*imm, rn.effective_width(state.width()));
+            apply_cmp_smt(&mut state, *rn, rhs);
         }
-        // TEST sets EFLAGS from `rn & rhs` (the AND/logical path: CF=OF=0,
-        // SF/ZF/PF from the result) without writing a register — the
-        // non-destructive sibling of AND, mirroring how CMP is to SUB.
         X86Instruction::TestReg { rn, rs } => {
-            let lhs = state.get_register(*rn).clone();
-            let rhs = state.get_register(*rs).clone();
-            let result = lhs.bvand(&rhs);
-            let flags = compute_eflags_logical(&result, state.width());
-            state.set_flags(flags);
+            let rhs = state.read_operand(*rs);
+            apply_test_smt(&mut state, *rn, rhs);
         }
         X86Instruction::TestImm { rn, imm } => {
-            let lhs = state.get_register(*rn).clone();
-            let rhs = state.imm_bv(*imm);
-            let result = lhs.bvand(&rhs);
-            let flags = compute_eflags_logical(&result, state.width());
-            state.set_flags(flags);
+            let rhs = state.imm_bv(*imm, rn.effective_width(state.width()));
+            apply_test_smt(&mut state, *rn, rhs);
         }
-        // NEG computes `rd = -rd` and sets EFLAGS as if from `0 - rd`. We
-        // reuse the SUB flag path with lhs = 0, rhs = old_rd so CF = (rd != 0)
-        // and OF/SF/ZF/PF match `sub` bit-for-bit.
         X86Instruction::Neg { rd } => {
-            let old = state.get_register(*rd).clone();
-            let zero = BV::from_u64(0, state.width());
+            let width = rd.effective_width(state.width());
+            let old = state.read_operand(*rd);
+            let zero = BV::from_u64(0, width);
             let result = old.bvneg();
-            let flags = compute_eflags_sub(&zero, &old, state.width());
-            state.set_register(*rd, result);
+            let flags = compute_eflags_sub(&zero, &old, width);
+            state.write_operand(*rd, result);
             state.set_flags(flags);
         }
-        // NOT computes `rd = !rd` (bitwise complement) and leaves EFLAGS
-        // UNCHANGED — exactly like MOV, which writes only its register and
-        // carries the incoming flag BVs forward untouched.
         X86Instruction::Not { rd } => {
-            let result = state.get_register(*rd).bvnot();
-            state.set_register(*rd, result);
+            let result = state.read_operand(*rd).bvnot();
+            state.write_operand(*rd, result);
         }
-        // INC computes `rd = rd + 1` and sets OF/SF/ZF/PF exactly as `add rd, 1`
-        // would, but — the load-bearing subtlety — leaves CF UNCHANGED (the
-        // incoming carry flows through). Capture the prior CF BV FIRST, compute
-        // the ADD flag path for `rd + 1`, then override CF back to the captured
-        // BV so it equals the incoming CF.
-        X86Instruction::Inc { rd } => {
-            let prev_cf = state.get_flags().cf.clone();
-            let old = state.get_register(*rd).clone();
-            let one = BV::from_u64(1, state.width());
-            let result = old.bvadd(&one);
-            let mut flags = compute_eflags_add(&old, &one, state.width());
-            flags.cf = prev_cf;
-            state.set_register(*rd, result);
+        X86Instruction::Inc { rd } | X86Instruction::Dec { rd } => {
+            let width = rd.effective_width(state.width());
+            let previous_cf = state.get_flags().cf.clone();
+            let old = state.read_operand(*rd);
+            let one = BV::from_u64(1, width);
+            let (result, mut flags) = if matches!(instruction, X86Instruction::Inc { .. }) {
+                (old.bvadd(&one), compute_eflags_add(&old, &one, width))
+            } else {
+                (old.bvsub(&one), compute_eflags_sub(&old, &one, width))
+            };
+            flags.cf = previous_cf;
+            state.write_operand(*rd, result);
             state.set_flags(flags);
         }
-        // DEC computes `rd = rd - 1`. Like INC it sets OF/SF/ZF/PF as `sub rd, 1`
-        // would while leaving CF UNCHANGED. Capture the prior CF BV first, derive
-        // flags from the SUB path for `rd - 1`, then restore CF.
-        X86Instruction::Dec { rd } => {
-            let prev_cf = state.get_flags().cf.clone();
-            let old = state.get_register(*rd).clone();
-            let one = BV::from_u64(1, state.width());
-            let result = old.bvsub(&one);
-            let mut flags = compute_eflags_sub(&old, &one, state.width());
-            flags.cf = prev_cf;
-            state.set_register(*rd, result);
-            state.set_flags(flags);
-        }
-        // Immediate-count shifts. The count is a concrete IR value, so we branch
-        // on the masked count at lowering time — no symbolic-count handling is
-        // needed. See `apply_shift_smt`.
         X86Instruction::Shl { rd, imm } => apply_shift_smt(&mut state, *rd, *imm, ShiftKind::Shl),
         X86Instruction::Shr { rd, imm } => apply_shift_smt(&mut state, *rd, *imm, ShiftKind::Shr),
         X86Instruction::Sar { rd, imm } => apply_shift_smt(&mut state, *rd, *imm, ShiftKind::Sar),
-        // Immediate-count rotates. Same concrete-count handling as the shifts,
-        // but a partial flag update (only CF, plus OF for count 1) — see
-        // `apply_rotate_smt`.
         X86Instruction::Rol { rd, imm } => apply_rotate_smt(&mut state, *rd, *imm, RotateKind::Rol),
         X86Instruction::Ror { rd, imm } => apply_rotate_smt(&mut state, *rd, *imm, RotateKind::Ror),
-        // IMUL (2-op): `rd = rd * rs`. rd is both source and destination.
         X86Instruction::ImulReg { rd, rs } => {
-            let lhs = state.get_register(*rd).clone();
-            let rhs = state.get_register(*rs).clone();
+            let lhs = state.read_operand(*rd);
+            let rhs = state.read_operand(*rs);
             apply_imul_smt(&mut state, *rd, &lhs, &rhs);
         }
-        // IMUL (3-op): `rd = rs * imm`. rd is purely written.
         X86Instruction::ImulRegImm { rd, rs, imm } => {
-            let lhs = state.get_register(*rs).clone();
-            let rhs = state.imm_bv(*imm);
+            let width = rd.effective_width(state.width());
+            let lhs = state.read_operand(*rs);
+            let rhs = state.imm_bv(*imm, width);
             apply_imul_smt(&mut state, *rd, &lhs, &rhs);
         }
-        // LEA computes `rd = base + disp` (wrapping at width) and leaves EFLAGS
-        // UNCHANGED — pure address arithmetic, exactly like MOV/NOT, which write
-        // only their register and carry the incoming flag BVs forward untouched.
-        // `disp` lowers as an immediate at the operand width.
         X86Instruction::Lea { rd, base, disp } => {
-            let base = state.get_register(*base).clone();
-            let disp = state.imm_bv(*disp);
-            let result = base.bvadd(&disp);
-            state.set_register(*rd, result);
+            let base = state.read_operand(*base);
+            let disp = state.imm_bv(*disp, base.get_size());
+            state.write_operand(*rd, base.bvadd(&disp));
         }
         X86Instruction::Cmov { rd, rs, cond } => {
             let pred = x86_condition_to_smt(*cond, state.get_flags());
-            let rs_val = state.get_register(*rs).clone();
-            let rd_old = state.get_register(*rd).clone();
-            state.set_register(*rd, pred.ite(&rs_val, &rd_old));
+            let old = state.get_register(*rd).clone();
+            let source = state.read_operand(*rs);
+            let written = state.operand_write_value(*rd, &source);
+            state.set_register(rd.canonical(), pred.ite(&written, &old));
         }
-        // Jcc reads EFLAGS but transfers control; nothing is observable
-        // in the data-state machine modelled here. Cycle 10 peels Jccs
-        // off the sequence before applying it symbolically.
         X86Instruction::Jcc { .. } => {}
     }
     state
@@ -1060,6 +1039,40 @@ mod tests {
                 solver.check(),
                 SatResult::Unsat,
                 "lea rd,[rs+{imm}] must equal mov rd,rs; add rd,{imm} on the result"
+            );
+        }
+    }
+
+    #[test]
+    fn partial_width_lea_truncates_the_native_address_before_writing() {
+        for (rd, rs) in [
+            (X86Register::EAX, X86Register::EBX),
+            (X86Register::AX, X86Register::BX),
+        ] {
+            let after_lea = apply_instruction(
+                MachineStateX86::new_symbolic("shared", 64),
+                &X86Instruction::Lea {
+                    rd,
+                    base: X86Register::RBX,
+                    disp: 0,
+                },
+            );
+            let after_mov = apply_instruction(
+                MachineStateX86::new_symbolic("shared", 64),
+                &X86Instruction::MovReg { rd, rs },
+            );
+
+            let solver = Solver::new();
+            solver.assert(
+                after_lea
+                    .get_register(X86Register::RAX)
+                    .eq(after_mov.get_register(X86Register::RAX))
+                    .not(),
+            );
+            assert_eq!(
+                solver.check(),
+                SatResult::Unsat,
+                "partial-width lea into {rd} must match the corresponding move from {rs}"
             );
         }
     }

--- a/src/semantics/state.rs
+++ b/src/semantics/state.rs
@@ -4,6 +4,7 @@
 
 use crate::ir::Register;
 use crate::ir::types::{AccessWidth, Condition};
+use crate::isa::x86::{X86Register, X86RegisterView};
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 
@@ -460,7 +461,7 @@ impl fmt::Display for ConcreteMachineState {
 /// reference R8..R15.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct X86ConcreteMachineState {
-    registers: HashMap<crate::isa::x86::X86Register, ConcreteValue>,
+    registers: HashMap<X86Register, ConcreteValue>,
     flags: Eflags,
     width: u32,
 }
@@ -469,7 +470,7 @@ impl X86ConcreteMachineState {
     pub fn new_zeroed(width: u32) -> Self {
         let mut registers = HashMap::new();
         for i in 0..16u8 {
-            if let Some(r) = crate::isa::x86::X86Register::from_index(i) {
+            if let Some(r) = X86Register::from_index(i) {
                 registers.insert(r, ConcreteValue::new(0));
             }
         }
@@ -484,14 +485,52 @@ impl X86ConcreteMachineState {
         self.width
     }
 
-    pub fn get_register(&self, reg: crate::isa::x86::X86Register) -> ConcreteValue {
-        *self.registers.get(&reg).unwrap_or(&ConcreteValue::new(0))
+    pub fn get_register(&self, reg: X86Register) -> ConcreteValue {
+        *self
+            .registers
+            .get(&reg.canonical())
+            .unwrap_or(&ConcreteValue::new(0))
     }
 
-    /// Set a register value, masking to the low `width` bits.
-    pub fn set_register(&mut self, reg: crate::isa::x86::X86Register, value: ConcreteValue) {
+    /// Set a complete architectural register value, masking to the machine
+    /// width. Register views are canonicalized because callers that initialize
+    /// or compare machine state operate on whole registers; instruction
+    /// execution uses [`Self::write_operand`] for architectural partial writes.
+    pub fn set_register(&mut self, reg: X86Register, value: ConcreteValue) {
         let masked = mask_to_width(value.as_u64(), self.width);
-        self.registers.insert(reg, ConcreteValue::new(masked));
+        self.registers
+            .insert(reg.canonical(), ConcreteValue::new(masked));
+    }
+
+    /// Read the value denoted by an instruction register operand.
+    pub(crate) fn read_operand(&self, reg: X86Register) -> ConcreteValue {
+        let full = self.get_register(reg).as_u64();
+        let value = match reg.view() {
+            X86RegisterView::Native => full,
+            X86RegisterView::Dword => full & 0xffff_ffff,
+            X86RegisterView::Word => full & 0xffff,
+            X86RegisterView::LowByte => full & 0xff,
+            X86RegisterView::HighByte => (full >> 8) & 0xff,
+        };
+        ConcreteValue::new(value)
+    }
+
+    /// Write the value denoted by an instruction register operand.
+    ///
+    /// Byte and word writes preserve the surrounding bits. A 32-bit write in
+    /// x86-64 clears the upper half, while in x86-32 it is a whole-register
+    /// write. Native operands retain the historical mode-width behavior.
+    pub(crate) fn write_operand(&mut self, reg: X86Register, value: ConcreteValue) {
+        let old = self.get_register(reg).as_u64();
+        let value = value.as_u64();
+        let merged = match reg.view() {
+            X86RegisterView::Native => value,
+            X86RegisterView::Dword => value & 0xffff_ffff,
+            X86RegisterView::Word => (old & !0xffff) | (value & 0xffff),
+            X86RegisterView::LowByte => (old & !0xff) | (value & 0xff),
+            X86RegisterView::HighByte => (old & !0xff00) | ((value & 0xff) << 8),
+        };
+        self.set_register(reg.canonical(), ConcreteValue::new(merged));
     }
 
     pub fn get_flags(&self) -> Eflags {
@@ -502,7 +541,7 @@ impl X86ConcreteMachineState {
         self.flags = flags;
     }
 
-    pub fn registers(&self) -> &HashMap<crate::isa::x86::X86Register, ConcreteValue> {
+    pub fn registers(&self) -> &HashMap<X86Register, ConcreteValue> {
         &self.registers
     }
 }
@@ -664,6 +703,56 @@ mod tests {
             state.get_register(X86Register::RAX).as_u64(),
             0x9abc_def0,
             "32-bit ISA must truncate writes to low 32 bits"
+        );
+    }
+
+    #[test]
+    fn x86_state_reads_and_writes_register_views() {
+        use crate::isa::x86::X86Register;
+        let mut state = X86ConcreteMachineState::new_zeroed(64);
+        state.set_register(X86Register::RAX, ConcreteValue::new(0x1122_3344_5566_7788));
+
+        assert_eq!(
+            state.read_operand(X86Register::AL).as_u64(),
+            0x88,
+            "AL reads bits 7:0"
+        );
+        assert_eq!(
+            state.read_operand(X86Register::AH).as_u64(),
+            0x77,
+            "AH reads bits 15:8"
+        );
+        assert_eq!(
+            state.read_operand(X86Register::AX).as_u64(),
+            0x7788,
+            "AX reads bits 15:0"
+        );
+        assert_eq!(
+            state.read_operand(X86Register::EAX).as_u64(),
+            0x5566_7788,
+            "EAX reads bits 31:0"
+        );
+
+        state.write_operand(X86Register::AL, ConcreteValue::new(0xaa));
+        assert_eq!(
+            state.get_register(X86Register::RAX).as_u64(),
+            0x1122_3344_5566_77aa
+        );
+        state.write_operand(X86Register::AH, ConcreteValue::new(0xbb));
+        assert_eq!(
+            state.get_register(X86Register::RAX).as_u64(),
+            0x1122_3344_5566_bbaa
+        );
+        state.write_operand(X86Register::AX, ConcreteValue::new(0xccdd));
+        assert_eq!(
+            state.get_register(X86Register::RAX).as_u64(),
+            0x1122_3344_5566_ccdd
+        );
+        state.write_operand(X86Register::EAX, ConcreteValue::new(0xdead_beef));
+        assert_eq!(
+            state.get_register(X86Register::RAX).as_u64(),
+            0x0000_0000_dead_beef,
+            "32-bit writes zero-extend in x86-64"
         );
     }
 

--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -292,9 +292,8 @@ pub enum DownstreamRegLiveness {
 /// contains `reg` is a clean, full-register kill. AArch64 has no sub-register
 /// aliasing trap for the X/W GPRs the optimization IR models — a W-form write
 /// zero-extends the full 64-bit register, so every modelled destination write
-/// fully redefines the architectural register. (Contrast the x86 helper, which
-/// must refuse to trust writes because that IR carries no operand width — see
-/// `x86_reg_downstream_liveness`.)
+/// fully redefines the architectural register. The x86 helper below must
+/// additionally distinguish full-width and partial-width destination views.
 ///
 /// This helper does **not** itself decide terminators / unsupported
 /// instructions / region boundaries — the byte-level scan in `src/main.rs`
@@ -326,23 +325,10 @@ fn aarch64_destination_fully_kills(instr: &Instruction, reg: Register) -> bool {
 
 /// Scan an x86 suffix to classify the downstream liveness of `reg`.
 ///
-/// Same read-before-overwrite walk as the AArch64 helper, but with a
-/// deliberately weaker kill rule to stay sound under issue #75.
-///
-/// **#75 hazard / x86 kill rule:** the x86 IR does NOT model operand width.
-/// A `MovImm { rd: RAX, .. }` in this IR could, once #75 lands, actually be a
-/// 32-bit (`mov eax, imm`) or 8-bit (`mov al, imm`) write that leaves the
-/// upper bits of RAX intact — i.e. a *partial* write that does NOT kill the
-/// full register. Trusting `destination()` as a full kill would therefore be
-/// unsound (the #224 bug class). So this helper treats **no** x86 write as a
-/// proven full overwrite today: a downstream write to `reg` does not return
-/// `Dead`; it neither observes nor kills `reg` and the scan keeps walking. The
-/// only definitive answer it can produce is `Read`. Because of this, the x86
-/// path can never narrow a register to dead with the current IR — that is the
-/// intended, vacuously-safe behaviour. When #75 adds widths, replace the
-/// `false` in `x86_destination_fully_kills` with a real full-width check and
-/// the narrowing turns on automatically with no change to the soundness
-/// contract.
+/// Same read-before-overwrite walk as the AArch64 helper. Native mode-width
+/// writes and dword writes are full architectural kills (a dword write
+/// zero-extends in x86-64); word and byte writes preserve surrounding bits and
+/// therefore cannot prove the old full-register value dead.
 pub fn x86_reg_downstream_liveness(
     reg: crate::isa::x86::X86Register,
     suffix: &[crate::isa::x86::X86Instruction],
@@ -358,17 +344,15 @@ pub fn x86_reg_downstream_liveness(
     DownstreamRegLiveness::Uncertain
 }
 
-/// True iff `instr` *provably* fully overwrites `reg` on x86.
-///
-/// Always `false` today: the x86 IR carries no operand width (#75), so no
-/// write can be proven to overwrite the whole architectural register. Kept as
-/// a named guard so the conservative posture is explicit and so #75 has one
-/// obvious place to turn on width-aware kills. See `x86_reg_downstream_liveness`.
+/// True iff `instr` provably fully overwrites `reg` on x86.
 fn x86_destination_fully_kills(
-    _instr: &crate::isa::x86::X86Instruction,
-    _reg: crate::isa::x86::X86Register,
+    instr: &crate::isa::x86::X86Instruction,
+    reg: crate::isa::x86::X86Register,
 ) -> bool {
-    false
+    instr.destination_operand().is_some_and(|destination| {
+        destination.canonical() == reg.canonical()
+            && destination.fully_overwrites_architectural_register()
+    })
 }
 
 /// Compute the set of registers read before written by a sequence of instructions.
@@ -1194,20 +1178,52 @@ mod tests {
     }
 
     #[test]
-    fn x86_reg_downstream_liveness_write_is_never_a_full_kill_no_width() {
+    fn x86_reg_downstream_liveness_distinguishes_full_and_partial_writes() {
         use crate::isa::x86::{X86Instruction, X86Register};
-        // `mov rax, rbx` looks like a full overwrite, but the IR carries no
-        // operand width (#75): it could be `mov eax/al, ...`. The predicate
-        // must NOT report Dead — it walks past the write as Uncertain so the
-        // caller keeps rax live.
-        let suffix = vec![X86Instruction::MovReg {
+        let native = [X86Instruction::MovReg {
             rd: X86Register::RAX,
             rs: X86Register::RBX,
         }];
         assert_eq!(
-            x86_reg_downstream_liveness(X86Register::RAX, &suffix),
-            DownstreamRegLiveness::Uncertain,
-            "x86 write must not be trusted as a full overwrite (#75)"
+            x86_reg_downstream_liveness(X86Register::RAX, &native),
+            DownstreamRegLiveness::Dead
+        );
+
+        let dword = [X86Instruction::MovReg {
+            rd: X86Register::EAX,
+            rs: X86Register::EBX,
+        }];
+        assert_eq!(
+            x86_reg_downstream_liveness(X86Register::RAX, &dword),
+            DownstreamRegLiveness::Dead,
+            "EAX zero-extension fully defines RAX"
+        );
+
+        for partial in [X86Register::AX, X86Register::AL, X86Register::AH] {
+            let suffix = [X86Instruction::MovImm {
+                rd: partial,
+                imm: 0,
+            }];
+            assert_eq!(
+                x86_reg_downstream_liveness(X86Register::RAX, &suffix),
+                DownstreamRegLiveness::Uncertain,
+                "{partial} preserves part of RAX"
+            );
+        }
+    }
+
+    #[test]
+    fn x86_instruction_metadata_canonicalizes_register_views() {
+        use crate::isa::x86::{X86Instruction, X86Register};
+        let instruction = X86Instruction::AddReg {
+            rd: X86Register::AL,
+            rs: X86Register::BL,
+        };
+        assert_eq!(instruction.destination_operand(), Some(X86Register::AL));
+        assert_eq!(instruction.destination(), Some(X86Register::RAX));
+        assert_eq!(
+            instruction.source_registers(),
+            vec![X86Register::RAX, X86Register::RBX]
         );
     }
 

--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -1206,8 +1206,8 @@ mod tests {
             }];
             assert_eq!(
                 x86_reg_downstream_liveness(X86Register::RAX, &suffix),
-                DownstreamRegLiveness::Uncertain,
-                "{partial} preserves part of RAX"
+                DownstreamRegLiveness::Read,
+                "{partial} reads the old RAX bits that its partial write preserves"
             );
         }
     }


### PR DESCRIPTION
## Summary

- represent native, dword, word, low-byte, and legacy high-byte GPR views in the x86 IR
- model partial writes and x86-64 dword zero-extension in concrete execution, SMT, liveness, costing, assembly, and search
- retain Capstone aliases end to end, enforce REX/high-byte constraints, and document the design in ADR-0010

## Validation

- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --all` (1,636 executable tests passed; 1 doctest ignored)
- `./ci_check.sh` (including cross-architecture fixture builds and `test_all.sh`)

Closes #75

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**