### PR TITLE
docs(search): pin move-wide topology note to PR #108

### DIFF
--- a/src/search/stochastic/mutation.rs
+++ b/src/search/stochastic/mutation.rs
@@ -860,8 +860,8 @@ impl Mutator {
             // outgoing arm than MOVN/MOVK. The top-level search accepts it as
             // a heuristic proposal without a Hastings correction.
             //
-            // Topology note: before this PR, MOVN had a direct MOVN ↔ MovImm
-            // edge. We removed it so MOVN now reaches MovImm via two hops
+            // Topology note: before PR #108, MOVN had a direct MOVN ↔ MovImm
+            // edge. PR #108 removed it, so MOVN now reaches MovImm via two hops
             // (MOVN → MOVZ → MovImm). Ergodicity is preserved — every move
             // family member can still reach every other — but mixing time
             // along the MOVN/MovImm corridor is one step longer. The trade


### PR DESCRIPTION
## Summary

- replace the ambiguous "before this PR" wording with an explicit PR #108 reference
- preserve the documented move-wide mutation topology and all runtime behavior

## Verification

- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test test_move_wide_opcode_mutation_reaches_declared_peers`
- `cargo test --all`
- `./ci_check.sh`

Closes #391

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**
