### PR TITLE
feat(auto): exclude windows with interior direct branch targets

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1113,7 +1113,15 @@ fn find_candidate_windows_with_backend<B: ElfOptimizationBackend>(
     patcher: &ElfPatcher,
 ) -> Result<Vec<SectionCandidateWindows>, Box<dyn std::error::Error>> {
     let cs = backend.disassembler()?;
-    let mut section_results = Vec::new();
+
+    // Phase 1: disassemble every executable section once, fail closed on any
+    // partial decode, and accumulate every direct branch/call target across the
+    // whole binary into one set. The set must be global and complete before any
+    // window is built: a branch (backward, or in another section) can name an
+    // address inside a run we have not yet seen, so a single forward pass cannot
+    // know all targets in time to split correctly (ADR-0009 Decision 4/5).
+    let mut decoded_sections = Vec::new();
+    let mut branch_targets = std::collections::HashSet::new();
 
     for section in patcher.get_text_sections()? {
         let section_end = section
@@ -1163,6 +1171,35 @@ fn find_candidate_windows_with_backend<B: ElfOptimizationBackend>(
         )
         .map_err(|error| format!("executable section '{}': {}", section.name, error))?;
 
+        for instruction in instructions.iter() {
+            let detail = cs.insn_detail(instruction).map_err(|error| {
+                format!(
+                    "failed to inspect instruction detail in executable section '{}' at 0x{:x}: {}",
+                    section.name,
+                    instruction.address(),
+                    error
+                )
+            })?;
+            branch_targets.extend(capstone_detail_direct_branch_targets(&detail));
+        }
+
+        decoded_sections.push((section, instructions));
+    }
+
+    // Phase 2: build maximal supported straight-line runs, splitting a run
+    // whenever an instruction other than the run's first sits at a collected
+    // branch target. In-place patching pins the window *end* but moves interior
+    // instruction addresses, so a target inside a rewritten window would be
+    // jumped into mid-instruction; a window may *begin* at a target (that
+    // address is fixed) but must not contain one past its first instruction.
+    //
+    // Splitting on instruction boundaries is sound for direct branches: linear
+    // disassembly always places a direct target on an instruction start, so a
+    // collected target that lands inside a run coincides with a boundary in
+    // that run. Mid-instruction, overlapping, and indirect targets are out of
+    // scope and are issue #619's soundness gate.
+    let mut section_results = Vec::new();
+    for (section, instructions) in decoded_sections {
         let mut candidates = Vec::new();
         let mut run_start = None;
         let mut run_end = section.virtual_addr;
@@ -1181,6 +1218,17 @@ fn find_candidate_windows_with_backend<B: ElfOptimizationBackend>(
                         instruction.address()
                     )
                 })?;
