### PR TITLE
test(aarch64): clarify multiply-family SP/XZR encodability coverage

### DIFF
--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -4067,6 +4067,11 @@ mod tests {
 
         for instr in [
             Instruction::Mul {
+                rd: Register::X0,
+                rn: Register::XZR,
+                rm: Register::X1,
+            },
+            Instruction::Mul {
                 rd: Register::XZR,
                 rn: Register::XZR,
                 rm: Register::XZR,
@@ -4080,6 +4085,12 @@ mod tests {
                 rd: Register::XZR,
                 rn: Register::XZR,
                 rm: Register::XZR,
+            },
+            Instruction::Madd {
+                rd: Register::X0,
+                rn: Register::XZR,
+                rm: Register::X2,
+                ra: Register::XZR,
             },
             Instruction::Madd {
                 rd: Register::XZR,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2644,6 +2644,8 @@ mod tests {
 
     #[test]
     fn parse_line_rejects_sp_in_multiply_family() {
+        // The IR-level test `test_is_encodable_multiply_family_rejects_sp_all_slots`
+        // exhaustively covers every slot; this table samples one slot per mnemonic.
         for text in [
             "mul sp, x1, x2",
             "sdiv x0, sp, x2",


### PR DESCRIPTION
Summary:
- add representative mixed ordinary-register/XZR acceptance cases for the shared three- and four-register AArch64 multiply-family encodability guards
- cross-reference the exhaustive IR all-slot SP coverage from the parser-boundary test

Testing:
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`
- `./ci_check.sh`

Closes #406

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**