### PR TITLE
test(validation): cover space-separated live-out contract

### DIFF
--- a/src/validation/live_out.rs
+++ b/src/validation/live_out.rs
@@ -870,6 +870,14 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_live_out_contract_space_separated_regs_only_flags_off() {
+        let live_out = parse_live_out_contract("x0 x1").unwrap();
+        assert!(live_out.contains_register(Register::X0));
+        assert!(live_out.contains_register(Register::X1));
+        assert!(!live_out.flags_live());
+    }
+
+    #[test]
     fn test_parse_live_out_contract_flags_only() {
         let live_out = parse_live_out_contract(";nzcv").unwrap();
         assert_eq!(live_out.len(), 0);


### PR DESCRIPTION
## Summary

- exercise `parse_live_out_contract("x0 x1")` directly
- assert both registers are live while NZCV remains off
- complete the space/comma × flags/no-flags parser test matrix

## Tests

- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`
- `./ci_check.sh`

The run template's Vow-specific `scripts/full_test.sh` command is not present in this s11 repository; the repository-required `./ci_check.sh` passed in full.

Closes #370

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**
