### PR TITLE
test(aarch64): guard CMP/CMN immediate register encoding

### DIFF
--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -3824,6 +3824,82 @@ mod tests {
         disassemble_and_verify(&bytes, "sub", &["x0", "sp", "#8"]);
     }
 
+    #[test]
+    fn test_cmp_imm_rejects_xzr_rn() {
+        let mut assembler = AArch64Assembler::new();
+        let result = assembler.assemble_instructions(
+            &[Instruction::Cmp {
+                rn: Register::XZR,
+                rm: Operand::Immediate(0),
+            }],
+            0,
+        );
+        assert!(
+            result.is_err(),
+            "CMP immediate must reject XZR rn instead of encoding SP"
+        );
+
+        for rm in [
+            Operand::Register(Register::X1),
+            Operand::ShiftedRegister {
+                reg: Register::X1,
+                kind: ShiftKind::Lsl,
+                amount: 1,
+            },
+        ] {
+            let mut assembler = AArch64Assembler::new();
+            let result = assembler.assemble_instructions(
+                &[Instruction::Cmp {
+                    rn: Register::XZR,
+                    rm,
+                }],
+                0,
+            );
+            assert!(
+                result.is_ok(),
+                "CMP register forms must keep accepting XZR rn: {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_cmn_imm_rejects_xzr_rn() {
+        let mut assembler = AArch64Assembler::new();
+        let result = assembler.assemble_instructions(
+            &[Instruction::Cmn {
+                rn: Register::XZR,
+                rm: Operand::Immediate(1),
+            }],
+            0,
+        );
+        assert!(
+            result.is_err(),
+            "CMN immediate must reject XZR rn instead of encoding SP"
+        );
+
+        for rm in [
+            Operand::Register(Register::X1),
+            Operand::ShiftedRegister {
+                reg: Register::X1,
+                kind: ShiftKind::Lsl,
+                amount: 1,
+            },
+        ] {
+            let mut assembler = AArch64Assembler::new();
+            let result = assembler.assemble_instructions(
+                &[Instruction::Cmn {
+                    rn: Register::XZR,
+                    rm,
+                }],
+                0,
+            );
+            assert!(
+                result.is_ok(),
+                "CMN register forms must keep accepting XZR rn: {result:?}"
+            );
+        }
+    }
+
     /// Capstone round-trip for ADDS with SP as `rn` — guards against silent
     /// off-by-one in the encoded slot. Capstone must disassemble back to
     /// `adds` with `sp` in the rn position.

--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -805,7 +805,7 @@ impl Instruction {
     /// This validates immediate operand ranges against AArch64 encoding constraints:
     /// - MOV immediate: 0 to 0xFFFF (16-bit)
     /// - ADD/SUB immediate: 0 to 0xFFF (12-bit unsigned); rd/rn ≠ XZR (Xn|SP slot, SP allowed)
-    /// - CMP/CMN immediate: 0 to 0xFFF (12-bit unsigned)
+    /// - CMP/CMN immediate: 0 to 0xFFF (12-bit unsigned); rn ≠ XZR (Xn|SP slot, SP allowed)
     /// - LSL/LSR/ASR immediate: 0 to 63
     /// - AND/ORR/EOR immediate: register, or encodable bitmask immediate
     ///   (rd ≠ XZR for the imm form — Xn|SP slot rejects the zero register)


### PR DESCRIPTION
Summary:
- add direct assembler rejection regressions for CMP/CMN immediate sources using XZR
- preserve register and shifted-register XZR controls
- clarify the Xn|SP immediate-source contract in IR documentation

Current main already contains the overlapping production encoder and encodability fixes, so this PR closes the remaining defense-in-depth coverage and documentation gaps.

Validation:
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test --all
- ./ci_check.sh

Closes #220

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**