### PR TITLE
fix(search): define zero solver timeout as skipping SMT

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,16 @@ Useful flags on `opt`:
 | `--timeout SECS` | wall-clock budget for the search |
 | `--beta`, `--iterations`, `--seed` | MCMC tuning for `stochastic` |
 | `--search-mode linear\|binary` | SMT synthesis search tuning |
-| `--solver-timeout SECS` | per-query SMT verifier/synthesis timeout |
+| `--solver-timeout SECS` | per-query SMT timeout; `0` disables SMT queries (never unbounded) |
 | `--no-symbolic` | run hybrid as all-stochastic workers |
+
+Every accepted optimization requires an SMT proof. Consequently,
+`--solver-timeout 0` prevents enumerative, stochastic, symbolic, hybrid, and
+LLM search from accepting a candidate; it is a query-disable sentinel, not a
+fast-only mode. An unset programmatic `SearchConfig::solver_timeout` still uses
+the 5-second fallback. See
+[ADR-0011](docs/adr/0011-zero-solver-timeout-disables-smt.md) for the policy and
+alternatives.
 
 Note: enumerative search scales with the generated instruction families in its
 candidate pool. At the default AArch64 8-register CLI scope,

--- a/docs/adr/0011-zero-solver-timeout-disables-smt.md
+++ b/docs/adr/0011-zero-solver-timeout-disables-smt.md
@@ -1,0 +1,102 @@
+# ADR-0011: Zero solver timeout disables SMT queries
+
+## Status
+
+Accepted for issue #670 on 2026-07-21.
+
+## Context
+
+Z3 interprets a zero timeout parameter as no timeout. s11 also exposes the
+per-query timeout as the CLI flag `--solver-timeout SECS` and the programmatic
+builder `SearchConfig::with_solver_timeout(Duration)`. Before PR #669, passing
+zero through those surfaces had inconsistent results: symbolic and stochastic
+search passed zero to Z3 and therefore allowed an unbounded query, while
+enumerative and LLM search skipped the query because they required at least one
+millisecond of usable budget.
+
+PR #669 routed the SMT-driven search paths through budget guards so a solver
+query cannot overrun the overall `--timeout`. That made zero uniformly skip SMT
+queries, but left the behavior undocumented. It also left the LLM path with a
+separate millisecond gate, creating a place where the policy could drift again.
+
+The ambiguity matters because `--solver-timeout 0` is accepted by clap, and a
+raw zero reaching Z3 changes a bounded search into a potentially unbounded one.
+Conversely, skipping SMT does not create a fast-only optimizer: s11 accepts a
+candidate only after a formal equivalence proof.
+
+## Decision
+
+A configured solver timeout of zero means **disable SMT queries**. It never
+means an unbounded Z3 query.
+
+This applies to both public configuration surfaces:
+
+- `s11 opt ... --solver-timeout 0` remains valid and selects the disable
+  sentinel.
+- `SearchConfig::with_solver_timeout(Duration::ZERO)` selects the same
+  sentinel, whether or not an overall search timeout is configured.
+
+`SearchConfig::solver_timeout_within_budget` is the canonical policy seam. It
+returns `None` when the configured solver timeout is zero, when the overall
+search budget is exhausted, or when the usable timeout is positive but below
+Z3's whole-millisecond granularity. No backend may pass those values to Z3.
+The LLM path, which computes its remaining budget around an external Codex
+call, delegates its equivalent remaining-budget calculation to the same seam.
+
+`solver_timeout: None` has a distinct existing meaning: use the shared
+five-second fallback. It does not disable SMT.
+
+The query-level contract is uniform across the four SMT-driven search paths:
+
+- enumerative search stops before verifying the candidate;
+- stochastic search stops when a cheaper proposal would require proof;
+- symbolic search treats the candidate as unproven;
+- LLM search does not run its candidate verifier.
+
+In every case the candidate is not accepted, no SMT query is counted, and no
+zero timeout reaches Z3. Hybrid search inherits the symbolic and stochastic
+behavior of its workers. Because all accepted optimizations require an SMT
+proof, a zero solver timeout means that the search cannot report an
+optimization.
+
+## Alternatives considered
+
+### Reject zero at the CLI
+
+A positive-only clap parser would remove the ambiguous CLI input, but it would
+not define the behavior of the public programmatic builder. Rejecting or
+panicking in the builder would also be a breaking API change. This option was
+rejected because zero already has one safe, consistent meaning across both
+surfaces.
+
+### Preserve Z3's zero-means-unbounded behavior
+
+Passing zero through would allow a single solver query to exceed the overall
+search deadline, reversing the budget guarantee established by PR #669. A
+special case that clamps zero only when an overall timeout exists would make
+the same input mean two different things depending on another option. This was
+rejected.
+
+### Add an explicit unbounded-solver flag
+
+A separate flag or typed configuration variant could represent an unbounded
+solver request without overloading `Duration::ZERO`. It would still need to be
+clamped whenever an overall search timeout is present. There is no current use
+case that justifies the extra CLI and API surface, so this remains an additive
+future option rather than part of this decision.
+
+## Consequences
+
+The CLI, builder, and all SMT-driven backends now have one documented zero
+policy, and future call sites can use the shared budget seam without knowing
+Z3's sentinel semantics. Existing positive timeouts and the unset five-second
+fallback are unchanged.
+
+Users who previously relied on symbolic or stochastic search passing zero to
+Z3 must choose a sufficiently large positive timeout instead. This qualifies
+PR #669's original “no public CLI behavior changes” statement for the reachable
+zero-timeout edge case.
+
+**Reversibility:** high. A future explicit unbounded option can be added without
+changing the meaning of zero. Reinterpreting zero itself would be a breaking
+semantic change and would require revisiting this ADR.

