### PR TITLE
fix(tests): drop redundant trim() before split_whitespace()

### DIFF
--- a/tests/integration/disasm_test.rs
+++ b/tests/integration/disasm_test.rs
@@ -56,7 +56,7 @@ fn test_disasm_simple_binary() {
                 && line
                     .split(':')
                     .nth(1)
-                    .map(|s| s.trim().split_whitespace().next())
+                    .map(|s| s.split_whitespace().next())
                     .and_then(|s| s)
                     .map(|s| s.len() == 8 && s.chars().all(|c| c.is_ascii_hexdigit()))
                     .unwrap_or(false)


### PR DESCRIPTION
## Summary
- `split_whitespace()` already skips leading/trailing whitespace, so the preceding `.trim()` call was redundant.

Fixes code-scanning alert #646 (`clippy::trim_split_whitespace`).

## Test plan
- [x] `./ci_check.sh` passes locally