### PR TITLE
chore(workflow): keep PLAN.md local to agent workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,8 @@ mutants.out.old/
 .clawpatch/
 .claude/
 
+# Workspace-local planning-to-implementation handoff
+/PLAN.md
+
 # criterion benchmark output and JSONL accumulator (issue #70)
 benches/results/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,15 @@ See [docs/capability.md](docs/capability.md) for the canonical instruction and I
 - ISA abstraction supporting AArch64 (primary), x86-64/x86-32, RISC-V (scaffolded)
 - Binary patching for applying optimizations (per-arch alignment + NOP padding)
 
+## Planning Artifact
+
+The automated planning stage (`prompts/plan.md`) writes or overwrites the
+repository-root `PLAN.md`, and the implementation stage (`prompts/impl.md`)
+reads it from the same workspace. This file is an ignored, workspace-local
+handoff, not durable project documentation. Do not stage, commit, or force-add
+it. Preserve lasting rationale in the issue or pull request, an ADR, or a
+deliberately named document instead.
+
 ## Development Commands
 
 This project uses `just` as the task runner. Common commands:

--- a/prompts/impl.md
+++ b/prompts/impl.md
@@ -1,6 +1,6 @@
 # Vow implementation stage: issue #{{issue.number}} {{issue.title}}
 
-You are the **implementation** agent. A planning pass has written `{{workspace.path}}/PLAN.md`. Read it first. If it is missing or stale, re-derive the slices from the issue body before writing code.
+You are the **implementation** agent. A planning pass has written `{{workspace.path}}/PLAN.md`. Read it first. It is an ignored, workspace-local handoff rather than a PR deliverable. If it is missing or stale, re-derive the slices from the issue body before writing code.
 
 ## Issue under work
 
@@ -47,6 +47,7 @@ You are the **implementation** agent. A planning pass has written `{{workspace.p
 
 ## Commit hygiene
 
+- Exclude the repository-root `PLAN.md` from every commit, even if it changes during implementation. Do not stage or force-add it.
 - Commit in small focused units that match the TDD slices. Many small commits beat one large one — they are easier to review, `git bisect`, and revert.
 - Write commit messages that describe the change and the why. Use a conventional prefix (`fix(...)`, `feat(...)`, `refactor(...)`) consistent with recent history (`git log --oneline -20`).
 - Commits in this repo must be authored as `p@ocmatos.com`. If the workspace git config has a different identity, set `user.email` to `p@ocmatos.com` for this repo only (`git config user.email p@ocmatos.com`) before committing.

--- a/prompts/plan.md
+++ b/prompts/plan.md
@@ -31,6 +31,10 @@ You are the **planning** agent. Do not write code in this stage. Produce a writt
 
 Write a plan to `{{workspace.path}}/PLAN.md` covering:
 
+`PLAN.md` is an ignored, workspace-local handoff to the implementation stage.
+It is overwritten for each issue in its prepared workspace and is not durable
+project documentation.
+
 1. **Problem restated** in one paragraph.
 2. **Files to touch** — exact paths in both `crates/` and `compiler/` if the change is cross-cutting, plus any `docs/spec/*.md` updates required by the change.
 3. **TDD slices** — a numbered list of small red-green-refactor steps. Each slice names the test file/location, the behavior under test, and the production code that will make it pass. Prefer vertical slices over horizontal refactors.
@@ -45,8 +49,9 @@ Write a plan to `{{workspace.path}}/PLAN.md` covering:
 - **Many small changes beat one large change.** If the issue is broad, split the plan into the minimal first slice that closes the issue, plus a follow-up list. Do not bundle refactors into a bug fix.
 - **Do not run `sudo`.** If a step needs root, plan an alternative.
 - **Do not modify the `symphony/` submodule** (if present) or anything under `build/` (gitignored compiler binary).
+- **Do not stage, commit, or force-add `PLAN.md`.** Preserve durable rationale in the issue or pull request, an ADR, or a deliberately named document instead.
 - **Operator merges with a merge commit (`gh pr merge --merge`).** Plan accordingly — do not plan for squash or rebase merges.
 
 ## Exit
 
-Once `PLAN.md` is written and committed locally is not required at this stage — the implementation stage reads it from the workspace. Exit cleanly. If you cannot produce a coherent plan (issue is ambiguous, contradictory, or already resolved), post `gh issue comment {{issue.number}} --body "<what blocks planning>"`, write the same explanation to `{{workspace.path}}/EVIDENCE.md`, and exit without applying any handoff label.
+Once `PLAN.md` is written, leave the ignored file in the workspace for the implementation stage to read and exit cleanly. Do not add it to Git. If you cannot produce a coherent plan (issue is ambiguous, contradictory, or already resolved), post `gh issue comment {{issue.number}} --body "<what blocks planning>"`, write the same explanation to `{{workspace.path}}/EVIDENCE.md`, and exit without applying any handoff label.


### PR DESCRIPTION
## Summary

- ignore the repository-root `PLAN.md` while leaving nested plans eligible for versioning
- document the planning artifact as a workspace-local plan-to-implementation handoff
- explicitly prevent both automation stages from staging, committing, or force-adding the artifact

## Verification

- `git check-ignore -v PLAN.md` (root artifact ignored)
- nested `docs/PLAN.md` control remains unignored
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`
- `./ci_check.sh`

An additional `cargo clippy --all-targets -- -D warnings` audit reports existing lints only in untouched Rust files; the configured all-targets analysis workflow is `continue-on-error`.

Closes #362

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**
