### PR TITLE
test(x86): cover nonzero mutate_opcode index selection

### DIFF
--- a/src/isa/x86.rs
+++ b/src/isa/x86.rs
@@ -4030,6 +4030,53 @@ mod tests {
     }
 
     #[test]
+    fn x86_mutator_opcode_mutates_cmp_at_selected_nonzero_index() {
+        use crate::search::config::MutationWeights;
+
+        let mutator = X86Mutator::new(
+            Vec::new(),
+            vec![7],
+            MutationWeights::default(),
+            crate::assembler::x86::X86Mode::Mode64,
+        );
+        let mut sequence = vec![
+            X86Instruction::MovImm {
+                rd: X86Register::RAX,
+                imm: 0,
+            },
+            X86Instruction::CmpReg {
+                rn: X86Register::RCX,
+                rs: X86Register::RBX,
+            },
+            X86Instruction::SubImm {
+                rd: X86Register::RDX,
+                imm: 1,
+            },
+        ];
+        let mut rng = BudgetedRng::new(vec![word_for_range(3, 1), word_for_range(1, 0)]);
+
+        mutator.mutate_opcode(&mut rng, &mut sequence);
+
+        assert_eq!(
+            sequence,
+            vec![
+                X86Instruction::MovImm {
+                    rd: X86Register::RAX,
+                    imm: 0,
+                },
+                X86Instruction::CmpImm {
+                    rn: X86Register::RCX,
+                    imm: 7,
+                },
+                X86Instruction::SubImm {
+                    rd: X86Register::RDX,
+                    imm: 1,
+                },
+            ]
+        );
+    }
+
+    #[test]
     fn x86_mutator_empty_register_pool_does_not_invent_writable_registers() {
         use crate::isa::traits::ISAMutator;
         use crate::search::config::MutationWeights;


### PR DESCRIPTION
Adds deterministic multi-instruction coverage for x86 CMP opcode mutation index selection.

- forces `mutate_opcode` to select a CMP at index 1
- verifies the CMP form changes while surrounding instructions remain unchanged
- leaves production mutation behavior unchanged

Closes #368

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**