### PR TITLE
fix(stochastic): use RangeInclusive::contains for bounds checks

### DIFF
--- a/src/search/stochastic/acceptance.rs
+++ b/src/search/stochastic/acceptance.rs
@@ -203,9 +203,9 @@ mod tests {
         assert!(p5 > p10);
 
         // All should be in [0, 1]
-        assert!(p1 >= 0.0 && p1 <= 1.0);
-        assert!(p5 >= 0.0 && p5 <= 1.0);
-        assert!(p10 >= 0.0 && p10 <= 1.0);
+        assert!((0.0..=1.0).contains(&p1));
+        assert!((0.0..=1.0).contains(&p5));
+        assert!((0.0..=1.0).contains(&p10));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replaced manual `x >= 0.0 && x <= 1.0` checks with `(0.0..=1.0).contains(&x)`.

Fixes code-scanning alerts #650, #651, #652 (`clippy::manual_range_contains`).

## Test plan
- [x] `./ci_check.sh` passes locally