### PR TITLE
refactor(cli): extract CLI report rendering into report module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod elf_patcher;
 pub mod ir;
 pub mod isa;
 pub mod parser;
+pub mod report;
 pub mod search;
 pub mod semantics;
 pub mod validation;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use s11::capstone_bridge_x86::{convert_to_x86_ir, convert_x86_capstone_op_for_op
 use s11::elf_patcher::{AddressWindow, DetectedArch, ElfPatcher, TextSection, parse_hex_address};
 use s11::ir::instructions::split_terminator;
 use s11::ir::{Instruction, Register};
+use s11::report;
 use s11::search::config::{
     Algorithm, LlmConfig, SearchConfig, SearchMode, StochasticConfig, SymbolicConfig,
 };
@@ -2028,152 +2029,23 @@ fn run_optimization(
 }
 
 /// Format a byte count with a unit chosen to keep ~3 significant digits visible.
-fn fmt_bytes(n: usize) -> String {
-    if n >= 1_048_576 {
-        format!("{:>7.2} MB", n as f64 / 1_048_576.0)
-    } else if n >= 1_024 {
-        format!("{:>7.2} kB", n as f64 / 1_024.0)
-    } else {
-        format!("{:>7} B ", n)
-    }
-}
-
-/// Format a Duration with a unit chosen to keep ~3 significant digits visible.
-fn fmt_dur(d: Duration) -> String {
-    let secs = d.as_secs_f64();
-    if secs >= 1.0 {
-        format!("{:>8.2} s ", secs)
-    } else if secs >= 0.001 {
-        format!("{:>8.2} ms", secs * 1_000.0)
-    } else {
-        format!("{:>8.1} µs", secs * 1_000_000.0)
-    }
-}
-
-/// Render the per-phase LLM timing breakdown as one `String` per output line.
-///
-/// Pure seam: the pluralization, the conditional SMT sub-section (with its
-/// average-formula-bytes computation), and the conditional share-percentage
-/// section are all decided here so they can be asserted without capturing
-/// stdout. `print_llm_timings` prints the lines.
-fn format_llm_timings(timings: &search::llm::LlmTimings, total: Duration) -> Vec<String> {
-    let codex = timings.codex_time;
-    let verify = timings.verify_time;
-    let other = total.saturating_sub(codex).saturating_sub(verify);
-    let mut lines = vec![
-        "\nLLM phase timing:".to_string(),
-        format!(
-            "  Codex calls:      {}   ({} call{})",
-            fmt_dur(codex),
-            timings.codex_calls,
-            if timings.codex_calls == 1 { "" } else { "s" }
-        ),
-        format!(
-            "  Verification:     {}   ({} verification{}, parse + fast + SMT)",
-            fmt_dur(verify),
-            timings.verifications,
-            if timings.verifications == 1 { "" } else { "s" }
-        ),
-    ];
-    if timings.smt_calls > 0 {
-        let avg_bytes = timings.smt_formula_bytes_total / timings.smt_calls as usize;
-        lines.push(format!(
-            "    SMT invoked:    {} time{}",
-            timings.smt_calls,
-            if timings.smt_calls == 1 { "" } else { "s" }
-        ));
-        lines.push(format!(
-            "    SMT formula:    {}  total   ({}  avg, {}  max)",
-            fmt_bytes(timings.smt_formula_bytes_total),
-            fmt_bytes(avg_bytes),
-            fmt_bytes(timings.smt_formula_bytes_max),
-        ));
-    }
-    lines.push(format!("  Other:            {}", fmt_dur(other)));
-    lines.push(format!("  Total:            {}", fmt_dur(total)));
-    if total.as_secs_f64() > 0.0 {
-        lines.push(format!(
-            "  Codex share:      {:>6.2}%",
-            100.0 * codex.as_secs_f64() / total.as_secs_f64()
-        ));
-        lines.push(format!(
-            "  Verify share:     {:>6.2}%",
-            100.0 * verify.as_secs_f64() / total.as_secs_f64()
-        ));
-    }
-    lines
-}
-
 /// Print the per-phase timing breakdown from an LLM-assisted run.
 fn print_llm_timings(timings: &search::llm::LlmTimings, total: Duration) {
-    for line in format_llm_timings(timings, total) {
+    for line in report::format_llm_timings(timings, total) {
         println!("{}", line);
     }
-}
-
-/// Render the unsupported-mnemonic ledger as one `String` per output line.
-///
-/// Pure seam: returns an empty `Vec` for an empty ledger (so the printer emits
-/// nothing), otherwise a header plus one frequency-ranked entry line.
-fn format_unsupported_mnemonic_ledger(
-    ledger: &search::llm::ledger::UnsupportedMnemonicLedger,
-) -> Vec<String> {
-    if ledger.is_empty() {
-        return Vec::new();
-    }
-    let mut lines =
-        vec!["\nUnsupported mnemonics emitted by the LLM (frequency-ranked):".to_string()];
-    for (mnem, count) in ledger.sorted_entries() {
-        lines.push(format!("  {:>5}  {}", count, mnem));
-    }
-    lines
 }
 
 /// Print the unsupported-mnemonic ledger from an LLM-assisted run.
 fn print_unsupported_mnemonic_ledger(ledger: &search::llm::ledger::UnsupportedMnemonicLedger) {
-    for line in format_unsupported_mnemonic_ledger(ledger) {
+    for line in report::format_unsupported_mnemonic_ledger(ledger) {
         println!("{}", line);
     }
 }
 
-/// Render the search-statistics report as one `String` per output line.
-///
-/// Pure: the seam that lets tests assert on the exact report without capturing
-/// stdout. `print_search_statistics` prints the lines. Mirrors the
-/// `build_equiv_report` precedent.
-fn format_search_statistics(stats: &search::result::SearchStatistics) -> Vec<String> {
-    let mut lines = vec![
-        "\nSearch Statistics:".to_string(),
-        format!("  Algorithm: {:?}", stats.algorithm),
-        format!("  Elapsed time: {:?}", stats.elapsed_time),
-        format!("  Candidates evaluated: {}", stats.candidates_evaluated),
-        format!(
-            "  Candidates pruned by cost: {}",
-            stats.candidates_pruned_by_cost
-        ),
-        format!(
-            "  Candidates passed fast test: {}",
-            stats.candidates_passed_fast
-        ),
-        format!("  SMT queries: {}", stats.smt_queries),
-        format!("  SMT equivalent: {}", stats.smt_equivalent),
-        format!("  Improvements found: {}", stats.improvements_found),
-        format!("  Original cost: {}", stats.original_cost),
-        format!("  Best cost found: {}", stats.best_cost_found),
-    ];
-    if stats.iterations > 0 {
-        lines.push(format!("  Iterations: {}", stats.iterations));
-        lines.push(format!(
-            "  Acceptance rate: {:.2}%",
-            stats.acceptance_rate() * 100.0
-        ));
-    }
-    lines
-}
-
 /// Print search statistics
 fn print_search_statistics(stats: &search::result::SearchStatistics) {
-    for line in format_search_statistics(stats) {
+    for line in report::format_search_statistics(stats) {
         println!("{}", line);
     }
 }
@@ -2720,108 +2592,6 @@ fn run_llm_opt(
     Ok(())
 }
 
-/// The presentation-and-policy outcome of an `equiv` run: the lines the CLI
-/// should print and the process exit code it should return.
-///
-/// Produced by [`build_equiv_report`] with no stdout writes and no
-/// `std::process::exit` of its own. Keeping policy (exit codes) and formatting
-/// out of `run_equiv` is what makes the not-equivalent / counterexample /
-/// unknown paths unit-testable — each previously called `std::process::exit`
-/// inline and could only be exercised by running the whole binary.
-#[derive(Debug, PartialEq, Eq)]
-struct EquivReport {
-    lines: Vec<String>,
-    exit_code: i32,
-}
-
-/// Append `state`'s live-out registers to `lines`, one `    <reg> = 0x…` entry
-/// each, sorted by register index for deterministic output. Shared by the
-/// input / output-1 / output-2 sections of a counterexample so the three
-/// previously-duplicated print loops live in one place.
-fn push_live_out_registers(
-    lines: &mut Vec<String>,
-    state: &semantics::ConcreteMachineState,
-    live_out: &LiveOut,
-) {
-    let mut regs: Vec<_> = live_out.iter().copied().collect();
-    regs.sort_by_key(|reg| reg.sort_key());
-    for reg in regs {
-        match reg {
-            Register::Vector(vector) => {
-                lines.push(format!("    {} = 0x{:032x}", reg, state.get_vector(vector)));
-            }
-            _ => lines.push(format!(
-                "    {} = 0x{:016x}",
-                reg,
-                state.get_register(reg).as_u64()
-            )),
-        }
-    }
-}
-
-/// Turn an [`EquivalenceResult`] into the lines to print and the exit code to
-/// return. Pure: no I/O, no process exit. `run_equiv` prints the lines and the
-/// `equiv` CLI arm maps the code (Equivalent → 0, NotEquivalent[Fast] → 1,
-/// Unknown → 2).
-///
-/// [`EquivalenceResult`]: semantics::EquivalenceResult
-fn build_equiv_report(
-    result: &semantics::EquivalenceResult,
-    seq1: &[Instruction],
-    seq2: &[Instruction],
-    live_out: &LiveOut,
-) -> EquivReport {
-    use semantics::EquivalenceResult;
-
-    match result {
-        EquivalenceResult::Equivalent => EquivReport {
-            lines: vec!["EQUIVALENT: The two sequences are semantically equivalent.".to_string()],
-            exit_code: 0,
-        },
-        EquivalenceResult::NotEquivalent => EquivReport {
-            lines: vec![
-                "NOT EQUIVALENT: The two sequences produce different results (verified by SMT)."
-                    .to_string(),
-            ],
-            exit_code: 1,
-        },
-        EquivalenceResult::NotEquivalentFast(input_state) => {
-            // Issue #69: strip terminators before re-running on the
-            // counterexample. The B1/B2 stubs panic if a branch reaches the
-            // concrete interpreter; the equivalence layer already excluded the
-            // terminator from its comparison via the precheck.
-            let (prefix1, _) = split_terminator(seq1);
-            let (prefix2, _) = split_terminator(seq2);
-
-            let output1 = semantics::apply_sequence_concrete(input_state.clone(), prefix1);
-            let output2 = semantics::apply_sequence_concrete(input_state.clone(), prefix2);
-
-            let mut lines = vec![
-                "NOT EQUIVALENT: The two sequences produce different results.".to_string(),
-                "\nCounterexample found:".to_string(),
-                "  Input state:".to_string(),
-            ];
-            push_live_out_registers(&mut lines, input_state, live_out);
-            lines.push("  Output from sequence 1:".to_string());
-            push_live_out_registers(&mut lines, &output1, live_out);
-            lines.push("  Output from sequence 2:".to_string());
-            push_live_out_registers(&mut lines, &output2, live_out);
-
-            EquivReport {
-                lines,
-                exit_code: 1,
-            }
-        }
-        EquivalenceResult::Unknown(reason) => EquivReport {
-            lines: vec![
-                "UNKNOWN: Could not determine equivalence.".to_string(),
-                format!("  Reason: {}", reason),
-            ],
-            exit_code: 2,
-        },
-    }
-}
-
 fn run_equiv(
     file1: &Path,
     file2: &Path,
@@ -2886,7 +2656,7 @@ fn run_equiv(
     // Check equivalence, then let the pure report builder decide what to print
     // and which exit code to surface. `main` performs the actual `process::exit`.
     let result = check_equivalence_with_config(&seq1, &seq2, &config);
-    let report = build_equiv_report(&result, &seq1, &seq2, &config.live_out);
+    let report = report::build_equiv_report(&result, &seq1, &seq2, &config.live_out);
     for line in &report.lines {
         println!("{}", line);
     }
@@ -5634,14 +5404,10 @@ mod cli_helper_tests {
     }
 
     #[test]
-    fn formatting_and_print_helpers_cover_optional_sections() {
-        assert_eq!(fmt_bytes(42), "     42 B ");
-        assert!(fmt_bytes(2_048).contains("kB"));
-        assert!(fmt_bytes(2_097_152).contains("MB"));
-        assert!(fmt_dur(Duration::from_nanos(500)).contains("µs"));
-        assert!(fmt_dur(Duration::from_millis(2)).contains("ms"));
-        assert!(fmt_dur(Duration::from_secs(2)).contains("s"));
-
+    fn print_wrappers_delegate_to_report_without_panicking() {
+        // The pure `report::format_*` seams are asserted in `s11::report`'s own
+        // unit tests and the `report` integration test. Here we only exercise
+        // the thin stdout wrappers that still live in the binary.
         let timings = LlmTimings {
             codex_calls: 1,
             codex_time: Duration::from_millis(2),
@@ -5663,159 +5429,6 @@ mod cli_helper_tests {
         stats.iterations = 10;
         stats.accepted_proposals = 5;
         print_search_statistics(&stats);
-    }
-
-    #[test]
-    fn format_search_statistics_emits_all_fields_and_acceptance_rate() {
-        let mut stats = SearchStatistics::new(Algorithm::Stochastic);
-        stats.elapsed_time = Duration::from_millis(5);
-        stats.candidates_evaluated = 100;
-        stats.candidates_pruned_by_cost = 3;
-        stats.candidates_passed_fast = 12;
-        stats.smt_queries = 4;
-        stats.smt_equivalent = 1;
-        stats.improvements_found = 2;
-        stats.original_cost = 20;
-        stats.best_cost_found = 18;
-        stats.iterations = 10;
-        stats.accepted_proposals = 5;
-
-        assert_eq!(
-            format_search_statistics(&stats),
-            vec![
-                "\nSearch Statistics:",
-                "  Algorithm: Stochastic",
-                "  Elapsed time: 5ms",
-                "  Candidates evaluated: 100",
-                "  Candidates pruned by cost: 3",
-                "  Candidates passed fast test: 12",
-                "  SMT queries: 4",
-                "  SMT equivalent: 1",
-                "  Improvements found: 2",
-                "  Original cost: 20",
-                "  Best cost found: 18",
-                "  Iterations: 10",
-                "  Acceptance rate: 50.00%",
-            ],
-        );
-    }
-
-    #[test]
-    fn format_unsupported_mnemonic_ledger_is_empty_for_empty_ledger() {
-        let ledger = UnsupportedMnemonicLedger::new();
-        assert!(format_unsupported_mnemonic_ledger(&ledger).is_empty());
-    }
-
-    #[test]
-    fn format_unsupported_mnemonic_ledger_ranks_entries_by_frequency() {
-        let mut ledger = UnsupportedMnemonicLedger::new();
-        ledger.record("ldr");
-        ledger.record("ldr");
-        ledger.record("adc");
-
-        assert_eq!(
-            format_unsupported_mnemonic_ledger(&ledger),
-            vec![
-                "\nUnsupported mnemonics emitted by the LLM (frequency-ranked):",
-                "      2  ldr",
-                "      1  adc",
-            ],
-        );
-    }
-
-    #[test]
-    fn format_llm_timings_plural_with_smt_and_share_sections() {
-        // codex 5ms / verify 30ms of a 50ms total → other 15ms; shares 10% / 60%.
-        let timings = LlmTimings {
-            codex_calls: 2,
-            codex_time: Duration::from_millis(5),
-            verifications: 3,
-            verify_time: Duration::from_millis(30),
-            smt_calls: 2,
-            smt_formula_bytes_total: 2_048,
-            smt_formula_bytes_max: 1_536,
-        };
-        let lines = format_llm_timings(&timings, Duration::from_millis(50));
-
-        assert_eq!(
-            lines.first().map(String::as_str),
-            Some("\nLLM phase timing:")
-        );
-        // Plural suffixes on counts > 1.
-        let codex_line = lines.iter().find(|l| l.contains("Codex calls:")).unwrap();
-        assert!(codex_line.ends_with("(2 calls)"), "got {codex_line:?}");
-        assert!(
-            lines
-                .iter()
-                .any(|l| l.contains("(3 verifications, parse + fast + SMT)"))
-        );
-        // SMT sub-section present; "invoked" line is pure text so pin it exactly.
-        assert!(lines.iter().any(|l| l == "    SMT invoked:    2 times"));
-        // Average formula bytes = 2048 / 2 smt_calls = 1024 = 1.00 kB.
-        assert!(
-            lines.iter().any(|l| l.contains("1.00 kB  avg")),
-            "avg not rendered from total/smt_calls: {lines:?}"
-        );
-        // Share section: codex 5/50 = 10%, verify 30/50 = 60%.
-        assert!(lines.iter().any(|l| l.ends_with(" 10.00%")), "{lines:?}");
-        assert!(lines.iter().any(|l| l.ends_with(" 60.00%")), "{lines:?}");
-    }
-
-    #[test]
-    fn format_llm_timings_singular_suffixes() {
-        let timings = LlmTimings {
-            codex_calls: 1,
-            codex_time: Duration::from_millis(5),
-            verifications: 1,
-            verify_time: Duration::from_millis(5),
-            smt_calls: 1,
-            smt_formula_bytes_total: 1_024,
-            smt_formula_bytes_max: 1_024,
-        };
-        let lines = format_llm_timings(&timings, Duration::from_millis(20));
-        assert!(lines.iter().any(|l| l.ends_with("(1 call)")));
-        assert!(
-            lines
-                .iter()
-                .any(|l| l.contains("(1 verification, parse + fast + SMT)"))
-        );
-        assert!(lines.iter().any(|l| l == "    SMT invoked:    1 time"));
-    }
-
-    #[test]
-    fn format_llm_timings_omits_smt_and_share_sections() {
-        // No SMT calls → no SMT sub-section; zero total → no share section.
-        let timings = LlmTimings {
-            codex_calls: 1,
-            codex_time: Duration::ZERO,
-            verifications: 1,
-            verify_time: Duration::ZERO,
-            smt_calls: 0,
-            smt_formula_bytes_total: 0,
-            smt_formula_bytes_max: 0,
-        };
-        let lines = format_llm_timings(&timings, Duration::ZERO);
-        assert!(!lines.iter().any(|l| l.contains("SMT invoked")));
-        assert!(!lines.iter().any(|l| l.contains("SMT formula")));
-        assert!(!lines.iter().any(|l| l.contains("share:")));
-        // Non-share lines still present, in order.
-        assert_eq!(
-            lines.first().map(String::as_str),
-            Some("\nLLM phase timing:")
-        );
-        assert!(lines.iter().any(|l| l.contains("Total:")));
-    }
-
-    #[test]
-    fn format_search_statistics_omits_iteration_lines_when_no_iterations() {
-        let stats = SearchStatistics::new(Algorithm::Enumerative);
-        let lines = format_search_statistics(&stats);
-        assert!(!lines.iter().any(|l| l.contains("Iterations:")));
-        assert!(!lines.iter().any(|l| l.contains("Acceptance rate:")));
-        assert_eq!(
-            lines.first().map(String::as_str),
-            Some("\nSearch Statistics:")
-        );
     }
 
     /// Regression for issue #243: the hybrid `SearchConfig` must inherit
@@ -6221,112 +5834,6 @@ mod cli_helper_tests {
 
         let llm_asm = TempFile::new("s11-llm", "s", "mov x0, x1\n");
         run_llm_opt(llm_asm.path(), "x0", 0, "test-model", 0, true).unwrap();
-    }
-
-    // ===== `equiv` report builder (extracted seam) =====
-    //
-    // Before this refactor these outcomes were only reachable through the CLI:
-    // the NotEquivalent/NotEquivalentFast/Unknown arms of `run_equiv` called
-    // `std::process::exit` inline, so no test could observe their formatting or
-    // exit codes. `build_equiv_report` is the pure seam that made them testable.
-
-    #[test]
-    fn equiv_report_equivalent_maps_to_exit_zero() {
-        let report = build_equiv_report(
-            &semantics::EquivalenceResult::Equivalent,
-            &[],
-            &[],
-            &LiveOut::from_registers(vec![]),
-        );
-        assert_eq!(report.exit_code, 0);
-        assert_eq!(
-            report.lines,
-            vec!["EQUIVALENT: The two sequences are semantically equivalent.".to_string()]
-        );
-    }
-
-    #[test]
-    fn equiv_report_not_equivalent_smt_maps_to_exit_one() {
-        let report = build_equiv_report(
-            &semantics::EquivalenceResult::NotEquivalent,
-            &[],
-            &[],
-            &LiveOut::from_registers(vec![]),
-        );
-        assert_eq!(report.exit_code, 1);
-        assert_eq!(
-            report.lines,
-            vec![
-                "NOT EQUIVALENT: The two sequences produce different results (verified by SMT)."
-                    .to_string()
-            ]
-        );
-    }
-
-    #[test]
-    fn equiv_report_unknown_maps_to_exit_two_with_reason() {
-        let report = build_equiv_report(
-            &semantics::EquivalenceResult::Unknown("solver timeout".to_string()),
-            &[],
-            &[],
-            &LiveOut::from_registers(vec![]),
-        );
-        assert_eq!(report.exit_code, 2);
-        assert_eq!(
-            report.lines,
-            vec![
-                "UNKNOWN: Could not determine equivalence.".to_string(),
-                "  Reason: solver timeout".to_string(),
-            ]
-        );
-    }
-
-    #[test]
-    fn equiv_report_counterexample_reruns_sequences_and_formats_live_registers() {
-        // seq1 computes x0 = x1 + 1; seq2 computes x0 = x1 + 2. With x1 = 5 in
-        // the counterexample input the two diverge on x0 (6 vs 7). The expected
-        // hex values below are worked out by hand, independent of the concrete
-        // interpreter the builder calls — so the assertion can actually disagree
-        // with the code.
-        let seq1 = vec![Instruction::Add {
-            rd: Register::X0,
-            rn: Register::X1,
-            rm: Operand::Immediate(1),
-        }];
-        let seq2 = vec![Instruction::Add {
-            rd: Register::X0,
-            rn: Register::X1,
-            rm: Operand::Immediate(2),
-        }];
-
-        let mut input = semantics::ConcreteMachineState::new_zeroed();
-        input.set_register(Register::X1, semantics::ConcreteValue::new(5));
-        let live_out = LiveOut::from_registers(vec![Register::X0, Register::X1]);
-
-        let report = build_equiv_report(
-            &semantics::EquivalenceResult::NotEquivalentFast(input),
-            &seq1,
-            &seq2,
-            &live_out,
-        );
-
-        assert_eq!(report.exit_code, 1);
-        assert_eq!(
-            report.lines,
-            vec![
-                "NOT EQUIVALENT: The two sequences produce different results.".to_string(),
-                "\nCounterexample found:".to_string(),
-                "  Input state:".to_string(),
-                "    x0 = 0x0000000000000000".to_string(),
-                "    x1 = 0x0000000000000005".to_string(),
-                "  Output from sequence 1:".to_string(),
-                "    x0 = 0x0000000000000006".to_string(),
-                "    x1 = 0x0000000000000005".to_string(),
-                "  Output from sequence 2:".to_string(),
-                "    x0 = 0x0000000000000007".to_string(),
-                "    x1 = 0x0000000000000005".to_string(),
-            ]
-        );
     }
 
     // ===== Issue #69: validate_basic_block =====

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,0 +1,531 @@
+//! CLI report rendering — the pure text-formatting seam.
+//!
+//! This module concentrates the functions that turn search results, LLM timing
+//! breakdowns, unsupported-mnemonic ledgers and equivalence outcomes into the
+//! exact lines the CLI prints. Every function here is pure: it returns
+//! `Vec<String>` (or a small report struct) and performs no I/O, so the
+//! byte-for-byte CLI output can be asserted directly without capturing stdout.
+//! The binary keeps the thin `print_*` wrappers that loop over these lines and
+//! `println!`, matching the pure-function `capstone_bridge` precedent of
+//! keeping stdout out of the library.
+//!
+//! Arch scope: [`format_search_statistics`], [`format_llm_timings`] and
+//! [`format_unsupported_mnemonic_ledger`] are architecture-neutral, but the
+//! [`build_equiv_report`] counterexample path is AArch64-specific — it re-runs
+//! the diverging prefixes through the AArch64 concrete interpreter and renders
+//! `Register` / vector values.
+
+use std::time::Duration;
+
+use crate::ir::instructions::split_terminator;
+use crate::ir::{Instruction, Register};
+use crate::search::llm::LlmTimings;
+use crate::search::llm::ledger::UnsupportedMnemonicLedger;
+use crate::search::result::SearchStatistics;
+use crate::semantics::{self, LiveOut};
+
+/// Format a byte count with a unit chosen to keep ~3 significant digits visible.
+pub fn fmt_bytes(n: usize) -> String {
+    if n >= 1_048_576 {
+        format!("{:>7.2} MB", n as f64 / 1_048_576.0)
+    } else if n >= 1_024 {
+        format!("{:>7.2} kB", n as f64 / 1_024.0)
+    } else {
+        format!("{:>7} B ", n)
+    }
+}
+
+/// Format a Duration with a unit chosen to keep ~3 significant digits visible.
+pub fn fmt_dur(d: Duration) -> String {
+    let secs = d.as_secs_f64();
+    if secs >= 1.0 {
+        format!("{:>8.2} s ", secs)
+    } else if secs >= 0.001 {
+        format!("{:>8.2} ms", secs * 1_000.0)
+    } else {
+        format!("{:>8.1} µs", secs * 1_000_000.0)
+    }
+}
+
+/// Render the per-phase LLM timing breakdown as one `String` per output line.
+///
+/// Pure seam: the pluralization, the conditional SMT sub-section (with its
+/// average-formula-bytes computation), and the conditional share-percentage
+/// section are all decided here so they can be asserted without capturing
+/// stdout. The binary's `print_llm_timings` prints the lines.
+pub fn format_llm_timings(timings: &LlmTimings, total: Duration) -> Vec<String> {
+    let codex = timings.codex_time;
+    let verify = timings.verify_time;
+    let other = total.saturating_sub(codex).saturating_sub(verify);
+    let mut lines = vec![
+        "\nLLM phase timing:".to_string(),
+        format!(
+            "  Codex calls:      {}   ({} call{})",
+            fmt_dur(codex),
+            timings.codex_calls,
+            if timings.codex_calls == 1 { "" } else { "s" }
+        ),
+        format!(
+            "  Verification:     {}   ({} verification{}, parse + fast + SMT)",
+            fmt_dur(verify),
+            timings.verifications,
+            if timings.verifications == 1 { "" } else { "s" }
+        ),
+    ];
+    if timings.smt_calls > 0 {
+        let avg_bytes = timings.smt_formula_bytes_total / timings.smt_calls as usize;
+        lines.push(format!(
+            "    SMT invoked:    {} time{}",
+            timings.smt_calls,
+            if timings.smt_calls == 1 { "" } else { "s" }
+        ));
+        lines.push(format!(
+            "    SMT formula:    {}  total   ({}  avg, {}  max)",
+            fmt_bytes(timings.smt_formula_bytes_total),
+            fmt_bytes(avg_bytes),
+            fmt_bytes(timings.smt_formula_bytes_max),
+        ));
+    }
+    lines.push(format!("  Other:            {}", fmt_dur(other)));
+    lines.push(format!("  Total:            {}", fmt_dur(total)));
+    if total.as_secs_f64() > 0.0 {
+        lines.push(format!(
+            "  Codex share:      {:>6.2}%",
+            100.0 * codex.as_secs_f64() / total.as_secs_f64()
+        ));
+        lines.push(format!(
+            "  Verify share:     {:>6.2}%",
+            100.0 * verify.as_secs_f64() / total.as_secs_f64()
+        ));
+    }
+    lines
+}
+
+/// Render the unsupported-mnemonic ledger as one `String` per output line.
+///
+/// Pure seam: returns an empty `Vec` for an empty ledger (so the printer emits
+/// nothing), otherwise a header plus one frequency-ranked entry line.
+pub fn format_unsupported_mnemonic_ledger(ledger: &UnsupportedMnemonicLedger) -> Vec<String> {
+    if ledger.is_empty() {
+        return Vec::new();
+    }
+    let mut lines =
+        vec!["\nUnsupported mnemonics emitted by the LLM (frequency-ranked):".to_string()];
+    for (mnem, count) in ledger.sorted_entries() {
+        lines.push(format!("  {:>5}  {}", count, mnem));
+    }
+    lines
+}
+
+/// Render the search-statistics report as one `String` per output line.
+///
+/// Pure: the seam that lets tests assert on the exact report without capturing
+/// stdout. The binary's `print_search_statistics` prints the lines. Mirrors the
+/// `build_equiv_report` precedent.
+pub fn format_search_statistics(stats: &SearchStatistics) -> Vec<String> {
+    let mut lines = vec![
+        "\nSearch Statistics:".to_string(),
+        format!("  Algorithm: {:?}", stats.algorithm),
+        format!("  Elapsed time: {:?}", stats.elapsed_time),
+        format!("  Candidates evaluated: {}", stats.candidates_evaluated),
+        format!(
+            "  Candidates pruned by cost: {}",
+            stats.candidates_pruned_by_cost
+        ),
+        format!(
+            "  Candidates passed fast test: {}",
+            stats.candidates_passed_fast
+        ),
+        format!("  SMT queries: {}", stats.smt_queries),
+        format!("  SMT equivalent: {}", stats.smt_equivalent),
+        format!("  Improvements found: {}", stats.improvements_found),
+        format!("  Original cost: {}", stats.original_cost),
+        format!("  Best cost found: {}", stats.best_cost_found),
+    ];
+    if stats.iterations > 0 {
+        lines.push(format!("  Iterations: {}", stats.iterations));
+        lines.push(format!(
+            "  Acceptance rate: {:.2}%",
+            stats.acceptance_rate() * 100.0
+        ));
+    }
+    lines
+}
+
+/// The presentation-and-policy outcome of an `equiv` run: the lines the CLI
+/// should print and the process exit code it should return.
+///
+/// Produced by [`build_equiv_report`] with no stdout writes and no
+/// `std::process::exit` of its own. Keeping policy (exit codes) and formatting
+/// out of `run_equiv` is what makes the not-equivalent / counterexample /
+/// unknown paths unit-testable — each previously called `std::process::exit`
+/// inline and could only be exercised by running the whole binary.
+#[derive(Debug, PartialEq, Eq)]
+pub struct EquivReport {
+    pub lines: Vec<String>,
+    pub exit_code: i32,
+}
+
+/// Append `state`'s live-out registers to `lines`, one `    <reg> = 0x…` entry
+/// each, sorted by register index for deterministic output. Shared by the
+/// input / output-1 / output-2 sections of a counterexample so the three
+/// previously-duplicated print loops live in one place.
+fn push_live_out_registers(
+    lines: &mut Vec<String>,
+    state: &semantics::ConcreteMachineState,
+    live_out: &LiveOut,
+) {
+    let mut regs: Vec<_> = live_out.iter().copied().collect();
+    regs.sort_by_key(|reg| reg.sort_key());
+    for reg in regs {
+        match reg {
+            Register::Vector(vector) => {
+                lines.push(format!("    {} = 0x{:032x}", reg, state.get_vector(vector)));
+            }
+            _ => lines.push(format!(
+                "    {} = 0x{:016x}",
+                reg,
+                state.get_register(reg).as_u64()
+            )),
+        }
+    }
+}
+
+/// Turn an [`EquivalenceResult`] into the lines to print and the exit code to
+/// return. Pure: no I/O, no process exit. `run_equiv` prints the lines and the
+/// `equiv` CLI arm maps the code (Equivalent → 0, NotEquivalent[Fast] → 1,
+/// Unknown → 2).
+///
+/// [`EquivalenceResult`]: semantics::EquivalenceResult
+pub fn build_equiv_report(
+    result: &semantics::EquivalenceResult,
+    seq1: &[Instruction],
+    seq2: &[Instruction],
+    live_out: &LiveOut,
+) -> EquivReport {
+    use semantics::EquivalenceResult;
+
+    match result {
+        EquivalenceResult::Equivalent => EquivReport {
+            lines: vec!["EQUIVALENT: The two sequences are semantically equivalent.".to_string()],
+            exit_code: 0,
+        },
+        EquivalenceResult::NotEquivalent => EquivReport {
+            lines: vec![
+                "NOT EQUIVALENT: The two sequences produce different results (verified by SMT)."
+                    .to_string(),
+            ],
+            exit_code: 1,
+        },
+        EquivalenceResult::NotEquivalentFast(input_state) => {
+            // Issue #69: strip terminators before re-running on the
+            // counterexample. The B1/B2 stubs panic if a branch reaches the
+            // concrete interpreter; the equivalence layer already excluded the
+            // terminator from its comparison via the precheck.
+            let (prefix1, _) = split_terminator(seq1);
+            let (prefix2, _) = split_terminator(seq2);
+
+            let output1 = semantics::apply_sequence_concrete(input_state.clone(), prefix1);
+            let output2 = semantics::apply_sequence_concrete(input_state.clone(), prefix2);
+
+            let mut lines = vec![
+                "NOT EQUIVALENT: The two sequences produce different results.".to_string(),
+                "\nCounterexample found:".to_string(),
+                "  Input state:".to_string(),
+            ];
+            push_live_out_registers(&mut lines, input_state, live_out);
+            lines.push("  Output from sequence 1:".to_string());
+            push_live_out_registers(&mut lines, &output1, live_out);
+            lines.push("  Output from sequence 2:".to_string());
+            push_live_out_registers(&mut lines, &output2, live_out);
+
+            EquivReport {
+                lines,
+                exit_code: 1,
+            }
+        }
+        EquivalenceResult::Unknown(reason) => EquivReport {
+            lines: vec![
+                "UNKNOWN: Could not determine equivalence.".to_string(),
+                format!("  Reason: {}", reason),
+            ],
+            exit_code: 2,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::Operand;
+    use crate::search::config::Algorithm;
+
+    #[test]
+    fn fmt_bytes_and_fmt_dur_pick_human_units() {
+        assert_eq!(fmt_bytes(42), "     42 B ");
+        assert!(fmt_bytes(2_048).contains("kB"));
+        assert!(fmt_bytes(2_097_152).contains("MB"));
+        assert!(fmt_dur(Duration::from_nanos(500)).contains("µs"));
+        assert!(fmt_dur(Duration::from_millis(2)).contains("ms"));
+        assert!(fmt_dur(Duration::from_secs(2)).contains("s"));
+    }
+
+    #[test]
+    fn format_search_statistics_emits_all_fields_and_acceptance_rate() {
+        let mut stats = SearchStatistics::new(Algorithm::Stochastic);
+        stats.elapsed_time = Duration::from_millis(5);
+        stats.candidates_evaluated = 100;
+        stats.candidates_pruned_by_cost = 3;
+        stats.candidates_passed_fast = 12;
+        stats.smt_queries = 4;
+        stats.smt_equivalent = 1;
+        stats.improvements_found = 2;
+        stats.original_cost = 20;
+        stats.best_cost_found = 18;
+        stats.iterations = 10;
+        stats.accepted_proposals = 5;
+
+        assert_eq!(
+            format_search_statistics(&stats),
+            vec![
+                "\nSearch Statistics:",
+                "  Algorithm: Stochastic",
+                "  Elapsed time: 5ms",
+                "  Candidates evaluated: 100",
+                "  Candidates pruned by cost: 3",
+                "  Candidates passed fast test: 12",
+                "  SMT queries: 4",
+                "  SMT equivalent: 1",
+                "  Improvements found: 2",
+                "  Original cost: 20",
+                "  Best cost found: 18",
+                "  Iterations: 10",
+                "  Acceptance rate: 50.00%",
+            ],
+        );
+    }
+
+    #[test]
+    fn format_search_statistics_omits_iteration_lines_when_no_iterations() {
+        let stats = SearchStatistics::new(Algorithm::Enumerative);
+        let lines = format_search_statistics(&stats);
+        assert!(!lines.iter().any(|l| l.contains("Iterations:")));
+        assert!(!lines.iter().any(|l| l.contains("Acceptance rate:")));
+        assert_eq!(
+            lines.first().map(String::as_str),
+            Some("\nSearch Statistics:")
+        );
+    }
+
+    #[test]
+    fn format_unsupported_mnemonic_ledger_is_empty_for_empty_ledger() {
+        let ledger = UnsupportedMnemonicLedger::new();
+        assert!(format_unsupported_mnemonic_ledger(&ledger).is_empty());
+    }
+
+    #[test]
+    fn format_unsupported_mnemonic_ledger_ranks_entries_by_frequency() {
+        let mut ledger = UnsupportedMnemonicLedger::new();
+        ledger.record("ldr");
+        ledger.record("ldr");
+        ledger.record("adc");
+
+        assert_eq!(
+            format_unsupported_mnemonic_ledger(&ledger),
+            vec![
+                "\nUnsupported mnemonics emitted by the LLM (frequency-ranked):",
+                "      2  ldr",
+                "      1  adc",
+            ],
+        );
+    }
+
+    #[test]
+    fn format_llm_timings_plural_with_smt_and_share_sections() {
+        // codex 5ms / verify 30ms of a 50ms total → other 15ms; shares 10% / 60%.
+        let timings = LlmTimings {
+            codex_calls: 2,
+            codex_time: Duration::from_millis(5),
+            verifications: 3,
+            verify_time: Duration::from_millis(30),
+            smt_calls: 2,
+            smt_formula_bytes_total: 2_048,
+            smt_formula_bytes_max: 1_536,
+        };
+        let lines = format_llm_timings(&timings, Duration::from_millis(50));
+
+        assert_eq!(
+            lines.first().map(String::as_str),
+            Some("\nLLM phase timing:")
+        );
+        // Plural suffixes on counts > 1.
+        let codex_line = lines.iter().find(|l| l.contains("Codex calls:")).unwrap();
+        assert!(codex_line.ends_with("(2 calls)"), "got {codex_line:?}");
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("(3 verifications, parse + fast + SMT)"))
+        );
+        // SMT sub-section present; "invoked" line is pure text so pin it exactly.
+        assert!(lines.iter().any(|l| l == "    SMT invoked:    2 times"));
+        // Average formula bytes = 2048 / 2 smt_calls = 1024 = 1.00 kB.
+        assert!(
+            lines.iter().any(|l| l.contains("1.00 kB  avg")),
+            "avg not rendered from total/smt_calls: {lines:?}"
+        );
+        // Share section: codex 5/50 = 10%, verify 30/50 = 60%.
+        assert!(lines.iter().any(|l| l.ends_with(" 10.00%")), "{lines:?}");
+        assert!(lines.iter().any(|l| l.ends_with(" 60.00%")), "{lines:?}");
+    }
+
+    #[test]
+    fn format_llm_timings_singular_suffixes() {
+        let timings = LlmTimings {
+            codex_calls: 1,
+            codex_time: Duration::from_millis(5),
+            verifications: 1,
+            verify_time: Duration::from_millis(5),
+            smt_calls: 1,
+            smt_formula_bytes_total: 1_024,
+            smt_formula_bytes_max: 1_024,
+        };
+        let lines = format_llm_timings(&timings, Duration::from_millis(20));
+        assert!(lines.iter().any(|l| l.ends_with("(1 call)")));
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("(1 verification, parse + fast + SMT)"))
+        );
+        assert!(lines.iter().any(|l| l == "    SMT invoked:    1 time"));
+    }
+
+    #[test]
+    fn format_llm_timings_omits_smt_and_share_sections() {
+        // No SMT calls → no SMT sub-section; zero total → no share section.
+        let timings = LlmTimings {
+            codex_calls: 1,
+            codex_time: Duration::ZERO,
+            verifications: 1,
+            verify_time: Duration::ZERO,
+            smt_calls: 0,
+            smt_formula_bytes_total: 0,
+            smt_formula_bytes_max: 0,
+        };
+        let lines = format_llm_timings(&timings, Duration::ZERO);
+        assert!(!lines.iter().any(|l| l.contains("SMT invoked")));
+        assert!(!lines.iter().any(|l| l.contains("SMT formula")));
+        assert!(!lines.iter().any(|l| l.contains("share:")));
+        // Non-share lines still present, in order.
+        assert_eq!(
+            lines.first().map(String::as_str),
+            Some("\nLLM phase timing:")
+        );
+        assert!(lines.iter().any(|l| l.contains("Total:")));
+    }
+
+    // ===== `equiv` report builder (extracted seam) =====
+    //
+    // Before this refactor these outcomes were only reachable through the CLI:
+    // the NotEquivalent/NotEquivalentFast/Unknown arms of `run_equiv` called
+    // `std::process::exit` inline, so no test could observe their formatting or
+    // exit codes. `build_equiv_report` is the pure seam that made them testable.
+
+    #[test]
+    fn equiv_report_equivalent_maps_to_exit_zero() {
+        let report = build_equiv_report(
+            &semantics::EquivalenceResult::Equivalent,
+            &[],
+            &[],
+            &LiveOut::from_registers(vec![]),
+        );
+        assert_eq!(report.exit_code, 0);
+        assert_eq!(
+            report.lines,
+            vec!["EQUIVALENT: The two sequences are semantically equivalent.".to_string()]
+        );
+    }
+
+    #[test]
+    fn equiv_report_not_equivalent_smt_maps_to_exit_one() {
+        let report = build_equiv_report(
+            &semantics::EquivalenceResult::NotEquivalent,
+            &[],
+            &[],
+            &LiveOut::from_registers(vec![]),
+        );
+        assert_eq!(report.exit_code, 1);
+        assert_eq!(
+            report.lines,
+            vec![
+                "NOT EQUIVALENT: The two sequences produce different results (verified by SMT)."
+                    .to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn equiv_report_unknown_maps_to_exit_two_with_reason() {
+        let report = build_equiv_report(
+            &semantics::EquivalenceResult::Unknown("solver timeout".to_string()),
+            &[],
+            &[],
+            &LiveOut::from_registers(vec![]),
+        );
+        assert_eq!(report.exit_code, 2);
+        assert_eq!(
+            report.lines,
+            vec![
+                "UNKNOWN: Could not determine equivalence.".to_string(),
+                "  Reason: solver timeout".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn equiv_report_counterexample_reruns_sequences_and_formats_live_registers() {
+        // seq1 computes x0 = x1 + 1; seq2 computes x0 = x1 + 2. With x1 = 5 in
+        // the counterexample input the two diverge on x0 (6 vs 7). The expected
+        // hex values below are worked out by hand, independent of the concrete
+        // interpreter the builder calls — so the assertion can actually disagree
+        // with the code.
+        let seq1 = vec![Instruction::Add {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Immediate(1),
+        }];
+        let seq2 = vec![Instruction::Add {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Immediate(2),
+        }];
+
+        let mut input = semantics::ConcreteMachineState::new_zeroed();
+        input.set_register(Register::X1, semantics::ConcreteValue::new(5));
+        let live_out = LiveOut::from_registers(vec![Register::X0, Register::X1]);
+
+        let report = build_equiv_report(
+            &semantics::EquivalenceResult::NotEquivalentFast(input),
+            &seq1,
+            &seq2,
+            &live_out,
+        );
+
+        assert_eq!(report.exit_code, 1);
+        assert_eq!(
+            report.lines,
+            vec![
+                "NOT EQUIVALENT: The two sequences produce different results.".to_string(),
+                "\nCounterexample found:".to_string(),
+                "  Input state:".to_string(),
+                "    x0 = 0x0000000000000000".to_string(),
+                "    x1 = 0x0000000000000005".to_string(),
+                "  Output from sequence 1:".to_string(),
+                "    x0 = 0x0000000000000006".to_string(),
+                "    x1 = 0x0000000000000005".to_string(),
+                "  Output from sequence 2:".to_string(),
+                "    x0 = 0x0000000000000007".to_string(),
+                "    x1 = 0x0000000000000005".to_string(),
+            ]
+        );
+    }
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -5,3 +5,4 @@ mod docs_capability;
 mod equiv_test;
 mod live_out_cli_test;
 mod opt_test;
+mod report;

--- a/tests/integration/report.rs
+++ b/tests/integration/report.rs
@@ -1,0 +1,165 @@
+//! Integration coverage for the extracted `s11::report` module.
+//!
+//! Before the CLI report-rendering cluster moved out of `main.rs` these
+//! functions lived in the binary crate and were unreachable from an
+//! integration test — the only way to observe their output was to run the CLI
+//! and capture stdout. Extracting them into `s11::report` makes the pure
+//! rendering seam testable from outside the crate. Expected strings are the
+//! byte-for-byte CLI contract.
+
+use std::time::Duration;
+
+use s11::ir::{Instruction, Operand, Register};
+use s11::report::{
+    build_equiv_report, fmt_bytes, fmt_dur, format_llm_timings, format_search_statistics,
+    format_unsupported_mnemonic_ledger,
+};
+use s11::search::config::Algorithm;
+use s11::search::llm::LlmTimings;
+use s11::search::llm::ledger::UnsupportedMnemonicLedger;
+use s11::search::result::SearchStatistics;
+use s11::semantics::{self, LiveOut};
+
+#[test]
+fn fmt_bytes_and_fmt_dur_pick_human_units() {
+    assert_eq!(fmt_bytes(42), "     42 B ");
+    assert!(fmt_bytes(2_048).contains("kB"));
+    assert!(fmt_bytes(2_097_152).contains("MB"));
+    assert!(fmt_dur(Duration::from_nanos(500)).contains("µs"));
+    assert!(fmt_dur(Duration::from_millis(2)).contains("ms"));
+    assert!(fmt_dur(Duration::from_secs(2)).contains("s"));
+}
+
+#[test]
+fn format_search_statistics_emits_all_fields_and_acceptance_rate() {
+    let mut stats = SearchStatistics::new(Algorithm::Stochastic);
+    stats.elapsed_time = Duration::from_millis(5);
+    stats.candidates_evaluated = 100;
+    stats.candidates_pruned_by_cost = 3;
+    stats.candidates_passed_fast = 12;
+    stats.smt_queries = 4;
+    stats.smt_equivalent = 1;
+    stats.improvements_found = 2;
+    stats.original_cost = 20;
+    stats.best_cost_found = 18;
+    stats.iterations = 10;
+    stats.accepted_proposals = 5;
+
+    assert_eq!(
+        format_search_statistics(&stats),
+        vec![
+            "\nSearch Statistics:",
+            "  Algorithm: Stochastic",
+            "  Elapsed time: 5ms",
+            "  Candidates evaluated: 100",
+            "  Candidates pruned by cost: 3",
+            "  Candidates passed fast test: 12",
+            "  SMT queries: 4",
+            "  SMT equivalent: 1",
+            "  Improvements found: 2",
+            "  Original cost: 20",
+            "  Best cost found: 18",
+            "  Iterations: 10",
+            "  Acceptance rate: 50.00%",
+        ],
+    );
+}
+
+#[test]
+fn format_unsupported_mnemonic_ledger_ranks_entries_by_frequency() {
+    let mut ledger = UnsupportedMnemonicLedger::new();
+    ledger.record("ldr");
+    ledger.record("ldr");
+    ledger.record("adc");
+
+    assert_eq!(
+        format_unsupported_mnemonic_ledger(&ledger),
+        vec![
+            "\nUnsupported mnemonics emitted by the LLM (frequency-ranked):",
+            "      2  ldr",
+            "      1  adc",
+        ],
+    );
+}
+
+#[test]
+fn format_llm_timings_renders_smt_and_share_sections() {
+    // codex 5ms / verify 30ms of a 50ms total → other 15ms; shares 10% / 60%.
+    let timings = LlmTimings {
+        codex_calls: 2,
+        codex_time: Duration::from_millis(5),
+        verifications: 3,
+        verify_time: Duration::from_millis(30),
+        smt_calls: 2,
+        smt_formula_bytes_total: 2_048,
+        smt_formula_bytes_max: 1_536,
+    };
+    let lines = format_llm_timings(&timings, Duration::from_millis(50));
+
+    assert_eq!(
+        lines.first().map(String::as_str),
+        Some("\nLLM phase timing:")
+    );
+    assert!(lines.iter().any(|l| l == "    SMT invoked:    2 times"));
+    assert!(lines.iter().any(|l| l.contains("1.00 kB  avg")));
+    assert!(lines.iter().any(|l| l.ends_with(" 10.00%")));
+    assert!(lines.iter().any(|l| l.ends_with(" 60.00%")));
+}
+
+#[test]
+fn build_equiv_report_formats_counterexample_and_exit_codes() {
+    // seq1 computes x0 = x1 + 1; seq2 computes x0 = x1 + 2. With x1 = 5 the two
+    // diverge on x0 (6 vs 7). Hex values worked out by hand, independent of the
+    // concrete interpreter the builder calls.
+    let seq1 = vec![Instruction::Add {
+        rd: Register::X0,
+        rn: Register::X1,
+        rm: Operand::Immediate(1),
+    }];
+    let seq2 = vec![Instruction::Add {
+        rd: Register::X0,
+        rn: Register::X1,
+        rm: Operand::Immediate(2),
+    }];
+
+    let mut input = semantics::ConcreteMachineState::new_zeroed();
+    input.set_register(Register::X1, semantics::ConcreteValue::new(5));
+    let live_out = LiveOut::from_registers(vec![Register::X0, Register::X1]);
+
+    let report = build_equiv_report(
+        &semantics::EquivalenceResult::NotEquivalentFast(input),
+        &seq1,
+        &seq2,
+        &live_out,
+    );
+
+    assert_eq!(report.exit_code, 1);
+    assert_eq!(
+        report.lines,
+        vec![
+            "NOT EQUIVALENT: The two sequences produce different results.".to_string(),
+            "\nCounterexample found:".to_string(),
+            "  Input state:".to_string(),
+            "    x0 = 0x0000000000000000".to_string(),
+            "    x1 = 0x0000000000000005".to_string(),
+            "  Output from sequence 1:".to_string(),
+            "    x0 = 0x0000000000000006".to_string(),
+            "    x1 = 0x0000000000000005".to_string(),
+            "  Output from sequence 2:".to_string(),
+            "    x0 = 0x0000000000000007".to_string(),
+            "    x1 = 0x0000000000000005".to_string(),
+        ]
+    );
+
+    let equivalent = build_equiv_report(
+        &semantics::EquivalenceResult::Equivalent,
+        &[],
+        &[],
+        &LiveOut::from_registers(vec![]),
+    );
+    assert_eq!(equivalent.exit_code, 0);
+    assert_eq!(
+        equivalent.lines,
+        vec!["EQUIVALENT: The two sequences are semantically equivalent.".to_string()]
+    );
+}


### PR DESCRIPTION
## Refactoring goal

Continue decomposing `src/main.rs` (the codebase's largest, hottest file) by extracting the **pure CLI report-rendering seam** into a new `s11::report` library module. This follows the same pattern as the recent `capstone_bridge` (#729) and `capstone_bridge_x86` (#739) extractions.

This was chosen by running the `improve-codebase-architecture` skill's process (parallel `Explore` fan-out applying the **deletion test** to candidate clusters). Two independent surveys converged on this cluster as the highest **leverage × safety** option: it has **zero coupling** to any `main`-local struct, is entirely pure functions over library types, and carries **zero behavior-change risk**. (It is the safest high-value move, not unambiguously *the* most impactful — see follow-ups.)

## What moved

A family of pure functions that turn search results, LLM timing breakdowns, unsupported-mnemonic ledgers and equivalence outcomes into the exact lines the CLI prints:

- `fmt_bytes` / `fmt_dur`
- `format_llm_timings`
- `format_unsupported_mnemonic_ledger`
- `format_search_statistics`
- `EquivReport` / `build_equiv_report`

The binary keeps the thin `print_*` wrappers (which loop and `println!`) and `run_equiv`, so **stdout stays out of the library** — matching the pure-function `capstone_bridge` precedent. The moved code is **byte-identical**; only paths (`crate::`) and visibility (`pub`) changed.

`src/main.rs`: **6939 → 6446 lines** (−493).

## Deepening / why it's a win

These functions were locked in the **binary crate**, so they were unreachable from integration tests — the only way to observe their output before was to run the CLI and capture stdout. After the move the pure rendering seam is testable from outside the crate. `tests/integration/report.rs` is new coverage that **could not have been written before this change**.

Arch-scope note in the module doc: the stats/timings renderers are architecture-neutral; the `build_equiv_report` counterexample path is AArch64-specific (it re-runs diverging prefixes through the AArch64 concrete interpreter).

## Tests that validate it

- **12 unit tests** relocated into `src/report::tests` (pin the exact byte-for-byte output — e.g. `format_search_statistics` full field list, LLM-timing plural/singular/omitted sections, the counterexample hex rendering, exit-code policy for equivalent/not-equivalent/unknown).
- **5 new integration tests** in `tests/integration/report.rs` exercising `s11::report::*` from outside the crate, with expected strings copied verbatim from the pre-existing tests (independent source of truth).
- A slimmed `print_wrappers_delegate_to_report_without_panicking` smoke test remains in `main.rs` for the wrappers that stay in the binary.

Developed test-first (TDD): the integration test was written against the not-yet-existing `s11::report` seam (red: `unresolved import s11::report`), then the code was moved to make it green.

## Verification

Full `./ci_check.sh` flow run locally and green:
- `cargo fmt -- --check` ✓
- `cargo build` ✓ (no new warnings)
- `./build_tests.sh` ✓
- `cargo test`: **1617 lib + 62 integration** pass ✓
- `./test_all.sh` disasm smoke ✓

## Follow-ups (deliberately out of scope)

- **Search-config builder family** (`build_*_search_config`, ~10 fns): higher raw leverage but requires moving `OptimizationOptions` into the lib and churning ~20 signatures — a separate PR.
- **Single-source the encodability rules** (the ISA/IR `is_encodable_*` predicates vs. the assembler's encoders): higher blast radius across all instructions; safer once done incrementally.