### PR TITLE
fix(parser): use split_once instead of manual splitn(2)

### DIFF
--- a/src/parser/x86.rs
+++ b/src/parser/x86.rs
@@ -1356,9 +1356,7 @@ mod tests {
         // Display → parse round-trip for both forms.
         for instr in [reg, imm] {
             let text = instr.to_string();
-            let mut parts = text.splitn(2, char::is_whitespace);
-            let mnemonic = parts.next().unwrap();
-            let ops = parts.next().unwrap();
+            let (mnemonic, ops) = text.split_once(char::is_whitespace).unwrap();
             assert_eq!(
                 x86_ir_from_mnemonic(mnemonic, ops).unwrap().unwrap(),
                 instr,


### PR DESCRIPTION
## Summary
- Replaced the manual `splitn(2, ..).next()`/`.next()` pair with `str::split_once`, which expresses the same "split into at most two pieces" intent directly.

Fixes code-scanning alerts #920, #921, #922 (`clippy::manual_split_once`).

## Test plan
- [x] `./ci_check.sh` passes locally