### PR TITLE
test(stochastic): tidy timeout test scaffolding

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3516,6 +3516,19 @@ mod cli_helper_tests {
         }
     }
 
+    fn assert_stochastic_config_matches_options(
+        config: &SearchConfig,
+        options: &OptimizationOptions,
+    ) {
+        assert_eq!(config.solver_timeout, Some(options.solver_timeout));
+        assert_eq!(config.stochastic.beta, options.beta);
+        assert_eq!(config.stochastic.iterations, options.iterations);
+        assert_eq!(config.stochastic.seed, options.seed);
+        assert_eq!(config.cost_metric, options.cost_metric);
+        assert_eq!(config.timeout, options.timeout);
+        assert_eq!(config.verbose, options.verbose);
+    }
+
     fn r10_zeroing_target() -> [X86Instruction; 2] {
         let zero_r10 = X86Instruction::XorReg {
             rd: X86Register::R10,
@@ -6908,13 +6921,7 @@ mod cli_helper_tests {
         let imms = vec![0, 7];
         let config = build_stochastic_search_config(&opts, regs.clone(), imms.clone());
 
-        assert_eq!(config.solver_timeout, Some(Duration::from_millis(17)));
-        assert_eq!(config.stochastic.beta, 2.5);
-        assert_eq!(config.stochastic.iterations, 123);
-        assert_eq!(config.stochastic.seed, Some(99));
-        assert_eq!(config.cost_metric, CostMetric::Latency);
-        assert_eq!(config.timeout, Some(Duration::from_millis(11)));
-        assert!(config.verbose);
+        assert_stochastic_config_matches_options(&config, &opts);
         assert_eq!(config.available_registers, regs);
         assert_eq!(config.available_immediates, imms);
     }
@@ -7033,13 +7040,7 @@ mod cli_helper_tests {
         ];
         let config = build_x86_stochastic_search_config(&target, &opts);
 
-        assert_eq!(config.solver_timeout, Some(Duration::from_millis(19)));
-        assert_eq!(config.stochastic.beta, 3.5);
-        assert_eq!(config.stochastic.iterations, 456);
-        assert_eq!(config.stochastic.seed, Some(101));
-        assert_eq!(config.cost_metric, CostMetric::CodeSize);
-        assert_eq!(config.timeout, Some(Duration::from_millis(13)));
-        assert!(config.verbose);
+        assert_stochastic_config_matches_options(&config, &opts);
         assert_eq!(
             config.x86_available_registers,
             vec![X86Register::R11, X86Register::R12]

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -550,7 +550,7 @@ mod tests {
     }
 
     std::thread_local! {
-        static RECORDED_SMT_TIMEOUT_MS: std::cell::Cell<Option<u64>> =
+        static RECORDED_SMT_TIMEOUT_MS: std::cell::Cell<Option<u128>> =
             const { std::cell::Cell::new(None) };
     }
 
@@ -626,7 +626,7 @@ mod tests {
             _width: u32,
             timeout: Duration,
         ) -> (EquivalenceResult, crate::semantics::EquivalenceMetrics) {
-            RECORDED_SMT_TIMEOUT_MS.with(|recorded| recorded.set(Some(timeout.as_millis() as u64)));
+            RECORDED_SMT_TIMEOUT_MS.with(|recorded| recorded.set(Some(timeout.as_millis())));
             let metrics = crate::semantics::EquivalenceMetrics {
                 smt_called: TIMEOUT_PROBE_SMT_CALLED.load(AtomicOrdering::SeqCst),
                 ..crate::semantics::EquivalenceMetrics::default()
@@ -659,7 +659,7 @@ mod tests {
         config: SearchConfig,
         verdict: usize,
         smt_called: bool,
-    ) -> (SearchStatistics, Option<u64>) {
+    ) -> (SearchStatistics, Option<u128>) {
         let _guard = set_timeout_probe_result(verdict, smt_called);
         let mut search: StochasticSearch<TimeoutProbeIsa> = StochasticSearch::new();
         let target = [TimeoutProbeInstruction(1), TimeoutProbeInstruction(2)];
@@ -672,7 +672,7 @@ mod tests {
         )
     }
 
-    fn run_timeout_probe_search(config: SearchConfig) -> Option<u64> {
+    fn run_timeout_probe_search(config: SearchConfig) -> Option<u128> {
         let (statistics, recorded_timeout) =
             run_timeout_probe_search_with(config, TIMEOUT_PROBE_EQUIVALENT, true);
         assert_eq!(statistics.smt_queries, 1);
@@ -740,6 +740,23 @@ mod tests {
         );
 
         assert_eq!(recorded_timeout, Some(17));
+    }
+
+    #[test]
+    fn timeout_probe_preserves_full_millisecond_value() {
+        let recorded_timeout = run_timeout_probe_search(
+            SearchConfig::default()
+                .with_stochastic(
+                    StochasticConfig::default()
+                        .with_iterations(1)
+                        .with_test_count(0)
+                        .with_seed(1),
+                )
+                .with_timeout_option(None)
+                .with_solver_timeout(Duration::MAX),
+        );
+
+        assert_eq!(recorded_timeout, Some(Duration::MAX.as_millis()));
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- preserve the full `u128` millisecond value in the stochastic timeout probe, with a `Duration::MAX` regression
- share common stochastic CLI option assertions across AArch64 and x86 tests while retaining ISA-specific coverage

Closes #365

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**