### PR TITLE
fix(release): finalize prerelease patch versions

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -69,8 +69,9 @@ sha256sum --check SHA256SUMS.txt
 `scripts/bump-version.sh` is standalone and reusable:
 
 ```sh
-scripts/bump-version.sh patch     # 0.1.0 -> 0.1.1
-scripts/bump-version.sh minor     # 0.1.0 -> 0.2.0
+scripts/bump-version.sh patch       # 0.1.0 -> 0.1.1
+scripts/bump-version.sh patch       # 0.1.1-dev -> 0.1.1
+scripts/bump-version.sh minor       # 0.1.0 -> 0.2.0
 scripts/bump-version.sh 1.0.0-rc.1  # explicit version
 ```
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -44,7 +44,11 @@ EOF
       exit 1
     fi
     case "$1" in
-      patch) patch=$((patch + 1)) ;;
+      patch)
+        if [ "$current" = "$base" ]; then
+          patch=$((patch + 1))
+        fi
+        ;;
       minor)
         minor=$((minor + 1))
         patch=0

--- a/tests/integration/bump_version_test.rs
+++ b/tests/integration/bump_version_test.rs
@@ -1,0 +1,45 @@
+use std::fs;
+use std::process::Command;
+
+fn assert_bump(current: &str, bump: &str, expected: &str) {
+    let temp_dir = tempfile::tempdir().expect("create temporary manifest directory");
+    let manifest = temp_dir.path().join("Cargo.toml");
+    fs::write(
+        &manifest,
+        format!(
+            "[package]\nname = \"version-fixture\"\nversion = \"{current}\"\n\n[dependencies]\nfixture = {{ version = \"9.8.7\" }}\n"
+        ),
+    )
+    .expect("write temporary manifest");
+
+    let output = Command::new(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/scripts/bump-version.sh"
+    ))
+    .arg(bump)
+    .env("MANIFEST", &manifest)
+    .output()
+    .expect("run bump-version.sh");
+
+    assert!(
+        output.status.success(),
+        "bump-version.sh failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(output.stdout, format!("{expected}\n").as_bytes());
+
+    let updated = fs::read_to_string(manifest).expect("read updated manifest");
+    assert!(
+        updated.contains(&format!("\nversion = \"{expected}\"\n")),
+        "package version was not updated:\n{updated}"
+    );
+    assert!(
+        updated.contains("fixture = { version = \"9.8.7\" }"),
+        "dependency version was unexpectedly changed:\n{updated}"
+    );
+}
+
+#[test]
+fn patch_from_prerelease_finalizes_current_version() {
+    assert_bump("0.1.1-dev", "patch", "0.1.1");
+}

--- a/tests/integration/bump_version_test.rs
+++ b/tests/integration/bump_version_test.rs
@@ -43,3 +43,28 @@ fn assert_bump(current: &str, bump: &str, expected: &str) {
 fn patch_from_prerelease_finalizes_current_version() {
     assert_bump("0.1.1-dev", "patch", "0.1.1");
 }
+
+#[test]
+fn patch_from_stable_version_increments_patch() {
+    assert_bump("0.1.0", "patch", "0.1.1");
+}
+
+#[test]
+fn patch_from_other_prerelease_finalizes_current_version() {
+    assert_bump("1.2.3-rc.1", "patch", "1.2.3");
+}
+
+#[test]
+fn minor_from_prerelease_increments_minor() {
+    assert_bump("1.2.3-dev", "minor", "1.3.0");
+}
+
+#[test]
+fn major_from_prerelease_increments_major() {
+    assert_bump("1.2.3-dev", "major", "2.0.0");
+}
+
+#[test]
+fn explicit_version_from_prerelease_is_used_verbatim() {
+    assert_bump("1.2.3-dev", "2.0.0", "2.0.0");
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,3 +1,4 @@
+mod bump_version_test;
 mod carry_chain;
 mod disasm_test;
 mod docs_capability;


### PR DESCRIPTION
## Summary

- make `patch` finalize an existing prerelease version without incrementing the numeric patch
- cover stable, prerelease, major/minor, and explicit-version behavior through the real script interface
- document prerelease patch finalization for standalone local use

## Testing

- `bash -n scripts/bump-version.sh`
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`
- `./ci_check.sh`

Closes #604

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**