### PR TITLE
docs(validation): explain exact diagnostic assertions

### DIFF
--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -413,6 +413,7 @@ mod tests {
     #[test]
     fn display_renders_message_without_type_prefix() {
         let err: ParseLiveOutError = parse_live_out_contract("x0;bogus").unwrap_err();
+        // Deliberately fragile: ADR-0006 diagnostic wording changes should require review.
         assert_eq!(
             err.to_string(),
             "unknown flag token 'bogus'; expected 'nzcv'"
@@ -993,6 +994,7 @@ mod tests {
     #[test]
     fn test_parse_live_out_contract_reversed_order_nzcv_x0_error() {
         let err = parse_live_out_contract("nzcv;x0").unwrap_err();
+        // Deliberately fragile: review the complete issue #181 diagnostic before changing it.
         assert_eq!(
             err.to_string(),
             "flag token 'nzcv' must follow the register list after ';' (for example ';nzcv'); got 'nzcv;x0'"


### PR DESCRIPTION
## Summary

- mark both exact `ParseLiveOutError::Display` comparisons as deliberately fragile
- make future ADR-0006 and issue #181 diagnostic wording changes require explicit review
- preserve the parser, diagnostics, and assertion strength unchanged

## Verification

- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`
- `./ci_check.sh`

The implementation prompt's Vow-specific `scripts/full_test.sh` is not present in this Rust repository; `./ci_check.sh` is the repository-prescribed full local gate and passed.

Closes #361

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**