+
+            // Close the current run just before an interior branch target so
+            // the target begins a fresh window. Within a contiguous run
+            // `run_end` already equals this instruction's address, so the
+            // flushed window ends exactly where the target starts.
+            if run_start.is_some_and(|start| start != instruction.address())
+                && branch_targets.contains(&instruction.address())
+            {
+                flush_candidate_run(&mut candidates, &mut run_start, run_end);
+            }
+
             let detail = cs.insn_detail(instruction).map_err(|error| {
                 format!(
                     "failed to inspect instruction detail in executable section '{}' at 0x{:x}: {}",
@@ -1245,6 +1293,47 @@ fn capstone_detail_has_rip_relative_memory(detail: &capstone::InsnDetail<'_>) ->
             capstone::arch::x86::X86OperandType::Mem(memory) if memory.base() == rip
         )
     })
+}
+
+/// Absolute target addresses named by a *direct* branch or call instruction, or
+/// an empty vector for non-branch instructions and indirect control transfers.
+///
+/// Capstone resolves a direct (PC-relative or absolute-immediate) branch/call
+/// target to an absolute address in an immediate operand, so the driver
+/// recovers the whole in-binary direct-target set by a linear scan
+/// (ADR-0009 Decision 4/5). Indirect control flow — register/memory jumps,
+/// jump tables, PLT stubs, computed gotos — carries no immediate here and is
+/// deliberately invisible; it is the separate soundness gate in issue #619.
+///
+/// Every immediate on a jump/call instruction is collected. On x86 the sole
+/// immediate is the target; on AArch64 `tbz`/`tbnz` also expose a small
+/// bit-position immediate, which is harmlessly over-collected: an extra target
+/// can only cause an extra window split, never an unsound admit, and a 0..=63
+/// bit index never coincides with a real in-section code address.
+#[cfg_attr(not(test), allow(dead_code))]
+fn capstone_detail_direct_branch_targets(detail: &capstone::InsnDetail<'_>) -> Vec<u64> {
+    let jump =
+        capstone::InsnGroupId(capstone::InsnGroupType::CS_GRP_JUMP as capstone::InsnGroupIdInt);
+    let groups = detail.groups();
+    if !groups.contains(&jump) && !capstone_detail_is_call(detail) {
+        return Vec::new();
+    }
+    detail
+        .arch_detail()
+        .operands()
+        .into_iter()
+        .filter_map(|operand| match operand {
+            capstone::arch::ArchOperand::X86Operand(op) => match op.op_type {
+                capstone::arch::x86::X86OperandType::Imm(value) => Some(value as u64),
+                _ => None,
+            },
+            capstone::arch::ArchOperand::Arm64Operand(op) => match op.op_type {
+                capstone::arch::arm64::Arm64OperandType::Imm(value) => Some(value as u64),
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect()
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
@@ -4405,6 +4494,184 @@ mod cli_helper_tests {
         assert_eq!(sections[0].candidates[0].end, 0x1004);
         assert_eq!(sections[0].candidates[1].start, 0x100b);
         assert_eq!(sections[0].candidates[1].end, 0x100f);
+    }
+
+    #[test]
+    fn direct_branch_targets_extract_absolute_x86_targets_and_skip_indirect() {
+        let cs = x86_64_test_capstone();
+
+        // je 0x1006: 74 04 at 0x1000 (next_ip 0x1002 + rel8 0x04). Capstone must
+        // hand back the *absolute* target, not the relative displacement.
+        let je = cs
+            .disasm_all(&[0x74, 0x04], 0x1000)
+            .expect("je should disassemble");
+        let detail = cs
+            .insn_detail(je.iter().next().expect("one je"))
+            .expect("je detail should be available");
+        assert_eq!(capstone_detail_direct_branch_targets(&detail), vec![0x1006]);
+
+        // call 0x1005: e8 00 00 00 00 at 0x1000 (next_ip 0x1005 + rel32 0).
+        let call = cs
+            .disasm_all(&[0xe8, 0x00, 0x00, 0x00, 0x00], 0x1000)
+            .expect("call should disassemble");
+        let detail = cs
+            .insn_detail(call.iter().next().expect("one call"))
+            .expect("call detail should be available");
+        assert_eq!(capstone_detail_direct_branch_targets(&detail), vec![0x1005]);
+
+        // jmp rax: ff e0 — an indirect branch carries no immediate target here
+        // (that is issue #619's territory, not this slice's).
+        let indirect = cs
+            .disasm_all(&[0xff, 0xe0], 0x1000)
+            .expect("jmp rax should disassemble");
+        let detail = cs
+            .insn_detail(indirect.iter().next().expect("one jmp rax"))
+            .expect("jmp rax detail should be available");
+        assert!(
+            capstone_detail_direct_branch_targets(&detail).is_empty(),
+            "indirect branches expose no direct target"
+        );
+
+        // add rax, 1: 48 83 c0 01 — the group filter must reject a plain
+        // arithmetic immediate so ordinary constants never become targets.
+        let add = cs
+            .disasm_all(&[0x48, 0x83, 0xc0, 0x01], 0x1000)
+            .expect("add should disassemble");
+        let detail = cs
+            .insn_detail(add.iter().next().expect("one add"))
+            .expect("add detail should be available");
+        assert!(
+            capstone_detail_direct_branch_targets(&detail).is_empty(),
+            "non-branch immediate operands must not be collected as targets"
+        );
+    }
+
+    #[test]
+    fn direct_branch_targets_extract_absolute_aarch64_targets() {
+        let cs = aarch64_test_capstone();
+        // cbz x0, 0x1000 assembled at 0x1004 resolves to the absolute 0x1000.
+        let bytes = assemble_aarch64_test_bytes(&[
+            Instruction::Add {
+                rd: Register::X0,
+                rn: Register::X0,
+                rm: Operand::Immediate(1),
+            },
+            Instruction::Cbz {
+                rn: Register::X0,
+                target: s11::ir::LabelId(0x1000),
+            },
+        ]);
+        let disassembly = cs
+            .disasm_all(&bytes, 0x1000)
+            .expect("fixture should disassemble");
+        let cbz = disassembly.get(1).expect("fixture should contain CBZ");
+        let detail = cs.insn_detail(cbz).expect("CBZ detail should be available");
+        assert_eq!(
+            capstone_detail_direct_branch_targets(&detail),
+            vec![0x1000],
+            "the register operand is skipped and the branch target resolves absolute"
+        );
+    }
+
+    #[test]
+    fn candidate_windows_split_at_interior_direct_branch_target() {
+        // add rax,1 (0x1000); add rax,1 (0x1004); add rax,1 (0x1008);
+        // jne 0x1004 (0x100c). Without the target split this is one window
+        // [0x1000,0x100e) whose interior contains the branch target 0x1004;
+        // the reorder-safe rule must split it at that boundary.
+        let text = [
+            0x48, 0x83, 0xc0, 0x01, // add rax, 1   @0x1000
+            0x48, 0x83, 0xc0, 0x01, // add rax, 1   @0x1004  <- jne target
+            0x48, 0x83, 0xc0, 0x01, // add rax, 1   @0x1008
+            0x75, 0xf6, // jne 0x1004               @0x100c
+        ];
+        let elf_bytes = build_minimal_elf64(&text, 0x1000, elf::abi::EM_X86_64);
+        let input = TempFile::new_bytes("s11-candidate-interior-target", "elf", &elf_bytes);
+        let patcher = ElfPatcher::new(input.path()).expect("x86-64 ELF should parse");
+
+        let sections =
+            find_candidate_windows(&patcher).expect("candidate discovery should succeed");
+
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].candidates.len(), 2);
+        assert_eq!(sections[0].candidates[0].start, 0x1000);
+        assert_eq!(
+            sections[0].candidates[0].end, 0x1004,
+            "the run must end where the interior branch target begins"
+        );
+        assert_eq!(
+            sections[0].candidates[1].start, 0x1004,
+            "the branch target begins the second window, never its interior"
+        );
+        assert_eq!(sections[0].candidates[1].end, 0x100e);
+    }
+
+    #[test]
+    fn candidate_windows_admit_window_that_begins_at_direct_branch_target() {
+        // jmp 0x1002 (0x1000); add rax,1 (0x1002); add rax,1 (0x1006). The jump
+        // target 0x1002 is fixed under rewrite, so a window may *begin* there —
+        // the run must be admitted whole, not split or refused at its start.
+        let text = [
+            0xeb, 0x00, // jmp 0x1002               @0x1000  (target 0x1002)
+            0x48, 0x83, 0xc0, 0x01, // add rax, 1   @0x1002  <- window start == target
+            0x48, 0x83, 0xc0, 0x01, // add rax, 1   @0x1006
+        ];
+        let elf_bytes = build_minimal_elf64(&text, 0x1000, elf::abi::EM_X86_64);
+        let input = TempFile::new_bytes("s11-candidate-start-target", "elf", &elf_bytes);
+        let patcher = ElfPatcher::new(input.path()).expect("x86-64 ELF should parse");
+
+        let sections =
+            find_candidate_windows(&patcher).expect("candidate discovery should succeed");
+
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].candidates.len(), 1);
+        assert_eq!(
+            sections[0].candidates[0].start, 0x1002,
+            "a window may begin exactly at a direct branch target"
+        );
+        assert_eq!(sections[0].candidates[0].end, 0x100a);
+    }
+
+    #[test]
+    fn candidate_windows_split_at_interior_direct_branch_target_aarch64() {
+        // Cross-arch coverage of the arm64 target-extraction path: a backward
+        // cbz whose target lands inside a straight-line run must split it.
+        let bytes = assemble_aarch64_test_bytes(&[
+            Instruction::Add {
+                rd: Register::X0,
+                rn: Register::X0,
+                rm: Operand::Immediate(1),
+            }, // 0x1000
+            Instruction::Add {
+                rd: Register::X0,
+                rn: Register::X0,
+                rm: Operand::Immediate(1),
+            }, // 0x1004  <- cbz target
+            Instruction::Add {
+                rd: Register::X0,
+                rn: Register::X0,
+                rm: Operand::Immediate(1),
+            }, // 0x1008
+            Instruction::Cbz {
+                rn: Register::X0,
+                target: s11::ir::LabelId(0x1004),
+            }, // 0x100c
+        ]);
+        let elf_bytes = build_minimal_elf64(&bytes, 0x1000, elf::abi::EM_AARCH64);
+        let input = TempFile::new_bytes("s11-candidate-interior-target-a64", "elf", &elf_bytes);
+        let patcher = ElfPatcher::new(input.path()).expect("AArch64 ELF should parse");
+
+        let sections =
+            find_candidate_windows(&patcher).expect("candidate discovery should succeed");
+
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].candidates.len(), 2);
+        assert_eq!(sections[0].candidates[0].start, 0x1000);
+        assert_eq!(sections[0].candidates[0].end, 0x1004);
+        assert_eq!(
+            sections[0].candidates[1].start, 0x1004,
+            "the cbz target begins the second window"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4607,6 +4607,36 @@ mod cli_helper_tests {
     }
 
     #[test]
+    fn candidate_windows_split_at_every_interior_direct_branch_target() {
+        // Two interior targets in one straight-line run must produce three
+        // windows, each beginning at a target and none holding one in its
+        // interior — the split composes across every collected target.
+        let text = [
+            0x48, 0x83, 0xc0, 0x01, // add rax, 1   @0x1000
+            0x48, 0x83, 0xc0, 0x01, // add rax, 1   @0x1004  <- jne target
+            0x48, 0x83, 0xc0, 0x01, // add rax, 1   @0x1008  <- jne target
+            0x48, 0x83, 0xc0, 0x01, // add rax, 1   @0x100c
+            0x75, 0xf2, // jne 0x1004               @0x1010
+            0x75, 0xf4, // jne 0x1008               @0x1012
+        ];
+        let elf_bytes = build_minimal_elf64(&text, 0x1000, elf::abi::EM_X86_64);
+        let input = TempFile::new_bytes("s11-candidate-two-targets", "elf", &elf_bytes);
+        let patcher = ElfPatcher::new(input.path()).expect("x86-64 ELF should parse");
+
+        let sections =
+            find_candidate_windows(&patcher).expect("candidate discovery should succeed");
+
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].candidates.len(), 3);
+        assert_eq!(sections[0].candidates[0].start, 0x1000);
+        assert_eq!(sections[0].candidates[0].end, 0x1004);
+        assert_eq!(sections[0].candidates[1].start, 0x1004);
+        assert_eq!(sections[0].candidates[1].end, 0x1008);
+        assert_eq!(sections[0].candidates[2].start, 0x1008);
+        assert_eq!(sections[0].candidates[2].end, 0x1012);
+    }
+
+    #[test]
     fn candidate_windows_admit_window_that_begins_at_direct_branch_target() {
         // jmp 0x1002 (0x1000); add rax,1 (0x1002); add rax,1 (0x1006). The jump
         // target 0x1002 is fixed under rewrite, so a window may *begin* there —

--- a/src/main.rs
+++ b/src/main.rs
@@ -1305,17 +1305,29 @@ fn capstone_detail_has_rip_relative_memory(detail: &capstone::InsnDetail<'_>) ->
 /// jump tables, PLT stubs, computed gotos — carries no immediate here and is
 /// deliberately invisible; it is the separate soundness gate in issue #619.
 ///
-/// Every immediate on a jump/call instruction is collected. On x86 the sole
-/// immediate is the target; on AArch64 `tbz`/`tbnz` also expose a small
-/// bit-position immediate, which is harmlessly over-collected: an extra target
-/// can only cause an extra window split, never an unsound admit, and a 0..=63
-/// bit index never coincides with a real in-section code address.
+/// The group filter accepts jumps, calls, and relative branches
+/// (`CS_GRP_BRANCH_RELATIVE`). The relative-branch group is load-bearing: x86
+/// `loop`/`loope`/`loopne` tag *only* as relative branches — Capstone never
+/// adds `CS_GRP_JUMP` to them (their instruction descriptor's `branch` flag is
+/// unset) — so filtering on jump/call alone would silently drop their targets
+/// and admit an unsound interior. Every immediate on such an instruction is
+/// collected. On x86 the sole immediate is the target; on AArch64 `tbz`/`tbnz`
+/// also expose a small bit-position immediate, which is harmlessly
+/// over-collected: an extra target can only cause an extra window split, never
+/// an unsound admit, and a 0..=63 bit index never coincides with a real
+/// in-section code address.
 #[cfg_attr(not(test), allow(dead_code))]
 fn capstone_detail_direct_branch_targets(detail: &capstone::InsnDetail<'_>) -> Vec<u64> {
     let jump =
         capstone::InsnGroupId(capstone::InsnGroupType::CS_GRP_JUMP as capstone::InsnGroupIdInt);
+    let branch_relative = capstone::InsnGroupId(
+        capstone::InsnGroupType::CS_GRP_BRANCH_RELATIVE as capstone::InsnGroupIdInt,
+    );
     let groups = detail.groups();
-    if !groups.contains(&jump) && !capstone_detail_is_call(detail) {
+    if !groups.contains(&jump)
+        && !groups.contains(&branch_relative)
+        && !capstone_detail_is_call(detail)
+    {
         return Vec::new();
     }
     detail
@@ -4543,6 +4555,49 @@ mod cli_helper_tests {
         assert!(
             capstone_detail_direct_branch_targets(&detail).is_empty(),
             "non-branch immediate operands must not be collected as targets"
+        );
+    }
+
+    #[test]
+    fn direct_branch_targets_include_relative_only_loop_family() {
+        // x86 `loop`/`loope`/`loopne` are tagged ONLY with CS_GRP_BRANCH_RELATIVE
+        // — Capstone never adds CS_GRP_JUMP to them — so a jump/call-only filter
+        // would drop their targets and admit an unsound interior. Each encodes a
+        // rel8 of 0xfe (-2): at 0x1000 the next IP is 0x1002, so the target is
+        // 0x1000. `jecxz` (0xe3), by contrast, does get CS_GRP_JUMP and is
+        // covered by the general path — pinned here so the two stay distinct.
+        let cs = x86_64_test_capstone();
+        for (label, opcode) in [("loop", 0xe2u8), ("loope", 0xe1), ("loopne", 0xe0)] {
+            let disasm = cs
+                .disasm_all(&[opcode, 0xfe], 0x1000)
+                .unwrap_or_else(|_| panic!("{label} should disassemble"));
+            let detail = cs
+                .insn_detail(
+                    disasm
+                        .iter()
+                        .next()
+                        .unwrap_or_else(|| panic!("one {label}")),
+                )
+                .unwrap_or_else(|_| panic!("{label} detail should be available"));
+            assert_eq!(
+                capstone_detail_direct_branch_targets(&detail),
+                vec![0x1000],
+                "{label} is a relative-only branch whose target must be collected"
+            );
+        }
+
+        // jecxz: 67 e3 fb — assert only that it is caught (it carries
+        // CS_GRP_JUMP), not its exact target; the point is the general jump path
+        // already covers it, unlike the loop family above.
+        let jecxz = cs
+            .disasm_all(&[0x67, 0xe3, 0xfb], 0x1000)
+            .expect("jecxz should disassemble");
+        let detail = cs
+            .insn_detail(jecxz.iter().next().expect("one jecxz"))
+            .expect("jecxz detail should be available");
+        assert!(
+            !capstone_detail_direct_branch_targets(&detail).is_empty(),
+            "jecxz carries CS_GRP_JUMP and its target must still be collected"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4760,6 +4760,49 @@ mod cli_helper_tests {
     }
 
     #[test]
+    fn candidate_windows_split_at_cross_section_direct_branch_target() {
+        // The global phase-1 target collection exists precisely so a branch in
+        // one executable section can split a run in another. Here `.other` at
+        // 0x2000 holds `jmp 0x1004`, which targets the interior of `.text`'s
+        // straight-line run at 0x1000 — the run must split at 0x1004 even though
+        // no branch lives in `.text` itself.
+        let text = [
+            0x48, 0x83, 0xc0, 0x01, // add rax, 1   @0x1000
+            0x48, 0x83, 0xc0, 0x01, // add rax, 1   @0x1004  <- cross-section target
+            0x48, 0x83, 0xc0, 0x01, // add rax, 1   @0x1008
+        ];
+        // jmp 0x1004 @0x2000: e9 <rel32>, next IP 0x2005, rel32 = 0x1004-0x2005
+        // = -0x1001 = 0xffffefff (little-endian ff ef ff ff).
+        let other = [0xe9, 0xff, 0xef, 0xff, 0xff];
+        let elf_bytes = build_elf64_with_executable_sections(
+            &[(".text", &text, 0x1000), (".other", &other, 0x2000)],
+            elf::abi::EM_X86_64,
+        );
+        let input = TempFile::new_bytes("s11-candidate-cross-section", "elf", &elf_bytes);
+        let patcher = ElfPatcher::new(input.path()).expect("x86-64 ELF should parse");
+
+        let sections =
+            find_candidate_windows(&patcher).expect("candidate discovery should succeed");
+
+        let text_section = sections
+            .iter()
+            .find(|s| s.section.name == ".text")
+            .expect("the .text section must be present");
+        assert_eq!(
+            text_section.candidates.len(),
+            2,
+            "the cross-section jmp target must split .text's run"
+        );
+        assert_eq!(text_section.candidates[0].start, 0x1000);
+        assert_eq!(text_section.candidates[0].end, 0x1004);
+        assert_eq!(
+            text_section.candidates[1].start, 0x1004,
+            "the cross-section target begins the second window"
+        );
+        assert_eq!(text_section.candidates[1].end, 0x100c);
+    }
+
+    #[test]
     fn candidate_windows_flush_supported_run_at_section_end() {
         let bytes = [0x48, 0x89, 0xd8]; // mov rax, rbx
         let elf_bytes = build_minimal_elf64(&bytes, 0x4000, elf::abi::EM_X86_64);


### PR DESCRIPTION
## Summary

- Implements **ADR-0009 Decision 4** on top of the #617 window-finder: no admitted candidate window may contain a **direct** branch/call target past its first instruction.
- In-place patching pins a window's *end* (NOP padding) but interior instruction addresses move when the search reorders/shortens the prefix, so a control transfer into a rewritten window's interior would land mid-instruction. A window may still *begin* at a target — that address is fixed.
- Adds `capstone_detail_direct_branch_targets`: for `CS_GRP_JUMP`/`CS_GRP_CALL` instructions it returns the immediate operand(s), which Capstone resolves to absolute addresses (x86 + AArch64). Indirect control flow carries no immediate here and stays invisible — that is #619's soundness gate.
- `find_candidate_windows_with_backend` is now two-phase: phase 1 disassembles each executable section once (fail-closed on partial decode) and accumulates the global direct-target set; phase 2 builds the runs and splits any run just before an interior target.

The set is collected globally-then-split because a backward or cross-section branch names an address inside a run a single forward pass has not yet seen. Splitting on instruction boundaries is sound for direct branches (linear disassembly always places a direct target on an instruction start); mid-instruction/overlapping/indirect targets are out of scope (#619).

Fixes #618

## Test plan

- [x] `cargo test --bin s11 candidate_windows` / `direct_branch_targets` — all passing
- [x] New: interior-split (x86-64 backward `jne`), begins-at-target admitted (x86-64), interior-split cross-arch (AArch64 `cbz`), and a helper unit test (direct→absolute target, indirect→empty, non-branch immediate→empty)
- [x] Existing target-carrying tests unchanged (`exclude_calls_and_split_both_sides`, `hold_supported_terminator_only_at_end`) and partial-decode fail-closed error wrapping preserved
- [x] `cargo fmt -- --check` clean; `RUSTFLAGS="-D warnings" cargo build` clean; `cargo clippy --all-targets` introduces no new warnings
- [x] `./ci_check.sh` — all checks passed