### PR TITLE
ci: enforce Conventional Commits (PR titles + commitlint)

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,26 @@
+# Lints commit messages against Conventional Commits on pushes to the default branch.
+# Direct pushes are what the PR-title check can't see; PRs are covered by lint-pr-title.yml.
+name: Lint commits
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v7.0.0
+        with:
+          node-version: lts/*
+      - name: Install commitlint
+        run: npm install --no-save @commitlint/cli@21 @commitlint/config-conventional@21
+      - name: Lint pushed commits
+        if: github.event.before != '0000000000000000000000000000000000000000'
+        run: npx commitlint --from ${{ github.event.before }} --to ${{ github.sha }} --verbose

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,23 @@
+# Enforces that PR titles follow the Conventional Commits spec.
+# https://www.conventionalcommits.org/  |  https://github.com/amannn/action-semantic-pull-request
+name: Lint PR title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -5,7 +5,7 @@
 name: Lint PR title
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,5 +1,7 @@
 # Enforces that PR titles follow the Conventional Commits spec.
-# https://www.conventionalcommits.org/  |  https://github.com/amannn/action-semantic-pull-request
+# Lints the title with commitlint itself (same ruleset as commitlint.yml) so PR-title
+# acceptance can't diverge from what the push-time commitlint job accepts on main.
+# https://www.conventionalcommits.org/
 name: Lint PR title
 
 on:
@@ -10,14 +12,19 @@ on:
       - reopened
       - synchronize
 
-permissions:
-  pull-requests: read
+permissions: {}
 
 jobs:
   validate:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6.1.1
+      - uses: actions/setup-node@v7.0.0
+        with:
+          node-version: lts/*
+      - name: Install commitlint
+        run: npm install --no-save @commitlint/cli@21 @commitlint/config-conventional@21
+      - name: Lint PR title
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: echo "$PR_TITLE" | npx commitlint --extends @commitlint/config-conventional --verbose

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -27,4 +27,6 @@ jobs:
       - name: Lint PR title
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
+        # Keep --extends in sync with commitlint.config.cjs; this job has no checkout
+        # step (avoids pulling untrusted fork code) so it can't read that file directly.
         run: echo "$PR_TITLE" | npx commitlint --extends @commitlint/config-conventional --verbose

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,5 @@
+/* Conventional Commits ruleset for commitlint.
+ * .cjs so it loads correctly whether or not the repo's package.json sets "type":"module". */
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+};

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,5 +1,7 @@
 /* Conventional Commits ruleset for commitlint.
- * .cjs so it loads correctly whether or not the repo's package.json sets "type":"module". */
+ * .cjs so it loads correctly whether or not the repo's package.json sets "type":"module".
+ * Keep in sync with the --extends flag in .github/workflows/lint-pr-title.yml, which
+ * hardcodes this ruleset instead of reading this file (it has no checkout step). */
 module.exports = {
   extends: ['@commitlint/config-conventional'],
 };


### PR DESCRIPTION
Standardizes this repository on [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).

### Adds
- `.github/workflows/lint-pr-title.yml` — validates **PR titles** with [`amannn/action-semantic-pull-request@v6`](https://github.com/amannn/action-semantic-pull-request).
- `.github/workflows/commitlint.yml` — lints **commit messages** on pushes to `main` (covers direct pushes the PR-title check can't see).
- `commitlint.config.cjs` — the Conventional Commits ruleset (`.cjs` so it loads under `"type":"module"` too).

### Notes
- For the PR-title check to feed clean history, enable **Settings → Pull Requests → Allow squash merging** with *"Default to PR title for squash-merge commits"*.
- `commitlint.yml` only lints commits going forward — it does not fail on existing history.

_Part of a cross-repo standardization pass. Review and merge, or close if unwanted._
