### PR TITLE
test(ir): strengthen instruction contract assertions

### DIFF
--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -4736,326 +4736,618 @@ mod tests {
     }
 
     #[test]
-    fn all_instruction_variants_cover_helpers_and_display() {
-        let cases = vec![
-            Instruction::MovReg {
-                rd: Register::X0,
-                rn: Register::X1,
+    fn representative_instruction_variants_match_helper_contracts() {
+        use Register::{X0, X1, X2, X3};
+
+        struct Expectation {
+            instruction: Instruction,
+            display: &'static str,
+            destination: Option<Register>,
+            destinations: &'static [Register],
+            sources: &'static [Register],
+            modifies_flags: bool,
+            reads_flags: bool,
+            encodable: bool,
+        }
+
+        let cases = [
+            Expectation {
+                instruction: Instruction::MovReg { rd: X0, rn: X1 },
+                display: "mov x0, x1",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::MovImm {
-                rd: Register::X0,
-                imm: 1,
+            Expectation {
+                instruction: Instruction::MovImm { rd: X0, imm: 1 },
+                display: "mov x0, #1",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Add {
-                rd: Register::X0,
-                rn: Register::X1,
-                rm: Operand::Register(Register::X2),
+            Expectation {
+                instruction: Instruction::Add {
+                    rd: X0,
+                    rn: X1,
+                    rm: Operand::Register(X2),
+                },
+                display: "add x0, x1, x2",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1, X2],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Sub {
-                rd: Register::X0,
-                rn: Register::X1,
-                rm: Operand::Immediate(1),
+            Expectation {
+                instruction: Instruction::Sub {
+                    rd: X0,
+                    rn: X1,
+                    rm: Operand::Immediate(1),
+                },
+                display: "sub x0, x1, #1",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::And {
-                rd: Register::X0,
-                rn: Register::X1,
-                rm: Operand::Register(Register::X2),
-                width: crate::ir::RegisterWidth::X64,
+            Expectation {
+                instruction: Instruction::And {
+                    rd: X0,
+                    rn: X1,
+                    rm: Operand::Register(X2),
+                    width: crate::ir::RegisterWidth::X64,
+                },
+                display: "and x0, x1, x2",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1, X2],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Orr {
-                rd: Register::X0,
-                rn: Register::X1,
-                rm: Operand::Register(Register::X2),
-                width: crate::ir::RegisterWidth::X64,
+            Expectation {
+                instruction: Instruction::Orr {
+                    rd: X0,
+                    rn: X1,
+                    rm: Operand::Register(X2),
+                    width: crate::ir::RegisterWidth::X64,
+                },
+                display: "orr x0, x1, x2",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1, X2],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Eor {
-                rd: Register::X0,
-                rn: Register::X1,
-                rm: Operand::Register(Register::X2),
-                width: crate::ir::RegisterWidth::X64,
+            Expectation {
+                instruction: Instruction::Eor {
+                    rd: X0,
+                    rn: X1,
+                    rm: Operand::Register(X2),
+                    width: crate::ir::RegisterWidth::X64,
+                },
+                display: "eor x0, x1, x2",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1, X2],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Lsl {
-                rd: Register::X0,
-                rn: Register::X1,
-                shift: Operand::Register(Register::X2),
+            Expectation {
+                instruction: Instruction::Lsl {
+                    rd: X0,
+                    rn: X1,
+                    shift: Operand::Register(X2),
+                },
+                display: "lsl x0, x1, x2",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1, X2],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Lsr {
-                rd: Register::X0,
-                rn: Register::X1,
-                shift: Operand::Immediate(2),
+            Expectation {
+                instruction: Instruction::Lsr {
+                    rd: X0,
+                    rn: X1,
+                    shift: Operand::Immediate(2),
+                },
+                display: "lsr x0, x1, #2",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Asr {
-                rd: Register::X0,
-                rn: Register::X1,
-                shift: Operand::Register(Register::X2),
+            Expectation {
+                instruction: Instruction::Asr {
+                    rd: X0,
+                    rn: X1,
+                    shift: Operand::Register(X2),
+                },
+                display: "asr x0, x1, x2",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1, X2],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Mul {
-                rd: Register::X0,
-                rn: Register::X1,
-                rm: Register::X2,
+            Expectation {
+                instruction: Instruction::Mul {
+                    rd: X0,
+                    rn: X1,
+                    rm: X2,
+                },
+                display: "mul x0, x1, x2",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1, X2],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Sdiv {
-                rd: Register::X0,
-                rn: Register::X1,
-                rm: Register::X2,
+            Expectation {
+                instruction: Instruction::Sdiv {
+                    rd: X0,
+                    rn: X1,
+                    rm: X2,
+                },
+                display: "sdiv x0, x1, x2",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1, X2],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Udiv {
-                rd: Register::X0,
-                rn: Register::X1,
-                rm: Register::X2,
+            Expectation {
+                instruction: Instruction::Udiv {
+                    rd: X0,
+                    rn: X1,
+                    rm: X2,
+                },
+                display: "udiv x0, x1, x2",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1, X2],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Madd {
-                rd: Register::X0,
-                rn: Register::X1,
-                rm: Register::X2,
-                ra: Register::X3,
+            Expectation {
+                instruction: Instruction::Madd {
+                    rd: X0,
+                    rn: X1,
+                    rm: X2,
+                    ra: X3,
+                },
+                display: "madd x0, x1, x2, x3",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1, X2, X3],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Msub {
-                rd: Register::X0,
-                rn: Register::X1,
-                rm: Register::X2,
-                ra: Register::X3,
+            Expectation {
+                instruction: Instruction::Msub {
+                    rd: X0,
+                    rn: X1,
+                    rm: X2,
+                    ra: X3,
+                },
+                display: "msub x0, x1, x2, x3",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1, X2, X3],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Mneg {
-                rd: Register::X0,
-                rn: Register::X1,
-                rm: Register::X2,
+            Expectation {
+                instruction: Instruction::Mneg {
+                    rd: X0,
+                    rn: X1,
+                    rm: X2,
+                },
+                display: "mneg x0, x1, x2",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1, X2],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Smulh {
-                rd: Register::X0,
-                rn: Register::X1,
-                rm: Register::X2,
+            Expectation {
+                instruction: Instruction::Smulh {
+                    rd: X0,
+                    rn: X1,
+                    rm: X2,
+                },
+                display: "smulh x0, x1, x2",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1, X2],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Umulh {
-                rd: Register::X0,
-                rn: Register::X1,
-                rm: Register::X2,
+            Expectation {
+                instruction: Instruction::Umulh {
+                    rd: X0,
+                    rn: X1,
+                    rm: X2,
+                },
+                display: "umulh x0, x1, x2",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1, X2],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Cmp {
-                rn: Register::X1,
-                rm: Operand::Immediate(1),
+            Expectation {
+                instruction: Instruction::Cmp {
+                    rn: X1,
+                    rm: Operand::Immediate(1),
+                },
+                display: "cmp x1, #1",
+                destination: None,
+                destinations: &[],
+                sources: &[X1],
+                modifies_flags: true,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Cmn {
-                rn: Register::X1,
-                rm: Operand::Register(Register::X2),
+            Expectation {
+                instruction: Instruction::Cmn {
+                    rn: X1,
+                    rm: Operand::Register(X2),
+                },
+                display: "cmn x1, x2",
+                destination: None,
+                destinations: &[],
+                sources: &[X1, X2],
+                modifies_flags: true,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Tst {
-                rn: Register::X1,
-                rm: Operand::Register(Register::X2),
-                width: crate::ir::RegisterWidth::X64,
+            Expectation {
+                instruction: Instruction::Tst {
+                    rn: X1,
+                    rm: Operand::Register(X2),
+                    width: crate::ir::RegisterWidth::X64,
+                },
+                display: "tst x1, x2",
+                destination: None,
+                destinations: &[],
+                sources: &[X1, X2],
+                modifies_flags: true,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Csel {
-                rd: Register::X0,
-                rn: Register::X1,
-                rm: Register::X2,
-                cond: Condition::EQ,
+            Expectation {
+                instruction: Instruction::Csel {
+                    rd: X0,
+                    rn: X1,
+                    rm: X2,
+                    cond: Condition::EQ,
+                },
+                display: "csel x0, x1, x2, eq",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1, X2],
+                modifies_flags: false,
+                reads_flags: true,
+                encodable: true,
             },
-            Instruction::Csinc {
-                rd: Register::X0,
-                rn: Register::X1,
-                rm: Register::X2,
-                cond: Condition::NE,
+            Expectation {
+                instruction: Instruction::Csinc {
+                    rd: X0,
+                    rn: X1,
+                    rm: X2,
+                    cond: Condition::NE,
+                },
+                display: "csinc x0, x1, x2, ne",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1, X2],
+                modifies_flags: false,
+                reads_flags: true,
+                encodable: true,
             },
-            Instruction::Csinv {
-                rd: Register::X0,
-                rn: Register::X1,
-                rm: Register::X2,
-                cond: Condition::LT,
+            Expectation {
+                instruction: Instruction::Csinv {
+                    rd: X0,
+                    rn: X1,
+                    rm: X2,
+                    cond: Condition::LT,
+                },
+                display: "csinv x0, x1, x2, lt",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1, X2],
+                modifies_flags: false,
+                reads_flags: true,
+                encodable: true,
             },
-            Instruction::Csneg {
-                rd: Register::X0,
-                rn: Register::X1,
-                rm: Register::X2,
-                cond: Condition::GT,
+            Expectation {
+                instruction: Instruction::Csneg {
+                    rd: X0,
+                    rn: X1,
+                    rm: X2,
+                    cond: Condition::GT,
+                },
+                display: "csneg x0, x1, x2, gt",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1, X2],
+                modifies_flags: false,
+                reads_flags: true,
+                encodable: true,
             },
-            Instruction::Mvn {
-                rd: Register::X0,
-                rm: Register::X1,
+            Expectation {
+                instruction: Instruction::Mvn { rd: X0, rm: X1 },
+                display: "mvn x0, x1",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Neg {
-                rd: Register::X0,
-                rm: Register::X1,
+            Expectation {
+                instruction: Instruction::Neg { rd: X0, rm: X1 },
+                display: "neg x0, x1",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Negs {
-                rd: Register::X0,
-                rm: Register::X1,
+            Expectation {
+                instruction: Instruction::Negs { rd: X0, rm: X1 },
+                display: "negs x0, x1",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1],
+                modifies_flags: true,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::MovN {
-                rd: Register::X0,
-                imm: 1,
-                shift: 16,
+            Expectation {
+                instruction: Instruction::MovN {
+                    rd: X0,
+                    imm: 1,
+                    shift: 16,
+                },
+                display: "movn x0, #1, lsl #16",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::MovZ {
-                rd: Register::X0,
-                imm: 1,
-                shift: 32,
+            Expectation {
+                instruction: Instruction::MovZ {
+                    rd: X0,
+                    imm: 1,
+                    shift: 32,
+                },
+                display: "movz x0, #1, lsl #32",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::MovK {
-                rd: Register::X0,
-                imm: 1,
-                shift: 48,
+            Expectation {
+                instruction: Instruction::MovK {
+                    rd: X0,
+                    imm: 1,
+                    shift: 48,
+                },
+                display: "movk x0, #1, lsl #48",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X0],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Bic {
-                rd: Register::X0,
-                rn: Register::X1,
-                rm: Operand::Register(Register::X2),
+            Expectation {
+                instruction: Instruction::Bic {
+                    rd: X0,
+                    rn: X1,
+                    rm: Operand::Register(X2),
+                },
+                display: "bic x0, x1, x2",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1, X2],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Bics {
-                rd: Register::X0,
-                rn: Register::X1,
-                rm: Operand::Register(Register::X2),
+            Expectation {
+                instruction: Instruction::Bics {
+                    rd: X0,
+                    rn: X1,
+                    rm: Operand::Register(X2),
+                },
+                display: "bics x0, x1, x2",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1, X2],
+                modifies_flags: true,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Orn {
-                rd: Register::X0,
-                rn: Register::X1,
-                rm: Operand::Register(Register::X2),
+            Expectation {
+                instruction: Instruction::Orn {
+                    rd: X0,
+                    rn: X1,
+                    rm: Operand::Register(X2),
+                },
+                display: "orn x0, x1, x2",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1, X2],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Eon {
-                rd: Register::X0,
-                rn: Register::X1,
-                rm: Operand::Register(Register::X2),
+            Expectation {
+                instruction: Instruction::Eon {
+                    rd: X0,
+                    rn: X1,
+                    rm: Operand::Register(X2),
+                },
+                display: "eon x0, x1, x2",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1, X2],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Adds {
-                rd: Register::X0,
-                rn: Register::X1,
-                rm: Operand::Immediate(1),
+            Expectation {
+                instruction: Instruction::Adds {
+                    rd: X0,
+                    rn: X1,
+                    rm: Operand::Immediate(1),
+                },
+                display: "adds x0, x1, #1",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1],
+                modifies_flags: true,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Subs {
-                rd: Register::X0,
-                rn: Register::X1,
-                rm: Operand::Register(Register::X2),
+            Expectation {
+                instruction: Instruction::Subs {
+                    rd: X0,
+                    rn: X1,
+                    rm: Operand::Register(X2),
+                },
+                display: "subs x0, x1, x2",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1, X2],
+                modifies_flags: true,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Ands {
-                rd: Register::X0,
-                rn: Register::X1,
-                rm: Operand::Register(Register::X2),
-                width: crate::ir::RegisterWidth::X64,
+            Expectation {
+                instruction: Instruction::Ands {
+                    rd: X0,
+                    rn: X1,
+                    rm: Operand::Register(X2),
+                    width: crate::ir::RegisterWidth::X64,
+                },
+                display: "ands x0, x1, x2",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1, X2],
+                modifies_flags: true,
+                reads_flags: false,
+                encodable: true,
             },
-            Instruction::Cset {
-                rd: Register::X0,
-                cond: Condition::GE,
+            Expectation {
+                instruction: Instruction::Cset {
+                    rd: X0,
+                    cond: Condition::GE,
+                },
+                display: "cset x0, ge",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[],
+                modifies_flags: false,
+                reads_flags: true,
+                encodable: true,
             },
-            Instruction::Csetm {
-                rd: Register::X0,
-                cond: Condition::LE,
+            Expectation {
+                instruction: Instruction::Csetm {
+                    rd: X0,
+                    cond: Condition::LE,
+                },
+                display: "csetm x0, le",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[],
+                modifies_flags: false,
+                reads_flags: true,
+                encodable: true,
             },
-            Instruction::Ror {
-                rd: Register::X0,
-                rn: Register::X1,
-                shift: Operand::Immediate(4),
+            Expectation {
+                instruction: Instruction::Ror {
+                    rd: X0,
+                    rn: X1,
+                    shift: Operand::Immediate(4),
+                },
+                display: "ror x0, x1, #4",
+                destination: Some(X0),
+                destinations: &[X0],
+                sources: &[X1],
+                modifies_flags: false,
+                reads_flags: false,
+                encodable: true,
             },
         ];
 
-        for instr in cases {
-            let rendered = format!("{}", instr);
-            assert!(!rendered.is_empty());
-            let _ = instr.destination();
-            let _ = instr.source_registers();
-            let _ = instr.modifies_flags();
-            let _ = instr.reads_flags();
-            let _ = instr.is_encodable_aarch64();
+        for case in cases {
+            let instruction = &case.instruction;
+            let context = format!("{instruction:?}");
+            assert_eq!(instruction.to_string(), case.display, "display: {context}");
+            assert_eq!(
+                instruction.destination(),
+                case.destination,
+                "destination: {context}"
+            );
+            assert_eq!(
+                instruction.destinations(),
+                case.destinations,
+                "destinations: {context}"
+            );
+            assert_eq!(
+                instruction.source_registers(),
+                case.sources,
+                "source registers: {context}"
+            );
+            assert_eq!(
+                instruction.modifies_flags(),
+                case.modifies_flags,
+                "flag writes: {context}"
+            );
+            assert_eq!(
+                instruction.reads_flags(),
+                case.reads_flags,
+                "flag reads: {context}"
+            );
+            assert_eq!(
+                instruction.is_encodable_aarch64(),
+                case.encodable,
+                "encodability: {context}"
+            );
         }
-
-        let cmp = Instruction::Cmp {
-            rn: Register::X1,
-            rm: Operand::Immediate(1),
-        };
-        assert_eq!(cmp.to_string(), "cmp x1, #1");
-        assert_eq!(cmp.destination(), None);
-        assert_eq!(cmp.source_registers(), vec![Register::X1]);
-        assert!(cmp.modifies_flags());
-        assert!(!cmp.reads_flags());
-
-        let csel = Instruction::Csel {
-            rd: Register::X0,
-            rn: Register::X1,
-            rm: Register::X2,
-            cond: Condition::EQ,
-        };
-        assert_eq!(csel.to_string(), "csel x0, x1, x2, eq");
-        assert_eq!(csel.destination(), Some(Register::X0));
-        assert_eq!(csel.source_registers(), vec![Register::X1, Register::X2]);
-        assert!(!csel.modifies_flags());
-        assert!(csel.reads_flags());
-
-        let adds = Instruction::Adds {
-            rd: Register::X0,
-            rn: Register::X1,
-            rm: Operand::Register(Register::X2),
-        };
-        assert_eq!(adds.to_string(), "adds x0, x1, x2");
-        assert_eq!(adds.destination(), Some(Register::X0));
-        assert_eq!(adds.source_registers(), vec![Register::X1, Register::X2]);
-        assert!(adds.modifies_flags());
-        assert!(!adds.reads_flags());
-
-        let madd = Instruction::Madd {
-            rd: Register::X0,
-            rn: Register::X1,
-            rm: Register::X2,
-            ra: Register::X3,
-        };
-        assert_eq!(madd.to_string(), "madd x0, x1, x2, x3");
-        assert_eq!(madd.destination(), Some(Register::X0));
-        assert_eq!(
-            madd.source_registers(),
-            vec![Register::X1, Register::X2, Register::X3]
-        );
-        assert!(!madd.modifies_flags());
-        assert!(!madd.reads_flags());
-        assert!(madd.is_encodable_aarch64());
-
-        let msub = Instruction::Msub {
-            rd: Register::X0,
-            rn: Register::X1,
-            rm: Register::X2,
-            ra: Register::X3,
-        };
-        assert_eq!(msub.to_string(), "msub x0, x1, x2, x3");
-        assert_eq!(msub.destination(), Some(Register::X0));
-        assert_eq!(
-            msub.source_registers(),
-            vec![Register::X1, Register::X2, Register::X3]
-        );
-        assert!(!msub.modifies_flags());
-        assert!(!msub.reads_flags());
-        assert!(msub.is_encodable_aarch64());
-
-        let mneg = Instruction::Mneg {
-            rd: Register::X0,
-            rn: Register::X1,
-            rm: Register::X2,
-        };
-        assert_eq!(mneg.to_string(), "mneg x0, x1, x2");
-        assert_eq!(mneg.destination(), Some(Register::X0));
-        assert_eq!(mneg.source_registers(), vec![Register::X1, Register::X2]);
-        assert!(!mneg.modifies_flags());
-        assert!(!mneg.reads_flags());
-        assert!(mneg.is_encodable_aarch64());
-
-        let smulh = Instruction::Smulh {
-            rd: Register::X0,
-            rn: Register::X1,
-            rm: Register::X2,
-        };
-        assert_eq!(smulh.to_string(), "smulh x0, x1, x2");
-        assert_eq!(smulh.destination(), Some(Register::X0));
-        assert_eq!(smulh.source_registers(), vec![Register::X1, Register::X2]);
-        assert!(!smulh.modifies_flags());
-        assert!(!smulh.reads_flags());
-        assert!(smulh.is_encodable_aarch64());
-
-        let umulh = Instruction::Umulh {
-            rd: Register::X0,
-            rn: Register::X1,
-            rm: Register::X2,
-        };
-        assert_eq!(umulh.to_string(), "umulh x0, x1, x2");
-        assert_eq!(umulh.destination(), Some(Register::X0));
-        assert_eq!(umulh.source_registers(), vec![Register::X1, Register::X2]);
-        assert!(!umulh.modifies_flags());
-        assert!(!umulh.reads_flags());
-        assert!(umulh.is_encodable_aarch64());
     }
 
     #[test]

--- a/src/isa/aarch64.rs
+++ b/src/isa/aarch64.rs
@@ -2731,34 +2731,194 @@ mod tests {
 
     #[test]
     fn all_instruction_families_cover_trait_methods() {
+        use Register::{X0, X1, X2, X3};
+
+        struct Expectation {
+            opcode_id: u8,
+            mnemonic: &'static str,
+            display: &'static str,
+            destination: Option<Register>,
+            sources: &'static [Register],
+            has_side_effects: bool,
+        }
+
+        impl Expectation {
+            const fn new(
+                opcode_id: u8,
+                mnemonic: &'static str,
+                display: &'static str,
+                destination: Option<Register>,
+                sources: &'static [Register],
+                has_side_effects: bool,
+            ) -> Self {
+                Self {
+                    opcode_id,
+                    mnemonic,
+                    display,
+                    destination,
+                    sources,
+                    has_side_effects,
+                }
+            }
+        }
+
         let generator = AArch64InstructionGenerator;
-        let seen: BTreeSet<u8> = all_instruction_families()
+        let instructions = all_instruction_families();
+        let expected = [
+            Expectation::new(0, "mov", "mov x0, x1", Some(X0), &[X1], false),
+            Expectation::new(1, "mov", "mov x0, #7", Some(X0), &[], false),
+            Expectation::new(2, "add", "add x0, x1, x2", Some(X0), &[X1, X2], false),
+            Expectation::new(3, "sub", "sub x0, x1, #3", Some(X0), &[X1], false),
+            Expectation::new(4, "and", "and x0, x1, x2", Some(X0), &[X1, X2], false),
+            Expectation::new(5, "orr", "orr x0, x1, x2", Some(X0), &[X1, X2], false),
+            Expectation::new(6, "eor", "eor x0, x1, x2", Some(X0), &[X1, X2], false),
+            Expectation::new(7, "lsl", "lsl x0, x1, x2", Some(X0), &[X1, X2], false),
+            Expectation::new(8, "lsr", "lsr x0, x1, #4", Some(X0), &[X1], false),
+            Expectation::new(9, "asr", "asr x0, x1, x2", Some(X0), &[X1, X2], false),
+            Expectation::new(10, "mul", "mul x0, x1, x2", Some(X0), &[X1, X2], false),
+            Expectation::new(11, "sdiv", "sdiv x0, x1, x2", Some(X0), &[X1, X2], false),
+            Expectation::new(12, "udiv", "udiv x0, x1, x2", Some(X0), &[X1, X2], false),
+            Expectation::new(13, "cmp", "cmp x1, x2", None, &[X1, X2], true),
+            Expectation::new(14, "cmn", "cmn x1, #9", None, &[X1], true),
+            Expectation::new(15, "tst", "tst x1, x2", None, &[X1, X2], true),
+            Expectation::new(
+                16,
+                "csel",
+                "csel x0, x1, x2, eq",
+                Some(X0),
+                &[X1, X2],
+                false,
+            ),
+            Expectation::new(
+                17,
+                "csinc",
+                "csinc x0, x1, x2, ne",
+                Some(X0),
+                &[X1, X2],
+                false,
+            ),
+            Expectation::new(
+                18,
+                "csinv",
+                "csinv x0, x1, x2, lt",
+                Some(X0),
+                &[X1, X2],
+                false,
+            ),
+            Expectation::new(
+                19,
+                "csneg",
+                "csneg x0, x1, x2, gt",
+                Some(X0),
+                &[X1, X2],
+                false,
+            ),
+            Expectation::new(20, "mvn", "mvn x0, x1", Some(X0), &[X1], false),
+            Expectation::new(21, "neg", "neg x0, x1", Some(X0), &[X1], false),
+            Expectation::new(22, "negs", "negs x0, x1", Some(X0), &[X1], true),
+            Expectation::new(23, "movn", "movn x0, #21930, lsl #16", Some(X0), &[], false),
+            Expectation::new(34, "movz", "movz x0, #21930, lsl #32", Some(X0), &[], false),
+            Expectation::new(
+                35,
+                "movk",
+                "movk x0, #21930, lsl #48",
+                Some(X0),
+                &[X0],
+                false,
+            ),
+            Expectation::new(24, "bic", "bic x0, x1, x2", Some(X0), &[X1, X2], false),
+            Expectation::new(25, "bics", "bics x0, x1, x2", Some(X0), &[X1, X2], true),
+            Expectation::new(26, "orn", "orn x0, x1, x2", Some(X0), &[X1, X2], false),
+            Expectation::new(27, "eon", "eon x0, x1, x2", Some(X0), &[X1, X2], false),
+            Expectation::new(28, "adds", "adds x0, x1, #1", Some(X0), &[X1], true),
+            Expectation::new(29, "subs", "subs x0, x1, x2", Some(X0), &[X1, X2], true),
+            Expectation::new(30, "ands", "ands x0, x1, x2", Some(X0), &[X1, X2], true),
+            Expectation::new(31, "cset", "cset x0, ge", Some(X0), &[], false),
+            Expectation::new(32, "csetm", "csetm x0, le", Some(X0), &[], false),
+            Expectation::new(33, "ror", "ror x0, x1, #8", Some(X0), &[X1], false),
+            Expectation::new(36, "clz", "clz x0, x1", Some(X0), &[X1], false),
+            Expectation::new(37, "cls", "cls x0, x1", Some(X0), &[X1], false),
+            Expectation::new(38, "rbit", "rbit x0, x1", Some(X0), &[X1], false),
+            Expectation::new(39, "rev", "rev x0, x1", Some(X0), &[X1], false),
+            Expectation::new(40, "rev32", "rev32 x0, x1", Some(X0), &[X1], false),
+            Expectation::new(41, "rev16", "rev16 x0, x1", Some(X0), &[X1], false),
+            Expectation::new(
+                42,
+                "madd",
+                "madd x0, x1, x2, x3",
+                Some(X0),
+                &[X1, X2, X3],
+                false,
+            ),
+            Expectation::new(
+                43,
+                "msub",
+                "msub x0, x1, x2, x3",
+                Some(X0),
+                &[X1, X2, X3],
+                false,
+            ),
+            Expectation::new(44, "mneg", "mneg x0, x1, x2", Some(X0), &[X1, X2], false),
+            Expectation::new(45, "smulh", "smulh x0, x1, x2", Some(X0), &[X1, X2], false),
+            Expectation::new(46, "umulh", "umulh x0, x1, x2", Some(X0), &[X1, X2], false),
+            Expectation::new(47, "ccmp", "ccmp x1, x2, #0, eq", None, &[X1, X2], true),
+            Expectation::new(48, "ccmn", "ccmn x1, #5, #0, eq", None, &[X1], true),
+            Expectation::new(49, "sxtb", "sxtb x0, w1", Some(X0), &[X1], false),
+            Expectation::new(50, "sxth", "sxth x0, w1", Some(X0), &[X1], false),
+            Expectation::new(51, "sxtw", "sxtw x0, w1", Some(X0), &[X1], false),
+            Expectation::new(52, "uxtb", "uxtb w0, w1", Some(X0), &[X1], false),
+            Expectation::new(53, "uxth", "uxth w0, w1", Some(X0), &[X1], false),
+            Expectation::new(54, "ubfx", "ubfx x0, x1, #8, #16", Some(X0), &[X1], false),
+            Expectation::new(55, "sbfx", "sbfx x0, x1, #8, #16", Some(X0), &[X1], false),
+            Expectation::new(56, "bfi", "bfi x0, x1, #4, #8", Some(X0), &[X0, X1], false),
+            Expectation::new(
+                57,
+                "bfxil",
+                "bfxil x0, x1, #4, #8",
+                Some(X0),
+                &[X0, X1],
+                false,
+            ),
+            Expectation::new(58, "ubfiz", "ubfiz x0, x1, #4, #8", Some(X0), &[X1], false),
+            Expectation::new(59, "sbfiz", "sbfiz x0, x1, #4, #8", Some(X0), &[X1], false),
+        ];
+
+        assert_eq!(instructions.len(), expected.len());
+        assert_eq!(expected.len(), generator.opcode_count() as usize);
+
+        let seen: BTreeSet<u8> = instructions
             .iter()
-            .map(|instr| {
-                let id = instr.opcode_id();
+            .zip(expected.iter())
+            .map(|(instr, expected)| {
+                let context = format!("{instr:?}");
+                let id = InstructionType::opcode_id(instr);
                 assert!(id < generator.opcode_count());
-                assert!(!instr.mnemonic().is_empty());
-                assert!(!format!("{}", instr).is_empty());
-                let _ = instr.destination();
-                let _ = instr.source_registers();
-                let should_update_flags = matches!(
-                    instr,
-                    Instruction::Cmp { .. }
-                        | Instruction::Cmn { .. }
-                        | Instruction::Tst { .. }
-                        | Instruction::Negs { .. }
-                        | Instruction::Bics { .. }
-                        | Instruction::Adds { .. }
-                        | Instruction::Subs { .. }
-                        | Instruction::Ands { .. }
-                        | Instruction::Ccmp { .. }
-                        | Instruction::Ccmn { .. }
+                assert_eq!(id, expected.opcode_id, "opcode id: {context}");
+                assert_eq!(
+                    InstructionType::mnemonic(instr),
+                    expected.mnemonic,
+                    "mnemonic: {context}"
                 );
-                assert_eq!(instr.has_side_effects(), should_update_flags);
+                assert_eq!(instr.to_string(), expected.display, "display: {context}");
+                assert_eq!(
+                    InstructionType::destination(instr),
+                    expected.destination,
+                    "destination: {context}"
+                );
+                assert_eq!(
+                    InstructionType::source_registers(instr),
+                    expected.sources,
+                    "source registers: {context}"
+                );
+                assert_eq!(
+                    InstructionType::has_side_effects(instr),
+                    expected.has_side_effects,
+                    "side effects: {context}"
+                );
                 id
             })
             .collect();
-        assert_eq!(seen.len(), all_instruction_families().len());
+        assert_eq!(seen.len(), instructions.len());
         assert_eq!(seen.len(), generator.opcode_count() as usize);
     }
 

--- a/src/isa/riscv.rs
+++ b/src/isa/riscv.rs
@@ -1244,16 +1244,185 @@ mod tests {
 
     #[test]
     fn all_instruction_families_cover_traits_and_display() {
+        use RiscVRegister::{X1, X2, X3};
+
+        struct Expectation {
+            opcode_id: u8,
+            mnemonic: &'static str,
+            display: &'static str,
+            destination: Option<RiscVRegister>,
+            sources: &'static [RiscVRegister],
+            has_side_effects: bool,
+        }
+
+        let expected = [
+            Expectation {
+                opcode_id: 0,
+                mnemonic: "add",
+                display: "add x1, x2, x3",
+                destination: Some(X1),
+                sources: &[X2, X3],
+                has_side_effects: false,
+            },
+            Expectation {
+                opcode_id: 1,
+                mnemonic: "sub",
+                display: "sub x1, x2, x3",
+                destination: Some(X1),
+                sources: &[X2, X3],
+                has_side_effects: false,
+            },
+            Expectation {
+                opcode_id: 2,
+                mnemonic: "and",
+                display: "and x1, x2, x3",
+                destination: Some(X1),
+                sources: &[X2, X3],
+                has_side_effects: false,
+            },
+            Expectation {
+                opcode_id: 3,
+                mnemonic: "or",
+                display: "or x1, x2, x3",
+                destination: Some(X1),
+                sources: &[X2, X3],
+                has_side_effects: false,
+            },
+            Expectation {
+                opcode_id: 4,
+                mnemonic: "xor",
+                display: "xor x1, x2, x3",
+                destination: Some(X1),
+                sources: &[X2, X3],
+                has_side_effects: false,
+            },
+            Expectation {
+                opcode_id: 5,
+                mnemonic: "sll",
+                display: "sll x1, x2, x3",
+                destination: Some(X1),
+                sources: &[X2, X3],
+                has_side_effects: false,
+            },
+            Expectation {
+                opcode_id: 6,
+                mnemonic: "srl",
+                display: "srl x1, x2, x3",
+                destination: Some(X1),
+                sources: &[X2, X3],
+                has_side_effects: false,
+            },
+            Expectation {
+                opcode_id: 7,
+                mnemonic: "sra",
+                display: "sra x1, x2, x3",
+                destination: Some(X1),
+                sources: &[X2, X3],
+                has_side_effects: false,
+            },
+            Expectation {
+                opcode_id: 8,
+                mnemonic: "addi",
+                display: "addi x1, x2, 7",
+                destination: Some(X1),
+                sources: &[X2],
+                has_side_effects: false,
+            },
+            Expectation {
+                opcode_id: 9,
+                mnemonic: "andi",
+                display: "andi x1, x2, 7",
+                destination: Some(X1),
+                sources: &[X2],
+                has_side_effects: false,
+            },
+            Expectation {
+                opcode_id: 10,
+                mnemonic: "ori",
+                display: "ori x1, x2, 7",
+                destination: Some(X1),
+                sources: &[X2],
+                has_side_effects: false,
+            },
+            Expectation {
+                opcode_id: 11,
+                mnemonic: "xori",
+                display: "xori x1, x2, 7",
+                destination: Some(X1),
+                sources: &[X2],
+                has_side_effects: false,
+            },
+            Expectation {
+                opcode_id: 12,
+                mnemonic: "slli",
+                display: "slli x1, x2, 4",
+                destination: Some(X1),
+                sources: &[X2],
+                has_side_effects: false,
+            },
+            Expectation {
+                opcode_id: 13,
+                mnemonic: "srli",
+                display: "srli x1, x2, 4",
+                destination: Some(X1),
+                sources: &[X2],
+                has_side_effects: false,
+            },
+            Expectation {
+                opcode_id: 14,
+                mnemonic: "srai",
+                display: "srai x1, x2, 4",
+                destination: Some(X1),
+                sources: &[X2],
+                has_side_effects: false,
+            },
+            Expectation {
+                opcode_id: 15,
+                mnemonic: "lui",
+                display: "lui x1, 74565",
+                destination: Some(X1),
+                sources: &[],
+                has_side_effects: false,
+            },
+        ];
+
         let generator = RiscVInstructionGenerator::rv32();
-        let ids: BTreeSet<u8> = all_instruction_families()
+        let instructions = all_instruction_families();
+        assert_eq!(instructions.len(), expected.len());
+        assert_eq!(expected.len(), generator.opcode_count() as usize);
+
+        let ids: BTreeSet<u8> = instructions
             .iter()
-            .map(|instr| {
-                assert_eq!(instr.destination(), RiscVRegister::X1);
-                let _ = instr.source_registers();
-                assert!(!format!("{}", instr).is_empty());
-                assert!(!instr.mnemonic().is_empty());
-                assert!(!instr.has_side_effects());
-                instr.opcode_id()
+            .zip(expected.iter())
+            .map(|(instr, expected)| {
+                let context = format!("{instr:?}");
+                assert_eq!(
+                    InstructionType::opcode_id(instr),
+                    expected.opcode_id,
+                    "opcode id: {context}"
+                );
+                assert_eq!(
+                    InstructionType::mnemonic(instr),
+                    expected.mnemonic,
+                    "mnemonic: {context}"
+                );
+                assert_eq!(instr.to_string(), expected.display, "display: {context}");
+                assert_eq!(
+                    InstructionType::destination(instr),
+                    expected.destination,
+                    "destination: {context}"
+                );
+                assert_eq!(
+                    InstructionType::source_registers(instr),
+                    expected.sources,
+                    "source registers: {context}"
+                );
+                assert_eq!(
+                    InstructionType::has_side_effects(instr),
+                    expected.has_side_effects,
+                    "side effects: {context}"
+                );
+                InstructionType::opcode_id(instr)
             })
             .collect();
         assert_eq!(ids.len(), generator.opcode_count() as usize);


### PR DESCRIPTION
## Summary

- replace the shallow AArch64 IR smoke loop with literal display, def/use, flag, and encodability contracts
- pin all generated AArch64 InstructionType metadata with independent side-effect expectations
- pin the full 16-family RISC-V scaffold trait and display surface

## Verification

- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo clippy --workspace --all-features -- -D warnings
- cargo test --all
- ./ci_check.sh

Closes #106

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**