### PR TITLE
refactor(x86): consolidate x86-32 R8–R15 register legality behind a single seam

### DIFF
--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -276,6 +276,19 @@ impl X86Register {
             _ => return None,
         })
     }
+
+    /// True when this GPR can be named as an operand while assembling in
+    /// `mode`. The extended registers R8..R15 require a REX prefix that does
+    /// not exist in 32-bit mode, so only the eight legacy GPRs are addressable
+    /// there; all sixteen are addressable in 64-bit mode. This is the single
+    /// source of truth for the x86-32 register-legality constraint that the
+    /// assembler prefilter and the search backends' register pools share.
+    pub fn is_available_in(self, mode: crate::assembler::x86::X86Mode) -> bool {
+        match mode {
+            crate::assembler::x86::X86Mode::Mode64 => true,
+            crate::assembler::x86::X86Mode::Mode32 => self.index().is_some_and(|i| i < 8),
+        }
+    }
 }
 
 impl fmt::Display for X86Register {
@@ -1136,10 +1149,10 @@ impl crate::isa::traits::Assembler<X86Instruction> for X86_32 {
 
     fn can_assemble(&self, instruction: &X86Instruction) -> bool {
         // In 32-bit mode, R8..R15 are illegal. The x86 assembler's reg_index_32
-        // rejects them; reproduce the same check here so trait dispatch can
-        // pre-filter sequences before invoking the heavier assemble path.
+        // rejects them; `is_available_in` is the shared source of truth so this
+        // prefilter cannot drift from the search backends' register pools.
         fn reg_ok_32(r: X86Register) -> bool {
-            r.index().is_some_and(|i| i < 8)
+            r.is_available_in(crate::assembler::x86::X86Mode::Mode32)
         }
         match instruction {
             X86Instruction::MovReg { rd, rs }
@@ -1248,10 +1261,7 @@ impl X86Mutator {
     ) -> Self {
         let registers = registers
             .into_iter()
-            .filter(|r| {
-                mode != crate::assembler::x86::X86Mode::Mode32
-                    || matches!(r.index(), Some(i) if i < 8)
-            })
+            .filter(|r| r.is_available_in(mode))
             .collect();
         let mov_immediates = immediates
             .iter()
@@ -3449,6 +3459,47 @@ mod tests {
         assert_eq!(X86Register::R13.index(), Some(13));
         assert_eq!(X86Register::R14.index(), Some(14));
         assert_eq!(X86Register::R15.index(), Some(15));
+    }
+
+    #[test]
+    fn x86_register_availability_by_mode() {
+        use crate::assembler::x86::X86Mode;
+
+        // 64-bit mode addresses all sixteen GPRs, including the extended file.
+        for r in [
+            X86Register::RAX,
+            X86Register::RDI,
+            X86Register::R8,
+            X86Register::R15,
+        ] {
+            assert!(
+                r.is_available_in(X86Mode::Mode64),
+                "{:?} must be available in 64-bit mode",
+                r
+            );
+        }
+
+        // 32-bit mode has no encoding for the extended registers R8..R15, but
+        // the eight legacy GPRs remain addressable.
+        for r in [X86Register::RAX, X86Register::RSP, X86Register::RDI] {
+            assert!(
+                r.is_available_in(X86Mode::Mode32),
+                "{:?} must be available in 32-bit mode",
+                r
+            );
+        }
+        for r in [
+            X86Register::R8,
+            X86Register::R9,
+            X86Register::R12,
+            X86Register::R15,
+        ] {
+            assert!(
+                !r.is_available_in(X86Mode::Mode32),
+                "{:?} must be unavailable in 32-bit mode",
+                r
+            );
+        }
     }
 
     #[test]

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -199,7 +199,7 @@ impl EnumerativeBackend<crate::isa::X86_32> for crate::isa::X86_32 {
             .x86_available_registers
             .iter()
             .copied()
-            .filter(|r| matches!(r.index(), Some(i) if i < 8))
+            .filter(|r| r.is_available_in(crate::assembler::x86::X86Mode::Mode32))
             .collect()
     }
 

--- a/src/search/stochastic/backend.rs
+++ b/src/search/stochastic/backend.rs
@@ -270,9 +270,7 @@ fn x86_random_sequence<R: RngExt>(
     let regs: Vec<_> = regs
         .iter()
         .copied()
-        .filter(|r| {
-            mode != crate::assembler::x86::X86Mode::Mode32 || matches!(r.index(), Some(i) if i < 8)
-        })
+        .filter(|r| r.is_available_in(mode))
         .collect();
     if regs.is_empty() {
         return Vec::new();

--- a/src/search/symbolic/backend.rs
+++ b/src/search/symbolic/backend.rs
@@ -203,7 +203,7 @@ impl SymbolicBackend<crate::isa::X86_32> for crate::isa::X86_32 {
             .x86_available_registers
             .iter()
             .copied()
-            .filter(|r| matches!(r.index(), Some(i) if i < 8))
+            .filter(|r| r.is_available_in(crate::assembler::x86::X86Mode::Mode32))
             .collect()
     }
 


### PR DESCRIPTION
## Refactoring goal

An architecture audit (following the `improve-codebase-architecture` "deepening opportunities" lens) surfaced a shallow, duplicated invariant: **"in 32-bit mode the extended registers R8–R15 are unaddressable"** was hand-copied as a raw `index < 8` bit-twiddle across **five** independent sites:

| Site | Role |
|------|------|
| `isa/x86.rs` `reg_ok_32` (in `Assembler::can_assemble`) | assembler prefilter |
| `isa/x86.rs` `X86Mutator::new` | stochastic mutator register pool |
| `search/stochastic/backend.rs` `x86_random_sequence` | stochastic random-sequence pool |
| `search/symbolic/backend.rs` `registers_from_config` (X86_32) | symbolic search register pool |
| `search/enumerative/search.rs` `registers_from_config` (X86_32) | enumerative search register pool |

Each copy was an independent chance to drift — if x86-32 register legality ever changed, all five would have to be found and edited in lockstep.

This PR concentrates that knowledge into one deep seam, `X86Register::is_available_in(mode)`, and routes all five call sites through it. The register-legality fact now lives in exactly one place, and the call sites read as intent (`r.is_available_in(mode)`) instead of a bit-twiddle.

## Scope — deliberately narrow

Two *lookalike* predicates were intentionally **left untouched** because they encode different facts, not the R8–R15 constraint:
- `isa/x86.rs` `x86_extension_source_ok`: `index < 8 && (src_width == 16 || index < 4)` — memory-base / byte-register width rule.
- `Setcc` legality: `index < 4` — the AH..BH low-byte constraint (no REX in 32-bit mode).

## TDD

Built test-first (red → green):

1. **Red** — added `x86_register_availability_by_mode`, which asserts the ISA fact against *named* registers (RAX/RSP/RDI available in 32-bit; R8/R9/R12/R15 unavailable in 32-bit; all available in 64-bit). It deliberately does **not** recompute `index < 8`, so it can genuinely disagree with the implementation (non-tautological). This failed to compile against the missing method.
2. **Green** — implemented `is_available_in`; the new test passes.
3. **Refactor** — rewired the five sites; behaviour preserved.

## Validation

Ran the full local `ci_check.sh` equivalent synchronously:

- `cargo fmt -- --check` ✓
- `cargo build` ✓
- `build_tests.sh` (AArch64 + x86-64 + x86-32 binaries) ✓
- `cargo test` — **1497 lib unit tests + 47 integration tests, 0 failed** ✓ (includes the existing Mode32 filter/parity tests that pin the behaviour this refactor preserves)
- `test_all.sh` (AArch64 disasm smoke suite) ✓