### PR TITLE
refactor(validation): re-export live-out parse error

### DIFF
--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -5,6 +5,15 @@ pub mod live_out;
 pub mod random;
 
 #[allow(unused_imports)]
-pub use live_out::compute_written_registers;
+pub use live_out::{ParseLiveOutError, compute_written_registers};
 #[allow(unused_imports)]
 pub use random::{RandomInputConfig, generate_edge_case_inputs, generate_random_inputs};
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn parse_live_out_error_is_reexported_from_validation() {
+        let _: crate::validation::ParseLiveOutError =
+            super::live_out::parse_live_out_contract("x0;bogus").unwrap_err();
+    }
+}


### PR DESCRIPTION
Re-export the existing `ParseLiveOutError` alias from `validation` so downstream callers can use the short public path without changing parser behavior or type identity. Add a compile-focused regression that pins `s11::validation::ParseLiveOutError`.

Verified with:
- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`
- `./ci_check.sh`

Closes #360

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**