### PR TITLE
refactor(cli): extract testable build_equiv_report seam from run_equiv

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2919,6 +2919,104 @@ fn run_llm_opt(
     Ok(())
 }
 
+/// The presentation-and-policy outcome of an `equiv` run: the lines the CLI
+/// should print and the process exit code it should return.
+///
+/// Produced by [`build_equiv_report`] with no stdout writes and no
+/// `std::process::exit` of its own. Keeping policy (exit codes) and formatting
+/// out of `run_equiv` is what makes the not-equivalent / counterexample /
+/// unknown paths unit-testable — each previously called `std::process::exit`
+/// inline and could only be exercised by running the whole binary.
+#[derive(Debug, PartialEq, Eq)]
+struct EquivReport {
+    lines: Vec<String>,
+    exit_code: i32,
+}
+
+/// Append `state`'s live-out registers to `lines`, one `    <reg> = 0x…` entry
+/// each, sorted by register index for deterministic output. Shared by the
+/// input / output-1 / output-2 sections of a counterexample so the three
+/// previously-duplicated print loops live in one place.
+fn push_live_out_registers(
+    lines: &mut Vec<String>,
+    state: &semantics::ConcreteMachineState,
+    live_out: &LiveOut,
+) {
+    let mut regs: Vec<(Register, u64)> = state
+        .registers()
+        .iter()
+        .filter(|(reg, _)| live_out.contains_register(**reg))
+        .map(|(reg, val)| (*reg, val.as_u64()))
+        .collect();
+    regs.sort_by_key(|(reg, _)| reg.index().unwrap_or(u8::MAX));
+    for (reg, val) in regs {
+        lines.push(format!("    {} = 0x{:016x}", reg, val));
+    }
+}
+
+/// Turn an [`EquivalenceResult`] into the lines to print and the exit code to
+/// return. Pure: no I/O, no process exit. `run_equiv` prints the lines and the
+/// `equiv` CLI arm maps the code (Equivalent → 0, NotEquivalent[Fast] → 1,
+/// Unknown → 2).
+///
+/// [`EquivalenceResult`]: semantics::EquivalenceResult
+fn build_equiv_report(
+    result: &semantics::EquivalenceResult,
+    seq1: &[Instruction],
+    seq2: &[Instruction],
+    live_out: &LiveOut,
+) -> EquivReport {
+    use semantics::EquivalenceResult;
+
+    match result {
+        EquivalenceResult::Equivalent => EquivReport {
+            lines: vec!["EQUIVALENT: The two sequences are semantically equivalent.".to_string()],
+            exit_code: 0,
+        },
+        EquivalenceResult::NotEquivalent => EquivReport {
+            lines: vec![
+                "NOT EQUIVALENT: The two sequences produce different results (verified by SMT)."
+                    .to_string(),
+            ],
+            exit_code: 1,
+        },
+        EquivalenceResult::NotEquivalentFast(input_state) => {
+            // Issue #69: strip terminators before re-running on the
+            // counterexample. The B1/B2 stubs panic if a branch reaches the
+            // concrete interpreter; the equivalence layer already excluded the
+            // terminator from its comparison via the precheck.
+            let (prefix1, _) = split_terminator(seq1);
+            let (prefix2, _) = split_terminator(seq2);
+
+            let output1 = semantics::apply_sequence_concrete(input_state.clone(), prefix1);
+            let output2 = semantics::apply_sequence_concrete(input_state.clone(), prefix2);
+
+            let mut lines = vec![
+                "NOT EQUIVALENT: The two sequences produce different results.".to_string(),
+                "\nCounterexample found:".to_string(),
+                "  Input state:".to_string(),
+            ];
+            push_live_out_registers(&mut lines, input_state, live_out);
+            lines.push("  Output from sequence 1:".to_string());
+            push_live_out_registers(&mut lines, &output1, live_out);
+            lines.push("  Output from sequence 2:".to_string());
+            push_live_out_registers(&mut lines, &output2, live_out);
+
+            EquivReport {
+                lines,
+                exit_code: 1,
+            }
+        }
+        EquivalenceResult::Unknown(reason) => EquivReport {
+            lines: vec![
+                "UNKNOWN: Could not determine equivalence.".to_string(),
+                format!("  Reason: {}", reason),
+            ],
+            exit_code: 2,
+        },
+    }
+}
+
 fn run_equiv(
     file1: &Path,
     file2: &Path,
@@ -2926,8 +3024,8 @@ fn run_equiv(
     timeout: u64,
     fast_only: bool,
     verbose: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    use semantics::{EquivalenceConfig, EquivalenceResult, check_equivalence_with_config};
+) -> Result<i32, Box<dyn std::error::Error>> {
+    use semantics::{EquivalenceConfig, check_equivalence_with_config};
 
     // Parse assembly files
     if verbose {
@@ -2980,61 +3078,14 @@ fn run_equiv(
         }
     }
 
-    // Check equivalence
+    // Check equivalence, then let the pure report builder decide what to print
+    // and which exit code to surface. `main` performs the actual `process::exit`.
     let result = check_equivalence_with_config(&seq1, &seq2, &config);
-
-    match result {
-        EquivalenceResult::Equivalent => {
-            println!("EQUIVALENT: The two sequences are semantically equivalent.");
-            Ok(())
-        }
-        EquivalenceResult::NotEquivalent => {
-            println!(
-                "NOT EQUIVALENT: The two sequences produce different results (verified by SMT)."
-            );
-            std::process::exit(1);
-        }
-        EquivalenceResult::NotEquivalentFast(input_state) => {
-            println!("NOT EQUIVALENT: The two sequences produce different results.");
-            println!("\nCounterexample found:");
-
-            // Issue #69: strip terminators before re-running on the counterexample.
-            // The B1/B2 stubs panic if a branch reaches the concrete interpreter;
-            // the equivalence layer already excluded the terminator from its
-            // comparison via the precheck.
-            let (prefix1, _) = split_terminator(&seq1);
-            let (prefix2, _) = split_terminator(&seq2);
-
-            // Run both sequences on the counterexample input
-            let output1 = semantics::apply_sequence_concrete(input_state.clone(), prefix1);
-            let output2 = semantics::apply_sequence_concrete(input_state.clone(), prefix2);
-
-            println!("  Input state:");
-            for (reg, val) in input_state.registers() {
-                if config.live_out.contains_register(*reg) {
-                    println!("    {} = 0x{:016x}", reg, val.as_u64());
-                }
-            }
-            println!("  Output from sequence 1:");
-            for (reg, val) in output1.registers() {
-                if config.live_out.contains_register(*reg) {
-                    println!("    {} = 0x{:016x}", reg, val.as_u64());
-                }
-            }
-            println!("  Output from sequence 2:");
-            for (reg, val) in output2.registers() {
-                if config.live_out.contains_register(*reg) {
-                    println!("    {} = 0x{:016x}", reg, val.as_u64());
-                }
-            }
-            std::process::exit(1);
-        }
-        EquivalenceResult::Unknown(reason) => {
-            println!("UNKNOWN: Could not determine equivalence.");
-            println!("  Reason: {}", reason);
-            std::process::exit(2);
-        }
+    let report = build_equiv_report(&result, &seq1, &seq2, &config.live_out);
+    for line in &report.lines {
+        println!("{}", line);
     }
+    Ok(report.exit_code)
 }
 
 // --- Main Function ---
@@ -3167,7 +3218,11 @@ fn main() {
             fast_only,
             verbose,
         } => match run_equiv(&file1, &file2, &live_out, timeout, fast_only, verbose) {
-            Ok(()) => {}
+            Ok(code) => {
+                if code != 0 {
+                    std::process::exit(code);
+                }
+            }
             Err(e) => {
                 eprintln!("Error: {}", e);
                 std::process::exit(1);
@@ -6261,10 +6316,120 @@ mod cli_helper_tests {
     fn run_equiv_and_llm_opt_accept_equivalent_tiny_files() {
         let asm1 = TempFile::new("s11-equiv-a", "s", "mov x0, x1\n");
         let asm2 = TempFile::new("s11-equiv-b", "s", "mov x0, x1\n");
-        run_equiv(asm1.path(), asm2.path(), "x0", 1, true, true).unwrap();
+        assert_eq!(
+            run_equiv(asm1.path(), asm2.path(), "x0", 1, true, true).unwrap(),
+            0,
+            "equivalent sequences must map to exit code 0"
+        );
 
         let llm_asm = TempFile::new("s11-llm", "s", "mov x0, x1\n");
         run_llm_opt(llm_asm.path(), "x0", 0, "test-model", 0, true).unwrap();
+    }
+
+    // ===== `equiv` report builder (extracted seam) =====
+    //
+    // Before this refactor these outcomes were only reachable through the CLI:
+    // the NotEquivalent/NotEquivalentFast/Unknown arms of `run_equiv` called
+    // `std::process::exit` inline, so no test could observe their formatting or
+    // exit codes. `build_equiv_report` is the pure seam that made them testable.
+
+    #[test]
+    fn equiv_report_equivalent_maps_to_exit_zero() {
+        let report = build_equiv_report(
+            &semantics::EquivalenceResult::Equivalent,
+            &[],
+            &[],
+            &LiveOut::from_registers(vec![]),
+        );
+        assert_eq!(report.exit_code, 0);
+        assert_eq!(
+            report.lines,
+            vec!["EQUIVALENT: The two sequences are semantically equivalent.".to_string()]
+        );
+    }
+
+    #[test]
+    fn equiv_report_not_equivalent_smt_maps_to_exit_one() {
+        let report = build_equiv_report(
+            &semantics::EquivalenceResult::NotEquivalent,
+            &[],
+            &[],
+            &LiveOut::from_registers(vec![]),
+        );
+        assert_eq!(report.exit_code, 1);
+        assert_eq!(
+            report.lines,
+            vec![
+                "NOT EQUIVALENT: The two sequences produce different results (verified by SMT)."
+                    .to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn equiv_report_unknown_maps_to_exit_two_with_reason() {
+        let report = build_equiv_report(
+            &semantics::EquivalenceResult::Unknown("solver timeout".to_string()),
+            &[],
+            &[],
+            &LiveOut::from_registers(vec![]),
+        );
+        assert_eq!(report.exit_code, 2);
+        assert_eq!(
+            report.lines,
+            vec![
+                "UNKNOWN: Could not determine equivalence.".to_string(),
+                "  Reason: solver timeout".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn equiv_report_counterexample_reruns_sequences_and_formats_live_registers() {
+        // seq1 computes x0 = x1 + 1; seq2 computes x0 = x1 + 2. With x1 = 5 in
+        // the counterexample input the two diverge on x0 (6 vs 7). The expected
+        // hex values below are worked out by hand, independent of the concrete
+        // interpreter the builder calls — so the assertion can actually disagree
+        // with the code.
+        let seq1 = vec![Instruction::Add {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Immediate(1),
+        }];
+        let seq2 = vec![Instruction::Add {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Immediate(2),
+        }];
+
+        let mut input = semantics::ConcreteMachineState::new_zeroed();
+        input.set_register(Register::X1, semantics::ConcreteValue::new(5));
+        let live_out = LiveOut::from_registers(vec![Register::X0, Register::X1]);
+
+        let report = build_equiv_report(
+            &semantics::EquivalenceResult::NotEquivalentFast(input),
+            &seq1,
+            &seq2,
+            &live_out,
+        );
+
+        assert_eq!(report.exit_code, 1);
+        assert_eq!(
+            report.lines,
+            vec![
+                "NOT EQUIVALENT: The two sequences produce different results.".to_string(),
+                "\nCounterexample found:".to_string(),
+                "  Input state:".to_string(),
+                "    x0 = 0x0000000000000000".to_string(),
+                "    x1 = 0x0000000000000005".to_string(),
+                "  Output from sequence 1:".to_string(),
+                "    x0 = 0x0000000000000006".to_string(),
+                "    x1 = 0x0000000000000005".to_string(),
+                "  Output from sequence 2:".to_string(),
+                "    x0 = 0x0000000000000007".to_string(),
+                "    x1 = 0x0000000000000005".to_string(),
+            ]
+        );
     }
 
     // ===== Issue #69: validate_basic_block =====

--- a/tests/integration/equiv_test.rs
+++ b/tests/integration/equiv_test.rs
@@ -87,6 +87,31 @@ fn equiv_memory_window_without_fast_only_does_not_warn() {
 }
 
 #[test]
+fn equiv_non_equivalent_exits_nonzero_and_prints_counterexample() {
+    // `mov x0, x1` vs `mov x0, x2` diverge on the live-out register x0 whenever
+    // x1 != x2, so the fast path returns a counterexample. This pins the CLI
+    // exit-code contract end-to-end: `main` must surface the report's non-zero
+    // code (previously an inline `std::process::exit(1)` inside `run_equiv`).
+    let output = run_equiv_fast_only("mov x0, x1\n", "mov x0, x2\n");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "non-equivalent sequences must exit with code 1, status: {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        stdout,
+        stderr
+    );
+    assert!(
+        stdout.contains("NOT EQUIVALENT") && stdout.contains("Counterexample found:"),
+        "stdout should report the counterexample, stdout:\n{}",
+        stdout
+    );
+}
+
+#[test]
 fn equiv_fast_only_register_window_does_not_warn() {
     let output = run_equiv_fast_only("mov x0, x1\n", "mov x0, x1\n");
 


### PR DESCRIPTION
## What & why

Architecture audit via the `improve-codebase-architecture` skill (deep-module lens: turn shallow modules into deep, testable ones). Two Explore passes over `main.rs` and `search`/`semantics` surfaced several candidates. This PR implements the one that is genuinely **TDD-shaped** (real red→green with *new* coverage), bounded, and deterministic to verify in one pass.

**Honest scoping note:** the highest *raw*-impact candidate was splitting the whole-binary optimization driver (`optimize_elf_binary_with_backend`) into "compute patched window bytes" vs. "narrate + write file". That was set aside for this change because its tests must run a real search (slow, nondeterministic) and it touches the core driver — a poor fit for a single, fully-verified refactoring. The x86-64/x86-32 backend duplication in the enumerative/symbolic paths is a good follow-up but is a green→green dedup, not TDD.

### The friction fixed

`run_equiv` (the `s11 equiv` subcommand) interleaved **report formatting** with **exit-code policy**: the `NotEquivalent`, `NotEquivalentFast` (counterexample), and `Unknown` arms each called `std::process::exit(...)` inline. Consequences:

- Three of the four result arms — including the counterexample **re-execution** and register formatting — were unreachable by any test (calling them would kill the test process).
- The counterexample printed three near-identical register loops iterating a `HashMap` (nondeterministic order).

### The deepening

Extract a pure, small-interface function:

```rust
fn build_equiv_report(result, seq1, seq2, live_out) -> EquivReport   // { lines, exit_code }
```

No stdout, no `process::exit`. `run_equiv` now returns the exit code and prints the lines; `main` performs the single `process::exit`. This matches the existing in-repo precedent `resolve_opt_target` ("extracted so it is exercised by table tests rather than only through this CLI arm"). A shared `push_live_out_registers` helper collapses the three duplicated loops into one and sorts by register index for deterministic output.

**Exit-code contract preserved:** Equivalent → 0, NotEquivalent / NotEquivalentFast → 1, Unknown → 2, parse errors → 1 (via `main`).

## Tests (written first — red before green)

The new seam did not exist, so the tests failed to compile first (confirmed 4× "cannot find function `build_equiv_report`"); implementing the builder turned them green.

- `equiv_report_equivalent_maps_to_exit_zero`
- `equiv_report_not_equivalent_smt_maps_to_exit_one`
- `equiv_report_unknown_maps_to_exit_two_with_reason`
- `equiv_report_counterexample_reruns_sequences_and_formats_live_registers` — **non-tautological**: `x0=x1+1` vs `x0=x1+2` with `x1=5`; expected `x0` values (6 vs 7) are worked out by hand, independent of the interpreter the builder calls.
- `equiv_non_equivalent_exits_nonzero_and_prints_counterexample` (integration) — runs the real `s11 equiv` binary and asserts exit code 1 + counterexample output, covering the exit-code mapping in `main` that unit tests cannot reach.

The pre-existing `run_equiv_and_llm_opt_accept_equivalent_tiny_files` now also asserts the returned exit code is 0.

## Verification

`./ci_check.sh` passes end-to-end: fmt, build, test-binary build, `cargo test` (1517 lib + 129 bin + 48 integration, 1 ignored), and `test_all.sh`. `cargo clippy` introduces no new warnings in the changed files.