--- a/src/main.rs
+++ b/src/main.rs
@@ -4143,6 +4143,25 @@ mod cli_helper_tests {
     }
 
     #[test]
+    fn opt_accepts_zero_solver_timeout_as_the_disable_sentinel() {
+        let Commands::Opt { solver_timeout, .. } = parse_opt(&[
+            "s11",
+            "opt",
+            "prog.elf",
+            "--start-addr",
+            "0x1000",
+            "--end-addr",
+            "0x1100",
+            "--solver-timeout",
+            "0",
+        ]) else {
+            panic!("expected the opt subcommand");
+        };
+
+        assert_eq!(solver_timeout, 0);
+    }
+
+    #[test]
     fn opt_help_mentions_auto_and_output() {
         use clap::CommandFactory;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -285,7 +285,7 @@ enum Commands {
         /// Search mode for symbolic synthesis
         #[arg(long, value_enum, default_value = "linear")]
         search_mode: CliSearchMode,
-        /// Solver timeout in seconds
+        /// Solver timeout in seconds; 0 disables SMT queries and does not request an unbounded solver query
         #[arg(long, default_value = "5")]
         solver_timeout: u64,
 
@@ -4009,6 +4009,24 @@ mod cli_helper_tests {
         assert!(
             opt_help.contains("9,728"),
             "opt help should mention the default AArch64 multiply candidate growth:\n{opt_help}"
+        );
+    }
+
+    #[test]
+    fn opt_help_defines_zero_solver_timeout_as_disabling_smt() {
+        use clap::CommandFactory;
+
+        let mut command = Args::command();
+        let opt_help = command
+            .find_subcommand_mut("opt")
+            .expect("opt subcommand should be registered")
+            .render_long_help()
+            .to_string();
+
+        assert!(
+            opt_help.contains("0 disables SMT queries")
+                && opt_help.contains("does not request an unbounded solver query"),
+            "opt help should define the zero solver-timeout policy:\n{opt_help}"
         );
     }
 

--- a/src/search/config.rs
+++ b/src/search/config.rs
@@ -337,6 +337,10 @@ pub struct SearchConfig {
     /// Overall timeout for the search
     pub timeout: Option<Duration>,
     /// Timeout for each SMT solver query used by verification/synthesis.
+    ///
+    /// A configured zero disables SMT queries. Search backends must resolve
+    /// this field through [`Self::solver_timeout_within_budget`] rather than
+    /// pass zero to Z3, where it would mean an unbounded query.
     pub solver_timeout: Option<Duration>,
     /// Number of worker threads (rayon) for algorithms that parallelise.
     /// `None` lets rayon pick its default (typically logical-core count).
@@ -420,6 +424,10 @@ impl SearchConfig {
         self
     }
 
+    /// Set the per-query SMT timeout.
+    ///
+    /// [`Duration::ZERO`] disables SMT queries; it never requests an
+    /// unbounded solver query.
     pub fn with_solver_timeout(mut self, timeout: Duration) -> Self {
         self.solver_timeout = Some(timeout);
         self
@@ -521,19 +529,41 @@ impl SearchConfig {
     /// `elapsed` is how long the overall search has been running. The result
     /// is [`solver_timeout`](Self::solver_timeout) capped at the time left
     /// before [`timeout`](Self::timeout) elapses (unbounded when `timeout` is
-    /// `None`). Returns `None` when the budget is exhausted: Z3 timeouts are
-    /// configured in whole milliseconds, so a sub-millisecond remainder cannot
-    /// be represented usefully and is treated as exhausted.
+    /// `None`). Returns `None` when SMT is disabled by a configured zero or
+    /// when the budget is exhausted. Z3 timeouts are configured in whole
+    /// milliseconds, so a positive sub-millisecond timeout cannot be
+    /// represented usefully and is also treated as exhausted.
     ///
     /// All SMT-driven backends resolve their per-query timeout here so the
     /// budget-clamping rule cannot drift between them.
     pub fn solver_timeout_within_budget(&self, elapsed: Duration) -> Option<Duration> {
-        let solver_timeout = self.solver_timeout();
-        let timeout = match self.timeout {
-            Some(search_timeout) => solver_timeout.min(search_timeout.checked_sub(elapsed)?),
-            None => solver_timeout,
-        };
-        (timeout.as_millis() > 0).then_some(timeout)
+        match self.timeout {
+            Some(search_timeout) => {
+                self.solver_timeout_with_remaining_budget(search_timeout.checked_sub(elapsed)?)
+            }
+            None => Self::solver_query_timeout(self.solver_timeout()),
+        }
+    }
+
+    /// Per-query SMT solver timeout capped by an already-computed remaining
+    /// search budget.
+    ///
+    /// The LLM backend computes its remaining budget around an external Codex
+    /// call, while the other SMT-driven backends provide total elapsed time to
+    /// [`Self::solver_timeout_within_budget`]. Both routes terminate here so
+    /// configured zero and sub-millisecond timeouts have one shared meaning.
+    pub(crate) fn solver_timeout_with_remaining_budget(
+        &self,
+        remaining: Duration,
+    ) -> Option<Duration> {
+        Self::solver_query_timeout(self.solver_timeout().min(remaining))
+    }
+
+    fn solver_query_timeout(timeout: Duration) -> Option<Duration> {
+        // Z3 interprets a zero timeout as unbounded. SearchConfig deliberately
+        // reserves zero for "skip SMT", and Z3 cannot represent positive
+        // sub-millisecond timeouts, so neither value may reach a backend.
+        (!timeout.is_zero() && timeout.as_millis() > 0).then_some(timeout)
     }
 }
 
@@ -788,6 +818,37 @@ mod tests {
         assert_eq!(
             unbounded_explicit.solver_timeout_within_budget(Duration::from_secs(999)),
             Some(Duration::from_secs(30))
+        );
+    }
+
+    #[test]
+    fn solver_timeout_with_remaining_budget_uses_the_shared_zero_policy() {
+        let disabled = SearchConfig::default().with_solver_timeout(Duration::ZERO);
+        assert_eq!(
+            disabled.solver_timeout_with_remaining_budget(Duration::from_secs(10)),
+            None
+        );
+        assert_eq!(disabled.solver_timeout_within_budget(Duration::ZERO), None);
+        assert_eq!(
+            disabled
+                .clone()
+                .with_timeout_option(None)
+                .solver_timeout_within_budget(Duration::from_secs(999)),
+            None
+        );
+
+        let configured = SearchConfig::default().with_solver_timeout(Duration::from_millis(25));
+        assert_eq!(
+            configured.solver_timeout_with_remaining_budget(Duration::from_secs(10)),
+            Some(Duration::from_millis(25))
+        );
+        assert_eq!(
+            configured.solver_timeout_with_remaining_budget(Duration::from_millis(7)),
+            Some(Duration::from_millis(7))
+        );
+        assert_eq!(
+            configured.solver_timeout_with_remaining_budget(Duration::from_micros(500)),
+            None
         );
     }
 

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -277,8 +277,9 @@ where
     I: ISA + EnumerativeBackend<I>,
 {
     let Some(smt_timeout) = config.solver_timeout_within_budget(start.elapsed()) else {
-        // No millisecond-granularity SMT budget remains for this candidate, so
-        // stop the whole parallel enumerative search rather than just this arm.
+        // SMT is disabled or no millisecond-granularity budget remains for
+        // this candidate. Stop the whole parallel enumerative search rather
+        // than just this arm.
         shared.stop.store(true, Ordering::Relaxed);
         return false;
     };
@@ -1778,6 +1779,32 @@ mod tests {
             &config,
             &shared,
             expired_start,
+        ));
+        assert!(shared.stop.load(Ordering::Relaxed));
+        assert_eq!(shared.smt_queries.load(Ordering::Relaxed), 0);
+        assert_eq!(shared.smt_elapsed_nanos.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn verify_candidate_stops_without_smt_when_solver_timeout_is_zero() {
+        let target = vec![Instruction::MovImm {
+            rd: Register::X0,
+            imm: 0,
+        }];
+        let candidate = target.clone();
+        let live_out = LiveOut::from_registers(vec![Register::X0]);
+        let config = SearchConfig::default()
+            .with_timeout_option(None)
+            .with_solver_timeout(std::time::Duration::ZERO);
+        let shared = SharedState::<AArch64>::new(u64::MAX);
+
+        assert!(!verify_candidate::<AArch64>(
+            &target,
+            &candidate,
+            &live_out,
+            &config,
+            &shared,
+            std::time::Instant::now(),
         ));
         assert!(shared.stop.load(Ordering::Relaxed));
         assert_eq!(shared.smt_queries.load(Ordering::Relaxed), 0);

--- a/src/search/llm/mod.rs
+++ b/src/search/llm/mod.rs
@@ -24,8 +24,6 @@ use self::ledger::UnsupportedMnemonicLedger;
 use self::outcome::{IterationOutcome, classify};
 use self::prompt::{OUTPUT_SCHEMA, build_prompt};
 
-const MIN_SMT_TIMEOUT: Duration = Duration::from_millis(1);
-
 /// LLM-assisted search using the Codex CLI.
 ///
 /// Each call to `search` invokes `codex exec` up to `LlmConfig.max_codex_calls`
@@ -182,7 +180,7 @@ impl SearchAlgorithm<crate::isa::AArch64> for LlmSearch {
             else {
                 if config.verbose {
                     eprintln!(
-                        "llm-search: timeout before verifying candidate on call {}",
+                        "llm-search: SMT disabled or budget exhausted before verifying candidate on call {}",
                         call_idx
                     );
                 }
@@ -311,9 +309,7 @@ fn verification_timeout_for_remaining(
     config: &SearchConfig,
     remaining: Duration,
 ) -> Option<Duration> {
-    let solver_timeout = config.solver_timeout();
-    let timeout = remaining.min(solver_timeout);
-    (timeout >= MIN_SMT_TIMEOUT).then_some(timeout)
+    config.solver_timeout_with_remaining_budget(remaining)
 }
 
 #[cfg(test)]
@@ -388,6 +384,16 @@ mod tests {
         assert_eq!(
             verification_timeout_for_remaining(&config, Duration::from_secs(10)),
             Some(Duration::from_millis(25))
+        );
+    }
+
+    #[test]
+    fn llm_zero_solver_timeout_skips_smt() {
+        let config = SearchConfig::default().with_solver_timeout(Duration::ZERO);
+
+        assert_eq!(
+            verification_timeout_for_remaining(&config, Duration::from_secs(10)),
+            None
         );
     }
 

--- a/src/search/stochastic/mcmc.rs
+++ b/src/search/stochastic/mcmc.rs
@@ -242,10 +242,10 @@ where
             if proposal_cost < best_cost {
                 let Some(smt_timeout) = config.solver_timeout_within_budget(start_time.elapsed())
                 else {
-                    // No millisecond-granularity SMT budget remains, so the
-                    // overall search deadline is effectively reached; stop
-                    // rather than hand Z3 a timeout it cannot honour. Mirrors
-                    // the enumerative path.
+                    // SMT is disabled or no millisecond-granularity budget
+                    // remains. Stop rather than hand Z3 its unbounded zero
+                    // sentinel or a timeout it cannot honour. Mirrors the
+                    // enumerative path.
                     break;
                 };
                 let (verdict, metrics) = <I as StochasticBackend<I>>::check_equivalence(
@@ -775,6 +775,28 @@ mod tests {
             (1..=50).contains(&recorded),
             "solver timeout should be clamped to the ~50ms budget, got {recorded}ms",
         );
+    }
+
+    #[test]
+    fn stochastic_zero_solver_timeout_skips_smt() {
+        let (statistics, recorded_timeout) = run_timeout_probe_search_with(
+            SearchConfig::default()
+                .with_timeout_option(None)
+                .with_solver_timeout(Duration::ZERO)
+                .with_stochastic(
+                    StochasticConfig::default()
+                        .with_iterations(1)
+                        .with_test_count(0)
+                        .with_seed(1),
+                ),
+            TIMEOUT_PROBE_EQUIVALENT,
+            true,
+        );
+
+        assert_eq!(recorded_timeout, None);
+        assert_eq!(statistics.smt_queries, 0);
+        assert_eq!(statistics.smt_equivalent, 0);
+        assert_eq!(statistics.improvements_found, 0);
     }
 
     #[test]

--- a/src/search/symbolic/synthesis.rs
+++ b/src/search/symbolic/synthesis.rs
@@ -357,9 +357,9 @@ where
         start_time: Instant,
     ) -> bool {
         let Some(timeout) = config.solver_timeout_within_budget(start_time.elapsed()) else {
-            // No millisecond-granularity SMT budget remains: we cannot fund a
-            // query, so treat the candidate as unproven rather than hand Z3 a
-            // timeout it cannot honour.
+            // SMT is disabled or no millisecond-granularity budget remains,
+            // so treat the candidate as unproven rather than hand Z3 its
+            // unbounded zero sentinel or a timeout it cannot honour.
             return false;
         };
         let width = <I as SymbolicBackend<I>>::width();
@@ -1465,6 +1465,31 @@ mod tests {
             (1..=50).contains(&recorded),
             "solver timeout should be clamped to the ~50ms budget, got {recorded}ms",
         );
+    }
+
+    #[test]
+    fn symbolic_zero_solver_timeout_skips_smt() {
+        let _guard = SYMBOLIC_INNER_LOOP_TEST_LOCK
+            .lock()
+            .expect("symbolic inner-loop test lock poisoned");
+        reset_symbolic_inner_loop_test_state();
+
+        let mut search: SymbolicSearch<TestIsa> = SymbolicSearch::new();
+        let config = SearchConfig::default()
+            .with_timeout_option(None)
+            .with_solver_timeout(Duration::ZERO);
+        let target = [TestInstruction(1)];
+        let candidate = [TestInstruction(2)];
+
+        assert!(!search.verify_equivalence(
+            &target,
+            &candidate,
+            &(),
+            &config,
+            std::time::Instant::now()
+        ));
+        assert_eq!(TEST_EQUIVALENCE_CHECKS.load(Ordering::SeqCst), 0);
+        assert_eq!(search.statistics().smt_queries, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reserve `--solver-timeout 0` / `Duration::ZERO` as the explicit SMT-disable sentinel rather than Z3 unbounded mode
- centralize the remaining-budget gate for enumerative, stochastic, symbolic, and LLM search and add backend regressions
- document candidate-acceptance consequences and alternatives in CLI help, README, and ADR-0011

## Validation

- `./ci_check.sh`
- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`

Closes #670

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**