### PR TITLE
ci: adopt semantic-release for releases

### DIFF
--- a/.github/semantic-release/prepare.sh
+++ b/.github/semantic-release/prepare.sh
@@ -10,11 +10,12 @@ TARGET="${TARGET:-x86_64-unknown-linux-gnu}"
 scripts/bump-version.sh "${VERSION}" >/dev/null
 cargo update -p s11
 
-# Fast release-time gate: fmt + unit tests. test.yml already runs the full
-# suite (incl. AArch64 integration tests) on the same push independently;
-# this catches an unformatted/broken tree before a release is cut from it.
-cargo fmt -- --check
-cargo test --lib --bins
+# Full synchronous gate before cutting a release: fmt, build, AArch64
+# integration-test binaries, and the full test suite. test.yml runs the
+# same checks independently on the same push, but release.yml has no
+# ordering dependency on it, so this is the only thing that actually
+# stops a broken tree from being tagged and published.
+./ci_check.sh
 
 cargo build --release --locked
 

--- a/.github/semantic-release/prepare.sh
+++ b/.github/semantic-release/prepare.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Invoked by semantic-release (@semantic-release/exec prepareCmd) with the next
+# version. Syncs the crate version via the repo's bump script, builds the
+# release binary, and stages the tarball + checksums for @semantic-release/github.
+set -euo pipefail
+VERSION="${1:?usage: prepare.sh <version>}"
+TAG="v${VERSION}"
+TARGET="${TARGET:-x86_64-unknown-linux-gnu}"
+
+scripts/bump-version.sh "${VERSION}" >/dev/null
+cargo update --workspace
+
+cargo build --release --locked
+
+STAGE="s11-${TAG}-${TARGET}"
+rm -rf release-upload
+mkdir -p "release-upload/${STAGE}"
+cp target/release/s11 README.md LICENSE "release-upload/${STAGE}/"
+tar -C release-upload -czf "release-upload/${STAGE}.tar.gz" "${STAGE}"
+rm -rf "release-upload/${STAGE:?}"
+( cd release-upload && sha256sum ./*.tar.gz > SHA256SUMS.txt )
+ls -la release-upload

--- a/.github/semantic-release/prepare.sh
+++ b/.github/semantic-release/prepare.sh
@@ -8,7 +8,7 @@ TAG="v${VERSION}"
 TARGET="${TARGET:-x86_64-unknown-linux-gnu}"
 
 scripts/bump-version.sh "${VERSION}" >/dev/null
-cargo update --workspace
+cargo update -p s11
 
 cargo build --release --locked
 

--- a/.github/semantic-release/prepare.sh
+++ b/.github/semantic-release/prepare.sh
@@ -10,6 +10,12 @@ TARGET="${TARGET:-x86_64-unknown-linux-gnu}"
 scripts/bump-version.sh "${VERSION}" >/dev/null
 cargo update -p s11
 
+# Fast release-time gate: fmt + unit tests. test.yml already runs the full
+# suite (incl. AArch64 integration tests) on the same push independently;
+# this catches an unformatted/broken tree before a release is cut from it.
+cargo fmt -- --check
+cargo test --lib --bins
+
 cargo build --release --locked
 
 STAGE="s11-${TAG}-${TARGET}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            libcapstone-dev z3 libz3-dev
+            libcapstone-dev gcc-aarch64-linux-gnu z3 libz3-dev
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh \
+            | sudo bash -s -- --to /usr/local/bin
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
   TARGET: x86_64-unknown-linux-gnu
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            libcapstone-dev gcc-aarch64-linux-gnu z3 libz3-dev
-          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh \
-            | sudo bash -s -- --to /usr/local/bin
+            libcapstone-dev z3 libz3-dev
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,32 +1,13 @@
 name: Release
 
+# Releases are cut by semantic-release: on every push to main it derives the
+# next version from Conventional Commit types, builds the Linux `s11` binary,
+# and publishes a GitHub Release (notes + CHANGELOG + tarball + checksums).
+# Replaces the previous manual workflow_dispatch pipeline.
 on:
-  workflow_dispatch:
-    inputs:
-      bump:
-        description: 'Semver bump (ignored if explicit `version` is set)'
-        type: choice
-        required: true
-        default: patch
-        options:
-          - patch
-          - minor
-          - major
-      version:
-        description: 'Explicit version (e.g. 1.2.3). Overrides `bump` if set.'
-        type: string
-        required: false
-        default: ''
-      draft:
-        description: 'Publish release as draft'
-        type: boolean
-        required: false
-        default: false
-      prerelease:
-        description: 'Mark release as pre-release'
-        type: boolean
-        required: false
-        default: false
+  push:
+    branches: [main]
+  workflow_dispatch: {}
 
 concurrency:
   group: release
@@ -34,31 +15,23 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write
+  pull-requests: write
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: "-D warnings"
   TARGET: x86_64-unknown-linux-gnu
 
 jobs:
   release:
-    name: Bump version and build Linux artifacts
+    name: semantic-release
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
-      - name: Checkout (full history for tagging)
-        uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Validate branch
-        run: |
-          if [ "${GITHUB_REF_NAME}" != "main" ]; then
-            echo "Release must be run from 'main' (got ${GITHUB_REF_NAME})." >&2
-            exit 1
-          fi
-
+          persist-credentials: false
       - name: Install system build deps
         run: |
           sudo apt-get update
@@ -66,109 +39,19 @@ jobs:
             libcapstone-dev gcc-aarch64-linux-gnu z3 libz3-dev
           curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh \
             | sudo bash -s -- --to /usr/local/bin
-
-      - name: Setup Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --profile minimal --default-toolchain stable --component rustfmt
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
-      - name: Configure git author
-        run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-
-      - name: Bump version
-        id: bump
-        env:
-          BUMP: ${{ inputs.bump }}
-          VERSION: ${{ inputs.version }}
-        run: |
-          set -euo pipefail
-          if [ -n "$VERSION" ]; then
-            NEW_VERSION="$(scripts/bump-version.sh "$VERSION")"
-          else
-            NEW_VERSION="$(scripts/bump-version.sh "$BUMP")"
-          fi
-          echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "tag=v${NEW_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Bumped to v${NEW_VERSION}"
-
-      - name: Verify tree (fmt + build + tests)
-        # ci_check.sh runs: cargo fmt --check, debug build, build_tests.sh,
-        # cargo test, and test_all.sh. It also refreshes Cargo.lock with the
-        # bumped version so the commit below stays in sync.
-        run: ./ci_check.sh
-
-      - name: Commit + tag
-        env:
-          TAG: ${{ steps.bump.outputs.tag }}
-        run: |
-          git add Cargo.toml Cargo.lock
-          git commit -m "chore(release): ${TAG}"
-          git tag -a "${TAG}" -m "Release ${TAG}"
-
-      - name: Build release binary
-        run: cargo build --release --locked
-
-      - name: Collect release artifacts
-        id: artifacts
-        env:
-          TAG: ${{ steps.bump.outputs.tag }}
-        run: |
-          set -euo pipefail
-          STAGE="s11-${TAG}-${TARGET}"
-          mkdir -p "release-upload/${STAGE}"
-          cp target/release/s11 "release-upload/${STAGE}/"
-          cp README.md LICENSE "release-upload/${STAGE}/"
-          tar -C release-upload -czf "release-upload/${STAGE}.tar.gz" "${STAGE}"
-          rm -rf "release-upload/${STAGE}"
-          (cd release-upload && sha256sum ./* > SHA256SUMS.txt)
-          ls -la release-upload
-
-      - name: Push version bump + tag
-        env:
-          TAG: ${{ steps.bump.outputs.tag }}
-        run: |
-          git push origin "HEAD:${GITHUB_REF_NAME}"
-          git push origin "${TAG}"
-
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.bump.outputs.tag }}
-          DRAFT: ${{ inputs.draft }}
-          PRERELEASE: ${{ inputs.prerelease }}
-        run: |
-          set -euo pipefail
-          args=(--generate-notes --title "${TAG}")
-          if [ "$DRAFT" = "true" ]; then args+=(--draft); fi
-          if [ "$PRERELEASE" = "true" ]; then args+=(--prerelease); fi
-          gh release create "${TAG}" \
-            "${args[@]}" \
-            ./release-upload/*
-
-      - name: Open next dev cycle
-        if: ${{ inputs.draft != true && inputs.prerelease != true }}
-        env:
-          VERSION: ${{ steps.bump.outputs.version }}
-        run: |
-          set -euo pipefail
-          BASE="${VERSION%%-*}"
-          IFS='.' read -r MA MI PA <<< "$BASE"
-          NEXT="${MA}.${MI}.$((PA + 1))-dev"
-          scripts/bump-version.sh "$NEXT"
-          # Sync the s11 entry in Cargo.lock to the new manifest version.
-          cargo update --workspace
-          git add Cargo.toml Cargo.lock
-          git commit -m "chore: open ${NEXT} dev cycle"
-          git push origin "HEAD:${GITHUB_REF_NAME}"
-
-      - name: Upload build artifacts (for debugging / reruns)
-        if: always()
-        uses: actions/upload-artifact@v7
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          name: linux-artifacts-${{ steps.bump.outputs.tag || 'unknown' }}
-          path: release-upload/
-          if-no-files-found: warn
-          retention-days: 14
+          components: rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-node@v7.0.0
+        with:
+          node-version: lts/*
+      - name: Run semantic-release
+        uses: cycjimmy/semantic-release-action@v6.0.0
+        with:
+          extra_plugins: |
+            @semantic-release/changelog@6
+            @semantic-release/git@10
+            @semantic-release/exec@7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,3 +54,11 @@ jobs:
             @semantic-release/exec@7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload build artifacts (for debugging / reruns)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-upload-${{ github.sha }}
+          path: release-upload/
+          if-no-files-found: warn
+          retention-days: 14

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,18 @@
+{
+  "branches": ["main"],
+  "tagFormat": "v${version}",
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    ["@semantic-release/changelog", { "changelogFile": "CHANGELOG.md" }],
+    ["@semantic-release/exec", { "prepareCmd": "bash .github/semantic-release/prepare.sh ${nextRelease.version}" }],
+    ["@semantic-release/github", { "assets": [
+      { "path": "release-upload/*.tar.gz" },
+      { "path": "release-upload/SHA256SUMS.txt" }
+    ] }],
+    ["@semantic-release/git", {
+      "assets": ["CHANGELOG.md", "Cargo.toml", "Cargo.lock"],
+      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+    }]
+  ]
+}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,48 +1,57 @@
 # Releasing s11
 
-Releases are cut by the [`Release`](../.github/workflows/release.yml) GitHub
-Actions workflow. It is **manually triggered** (`workflow_dispatch`) and must be
-run from `main`. The workflow bumps the version, verifies the tree, builds a
-Linux release binary, tags the commit, and publishes a GitHub Release with
-auto-generated notes.
+Releases are cut automatically by [semantic-release](https://semantic-release.org/),
+driven by the [`Release`](../.github/workflows/release.yml) GitHub Actions
+workflow. It runs on **every push to `main`**, derives the next version from
+[Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) types
+in the unreleased history, verifies the tree, builds a Linux release binary,
+tags the commit, and publishes a GitHub Release with generated notes and a
+`CHANGELOG.md` entry. There is no manual bump/draft/prerelease input — the
+version and whether a release happens at all are derived entirely from
+commit messages (see `.releaserc.json`).
 
 ## Cutting a release
 
-1. Make sure `main` is green and contains everything you want to ship.
-2. Go to **Actions → Release → Run workflow** (or `gh workflow run release.yml`).
-3. Choose the inputs:
-
-   | Input        | Default | Meaning                                                              |
-   | ------------ | ------- | -------------------------------------------------------------------- |
-   | `bump`       | `patch` | Semver increment: `patch`, `minor`, or `major`.                      |
-   | `version`    | `''`    | Explicit version (e.g. `1.2.3`). Overrides `bump` when set.          |
-   | `draft`      | `false` | Publish the GitHub Release as a draft.                               |
-   | `prerelease` | `false` | Mark the GitHub Release as a pre-release.                            |
-
-4. Run it. On success you get:
-   - a `chore(release): vX.Y.Z` commit and an annotated `vX.Y.Z` tag on `main`,
-   - a GitHub Release `vX.Y.Z` with generated notes and the build artifacts,
-   - a follow-up `chore: open X.Y.(Z+1)-dev dev cycle` commit (skipped for
-     draft / pre-release runs).
+1. Merge commits with Conventional Commit prefixes (`feat:`, `fix:`, `perf:`,
+   `BREAKING CHANGE:` in the footer, etc.) to `main`. Non-release-worthy
+   types (`chore:`, `docs:`, `ci:`, ...) don't trigger a release on their own.
+2. That push is all it takes — the `Release` workflow runs automatically.
+3. On success you get:
+   - a `vX.Y.Z` tag and GitHub Release with generated notes and the build
+     artifacts (`s11-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz`, `SHA256SUMS.txt`),
+   - an updated `CHANGELOG.md`,
+   - a `chore(release): X.Y.Z [skip ci]` commit (pushed back to `main` by
+     `@semantic-release/git`) containing the CHANGELOG, `Cargo.toml`, and
+     `Cargo.lock` changes. `[skip ci]` prevents this commit from re-triggering
+     the release workflow.
+4. `workflow_dispatch` is also available (Actions → Release → Run workflow)
+   as a manual retry if a release run needs to be re-triggered on the same
+   unreleased history — it takes no inputs.
 
 ## What the workflow does
 
-1. **Validate branch** — refuses to run anywhere but `main`.
-2. **Install deps** — `libcapstone-dev`, `z3` + `libz3-dev`,
+1. **Install deps** — `libcapstone-dev`, `z3` + `libz3-dev`,
    `gcc-aarch64-linux-gnu`, `just`, and a stable Rust toolchain (mirrors CI).
-3. **Bump version** — [`scripts/bump-version.sh`](../scripts/bump-version.sh)
-   rewrites the `[package]` version in `Cargo.toml`.
-4. **Verify** — runs [`ci_check.sh`](../ci_check.sh) (fmt check, build,
-   `build_tests.sh`, `cargo test`, `test_all.sh`). This also refreshes
-   `Cargo.lock` with the new version.
-5. **Commit + tag** — commits `Cargo.toml` + `Cargo.lock` and creates an
-   annotated tag.
-6. **Build + package** — `cargo build --release --locked`, then tars the
-   `s11` binary with `README.md` and `LICENSE` into
-   `s11-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz` and writes `SHA256SUMS.txt`.
-7. **Push + publish** — pushes the bump and tag, then
-   `gh release create --generate-notes` attaches the artifacts.
-8. **Open next dev cycle** — bumps to `X.Y.(Z+1)-dev` and pushes.
+2. **Run semantic-release** ([`cycjimmy/semantic-release-action`](https://github.com/cycjimmy/semantic-release-action)),
+   which runs the plugin pipeline configured in
+   [`.releaserc.json`](../.releaserc.json):
+   - `@semantic-release/commit-analyzer` + `@semantic-release/release-notes-generator`
+     determine whether a release is due and compute the next version from
+     Conventional Commits.
+   - `@semantic-release/changelog` updates `CHANGELOG.md`.
+   - `@semantic-release/exec` runs [`.github/semantic-release/prepare.sh`](../.github/semantic-release/prepare.sh),
+     which bumps `Cargo.toml`/`Cargo.lock` via
+     [`scripts/bump-version.sh`](../scripts/bump-version.sh), runs the full
+     [`ci_check.sh`](../ci_check.sh) gate (fmt check, build, `build_tests.sh`,
+     `cargo test`, `test_all.sh`) to verify the tree, then builds the release
+     binary and stages the tarball + `SHA256SUMS.txt`.
+   - `@semantic-release/github` creates the GitHub Release and attaches the
+     staged artifacts.
+   - `@semantic-release/git` commits `CHANGELOG.md`, `Cargo.toml`, and
+     `Cargo.lock` back to `main` and tags the release commit as `vX.Y.Z`.
+3. **Upload build artifacts** (`if: always()`) — uploads `release-upload/`
+   as a workflow artifact for post-mortem/rerun debugging even if a later
+   step (e.g. the git push or GitHub publish) fails.
 
 ## Artifacts and runtime dependencies
 
@@ -66,5 +75,6 @@ scripts/bump-version.sh 1.0.0-rc.1  # explicit version
 ```
 
 It prints the new version to stdout and edits only the `[package]` version line.
-Prefer the workflow for real releases so tagging, verification, and note
-generation stay consistent.
+Real releases are still driven by semantic-release (via Conventional Commits
+on `main`) so tagging, verification, and note generation stay consistent —
+use this script only for local experimentation.


### PR DESCRIPTION
Adopts [**semantic-release**](https://github.com/semantic-release/semantic-release) for versioned releases, driven by [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).

### What changes
- `.github/workflows/release.yml` — replaced with a semantic-release workflow. On every push to `main` it derives the next version from commit types and publishes a **GitHub Release + CHANGELOG.md** with the Linux `s11` binary + tarball + SHA256SUMS attached.
- `.releaserc.json` — config (`tagFormat: v${version}`; plugins commit-analyzer, release-notes-generator, changelog, exec, github, git).
- `.github/semantic-release/prepare.sh` — invoked by `@semantic-release/exec`; syncs the manifest version and runs the **existing build** to produce the artifacts.

### ⚠️ Merging this PR triggers the first release immediately
Releases now fire **automatically** on push to `main`, replacing the previous manual workflow_dispatch pipeline. Note the common semantic-release gotcha: it publishes **all unreleased history**, not just commits made after the merge. So **merging this draft itself cuts the first release** (the merge is a push to `main`), because this repo's history already contains `feat:`/`fix:` commits. With no prior tag, that first release is **v1.0.0** (leapfrogging `0.1.0` in Cargo.toml).

### Other notes
- The manifest version is kept in sync automatically (committed back by `@semantic-release/git` as `chore(release): … [skip ci]`, which also prevents a release loop).
- If `main` has branch protection that blocks pushes, allow the Actions bot to push the release commit or the `git` step fails.
- No registry publishing (crates.io / PyPI / npm) is wired — GitHub Release + CHANGELOG only.

> **Draft — review and do one real run before relying on it.** The build/artifact steps are carried over from your existing pipeline; give them a live run (e.g. a throwaway branch or manual dispatch) before merging, since merge = first release.
