### PR TITLE
docs(enumerative): clarify candidate pool growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ Useful flags on `opt`:
 
 Note: enumerative search scales with the generated instruction families in its
 candidate pool. At the default AArch64 8-register CLI scope,
-multiply-accumulate and high-half multiply add 9,728 candidates per length
-bucket; use `--timeout` or smaller optimization windows to bound runtime.
+multiply-accumulate and high-half multiply add 9,728 additional instructions to
+the candidate pool. The sequence space in each length bucket therefore grows as
+`pool_size^L`; use `--timeout` or smaller optimization windows to bound runtime.
 
 `equiv` — check whether two assembly files are semantically equivalent
 on a chosen live-out set:

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -305,8 +305,9 @@ Exhaustively searches all possible instruction sequences up to a given length. G
 
 Note: enumerative search scales with the generated instruction families in its
 candidate pool. At the default AArch64 8-register CLI scope,
-multiply-accumulate and high-half multiply add 9,728 candidates per length
-bucket; use `--timeout` or smaller optimization windows to bound runtime.
+multiply-accumulate and high-half multiply add 9,728 additional instructions to
+the candidate pool. The sequence space in each length bucket therefore grows as
+`pool_size^L`; use `--timeout` or smaller optimization windows to bound runtime.
 
 ### 2. Stochastic Search (MCMC)
 

--- a/docs/capability.md
+++ b/docs/capability.md
@@ -27,10 +27,13 @@ Algorithms:
 - Enumerative, stochastic, symbolic, hybrid, and LLM-assisted search are
   available for AArch64.
 - Enumerative search scales with the generated instruction families in its
-  candidate pool. At the default AArch64 8-register CLI scope, `madd`/`msub`
-  contribute `2 * 8^4` and `mneg`/`smulh`/`umulh` contribute `3 * 8^3`, or
-  9,728 extra candidates per length bucket; use `--timeout` or smaller
-  optimization windows to bound runtime.
+  candidate pool. The source entry point is
+  [`generate_all_instructions`](../src/search/candidate.rs). At the default
+  AArch64 8-register CLI scope, `madd`/`msub` contribute `2 * 8^4` and
+  `mneg`/`smulh`/`umulh` contribute `3 * 8^3`, adding 9,728 additional
+  instructions to the candidate pool. The sequence space in each length bucket
+  therefore grows as `pool_size^L`; use `--timeout` or smaller optimization
+  windows to bound runtime.
 - Hybrid and LLM remain AArch64-only.
 
 Rewritable straight-line mnemonics accepted by the parser and Capstone bridge:

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,7 +230,16 @@ enum Commands {
     },
     /// Optimize a window of instructions in an ELF binary
     #[command(
-        after_help = "Auto mode: `--auto` superoptimizes the whole binary and is mutually exclusive with --start-addr/--end-addr. Use -o/--output to name the result file; when omitted the result is written next to the input as <stem>_optimized.<ext>.\n\nNote: enumerative search scales with the generated instruction families in its candidate pool. At the default AArch64 8-register CLI scope, multiply-accumulate and high-half multiply add 9,728 candidates per length bucket; use --timeout or smaller windows to bound runtime."
+        after_help = concat!(
+            "Auto mode: `--auto` superoptimizes the whole binary and is mutually ",
+            "exclusive with --start-addr/--end-addr. Use -o/--output to name the ",
+            "result file; when omitted the result is written next to the input as ",
+            "<stem>_optimized.<ext>.\n\n",
+            "Note: enumerative search scales with the generated instruction families ",
+            "in its candidate pool. At the default AArch64 8-register CLI scope, ",
+            "multiply-accumulate and high-half multiply add 9,728 candidates per ",
+            "length bucket; use --timeout or smaller windows to bound runtime."
+        )
     )]
     Opt {
         /// Path to ELF binary to optimize

--- a/tests/integration/docs_capability.rs
+++ b/tests/integration/docs_capability.rs
@@ -142,8 +142,24 @@ fn enumerative_candidate_growth_visible_in_public_docs() {
             "{doc} must document enumerative candidate-pool growth"
         );
         assert!(
-            body.contains("candidate pool") && body.contains("length bucket"),
-            "{doc} must use candidate-pool and length-bucket wording"
+            body.contains("candidate pool"),
+            "{doc} must use candidate-pool wording"
+        );
+        assert!(
+            body.contains("length bucket"),
+            "{doc} must use length-bucket wording"
+        );
+    }
+
+    for doc in ["README.md", "TUTORIAL.md"] {
+        let body = normalized_doc(doc);
+        assert!(
+            body.contains("add 9,728 additional instructions to the candidate pool"),
+            "{doc} must identify 9,728 as additional candidate-pool instructions"
+        );
+        assert!(
+            body.contains("pool_size^l"),
+            "{doc} must document length-L sequence-space growth from the pool"
         );
     }
 
@@ -151,6 +167,14 @@ fn enumerative_candidate_growth_visible_in_public_docs() {
     assert!(
         matrix.contains("9,728") && matrix.contains("8^4") && matrix.contains("8^3"),
         "docs/capability.md must keep the default AArch64 multiply-candidate budget visible"
+    );
+    assert!(
+        matrix.contains("generate_all_instructions"),
+        "docs/capability.md must name the candidate-generation source entry point"
+    );
+    assert!(
+        matrix.contains("(../src/search/candidate.rs)"),
+        "docs/capability.md must link the candidate-generation source file"
     );
 }
 


### PR DESCRIPTION
Summary:
- clarify that the AArch64 multiply families add 9,728 instructions to the candidate pool and that length-L sequence space scales as `pool_size^L`
- link `generate_all_instructions` from the capability matrix and sharpen docs-visibility diagnostics
- wrap the `opt` `after_help` source without changing its rendered output

Tests:
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --all` (after generating the documented ELF fixtures)
- `./ci_check.sh`
- rendered `s11 opt --help` SHA-256 unchanged before/after

Closes #408

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**