### PR TITLE
refactor(validation): lift downstream-liveness wiring into the library

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,6 @@ use s11::search::parallel::{ParallelConfig, run_parallel_search};
 use s11::search::{EnumerativeSearch, SearchAlgorithm, StochasticSearch, SymbolicSearch};
 use s11::semantics::LiveOut;
 use s11::semantics::cost::CostMetric;
-use s11::validation::downstream::{ScanStep, scan_flags_live, scan_regs_live};
 #[allow(unused_imports)]
 use s11::{assembler, elf_patcher, ir, isa, parser, search, semantics, validation};
 
@@ -769,7 +768,7 @@ impl ElfOptimizationBackend for AArch64OptimizationBackend {
             DownstreamLiveRegs::Unknown
         } else {
             let candidates = validation::live_out::compute_written_registers(prefix);
-            DownstreamLiveRegs::Aarch64(aarch64_downstream_regs_live_from_section(
+            DownstreamLiveRegs::Aarch64(validation::downstream::aarch64_downstream_regs_live(
                 patcher,
                 section,
                 end_addr,
@@ -778,7 +777,7 @@ impl ElfOptimizationBackend for AArch64OptimizationBackend {
             ))
         };
         OptimizationContext {
-            downstream_flags_live: aarch64_downstream_flags_live_from_section(
+            downstream_flags_live: validation::downstream::aarch64_downstream_flags_live(
                 patcher, section, end_addr, cs,
             ),
             downstream_live_regs,
@@ -958,7 +957,7 @@ impl ElfOptimizationBackend for X86OptimizationBackend {
             let candidates = semantics::live_out::RegisterSet::from_registers(
                 ir.iter().filter_map(|i| i.destination()).collect(),
             );
-            DownstreamLiveRegs::X86(x86_downstream_regs_live_from_section(
+            DownstreamLiveRegs::X86(validation::downstream::x86_downstream_regs_live(
                 self.arch(),
                 patcher,
                 section,
@@ -968,7 +967,7 @@ impl ElfOptimizationBackend for X86OptimizationBackend {
             ))
         };
         OptimizationContext {
-            downstream_flags_live: x86_downstream_flags_live_from_section(
+            downstream_flags_live: validation::downstream::x86_downstream_flags_live(
                 self.arch(),
                 patcher,
                 section,
@@ -2263,239 +2262,6 @@ fn convert_to_ir(instructions: &capstone::Instructions) -> Result<Vec<Instructio
     Ok(ir_instructions)
 }
 
-/// Resolve the in-section fall-through suffix after an optimization window
-/// ending at `end_addr`. `None` means there is no analyzable suffix — the
-/// window already reaches the section end, or the bytes are unavailable — in
-/// which case downstream liveness is unknown and the caller keeps every
-/// candidate live (the conservative default). The four `*_from_section`
-/// wrappers below all funnel through here rather than repeating the suffix math.
-fn fall_through_suffix(
-    patcher: &ElfPatcher,
-    section: &TextSection,
-    end_addr: u64,
-) -> Option<Vec<u8>> {
-    let section_end = section.virtual_addr + section.size;
-    if end_addr >= section_end {
-        return None;
-    }
-    let suffix_window = AddressWindow {
-        start: end_addr,
-        end: section_end,
-    };
-    patcher.get_instructions_in_window(&suffix_window).ok()
-}
-
-/// Decode one AArch64 Capstone `(mnemonic, op_str)` pair into a downstream scan
-/// step, reusing the shared Capstone→IR bridge so the fall-through scan honors
-/// exactly the same supported-mnemonic set as the optimizer.
-fn aarch64_scan_step(mnemonic: &str, op_str: &str) -> ScanStep<Instruction> {
-    match convert_capstone_op(mnemonic, op_str) {
-        ConvertOutcome::Instruction(instr) => ScanStep::Decoded(instr),
-        ConvertOutcome::Skip => ScanStep::Skipped,
-        ConvertOutcome::Unsupported(_) => ScanStep::Opaque,
-    }
-}
-
-fn aarch64_downstream_flags_live_from_bytes(cs: &Capstone, bytes: &[u8], start_addr: u64) -> bool {
-    scan_flags_live(
-        cs,
-        bytes,
-        start_addr,
-        aarch64_scan_step,
-        |instr: &Instruction| {
-            validation::live_out::flags_read_before_overwrite_after_window(std::slice::from_ref(
-                instr,
-            ))
-        },
-        |instr: &Instruction| instr.modifies_flags(),
-        |instr: &Instruction| instr.is_terminator(),
-    )
-}
-
-fn aarch64_downstream_flags_live_from_section(
-    patcher: &ElfPatcher,
-    section: &TextSection,
-    end_addr: u64,
-    cs: &Capstone,
-) -> bool {
-    match fall_through_suffix(patcher, section, end_addr) {
-        Some(bytes) => aarch64_downstream_flags_live_from_bytes(cs, &bytes, end_addr),
-        None => true,
-    }
-}
-
-/// Compute the subset of `candidates` (registers the window writes) that are
-/// provably *live* downstream of an AArch64 window, given the fall-through
-/// bytes that follow it.
-///
-/// This is the register counterpart to `aarch64_downstream_flags_live_from_bytes`
-/// and walks the suffix the same way: disassemble one instruction at a time,
-/// convert it to IR, and stop at the first uncertainty.
-///
-/// **Soundness discipline (the #224 bug class).** A candidate register stays in
-/// the live set unless the scan can *prove* it dead. Concretely, a candidate R
-/// is dropped from live-out only when, walking forward from the window, the
-/// first instruction that mentions R fully overwrites R *before reading it*
-/// (`DownstreamRegLiveness::Dead`). Every other situation keeps R live:
-/// * R is read by a later instruction before any full overwrite (`Read`);
-/// * the scan hits a terminator (which on AArch64 includes `B`/`BR`/`BL`/`RET`,
-///   so the call/ret ABI is covered — any window-written register may be
-///   observable across the transfer, so all still-undecided candidates are
-///   pinned live);
-/// * an instruction is unsupported by the optimization IR or fails to
-///   disassemble (we cannot reason about its reads/writes);
-/// * control leaves the analyzable region (handled by the caller, which passes
-///   only in-region bytes and treats an empty / out-of-range window as "all
-///   live").
-///
-/// `Skip` (NOP) instructions neither read nor write and are stepped over.
-fn aarch64_downstream_regs_live_from_bytes(
-    cs: &Capstone,
-    bytes: &[u8],
-    start_addr: u64,
-    candidates: &semantics::live_out::RegisterSet<Register>,
-) -> semantics::live_out::RegisterSet<Register> {
-    scan_regs_live(
-        cs,
-        bytes,
-        start_addr,
-        candidates,
-        aarch64_scan_step,
-        |instr: &Instruction| instr.is_terminator(),
-        |reg: Register, instr: &Instruction| {
-            validation::live_out::aarch64_reg_downstream_liveness(reg, std::slice::from_ref(instr))
-        },
-    )
-}
-
-/// Section wrapper for `aarch64_downstream_regs_live_from_bytes`. Returns all
-/// candidates live whenever the suffix is unavailable or the window already
-/// reaches the section end (the byte-scan default for an unanalyzable region).
-fn aarch64_downstream_regs_live_from_section(
-    patcher: &ElfPatcher,
-    section: &TextSection,
-    end_addr: u64,
-    cs: &Capstone,
-    candidates: &semantics::live_out::RegisterSet<Register>,
-) -> semantics::live_out::RegisterSet<Register> {
-    match fall_through_suffix(patcher, section, end_addr) {
-        Some(bytes) => aarch64_downstream_regs_live_from_bytes(cs, &bytes, end_addr, candidates),
-        None => candidates.clone(),
-    }
-}
-
-/// Decode one x86 Capstone `(mnemonic, op_str)` pair into a downstream scan
-/// step. `nop` carries no observable state and is stepped over; anything the
-/// shared x86 IR does not model (including `call`/`ret`) is opaque and pins the
-/// remaining state live.
-fn x86_scan_step(mnemonic: &str, op_str: &str) -> ScanStep<isa::x86::X86Instruction> {
-    match x86_ir_from_mnemonic(mnemonic, op_str) {
-        Ok(Some(instr)) => ScanStep::Decoded(instr),
-        Ok(None) if mnemonic.eq_ignore_ascii_case("nop") => ScanStep::Skipped,
-        Ok(None) => ScanStep::Opaque,
-        Err(_) => ScanStep::Opaque,
-    }
-}
-
-fn x86_downstream_flags_live_from_bytes<I>(cs: &Capstone, bytes: &[u8], start_addr: u64) -> bool
-where
-    I: isa::FlagsAnalysis<isa::x86::X86Instruction>,
-{
-    scan_flags_live(
-        cs,
-        bytes,
-        start_addr,
-        x86_scan_step,
-        |instr: &isa::x86::X86Instruction| {
-            <I as isa::FlagsAnalysis<isa::x86::X86Instruction>>::reads_flags(instr)
-        },
-        |instr: &isa::x86::X86Instruction| {
-            <I as isa::FlagsAnalysis<isa::x86::X86Instruction>>::modifies_flags(instr)
-        },
-        |instr: &isa::x86::X86Instruction| instr.is_terminator(),
-    )
-}
-
-fn x86_downstream_flags_live_from_section(
-    arch: DetectedArch,
-    patcher: &ElfPatcher,
-    section: &TextSection,
-    end_addr: u64,
-    cs: &Capstone,
-) -> bool {
-    let Some(bytes) = fall_through_suffix(patcher, section, end_addr) else {
-        return true;
-    };
-
-    match arch {
-        DetectedArch::X86_64 => {
-            x86_downstream_flags_live_from_bytes::<isa::X86_64>(cs, &bytes, end_addr)
-        }
-        DetectedArch::X86_32 => {
-            x86_downstream_flags_live_from_bytes::<isa::X86_32>(cs, &bytes, end_addr)
-        }
-        DetectedArch::Aarch64 => true,
-    }
-}
-
-/// Compute the subset of `candidates` (registers an x86 window writes) that are
-/// provably *live* downstream, given the fall-through bytes that follow.
-///
-/// Structurally identical to the AArch64 register scan. The x86 kill rule
-/// distinguishes full architectural writes (native or dword) from word and
-/// byte writes that preserve surrounding bits. An instruction that reads a
-/// candidate first keeps it live; an unsupported instruction — including
-/// `call`/`ret`, since neither is modelled in the x86 IR — a terminator, a
-/// disassembly failure, or the end of the in-region suffix conservatively
-/// pins every unresolved candidate live.
-///
-/// Unlike the flags scan, this needs no ISA-marker type parameter: register
-/// reads/kills are width-independent in the shared x86 IR, and the `cs`
-/// disassembler is already configured for the right mode by the caller.
-fn x86_downstream_regs_live_from_bytes(
-    cs: &Capstone,
-    bytes: &[u8],
-    start_addr: u64,
-    candidates: &semantics::live_out::RegisterSet<isa::x86::X86Register>,
-) -> semantics::live_out::RegisterSet<isa::x86::X86Register> {
-    scan_regs_live(
-        cs,
-        bytes,
-        start_addr,
-        candidates,
-        x86_scan_step,
-        |instr: &isa::x86::X86Instruction| instr.is_terminator(),
-        |reg: isa::x86::X86Register, instr: &isa::x86::X86Instruction| {
-            validation::live_out::x86_reg_downstream_liveness(reg, std::slice::from_ref(instr))
-        },
-    )
-}
-
-/// Section wrapper for `x86_downstream_regs_live_from_bytes`. Returns all
-/// candidates live whenever the suffix is unavailable, the window reaches the
-/// section end, or the arch is not an x86 mode.
-fn x86_downstream_regs_live_from_section(
-    arch: DetectedArch,
-    patcher: &ElfPatcher,
-    section: &TextSection,
-    end_addr: u64,
-    cs: &Capstone,
-    candidates: &semantics::live_out::RegisterSet<isa::x86::X86Register>,
-) -> semantics::live_out::RegisterSet<isa::x86::X86Register> {
-    let Some(bytes) = fall_through_suffix(patcher, section, end_addr) else {
-        return candidates.clone();
-    };
-
-    match arch {
-        // Register liveness is width-independent; the mode-configured `cs`
-        // already drives the correct x86-32/x86-64 disassembly.
-        DetectedArch::X86_64 | DetectedArch::X86_32 => {
-            x86_downstream_regs_live_from_bytes(cs, &bytes, end_addr, candidates)
-        }
-        DetectedArch::Aarch64 => candidates.clone(),
-    }
-}
-
 /// Flags-only context derivation, used as the trait default and by callers
 /// that do not have the window IR available to derive register liveness. The
 /// register-liveness narrowing (#621) needs the window's written set, so it is
@@ -2510,7 +2276,7 @@ fn optimization_context_for_backend(
 ) -> OptimizationContext {
     if arch == DetectedArch::Aarch64 {
         return OptimizationContext {
-            downstream_flags_live: aarch64_downstream_flags_live_from_section(
+            downstream_flags_live: validation::downstream::aarch64_downstream_flags_live(
                 patcher, section, end_addr, cs,
             ),
             downstream_live_regs: DownstreamLiveRegs::Unknown,
@@ -2519,7 +2285,7 @@ fn optimization_context_for_backend(
 
     if matches!(arch, DetectedArch::X86_64 | DetectedArch::X86_32) {
         return OptimizationContext {
-            downstream_flags_live: x86_downstream_flags_live_from_section(
+            downstream_flags_live: validation::downstream::x86_downstream_flags_live(
                 arch, patcher, section, end_addr, cs,
             ),
             downstream_live_regs: DownstreamLiveRegs::Unknown,
@@ -2558,7 +2324,7 @@ fn validate_basic_block(ir: &[Instruction]) -> Result<(), String> {
 // (`convert_to_x86_ir`) and the length-1 enumerator used by the
 // enumerative x86 pipeline.
 
-use parser::x86::{X86ParseMode, x86_ir_from_mnemonic, x86_ir_from_mnemonic_for_mode};
+use parser::x86::{X86ParseMode, x86_ir_from_mnemonic_for_mode};
 
 /// Reject any non-terminal Jcc in an x86 optimization window. The
 /// optimizer only special-cases a trailing Jcc (peeled by
@@ -4277,12 +4043,6 @@ mod cli_helper_tests {
             .expect("test capstone should build")
     }
 
-    fn assemble_x86_64_test_bytes(instructions: &[X86Instruction]) -> Vec<u8> {
-        assembler::x86::X86Assembler::new_64()
-            .assemble_instructions(instructions)
-            .expect("test instruction should assemble")
-    }
-
     fn x86_64_test_capstone() -> Capstone {
         Capstone::new()
             .x86()
@@ -4802,316 +4562,6 @@ mod cli_helper_tests {
         assert!(error.contains("x86-64 window 0x5000-0x5001"), "{error}");
         assert!(error.contains("decoded only 0 bytes"), "{error}");
         assert!(error.contains("first undecoded byte at 0x5000"), "{error}");
-    }
-
-    #[test]
-    fn downstream_flags_live_scan_marks_dead_when_first_flag_event_writes() {
-        let bytes = assemble_aarch64_test_bytes(&[
-            Instruction::Cmp {
-                rn: Register::X0,
-                rm: Operand::Immediate(0),
-            },
-            Instruction::Csel {
-                rd: Register::X1,
-                rn: Register::X2,
-                rm: Register::X3,
-                cond: s11::ir::Condition::EQ,
-            },
-        ]);
-        let cs = aarch64_test_capstone();
-
-        assert!(!aarch64_downstream_flags_live_from_bytes(
-            &cs, &bytes, 0x1000
-        ));
-    }
-
-    #[test]
-    fn downstream_flags_live_scan_marks_live_when_first_flag_event_reads() {
-        let bytes = assemble_aarch64_test_bytes(&[Instruction::Csel {
-            rd: Register::X1,
-            rn: Register::X2,
-            rm: Register::X3,
-            cond: s11::ir::Condition::EQ,
-        }]);
-        let cs = aarch64_test_capstone();
-
-        assert!(aarch64_downstream_flags_live_from_bytes(
-            &cs, &bytes, 0x1000
-        ));
-    }
-
-    #[test]
-    fn downstream_flags_live_scan_marks_dead_for_known_non_flag_suffix() {
-        let bytes = assemble_aarch64_test_bytes(&[Instruction::Add {
-            rd: Register::X1,
-            rn: Register::X2,
-            rm: Operand::Immediate(1),
-        }]);
-        let cs = aarch64_test_capstone();
-
-        assert!(!aarch64_downstream_flags_live_from_bytes(
-            &cs, &bytes, 0x1000
-        ));
-    }
-
-    #[test]
-    fn downstream_flags_live_scan_is_conservative_for_unknown_context() {
-        let cs = aarch64_test_capstone();
-
-        assert!(aarch64_downstream_flags_live_from_bytes(&cs, &[], 0x1000));
-        assert!(aarch64_downstream_flags_live_from_bytes(
-            &cs,
-            &[0xff],
-            0x1000
-        ));
-        // LDR literal decodes in Capstone but is intentionally unsupported by
-        // the AArch64 optimization IR parser.
-        assert!(aarch64_downstream_flags_live_from_bytes(
-            &cs,
-            &[0x00, 0x00, 0x00, 0x58],
-            0x1000
-        ));
-    }
-
-    #[test]
-    fn downstream_flags_live_scan_is_conservative_for_unanalysed_branch() {
-        let bytes = assemble_aarch64_test_bytes(&[Instruction::B {
-            target: s11::ir::LabelId(0x1000),
-        }]);
-        let cs = aarch64_test_capstone();
-
-        assert!(aarch64_downstream_flags_live_from_bytes(
-            &cs, &bytes, 0x1000
-        ));
-    }
-
-    #[test]
-    fn x86_downstream_flags_live_scan_marks_live_when_first_flag_event_reads() {
-        use isa::x86::X86Condition;
-
-        let bytes = assemble_x86_64_test_bytes(&[X86Instruction::Jcc {
-            cond: X86Condition::E,
-        }]);
-        let cs = x86_64_test_capstone();
-
-        assert!(x86_downstream_flags_live_from_bytes::<isa::X86_64>(
-            &cs, &bytes, 0x1000
-        ));
-    }
-
-    #[test]
-    fn x86_downstream_flags_live_scan_marks_dead_when_first_flag_event_writes() {
-        let bytes = assemble_x86_64_test_bytes(&[
-            X86Instruction::CmpReg {
-                rn: X86Register::RAX,
-                rs: X86Register::RBX,
-            },
-            X86Instruction::MovImm {
-                rd: X86Register::RAX,
-                imm: 0,
-            },
-        ]);
-        let cs = x86_64_test_capstone();
-
-        assert!(!x86_downstream_flags_live_from_bytes::<isa::X86_64>(
-            &cs, &bytes, 0x1000
-        ));
-    }
-
-    #[test]
-    fn x86_downstream_flags_live_scan_marks_dead_for_known_non_flag_suffix() {
-        let bytes = assemble_x86_64_test_bytes(&[X86Instruction::MovImm {
-            rd: X86Register::RAX,
-            imm: 0,
-        }]);
-        let cs = x86_64_test_capstone();
-
-        assert!(!x86_downstream_flags_live_from_bytes::<isa::X86_64>(
-            &cs, &bytes, 0x1000
-        ));
-    }
-
-    #[test]
-    fn x86_downstream_flags_live_scan_is_conservative_for_unknown_context() {
-        let cs = x86_64_test_capstone();
-
-        assert!(x86_downstream_flags_live_from_bytes::<isa::X86_64>(
-            &cs,
-            &[],
-            0x1000
-        ));
-        assert!(x86_downstream_flags_live_from_bytes::<isa::X86_64>(
-            &cs,
-            &[0xff],
-            0x1000
-        ));
-        assert!(x86_downstream_flags_live_from_bytes::<isa::X86_64>(
-            &cs,
-            &[0xc3],
-            0x1000
-        ));
-    }
-
-    // ---- downstream register-liveness byte scans (#621) ----
-
-    fn x86_64_regset(regs: &[X86Register]) -> semantics::live_out::RegisterSet<X86Register> {
-        semantics::live_out::RegisterSet::from_registers(regs.to_vec())
-    }
-
-    fn aarch64_regset(regs: &[Register]) -> semantics::live_out::RegisterSet<Register> {
-        semantics::live_out::RegisterSet::from_registers(regs.to_vec())
-    }
-
-    #[test]
-    fn downstream_regs_live_scan_marks_dead_when_later_full_overwrite_precedes_any_read() {
-        // Window wrote X0. Suffix `mov x0, x1` fully overwrites x0 before any
-        // read, so X0 is dead/optimizable.
-        let bytes = assemble_aarch64_test_bytes(&[Instruction::MovReg {
-            rd: Register::X0,
-            rn: Register::X1,
-        }]);
-        let cs = aarch64_test_capstone();
-        let live = aarch64_downstream_regs_live_from_bytes(
-            &cs,
-            &bytes,
-            0x1000,
-            &aarch64_regset(&[Register::X0]),
-        );
-        assert!(
-            !live.contains(Register::X0),
-            "x0 fully overwritten before any read must be dropped from live-out"
-        );
-    }
-
-    #[test]
-    fn downstream_regs_live_scan_marks_live_when_read_before_overwrite() {
-        // Window wrote RAX. Suffix `add x2, x0, #1` reads x0 before any
-        // redefinition — x0 must stay live.
-        let bytes = assemble_aarch64_test_bytes(&[Instruction::Add {
-            rd: Register::X2,
-            rn: Register::X0,
-            rm: Operand::Immediate(1),
-        }]);
-        let cs = aarch64_test_capstone();
-        let live = aarch64_downstream_regs_live_from_bytes(
-            &cs,
-            &bytes,
-            0x1000,
-            &aarch64_regset(&[Register::X0]),
-        );
-        assert!(
-            live.contains(Register::X0),
-            "x0 read before any overwrite must stay live"
-        );
-    }
-
-    #[test]
-    fn downstream_regs_live_scan_conservative_for_unknown_context() {
-        let cs = aarch64_test_capstone();
-        let candidates = aarch64_regset(&[Register::X0, Register::X1]);
-
-        // Empty suffix → both candidates live.
-        let empty = aarch64_downstream_regs_live_from_bytes(&cs, &[], 0x1000, &candidates);
-        assert!(empty.contains(Register::X0) && empty.contains(Register::X1));
-
-        // Undisassemblable byte → live.
-        let garbage = aarch64_downstream_regs_live_from_bytes(&cs, &[0xff], 0x1000, &candidates);
-        assert!(garbage.contains(Register::X0) && garbage.contains(Register::X1));
-
-        // LDR-literal decodes in Capstone but is unsupported by the IR → live.
-        let unsupported = aarch64_downstream_regs_live_from_bytes(
-            &cs,
-            &[0x00, 0x00, 0x00, 0x58],
-            0x1000,
-            &candidates,
-        );
-        assert!(unsupported.contains(Register::X0) && unsupported.contains(Register::X1));
-    }
-
-    #[test]
-    fn downstream_regs_live_scan_marks_live_across_call_ret() {
-        let cs = aarch64_test_capstone();
-        let candidates = aarch64_regset(&[Register::X0, Register::X1]);
-
-        // `bl #0` is a call terminator → every window register may be
-        // observable across the ABI; keep them all live.
-        let bl_bytes = assemble_aarch64_test_bytes(&[Instruction::Bl {
-            target: s11::ir::LabelId(0x1000),
-        }]);
-        let across_call =
-            aarch64_downstream_regs_live_from_bytes(&cs, &bl_bytes, 0x1000, &candidates);
-        assert!(across_call.contains(Register::X0) && across_call.contains(Register::X1));
-
-        // `ret` is a return terminator → same ABI-observable rule.
-        let ret_bytes = assemble_aarch64_test_bytes(&[Instruction::Ret { rn: Register::X30 }]);
-        let across_ret =
-            aarch64_downstream_regs_live_from_bytes(&cs, &ret_bytes, 0x1000, &candidates);
-        assert!(across_ret.contains(Register::X0) && across_ret.contains(Register::X1));
-    }
-
-    #[test]
-    fn x86_partial_write_does_not_kill() {
-        // Window wrote RAX. Suffix `mov al, 0` leaves the rest of RAX intact,
-        // so the downstream scan must not treat it as a full-register kill.
-        let bytes = assemble_x86_64_test_bytes(&[X86Instruction::MovImm {
-            rd: X86Register::AL,
-            imm: 0,
-        }]);
-        let cs = x86_64_test_capstone();
-        let live = x86_downstream_regs_live_from_bytes(
-            &cs,
-            &bytes,
-            0x1000,
-            &x86_64_regset(&[X86Register::RAX]),
-        );
-        assert!(
-            live.contains(X86Register::RAX),
-            "an AL write preserves upper RAX bits, so RAX stays live"
-        );
-    }
-
-    #[test]
-    fn x86_downstream_regs_live_scan_marks_live_when_read_before_overwrite() {
-        // `add rbx, rax` reads rax before any redefinition → rax stays live.
-        let bytes = assemble_x86_64_test_bytes(&[X86Instruction::AddReg {
-            rd: X86Register::RBX,
-            rs: X86Register::RAX,
-        }]);
-        let cs = x86_64_test_capstone();
-        let live = x86_downstream_regs_live_from_bytes(
-            &cs,
-            &bytes,
-            0x1000,
-            &x86_64_regset(&[X86Register::RAX]),
-        );
-        assert!(live.contains(X86Register::RAX));
-    }
-
-    #[test]
-    fn x86_downstream_regs_live_scan_conservative_across_call_ret_and_unknown() {
-        let cs = x86_64_test_capstone();
-        let candidates = x86_64_regset(&[X86Register::RAX]);
-
-        // Empty suffix → live.
-        assert!(
-            x86_downstream_regs_live_from_bytes(&cs, &[], 0x1000, &candidates)
-                .contains(X86Register::RAX)
-        );
-        // `ret` (0xc3) is not modelled in the x86 IR → unsupported → live.
-        assert!(
-            x86_downstream_regs_live_from_bytes(&cs, &[0xc3], 0x1000, &candidates)
-                .contains(X86Register::RAX)
-        );
-        // `call rel32` (e8 00 00 00 00) is likewise not modelled → live.
-        assert!(
-            x86_downstream_regs_live_from_bytes(
-                &cs,
-                &[0xe8, 0x00, 0x00, 0x00, 0x00],
-                0x1000,
-                &candidates
-            )
-            .contains(X86Register::RAX)
-        );
     }
 
     #[test]

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -41,3 +41,102 @@ impl Drop for TempFile {
         let _ = std::fs::remove_file(&self.path);
     }
 }
+
+/// Build a minimal, self-contained ELF64 image with a single executable
+/// `.text` section holding `text_bytes` at virtual address `text_vaddr`.
+///
+/// Just enough of the ELF layout is populated for `ElfPatcher::new` to parse
+/// the file and expose one `.text` `TextSection`. Shared by the tests that
+/// exercise binary-reading code paths across modules.
+#[allow(dead_code)]
+pub(crate) fn build_minimal_elf64(text_bytes: &[u8], text_vaddr: u64, machine: u16) -> Vec<u8> {
+    let elf_header_size = 64usize;
+    let shentsize = 64usize;
+    let shnum = 3usize;
+    let shstrtab: &[u8] = b"\0.text\0.shstrtab\0";
+    let text_offset = elf_header_size;
+    let shstrtab_offset = text_offset + text_bytes.len();
+    let shoff = shstrtab_offset + shstrtab.len();
+    let total_size = shoff + shentsize * shnum;
+
+    let mut buf = vec![0u8; total_size];
+
+    buf[0..4].copy_from_slice(b"\x7fELF");
+    buf[4] = elf::abi::ELFCLASS64;
+    buf[5] = elf::abi::ELFDATA2LSB;
+    buf[6] = elf::abi::EV_CURRENT;
+    buf[16..18].copy_from_slice(&elf::abi::ET_EXEC.to_le_bytes());
+    buf[18..20].copy_from_slice(&machine.to_le_bytes());
+    buf[20..24].copy_from_slice(&(elf::abi::EV_CURRENT as u32).to_le_bytes());
+    buf[40..48].copy_from_slice(&(shoff as u64).to_le_bytes());
+    buf[52..54].copy_from_slice(&(elf_header_size as u16).to_le_bytes());
+    buf[58..60].copy_from_slice(&(shentsize as u16).to_le_bytes());
+    buf[60..62].copy_from_slice(&(shnum as u16).to_le_bytes());
+    buf[62..64].copy_from_slice(&2u16.to_le_bytes());
+
+    buf[text_offset..text_offset + text_bytes.len()].copy_from_slice(text_bytes);
+    buf[shstrtab_offset..shstrtab_offset + shstrtab.len()].copy_from_slice(shstrtab);
+
+    // `fields` follows the Elf64_Shdr layout:
+    // fields[0] => sh_name (u32), fields[1] => sh_type (u32),
+    // fields[2] => sh_flags (u64), fields[3] => sh_addr (u64),
+    // fields[4] => sh_offset (u64), fields[5] => sh_size (u64),
+    // fields[6] => sh_link (u32), fields[7] => sh_info (u32),
+    // fields[8] => sh_addralign (u64), fields[9] => sh_entsize (u64).
+    let mut write_shdr = |index: usize, fields: [u64; 10]| {
+        let base = shoff + index * shentsize;
+        buf[base..base + 4].copy_from_slice(&(fields[0] as u32).to_le_bytes());
+        buf[base + 4..base + 8].copy_from_slice(&(fields[1] as u32).to_le_bytes());
+        buf[base + 8..base + 16].copy_from_slice(&fields[2].to_le_bytes());
+        buf[base + 16..base + 24].copy_from_slice(&fields[3].to_le_bytes());
+        buf[base + 24..base + 32].copy_from_slice(&fields[4].to_le_bytes());
+        buf[base + 32..base + 40].copy_from_slice(&fields[5].to_le_bytes());
+        buf[base + 40..base + 44].copy_from_slice(&(fields[6] as u32).to_le_bytes());
+        buf[base + 44..base + 48].copy_from_slice(&(fields[7] as u32).to_le_bytes());
+        buf[base + 48..base + 56].copy_from_slice(&fields[8].to_le_bytes());
+        buf[base + 56..base + 64].copy_from_slice(&fields[9].to_le_bytes());
+    };
+    write_shdr(0, [0; 10]);
+    write_shdr(
+        1,
+        [
+            1,
+            elf::abi::SHT_PROGBITS as u64,
+            (elf::abi::SHF_ALLOC | elf::abi::SHF_EXECINSTR) as u64,
+            text_vaddr,
+            text_offset as u64,
+            text_bytes.len() as u64,
+            0,
+            0,
+            1,
+            0,
+        ],
+    );
+    write_shdr(
+        2,
+        [
+            7,
+            elf::abi::SHT_STRTAB as u64,
+            0,
+            0,
+            shstrtab_offset as u64,
+            shstrtab.len() as u64,
+            0,
+            0,
+            1,
+            0,
+        ],
+    );
+
+    buf
+}
+
+#[allow(dead_code)]
+pub(crate) fn build_minimal_aarch64_elf(text_bytes: &[u8], text_vaddr: u64) -> Vec<u8> {
+    build_minimal_elf64(text_bytes, text_vaddr, elf::abi::EM_AARCH64)
+}
+
+#[allow(dead_code)]
+pub(crate) fn build_minimal_x86_64_elf(text_bytes: &[u8], text_vaddr: u64) -> Vec<u8> {
+    build_minimal_elf64(text_bytes, text_vaddr, elf::abi::EM_X86_64)
+}

--- a/src/validation/downstream.rs
+++ b/src/validation/downstream.rs
@@ -13,10 +13,16 @@
 //!   (the AArch64 Capstone bridge vs. `x86_ir_from_mnemonic`), and
 //! * the per-instruction liveness rule applied to a decoded instruction.
 //!
-//! Both knobs are supplied by the caller as closures, so this module owns the
-//! shared scanning discipline once — including the soundness default that an
-//! *un-analyzable* suffix keeps everything live — instead of the four
-//! copy-pasted scanners the CLI used to carry.
+//! [`scan_flags_live`] and [`scan_regs_live`] own the shared scanning discipline
+//! once — including the soundness default that an *un-analyzable* suffix keeps
+//! everything live — taking those two knobs as closures. On top of them this
+//! module supplies the per-architecture wiring (the Capstone→IR decoders and the
+//! fall-through suffix resolution) and exposes one small section-level entry
+//! point per (architecture, scanned state): [`aarch64_downstream_flags_live`],
+//! [`aarch64_downstream_regs_live`], [`x86_downstream_flags_live`], and
+//! [`x86_downstream_regs_live`]. That wiring used to be copy-pasted in the CLI
+//! binary root, out of reach of library tests; consolidating it here keeps every
+//! downstream-liveness decision — and its soundness default — in one place.
 //!
 //! The per-instruction liveness primitives themselves live next door in
 //! [`super::live_out`] (`aarch64_reg_downstream_liveness`,
@@ -25,7 +31,12 @@
 use capstone::prelude::*;
 
 use super::live_out::DownstreamRegLiveness;
-use crate::isa::RegisterType;
+use crate::capstone_bridge::{ConvertOutcome, convert_capstone_op};
+use crate::elf_patcher::{AddressWindow, DetectedArch, ElfPatcher, TextSection};
+use crate::ir::{Instruction, Register};
+use crate::isa::x86::{X86Instruction, X86Register};
+use crate::isa::{FlagsAnalysis, RegisterType, X86_32, X86_64};
+use crate::parser::x86::x86_ir_from_mnemonic;
 use crate::semantics::live_out::RegisterSet;
 
 /// One decoded step of a downstream suffix scan — the caller's `decode` closure
@@ -204,10 +215,219 @@ where
     pin_all_remaining_live!();
 }
 
+// ---------------------------------------------------------------------------
+// Per-architecture wiring. The scanners above own the shared discipline; the
+// functions below supply the two knobs (Capstone→IR decode, per-instruction
+// rule), resolve the fall-through suffix from the ELF section, and expose one
+// small section-level entry point per (architecture, scanned state). These used
+// to live in the CLI binary root, out of reach of library tests; keeping them
+// here co-locates all downstream-liveness logic in one module.
+// ---------------------------------------------------------------------------
+
+/// Resolve the in-section fall-through suffix after an optimization window
+/// ending at `end_addr`. `None` means there is no analyzable suffix — the
+/// window already reaches the section end, or the bytes are unavailable — in
+/// which case downstream liveness is unknown and the caller keeps every
+/// candidate live (the conservative default). The section-level entry points
+/// below all funnel through here rather than repeating the suffix math.
+fn fall_through_suffix(
+    patcher: &ElfPatcher,
+    section: &TextSection,
+    end_addr: u64,
+) -> Option<Vec<u8>> {
+    let section_end = section.virtual_addr + section.size;
+    if end_addr >= section_end {
+        return None;
+    }
+    let suffix_window = AddressWindow {
+        start: end_addr,
+        end: section_end,
+    };
+    patcher.get_instructions_in_window(&suffix_window).ok()
+}
+
+/// Decode one AArch64 Capstone `(mnemonic, op_str)` pair into a downstream scan
+/// step, reusing the shared Capstone→IR bridge so the fall-through scan honors
+/// exactly the same supported-mnemonic set as the optimizer.
+fn aarch64_scan_step(mnemonic: &str, op_str: &str) -> ScanStep<Instruction> {
+    match convert_capstone_op(mnemonic, op_str) {
+        ConvertOutcome::Instruction(instr) => ScanStep::Decoded(instr),
+        ConvertOutcome::Skip => ScanStep::Skipped,
+        ConvertOutcome::Unsupported(_) => ScanStep::Opaque,
+    }
+}
+
+fn aarch64_downstream_flags_live_from_bytes(cs: &Capstone, bytes: &[u8], start_addr: u64) -> bool {
+    scan_flags_live(
+        cs,
+        bytes,
+        start_addr,
+        aarch64_scan_step,
+        |instr: &Instruction| {
+            super::live_out::flags_read_before_overwrite_after_window(std::slice::from_ref(instr))
+        },
+        |instr: &Instruction| instr.modifies_flags(),
+        |instr: &Instruction| instr.is_terminator(),
+    )
+}
+
+fn aarch64_downstream_regs_live_from_bytes(
+    cs: &Capstone,
+    bytes: &[u8],
+    start_addr: u64,
+    candidates: &RegisterSet<Register>,
+) -> RegisterSet<Register> {
+    scan_regs_live(
+        cs,
+        bytes,
+        start_addr,
+        candidates,
+        aarch64_scan_step,
+        |instr: &Instruction| instr.is_terminator(),
+        |reg: Register, instr: &Instruction| {
+            super::live_out::aarch64_reg_downstream_liveness(reg, std::slice::from_ref(instr))
+        },
+    )
+}
+
+/// Decode one x86 Capstone `(mnemonic, op_str)` pair into a downstream scan
+/// step. `nop` carries no observable state and is stepped over; anything the
+/// shared x86 IR does not model (including `call`/`ret`) is opaque and pins the
+/// remaining state live.
+fn x86_scan_step(mnemonic: &str, op_str: &str) -> ScanStep<X86Instruction> {
+    match x86_ir_from_mnemonic(mnemonic, op_str) {
+        Ok(Some(instr)) => ScanStep::Decoded(instr),
+        Ok(None) if mnemonic.eq_ignore_ascii_case("nop") => ScanStep::Skipped,
+        Ok(None) => ScanStep::Opaque,
+        Err(_) => ScanStep::Opaque,
+    }
+}
+
+fn x86_downstream_flags_live_from_bytes<I>(cs: &Capstone, bytes: &[u8], start_addr: u64) -> bool
+where
+    I: FlagsAnalysis<X86Instruction>,
+{
+    scan_flags_live(
+        cs,
+        bytes,
+        start_addr,
+        x86_scan_step,
+        |instr: &X86Instruction| <I as FlagsAnalysis<X86Instruction>>::reads_flags(instr),
+        |instr: &X86Instruction| <I as FlagsAnalysis<X86Instruction>>::modifies_flags(instr),
+        |instr: &X86Instruction| instr.is_terminator(),
+    )
+}
+
+fn x86_downstream_regs_live_from_bytes(
+    cs: &Capstone,
+    bytes: &[u8],
+    start_addr: u64,
+    candidates: &RegisterSet<X86Register>,
+) -> RegisterSet<X86Register> {
+    scan_regs_live(
+        cs,
+        bytes,
+        start_addr,
+        candidates,
+        x86_scan_step,
+        |instr: &X86Instruction| instr.is_terminator(),
+        |reg: X86Register, instr: &X86Instruction| {
+            super::live_out::x86_reg_downstream_liveness(reg, std::slice::from_ref(instr))
+        },
+    )
+}
+
+/// Whether the AArch64 condition flags (NZCV) may be read downstream of a window
+/// ending at `end_addr`. Returns the conservative `true` whenever the
+/// fall-through suffix is unavailable or the window already reaches the section
+/// end; otherwise scans the suffix and returns `false` only when a decoded
+/// instruction is proven to overwrite the flags before any read.
+pub fn aarch64_downstream_flags_live(
+    patcher: &ElfPatcher,
+    section: &TextSection,
+    end_addr: u64,
+    cs: &Capstone,
+) -> bool {
+    match fall_through_suffix(patcher, section, end_addr) {
+        Some(bytes) => aarch64_downstream_flags_live_from_bytes(cs, &bytes, end_addr),
+        None => true,
+    }
+}
+
+/// The subset of `candidates` (registers the AArch64 window writes) that are
+/// provably live downstream of the window. Returns every candidate live when the
+/// suffix is unavailable or the window already reaches the section end (issue
+/// #621's conservative default).
+pub fn aarch64_downstream_regs_live(
+    patcher: &ElfPatcher,
+    section: &TextSection,
+    end_addr: u64,
+    cs: &Capstone,
+    candidates: &RegisterSet<Register>,
+) -> RegisterSet<Register> {
+    match fall_through_suffix(patcher, section, end_addr) {
+        Some(bytes) => aarch64_downstream_regs_live_from_bytes(cs, &bytes, end_addr, candidates),
+        None => candidates.clone(),
+    }
+}
+
+/// Whether the x86 condition flags (EFLAGS) may be read downstream of a window
+/// ending at `end_addr`. Dispatches to the mode-specific flag analysis; an
+/// unavailable suffix and non-x86 `arch` values return the conservative `true`.
+pub fn x86_downstream_flags_live(
+    arch: DetectedArch,
+    patcher: &ElfPatcher,
+    section: &TextSection,
+    end_addr: u64,
+    cs: &Capstone,
+) -> bool {
+    let Some(bytes) = fall_through_suffix(patcher, section, end_addr) else {
+        return true;
+    };
+
+    match arch {
+        DetectedArch::X86_64 => {
+            x86_downstream_flags_live_from_bytes::<X86_64>(cs, &bytes, end_addr)
+        }
+        DetectedArch::X86_32 => {
+            x86_downstream_flags_live_from_bytes::<X86_32>(cs, &bytes, end_addr)
+        }
+        DetectedArch::Aarch64 => true,
+    }
+}
+
+/// The subset of `candidates` (registers the x86 window writes) that are provably
+/// live downstream. Register liveness is width-independent, so the
+/// mode-configured `cs` drives the correct x86-32/x86-64 disassembly; an
+/// unavailable suffix and non-x86 `arch` values return every candidate live.
+pub fn x86_downstream_regs_live(
+    arch: DetectedArch,
+    patcher: &ElfPatcher,
+    section: &TextSection,
+    end_addr: u64,
+    cs: &Capstone,
+    candidates: &RegisterSet<X86Register>,
+) -> RegisterSet<X86Register> {
+    let Some(bytes) = fall_through_suffix(patcher, section, end_addr) else {
+        return candidates.clone();
+    };
+
+    match arch {
+        DetectedArch::X86_64 | DetectedArch::X86_32 => {
+            x86_downstream_regs_live_from_bytes(cs, &bytes, end_addr, candidates)
+        }
+        DetectedArch::Aarch64 => candidates.clone(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ir::Register;
+    use crate::assembler::AArch64Assembler;
+    use crate::assembler::x86::X86Assembler;
+    use crate::ir::{Condition, Instruction, LabelId, Operand, Register};
+    use crate::isa::x86::{X86Instruction, X86Register};
+    use crate::test_utils::{TempFile, build_minimal_aarch64_elf, build_minimal_x86_64_elf};
 
     /// AArch64 `NOP` (`0xD503201F`, little-endian). Decodes to exactly one
     /// instruction so the scripted `decode` closure is invoked once per copy.
@@ -412,5 +632,515 @@ mod tests {
             vec![step],
         );
         assert_eq!(sorted(&out), vec![Register::X0, Register::X2]);
+    }
+
+    // ---- Section-level entry points (the deep public interface) ----
+
+    fn assemble_aarch64_test_bytes(instructions: &[Instruction]) -> Vec<u8> {
+        AArch64Assembler::new()
+            .assemble_instructions(instructions, 0x1000)
+            .expect("test instruction should assemble")
+    }
+
+    fn assemble_x86_64_test_bytes(instructions: &[X86Instruction]) -> Vec<u8> {
+        X86Assembler::new_64()
+            .assemble_instructions(instructions)
+            .expect("test instruction should assemble")
+    }
+
+    fn aarch64_test_capstone() -> Capstone {
+        Capstone::new()
+            .arm64()
+            .mode(capstone::arch::arm64::ArchMode::Arm)
+            .detail(true)
+            .build()
+            .expect("test capstone should build")
+    }
+
+    fn x86_64_test_capstone() -> Capstone {
+        Capstone::new()
+            .x86()
+            .mode(capstone::arch::x86::ArchMode::Mode64)
+            .syntax(capstone::arch::x86::ArchSyntax::Intel)
+            .detail(true)
+            .build()
+            .expect("test capstone should build")
+    }
+
+    /// Materialize `elf` to a temp file and return its patcher plus the single
+    /// `.text` section. The `TempFile` is returned so the caller keeps the
+    /// backing file alive for the patcher's lifetime.
+    fn patcher_with_text(elf: &[u8]) -> (TempFile, ElfPatcher, TextSection) {
+        let file = TempFile::new_bytes("s11-downstream-section", "elf", elf);
+        let patcher = ElfPatcher::new(file.path()).expect("synthetic ELF should parse");
+        let section = patcher
+            .get_text_sections()
+            .expect("ELF should expose an executable section")
+            .into_iter()
+            .next()
+            .expect("minimal ELF should contain .text");
+        (file, patcher, section)
+    }
+
+    #[test]
+    fn aarch64_flags_live_defaults_conservative_at_section_end() {
+        // The window covers the whole section, so there is no analyzable
+        // fall-through suffix and the flags stay conservatively live.
+        let text = assemble_aarch64_test_bytes(&[Instruction::Add {
+            rd: Register::X1,
+            rn: Register::X2,
+            rm: Operand::Immediate(1),
+        }]);
+        let (_file, patcher, section) =
+            patcher_with_text(&build_minimal_aarch64_elf(&text, 0x1000));
+        let cs = aarch64_test_capstone();
+        let end = section.virtual_addr + section.size;
+        assert!(aarch64_downstream_flags_live(&patcher, &section, end, &cs));
+    }
+
+    #[test]
+    fn aarch64_flags_dead_when_suffix_proves_them_dead() {
+        // Window is the empty prefix; the whole section is the fall-through
+        // suffix. A lone non-flag ADD then the section ends, so nothing can
+        // read the flags: they are dead.
+        let text = assemble_aarch64_test_bytes(&[Instruction::Add {
+            rd: Register::X1,
+            rn: Register::X2,
+            rm: Operand::Immediate(1),
+        }]);
+        let (_file, patcher, section) =
+            patcher_with_text(&build_minimal_aarch64_elf(&text, 0x1000));
+        let cs = aarch64_test_capstone();
+        assert!(!aarch64_downstream_flags_live(
+            &patcher,
+            &section,
+            section.virtual_addr,
+            &cs
+        ));
+    }
+
+    #[test]
+    fn aarch64_regs_default_all_live_at_section_end() {
+        let text = assemble_aarch64_test_bytes(&[Instruction::MovReg {
+            rd: Register::X0,
+            rn: Register::X1,
+        }]);
+        let (_file, patcher, section) =
+            patcher_with_text(&build_minimal_aarch64_elf(&text, 0x1000));
+        let cs = aarch64_test_capstone();
+        let candidates = RegisterSet::from_registers(vec![Register::X0]);
+        let end = section.virtual_addr + section.size;
+        let live = aarch64_downstream_regs_live(&patcher, &section, end, &cs, &candidates);
+        assert!(live.contains(Register::X0));
+    }
+
+    #[test]
+    fn aarch64_regs_dead_when_suffix_fully_overwrites() {
+        // Suffix `mov x0, x1` fully overwrites X0 before any read → dead.
+        let text = assemble_aarch64_test_bytes(&[Instruction::MovReg {
+            rd: Register::X0,
+            rn: Register::X1,
+        }]);
+        let (_file, patcher, section) =
+            patcher_with_text(&build_minimal_aarch64_elf(&text, 0x1000));
+        let cs = aarch64_test_capstone();
+        let candidates = RegisterSet::from_registers(vec![Register::X0]);
+        let live = aarch64_downstream_regs_live(
+            &patcher,
+            &section,
+            section.virtual_addr,
+            &cs,
+            &candidates,
+        );
+        assert!(!live.contains(Register::X0));
+    }
+
+    #[test]
+    fn x86_flags_live_defaults_conservative_at_section_end() {
+        let text = assemble_x86_64_test_bytes(&[X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: 0,
+        }]);
+        let (_file, patcher, section) = patcher_with_text(&build_minimal_x86_64_elf(&text, 0x1000));
+        let cs = x86_64_test_capstone();
+        let end = section.virtual_addr + section.size;
+        assert!(x86_downstream_flags_live(
+            DetectedArch::X86_64,
+            &patcher,
+            &section,
+            end,
+            &cs
+        ));
+    }
+
+    #[test]
+    fn x86_flags_dead_when_suffix_proves_them_dead() {
+        // The whole section is the suffix: a lone non-flag `mov rax, 0` then the
+        // section ends, so the flags are dead.
+        let text = assemble_x86_64_test_bytes(&[X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: 0,
+        }]);
+        let (_file, patcher, section) = patcher_with_text(&build_minimal_x86_64_elf(&text, 0x1000));
+        let cs = x86_64_test_capstone();
+        assert!(!x86_downstream_flags_live(
+            DetectedArch::X86_64,
+            &patcher,
+            &section,
+            section.virtual_addr,
+            &cs
+        ));
+    }
+
+    #[test]
+    fn x86_regs_default_all_live_at_section_end() {
+        let text = assemble_x86_64_test_bytes(&[X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: 0,
+        }]);
+        let (_file, patcher, section) = patcher_with_text(&build_minimal_x86_64_elf(&text, 0x1000));
+        let cs = x86_64_test_capstone();
+        let candidates = RegisterSet::from_registers(vec![X86Register::RAX]);
+        let end = section.virtual_addr + section.size;
+        let live = x86_downstream_regs_live(
+            DetectedArch::X86_64,
+            &patcher,
+            &section,
+            end,
+            &cs,
+            &candidates,
+        );
+        assert!(live.contains(X86Register::RAX));
+    }
+
+    #[test]
+    fn x86_regs_dead_when_suffix_fully_overwrites() {
+        // Suffix `mov rax, 0` is a full-register write before any read → dead.
+        let text = assemble_x86_64_test_bytes(&[X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: 0,
+        }]);
+        let (_file, patcher, section) = patcher_with_text(&build_minimal_x86_64_elf(&text, 0x1000));
+        let cs = x86_64_test_capstone();
+        let candidates = RegisterSet::from_registers(vec![X86Register::RAX]);
+        let live = x86_downstream_regs_live(
+            DetectedArch::X86_64,
+            &patcher,
+            &section,
+            section.virtual_addr,
+            &cs,
+            &candidates,
+        );
+        assert!(!live.contains(X86Register::RAX));
+    }
+
+    // ---- Byte-level scanner characterization (migrated from the CLI binary) ----
+
+    #[test]
+    fn downstream_flags_live_scan_marks_dead_when_first_flag_event_writes() {
+        let bytes = assemble_aarch64_test_bytes(&[
+            Instruction::Cmp {
+                rn: Register::X0,
+                rm: Operand::Immediate(0),
+            },
+            Instruction::Csel {
+                rd: Register::X1,
+                rn: Register::X2,
+                rm: Register::X3,
+                cond: Condition::EQ,
+            },
+        ]);
+        let cs = aarch64_test_capstone();
+
+        assert!(!aarch64_downstream_flags_live_from_bytes(
+            &cs, &bytes, 0x1000
+        ));
+    }
+
+    #[test]
+    fn downstream_flags_live_scan_marks_live_when_first_flag_event_reads() {
+        let bytes = assemble_aarch64_test_bytes(&[Instruction::Csel {
+            rd: Register::X1,
+            rn: Register::X2,
+            rm: Register::X3,
+            cond: Condition::EQ,
+        }]);
+        let cs = aarch64_test_capstone();
+
+        assert!(aarch64_downstream_flags_live_from_bytes(
+            &cs, &bytes, 0x1000
+        ));
+    }
+
+    #[test]
+    fn downstream_flags_live_scan_marks_dead_for_known_non_flag_suffix() {
+        let bytes = assemble_aarch64_test_bytes(&[Instruction::Add {
+            rd: Register::X1,
+            rn: Register::X2,
+            rm: Operand::Immediate(1),
+        }]);
+        let cs = aarch64_test_capstone();
+
+        assert!(!aarch64_downstream_flags_live_from_bytes(
+            &cs, &bytes, 0x1000
+        ));
+    }
+
+    #[test]
+    fn downstream_flags_live_scan_is_conservative_for_unknown_context() {
+        let cs = aarch64_test_capstone();
+
+        assert!(aarch64_downstream_flags_live_from_bytes(&cs, &[], 0x1000));
+        assert!(aarch64_downstream_flags_live_from_bytes(
+            &cs,
+            &[0xff],
+            0x1000
+        ));
+        // LDR literal decodes in Capstone but is intentionally unsupported by
+        // the AArch64 optimization IR parser.
+        assert!(aarch64_downstream_flags_live_from_bytes(
+            &cs,
+            &[0x00, 0x00, 0x00, 0x58],
+            0x1000
+        ));
+    }
+
+    #[test]
+    fn downstream_flags_live_scan_is_conservative_for_unanalysed_branch() {
+        let bytes = assemble_aarch64_test_bytes(&[Instruction::B {
+            target: LabelId(0x1000),
+        }]);
+        let cs = aarch64_test_capstone();
+
+        assert!(aarch64_downstream_flags_live_from_bytes(
+            &cs, &bytes, 0x1000
+        ));
+    }
+
+    #[test]
+    fn x86_downstream_flags_live_scan_marks_live_when_first_flag_event_reads() {
+        use crate::isa::x86::X86Condition;
+
+        let bytes = assemble_x86_64_test_bytes(&[X86Instruction::Jcc {
+            cond: X86Condition::E,
+        }]);
+        let cs = x86_64_test_capstone();
+
+        assert!(x86_downstream_flags_live_from_bytes::<X86_64>(
+            &cs, &bytes, 0x1000
+        ));
+    }
+
+    #[test]
+    fn x86_downstream_flags_live_scan_marks_dead_when_first_flag_event_writes() {
+        let bytes = assemble_x86_64_test_bytes(&[
+            X86Instruction::CmpReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            X86Instruction::MovImm {
+                rd: X86Register::RAX,
+                imm: 0,
+            },
+        ]);
+        let cs = x86_64_test_capstone();
+
+        assert!(!x86_downstream_flags_live_from_bytes::<X86_64>(
+            &cs, &bytes, 0x1000
+        ));
+    }
+
+    #[test]
+    fn x86_downstream_flags_live_scan_marks_dead_for_known_non_flag_suffix() {
+        let bytes = assemble_x86_64_test_bytes(&[X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: 0,
+        }]);
+        let cs = x86_64_test_capstone();
+
+        assert!(!x86_downstream_flags_live_from_bytes::<X86_64>(
+            &cs, &bytes, 0x1000
+        ));
+    }
+
+    #[test]
+    fn x86_downstream_flags_live_scan_is_conservative_for_unknown_context() {
+        let cs = x86_64_test_capstone();
+
+        assert!(x86_downstream_flags_live_from_bytes::<X86_64>(
+            &cs,
+            &[],
+            0x1000
+        ));
+        assert!(x86_downstream_flags_live_from_bytes::<X86_64>(
+            &cs,
+            &[0xff],
+            0x1000
+        ));
+        assert!(x86_downstream_flags_live_from_bytes::<X86_64>(
+            &cs,
+            &[0xc3],
+            0x1000
+        ));
+    }
+
+    fn x86_64_regset(regs: &[X86Register]) -> RegisterSet<X86Register> {
+        RegisterSet::from_registers(regs.to_vec())
+    }
+
+    fn aarch64_regset(regs: &[Register]) -> RegisterSet<Register> {
+        RegisterSet::from_registers(regs.to_vec())
+    }
+
+    #[test]
+    fn downstream_regs_live_scan_marks_dead_when_later_full_overwrite_precedes_any_read() {
+        // Window wrote X0. Suffix `mov x0, x1` fully overwrites x0 before any
+        // read, so X0 is dead/optimizable.
+        let bytes = assemble_aarch64_test_bytes(&[Instruction::MovReg {
+            rd: Register::X0,
+            rn: Register::X1,
+        }]);
+        let cs = aarch64_test_capstone();
+        let live = aarch64_downstream_regs_live_from_bytes(
+            &cs,
+            &bytes,
+            0x1000,
+            &aarch64_regset(&[Register::X0]),
+        );
+        assert!(
+            !live.contains(Register::X0),
+            "x0 fully overwritten before any read must be dropped from live-out"
+        );
+    }
+
+    #[test]
+    fn downstream_regs_live_scan_marks_live_when_read_before_overwrite() {
+        // Window wrote RAX. Suffix `add x2, x0, #1` reads x0 before any
+        // redefinition — x0 must stay live.
+        let bytes = assemble_aarch64_test_bytes(&[Instruction::Add {
+            rd: Register::X2,
+            rn: Register::X0,
+            rm: Operand::Immediate(1),
+        }]);
+        let cs = aarch64_test_capstone();
+        let live = aarch64_downstream_regs_live_from_bytes(
+            &cs,
+            &bytes,
+            0x1000,
+            &aarch64_regset(&[Register::X0]),
+        );
+        assert!(
+            live.contains(Register::X0),
+            "x0 read before any overwrite must stay live"
+        );
+    }
+
+    #[test]
+    fn downstream_regs_live_scan_conservative_for_unknown_context() {
+        let cs = aarch64_test_capstone();
+        let candidates = aarch64_regset(&[Register::X0, Register::X1]);
+
+        // Empty suffix → both candidates live.
+        let empty = aarch64_downstream_regs_live_from_bytes(&cs, &[], 0x1000, &candidates);
+        assert!(empty.contains(Register::X0) && empty.contains(Register::X1));
+
+        // Undisassemblable byte → live.
+        let garbage = aarch64_downstream_regs_live_from_bytes(&cs, &[0xff], 0x1000, &candidates);
+        assert!(garbage.contains(Register::X0) && garbage.contains(Register::X1));
+
+        // LDR-literal decodes in Capstone but is unsupported by the IR → live.
+        let unsupported = aarch64_downstream_regs_live_from_bytes(
+            &cs,
+            &[0x00, 0x00, 0x00, 0x58],
+            0x1000,
+            &candidates,
+        );
+        assert!(unsupported.contains(Register::X0) && unsupported.contains(Register::X1));
+    }
+
+    #[test]
+    fn downstream_regs_live_scan_marks_live_across_call_ret() {
+        let cs = aarch64_test_capstone();
+        let candidates = aarch64_regset(&[Register::X0, Register::X1]);
+
+        // `bl #0` is a call terminator → every window register may be
+        // observable across the ABI; keep them all live.
+        let bl_bytes = assemble_aarch64_test_bytes(&[Instruction::Bl {
+            target: LabelId(0x1000),
+        }]);
+        let across_call =
+            aarch64_downstream_regs_live_from_bytes(&cs, &bl_bytes, 0x1000, &candidates);
+        assert!(across_call.contains(Register::X0) && across_call.contains(Register::X1));
+
+        // `ret` is a return terminator → same ABI-observable rule.
+        let ret_bytes = assemble_aarch64_test_bytes(&[Instruction::Ret { rn: Register::X30 }]);
+        let across_ret =
+            aarch64_downstream_regs_live_from_bytes(&cs, &ret_bytes, 0x1000, &candidates);
+        assert!(across_ret.contains(Register::X0) && across_ret.contains(Register::X1));
+    }
+
+    #[test]
+    fn x86_partial_write_does_not_kill() {
+        // Window wrote RAX. Suffix `mov al, 0` leaves the rest of RAX intact,
+        // so the downstream scan must not treat it as a full-register kill.
+        let bytes = assemble_x86_64_test_bytes(&[X86Instruction::MovImm {
+            rd: X86Register::AL,
+            imm: 0,
+        }]);
+        let cs = x86_64_test_capstone();
+        let live = x86_downstream_regs_live_from_bytes(
+            &cs,
+            &bytes,
+            0x1000,
+            &x86_64_regset(&[X86Register::RAX]),
+        );
+        assert!(
+            live.contains(X86Register::RAX),
+            "an AL write preserves upper RAX bits, so RAX stays live"
+        );
+    }
+
+    #[test]
+    fn x86_downstream_regs_live_scan_marks_live_when_read_before_overwrite() {
+        // `add rbx, rax` reads rax before any redefinition → rax stays live.
+        let bytes = assemble_x86_64_test_bytes(&[X86Instruction::AddReg {
+            rd: X86Register::RBX,
+            rs: X86Register::RAX,
+        }]);
+        let cs = x86_64_test_capstone();
+        let live = x86_downstream_regs_live_from_bytes(
+            &cs,
+            &bytes,
+            0x1000,
+            &x86_64_regset(&[X86Register::RAX]),
+        );
+        assert!(live.contains(X86Register::RAX));
+    }
+
+    #[test]
+    fn x86_downstream_regs_live_scan_conservative_across_call_ret_and_unknown() {
+        let cs = x86_64_test_capstone();
+        let candidates = x86_64_regset(&[X86Register::RAX]);
+
+        // Empty suffix → live.
+        assert!(
+            x86_downstream_regs_live_from_bytes(&cs, &[], 0x1000, &candidates)
+                .contains(X86Register::RAX)
+        );
+        // `ret` (0xc3) is not modelled in the x86 IR → unsupported → live.
+        assert!(
+            x86_downstream_regs_live_from_bytes(&cs, &[0xc3], 0x1000, &candidates)
+                .contains(X86Register::RAX)
+        );
+        // `call rel32` (e8 00 00 00 00) is likewise not modelled → live.
+        assert!(
+            x86_downstream_regs_live_from_bytes(
+                &cs,
+                &[0xe8, 0x00, 0x00, 0x00, 0x00],
+                0x1000,
+                &candidates
+            )
+            .contains(X86Register::RAX)
+        );
     }
 }


### PR DESCRIPTION
## Refactoring goal

An architecture audit (via the `improve-codebase-architecture` skill) flagged `src/main.rs` — the largest, most-churned file — as a god-module holding domain logic stranded in the binary root, out of reach of library unit tests. Four parallel exploration passes surfaced several deepening candidates:

| Candidate | Verdict |
|---|---|
| **Downstream-liveness wiring → `validation::downstream`** (this PR) | **Chosen** — two passes ranked it #1/#2; all deps already lib-side; behavior-preserving; well-tested. |
| `mutation.rs` opcode peer-graph → data table | Highest raw impact, but demands a bit-identical RNG draw sequence — too risky for an unattended run. |
| `candidate.rs::generate_all_instructions` (700-line monolith) → per-family seams | Strong and file-local; good follow-up, but less architecturally significant than removing binary-root logic. |
| `equivalence.rs` x86 fast-path dedup (route through `validation::random`) | Rejected — changes random-input generation, i.e. **not** behavior-preserving. |
| `AcceptanceCriterion` narrowing / delete dead `_in_place` helpers | Low impact. |

The shared scanning discipline (`scan_flags_live` / `scan_regs_live`) already lived in `s11::validation::downstream`, but the **per-architecture wiring** that feeds it lived in `main.rs`:

- `fall_through_suffix` (resolve the in-section suffix after a window)
- `aarch64_scan_step` / `x86_scan_step` (Capstone → optimizer IR decoders)
- four `*_downstream_{flags,regs}_live_from_bytes` scanners
- four `*_downstream_{flags,regs}_live_from_section` wrappers

So one concept — "what architectural state can the fall-through successor still observe?" — was split across the binary/library boundary, and its ~15 characterization tests could only run inside the binary's in-file test module. The soundness default (an *un-analyzable* suffix keeps everything live — the #224 / #621 bug class) had no single owner.

## What changed

Moved the wiring next to the discipline it builds on, and **narrowed the public face** so this is a genuine deepening, not just a relocation:

- `fall_through_suffix` and the two Capstone→IR decoders are now **private** module internals.
- The byte-level scanners stay **module-private** (tested in-module).
- The module exposes **one narrow section-level entry point per (architecture, scanned state)** — the only surface `main.rs` consumes:
  - `aarch64_downstream_flags_live`, `aarch64_downstream_regs_live`
  - `x86_downstream_flags_live`, `x86_downstream_regs_live`
- `main.rs` drops **~560 lines** and simply calls the four public entries; all downstream-liveness logic — and its soundness default — now lives in one library module.

Behavior-preserving: the scanners, decoders, and section wrappers moved verbatim; only their home and visibility changed, plus the `x86` dispatch keeps its per-mode `FlagsAnalysis` markers (no over-unification across ISAs).

## Tests that validate it

Developed test-first against the new library interface (the four public functions were referenced by failing tests before they existed — red → green):

- **New section-level unit tests** (8) directly exercise the public entry points against a real `ElfPatcher`/`TextSection`, pinning both branches of every function: the conservative default when the window reaches the section end, and delegation to the scanner for an analyzable suffix.
- **Migrated byte-level characterization tests** (15) moved from `main.rs` into the module next to their subjects (flag/register kill, read-before-overwrite, terminator/opaque conservatism, x86 partial-write, call/ret ABI).
- Added a shared minimal-ELF builder to `test_utils` for the section-level tests. (Two pre-existing minimal-ELF builders — in the `elf_patcher` and `main.rs` test modules — are left to consolidate onto this shared helper as a follow-up, to keep this PR scoped.)

## Verification

- `cargo fmt -- --check` ✓
- `cargo build` ✓
- `./build_tests.sh` (cross-compiled AArch64 + x86 fixtures) ✓
- `cargo test` — **1787 passing** (lib 1595, bin 135, integration 57), 0 failed ✓
- `./test_all.sh` end-to-end opt smoke suite ✓