### PR TITLE
test(search): polish symbolic cost and window bounds

### DIFF
--- a/src/search/config.rs
+++ b/src/search/config.rs
@@ -268,6 +268,11 @@ impl SymbolicConfig {
         self
     }
 
+    pub fn with_cost_bound_option(mut self, bound: Option<u64>) -> Self {
+        self.cost_bound = bound;
+        self
+    }
+
     pub fn with_search_mode(mut self, mode: SearchMode) -> Self {
         self.search_mode = mode;
         self
@@ -810,12 +815,15 @@ mod tests {
     fn test_symbolic_config_builder() {
         let config = SymbolicConfig::default()
             .with_window_size(5)
-            .with_cost_bound(2)
+            .with_cost_bound_option(Some(2))
             .with_search_mode(SearchMode::Binary);
 
         assert_eq!(config.window_size, 5);
         assert_eq!(config.cost_bound, Some(2));
         assert_eq!(config.search_mode, SearchMode::Binary);
+
+        let config = config.with_cost_bound(3).with_cost_bound_option(None);
+        assert_eq!(config.cost_bound, None);
     }
 
     #[test]

--- a/src/search/config.rs
+++ b/src/search/config.rs
@@ -234,11 +234,11 @@ pub const DEFAULT_SYMBOLIC_SOLVER_TIMEOUT: Duration = Duration::from_secs(30);
 pub struct SymbolicConfig {
     /// Maximum number of synthesized non-terminator instructions to consider.
     ///
-    /// The default of 3 is actively enforced, so it caps candidate lengths for
-    /// targets with more than four rewritable instructions. A value of 0
-    /// disables candidate search. If the target ends in a fixed terminator,
-    /// that terminator is appended after synthesis and does not count against
-    /// this window.
+    /// The default of 3 is actively enforced, so synthesized candidates are
+    /// capped at three non-terminator instructions unless the caller raises
+    /// the window. A value of 0 disables candidate search. If the target ends
+    /// in a fixed terminator, that terminator is appended after synthesis and
+    /// does not count against this window.
     pub window_size: usize,
     /// Exclusive initial cost bound.
     ///

--- a/src/search/config.rs
+++ b/src/search/config.rs
@@ -234,14 +234,19 @@ pub const DEFAULT_SYMBOLIC_SOLVER_TIMEOUT: Duration = Duration::from_secs(30);
 pub struct SymbolicConfig {
     /// Maximum number of synthesized non-terminator instructions to consider.
     ///
-    /// A value of 0 disables candidate search. If the target ends in a fixed
-    /// terminator, that terminator is appended after synthesis and does not
-    /// count against this window.
+    /// The default of 3 is actively enforced, so it caps candidate lengths for
+    /// targets with more than four rewritable instructions. A value of 0
+    /// disables candidate search. If the target ends in a fixed terminator,
+    /// that terminator is appended after synthesis and does not count against
+    /// this window.
     pub window_size: usize,
     /// Exclusive initial cost bound.
     ///
     /// Candidate sequences must be strictly cheaper than this bound and the
-    /// original target cost. `None` uses the original target cost.
+    /// original target cost. `None` leaves the original target cost as the
+    /// exclusive ceiling. `Some(0)` disables candidate verification because no
+    /// `u64` cost can be strictly below zero. Values above the original cost
+    /// have no further effect because the original cost remains the ceiling.
     pub cost_bound: Option<u64>,
     /// Search mode (linear or binary)
     pub search_mode: SearchMode,
@@ -268,6 +273,9 @@ impl SymbolicConfig {
         self
     }
 
+    /// Sets or clears the explicit initial cost bound.
+    ///
+    /// Passing `None` clears a previously configured bound.
     pub fn with_cost_bound_option(mut self, bound: Option<u64>) -> Self {
         self.cost_bound = bound;
         self

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -854,6 +854,35 @@ mod tests {
     }
 
     #[test]
+    fn symbolic_cost_bound_and_window_size_are_enforced_together() {
+        let _guard = SYMBOLIC_INNER_LOOP_TEST_LOCK
+            .lock()
+            .expect("symbolic inner-loop test lock poisoned");
+        reset_symbolic_inner_loop_test_state();
+
+        let mut search: SymbolicSearch<TestIsa> = SymbolicSearch::new();
+        let config = SearchConfig::default().with_symbolic(
+            SymbolicConfig::default()
+                .with_window_size(2)
+                .with_cost_bound(2),
+        );
+        let target = [
+            TestInstruction(100),
+            TestInstruction(101),
+            TestInstruction(102),
+            TestInstruction(103),
+        ];
+
+        let result = search.search(&target, &(), &config);
+
+        assert!(!result.found_optimization);
+        assert!(result.optimized_sequence.is_none());
+        assert_eq!(TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst), 1);
+        assert_eq!(result.statistics.candidates_evaluated, 2);
+        assert_eq!(result.statistics.candidates_pruned_by_cost, 1);
+    }
+
+    #[test]
     fn symbolic_search_drops_flag_writer_only_when_flags_are_dead() {
         let config = SearchConfig::default()
             .with_solver_timeout(Duration::from_secs(5))

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -466,6 +466,7 @@ mod tests {
     static TEST_EQUIVALENCE_SMT_CALLED: AtomicBool = AtomicBool::new(false);
     static TEST_RECORDED_TIMEOUT_MS: AtomicU64 = AtomicU64::new(u64::MAX);
     static TEST_SEQUENCE_COST_DELAY_MS: AtomicU64 = AtomicU64::new(0);
+    static TEST_GENERATED_CANDIDATE_COST_OVERRIDE: AtomicU64 = AtomicU64::new(0);
     static TEST_STOP_FLAG: Mutex<Option<Arc<AtomicBool>>> = Mutex::new(None);
     static SYMBOLIC_INNER_LOOP_TEST_LOCK: Mutex<()> = Mutex::new(());
 
@@ -492,6 +493,7 @@ mod tests {
         TEST_EQUIVALENCE_SMT_CALLED.store(false, Ordering::SeqCst);
         TEST_RECORDED_TIMEOUT_MS.store(u64::MAX, Ordering::SeqCst);
         TEST_SEQUENCE_COST_DELAY_MS.store(0, Ordering::SeqCst);
+        TEST_GENERATED_CANDIDATE_COST_OVERRIDE.store(0, Ordering::SeqCst);
         let mut slot = TEST_STOP_FLAG.lock().expect("test stop flag lock poisoned");
         *slot = None;
     }
@@ -658,6 +660,13 @@ mod tests {
             if delay_ms > 0 {
                 std::thread::sleep(Duration::from_millis(delay_ms));
             }
+            let generated_cost = TEST_GENERATED_CANDIDATE_COST_OVERRIDE.load(Ordering::SeqCst);
+            if generated_cost > 0
+                && !seq.is_empty()
+                && seq.iter().all(|instruction| instruction.0 == 0)
+            {
+                return generated_cost;
+            }
             seq.len() as u64
         }
 
@@ -816,6 +825,29 @@ mod tests {
         let mut search: SymbolicSearch<TestIsa> = SymbolicSearch::new();
         let config =
             SearchConfig::default().with_symbolic(SymbolicConfig::default().with_cost_bound(1));
+        let target = [TestInstruction(100), TestInstruction(101)];
+
+        let result = search.search(&target, &(), &config);
+
+        assert!(!result.found_optimization);
+        assert!(result.optimized_sequence.is_none());
+        assert_eq!(result.statistics.best_cost_found, 2);
+        assert_eq!(TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst), 0);
+        assert_eq!(result.statistics.candidates_evaluated, 1);
+        assert_eq!(result.statistics.candidates_pruned_by_cost, 1);
+    }
+
+    #[test]
+    fn symbolic_cost_bound_above_original_cost_keeps_original_ceiling() {
+        let _guard = SYMBOLIC_INNER_LOOP_TEST_LOCK
+            .lock()
+            .expect("symbolic inner-loop test lock poisoned");
+        reset_symbolic_inner_loop_test_state();
+        TEST_GENERATED_CANDIDATE_COST_OVERRIDE.store(3, Ordering::SeqCst);
+
+        let mut search: SymbolicSearch<TestIsa> = SymbolicSearch::new();
+        let config =
+            SearchConfig::default().with_symbolic(SymbolicConfig::default().with_cost_bound(4));
         let target = [TestInstruction(100), TestInstruction(101)];
 
         let result = search.search(&target, &(), &config);


### PR DESCRIPTION
Summary:
- document the actively enforced default symbolic window and cost-bound edge semantics
- add an Option-accepting builder that can clear an explicit cost bound
- cover combined window/cost enforcement and loose bounds above original cost

Tests:
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test --all
- ./ci_check.sh

Closes #518

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**