### PR TITLE
refactor(validation): use live-out error alias in contract parser

### DIFF
--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -135,14 +135,14 @@ pub fn parse_live_out_contract(s: &str) -> Result<LiveOut, ParseLiveOutError> {
     let trimmed = s.trim();
     let semicolon_count = trimmed.matches(';').count();
     if semicolon_count > 1 {
-        return Err(ParseRegisterSetError::new(format!(
+        return Err(ParseLiveOutError::new(format!(
             "--live-out accepts at most one ';' (got: '{}')",
             s
         )));
     }
     if semicolon_count == 0 {
         if trimmed.eq_ignore_ascii_case("nzcv") {
-            return Err(ParseRegisterSetError::new(format!(
+            return Err(ParseLiveOutError::new(format!(
                 "flag-only live-out requires a leading ';' (e.g. \";nzcv\"); got '{}'",
                 s
             )));
@@ -163,13 +163,13 @@ pub fn parse_live_out_contract(s: &str) -> Result<LiveOut, ParseLiveOutError> {
         "" => false,
         "nzcv" => true,
         "n" | "z" | "c" | "v" => {
-            return Err(ParseRegisterSetError::new(format!(
+            return Err(ParseLiveOutError::new(format!(
                 "per-flag token '{}' is reserved for a future extension; use 'nzcv' for all flags",
                 flags_tok
             )));
         }
         other => {
-            return Err(ParseRegisterSetError::new(format!(
+            return Err(ParseLiveOutError::new(format!(
                 "unknown flag token '{}'; expected 'nzcv'",
                 other
             )));


### PR DESCRIPTION
## Summary

- construct `parse_live_out_contract`'s four contract-owned errors through `ParseLiveOutError`
- retain `ParseRegisterSetError` for genuine register-set parsing paths
- preserve parser behavior and diagnostics

## Testing

- `cargo test validation::live_out::tests`
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --all` (after `./build_tests.sh` generated required integration fixtures)
- `./ci_check.sh`

The prompt-listed Vow command `scripts/full_test.sh` is not present in this s11 repository; the repository-mandated `./ci_check.sh` passed in full.

Closes #359

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**