### PR TITLE
fix(ir): inline single-element for loop in encodability test

### DIFF
--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -4902,32 +4902,31 @@ mod tests {
             }
             .is_encodable_aarch64()
         );
-        for victim in [Register::XZR] {
-            assert!(
-                !Instruction::Add {
-                    rd: victim,
-                    rn: Register::X1,
-                    rm: Operand::ExtendedRegister {
-                        reg: Register::X2,
-                        kind: ExtendKind::Uxtb,
-                        shift: 0,
-                    },
-                }
-                .is_encodable_aarch64()
-            );
-            assert!(
-                !Instruction::Add {
-                    rd: Register::X0,
-                    rn: victim,
-                    rm: Operand::ExtendedRegister {
-                        reg: Register::X2,
-                        kind: ExtendKind::Uxtb,
-                        shift: 0,
-                    },
-                }
-                .is_encodable_aarch64()
-            );
-        }
+        let victim = Register::XZR;
+        assert!(
+            !Instruction::Add {
+                rd: victim,
+                rn: Register::X1,
+                rm: Operand::ExtendedRegister {
+                    reg: Register::X2,
+                    kind: ExtendKind::Uxtb,
+                    shift: 0,
+                },
+            }
+            .is_encodable_aarch64()
+        );
+        assert!(
+            !Instruction::Add {
+                rd: Register::X0,
+                rn: victim,
+                rm: Operand::ExtendedRegister {
+                    reg: Register::X2,
+                    kind: ExtendKind::Uxtb,
+                    shift: 0,
+                },
+            }
+            .is_encodable_aarch64()
+        );
         // Inner-reg slot: SP rejected, XZR allowed.
         assert!(
             !Instruction::Add {


### PR DESCRIPTION
## Summary
- The `for victim in [Register::XZR]` loop only ever iterated over one element; inlined it to a plain `let` binding.

Fixes code-scanning alert #877 (`clippy::single_element_loop`).

## Test plan
- [x] `./ci_check.sh` passes locally