### PR TITLE
refactor(driver): extract candidate-window planner into a pure tested seam

### DIFF
--- a/src/candidate_windows.rs
+++ b/src/candidate_windows.rs
@@ -1,0 +1,246 @@
+//! Candidate-window planning for the whole-binary `--auto` driver (ADR-0009).
+//!
+//! The driver's entire risk budget is spent in *window selection*: a window
+//! rewritten when it should not have been produces a wrong binary, so the rules
+//! that split a decoded section into rewritable straight-line runs are the
+//! soundness-critical core of ADR-0009 Decision 4/5.
+//!
+//! Those rules used to live inline in the binary's
+//! `find_candidate_windows_with_backend`, interleaved with Capstone iteration
+//! and ELF I/O — a shallow arrangement where the state machine could only be
+//! exercised by building a full ELF fixture in memory. This module lifts the
+//! run-splitting algorithm into a **pure seam**: the caller classifies each
+//! decoded instruction into a [`WindowInstruction`] descriptor (Capstone stays
+//! in the adapter), and [`plan_candidate_windows`] applies the split rules with
+//! no knowledge of Capstone, `ElfPatcher`, or byte layout. Every rule is then a
+//! fixture-free unit test.
+
+use crate::elf_patcher::AddressWindow;
+use std::collections::HashSet;
+
+/// How a single decoded instruction participates in a straight-line run.
+///
+/// The adapter collapses the three "close the run and drop this instruction"
+/// cases (a call, an x86-64 RIP-relative memory operand, and an unsupported
+/// mnemonic) into [`WindowRole::Excluded`]: all three flush the open run at the
+/// previous instruction's end without contributing the instruction itself, so
+/// the planner treats them identically.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WindowRole {
+    /// A rewritable body instruction: it starts or extends the current run.
+    StraightLine,
+    /// A supported control-flow terminator: it closes the run *inclusively*
+    /// (held fixed as the run's final instruction), but only when a run is open.
+    Terminator,
+    /// A call, RIP-relative memory operand, or unsupported instruction: it
+    /// closes the open run at the previous instruction's end and is itself
+    /// excluded from every window.
+    Excluded,
+}
+
+/// A decoded instruction reduced to exactly what window planning needs: its
+/// start address, its end address (`address + byte length`), and its role.
+///
+/// Keeping the descriptor this small is the point — the overflow-checked end
+/// computation and the Capstone group/operand inspection that produce it belong
+/// to the adapter, not to the split algorithm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WindowInstruction {
+    /// The instruction's virtual address.
+    pub address: u64,
+    /// One past the instruction's last byte (`address + byte length`).
+    pub end: u64,
+    /// The instruction's role in a straight-line run.
+    pub role: WindowRole,
+}
+
+impl WindowInstruction {
+    /// Convenience constructor used by the adapter and tests.
+    pub fn new(address: u64, end: u64, role: WindowRole) -> Self {
+        Self { address, end, role }
+    }
+}
+
+/// Split one section's classified instruction stream into candidate windows.
+///
+/// `instructions` are the section's decoded instructions in address order;
+/// `branch_targets` is the *global* set of direct branch/call target addresses
+/// collected across the whole binary (a target in another section can name an
+/// address inside this run, so the set must be complete before planning — see
+/// ADR-0009 Decision 4/5).
+///
+/// The rules, applied per instruction:
+/// * An instruction whose address is a collected branch target and is not the
+///   current run's first instruction closes the run just before it, so the
+///   target begins a fresh window (a window may *begin* at a target but must not
+///   contain one past its first instruction).
+/// * [`WindowRole::StraightLine`] starts or extends the run.
+/// * [`WindowRole::Terminator`] closes an open run inclusively; with no open run
+///   it produces nothing.
+/// * [`WindowRole::Excluded`] closes an open run at the previous instruction's
+///   end and is itself dropped.
+pub fn plan_candidate_windows(
+    instructions: &[WindowInstruction],
+    branch_targets: &HashSet<u64>,
+) -> Vec<AddressWindow> {
+    let mut candidates = Vec::new();
+    // The currently open run, tracked as the window it will become. `end` is
+    // extended as straight-line/terminator instructions are absorbed.
+    let mut run: Option<AddressWindow> = None;
+
+    for insn in instructions {
+        // Close the current run just before an interior branch target so the
+        // target begins a fresh window. A run whose first instruction *is* the
+        // target is left intact — a window may begin at a target.
+        let splits_here = run.as_ref().is_some_and(|open| {
+            open.start != insn.address && branch_targets.contains(&insn.address)
+        });
+        if splits_here {
+            candidates.push(run.take().expect("run is open when splits_here is true"));
+        }
+
+        match insn.role {
+            WindowRole::Excluded => {
+                if let Some(open) = run.take() {
+                    candidates.push(open);
+                }
+            }
+            WindowRole::StraightLine => match run.as_mut() {
+                Some(open) => open.end = insn.end,
+                None => {
+                    run = Some(AddressWindow {
+                        start: insn.address,
+                        end: insn.end,
+                    })
+                }
+            },
+            WindowRole::Terminator => {
+                if let Some(mut open) = run.take() {
+                    open.end = insn.end;
+                    candidates.push(open);
+                }
+            }
+        }
+    }
+
+    if let Some(open) = run.take() {
+        candidates.push(open);
+    }
+    candidates
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sl(address: u64, len: u64) -> WindowInstruction {
+        WindowInstruction::new(address, address + len, WindowRole::StraightLine)
+    }
+    fn term(address: u64, len: u64) -> WindowInstruction {
+        WindowInstruction::new(address, address + len, WindowRole::Terminator)
+    }
+    fn excl(address: u64, len: u64) -> WindowInstruction {
+        WindowInstruction::new(address, address + len, WindowRole::Excluded)
+    }
+    fn targets(addrs: &[u64]) -> HashSet<u64> {
+        addrs.iter().copied().collect()
+    }
+    /// Compare against hand-derived `(start, end)` pairs so the expected values
+    /// come from the ADR rules, not from re-running the algorithm.
+    fn bounds(windows: &[AddressWindow]) -> Vec<(u64, u64)> {
+        windows.iter().map(|w| (w.start, w.end)).collect()
+    }
+
+    #[test]
+    fn empty_stream_has_no_windows() {
+        assert!(plan_candidate_windows(&[], &targets(&[])).is_empty());
+    }
+
+    #[test]
+    fn contiguous_straight_line_run_is_one_window() {
+        // 3 × 4-byte AArch64-style instrs at 0x1000, 0x1004, 0x1008.
+        let stream = [sl(0x1000, 4), sl(0x1004, 4), sl(0x1008, 4)];
+        assert_eq!(
+            bounds(&plan_candidate_windows(&stream, &targets(&[]))),
+            vec![(0x1000, 0x100c)],
+        );
+    }
+
+    #[test]
+    fn terminator_closes_the_run_inclusively() {
+        // add ...; je +0  ->  the Jcc is held fixed as the window's final insn.
+        let stream = [sl(0x1000, 4), term(0x1004, 2)];
+        assert_eq!(
+            bounds(&plan_candidate_windows(&stream, &targets(&[]))),
+            vec![(0x1000, 0x1006)],
+        );
+    }
+
+    #[test]
+    fn lone_terminator_without_a_prefix_yields_no_window() {
+        let stream = [term(0x2000, 2)];
+        assert!(plan_candidate_windows(&stream, &targets(&[])).is_empty());
+    }
+
+    #[test]
+    fn excluded_instruction_splits_the_run_and_is_omitted() {
+        // Models a call / RIP-relative op / unsupported mnemonic in the middle:
+        // the two straight-line halves survive; the excluded insn is in neither.
+        let stream = [sl(0x1000, 4), excl(0x1004, 4), sl(0x1008, 4)];
+        assert_eq!(
+            bounds(&plan_candidate_windows(&stream, &targets(&[]))),
+            vec![(0x1000, 0x1004), (0x1008, 0x100c)],
+        );
+    }
+
+    #[test]
+    fn interior_branch_target_starts_a_fresh_window() {
+        // 0x1004 is named by some branch: the run must split there so the target
+        // begins a window and is never jumped into mid-window.
+        let stream = [sl(0x1000, 4), sl(0x1004, 4), sl(0x1008, 4)];
+        assert_eq!(
+            bounds(&plan_candidate_windows(&stream, &targets(&[0x1004]))),
+            vec![(0x1000, 0x1004), (0x1004, 0x100c)],
+        );
+    }
+
+    #[test]
+    fn window_may_begin_at_a_branch_target() {
+        // A target that coincides with the run's first instruction does NOT
+        // split — the address is fixed and begins the window legitimately.
+        let stream = [sl(0x1000, 4), sl(0x1004, 4)];
+        assert_eq!(
+            bounds(&plan_candidate_windows(&stream, &targets(&[0x1000]))),
+            vec![(0x1000, 0x1008)],
+        );
+    }
+
+    #[test]
+    fn terminator_at_an_interior_target_closes_prefix_and_is_dropped() {
+        // Ordering subtlety: the pre-split flushes the [0x1000,0x1004) prefix,
+        // leaving no open run, so the terminator itself contributes no window.
+        let stream = [sl(0x1000, 4), term(0x1004, 4)];
+        assert_eq!(
+            bounds(&plan_candidate_windows(&stream, &targets(&[0x1004]))),
+            vec![(0x1000, 0x1004)],
+        );
+    }
+
+    #[test]
+    fn multiple_runs_separated_by_exclusions_and_terminators() {
+        // sl,sl | excl | sl,term | excl | sl  ->  three surviving windows.
+        let stream = [
+            sl(0x1000, 4),
+            sl(0x1004, 4),
+            excl(0x1008, 4),
+            sl(0x100c, 4),
+            term(0x1010, 4),
+            excl(0x1014, 4),
+            sl(0x1018, 4),
+        ];
+        assert_eq!(
+            bounds(&plan_candidate_windows(&stream, &targets(&[]))),
+            vec![(0x1000, 0x1008), (0x100c, 0x1014), (0x1018, 0x101c)],
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod assembler;
 pub mod bench_support;
+pub mod candidate_windows;
 pub mod capstone_bridge;
 pub mod capstone_bridge_x86;
 pub mod docs_support;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 mod test_utils;
 
 use s11::assembler::AArch64Assembler;
+use s11::candidate_windows::{WindowInstruction, WindowRole, plan_candidate_windows};
 use s11::capstone_bridge::{ConvertOutcome, convert_capstone_op};
 use s11::capstone_bridge_x86::{convert_to_x86_ir, convert_x86_capstone_op_for_optimization};
 use s11::elf_patcher::{AddressWindow, DetectedArch, ElfPatcher, TextSection, parse_hex_address};
@@ -1217,10 +1218,12 @@ fn find_candidate_windows_with_backend<B: ElfOptimizationBackend>(
     // scope and are issue #619's soundness gate.
     let mut section_results = Vec::new();
     for (section, instructions) in decoded_sections {
-        let mut candidates = Vec::new();
-        let mut run_start = None;
-        let mut run_end = section.virtual_addr;
-
+        // Classify each decoded instruction into a lightweight descriptor, then
+        // hand the whole section to the pure `candidate_windows` planner. The
+        // Capstone group/operand inspection and the overflow-checked end
+        // computation stay here in the adapter; the soundness-critical
+        // run-splitting rules (ADR-0009 Decision 4/5) live behind the seam.
+        let mut planned = Vec::with_capacity(instructions.len());
         for instruction in instructions.iter() {
             let instruction_end = instruction
                 .address()
@@ -1236,16 +1239,6 @@ fn find_candidate_windows_with_backend<B: ElfOptimizationBackend>(
                     )
                 })?;
 
-            // Close the current run just before an interior branch target so
-            // the target begins a fresh window. Within a contiguous run
-            // `run_end` already equals this instruction's address, so the
-            // flushed window ends exactly where the target starts.
-            if run_start.is_some_and(|start| start != instruction.address())
-                && branch_targets.contains(&instruction.address())
-            {
-                flush_candidate_run(&mut candidates, &mut run_start, run_end);
-            }
-
             let detail = cs.insn_detail(instruction).map_err(|error| {
                 format!(
                     "failed to inspect instruction detail in executable section '{}' at 0x{:x}: {}",
@@ -1255,37 +1248,29 @@ fn find_candidate_windows_with_backend<B: ElfOptimizationBackend>(
                 )
             })?;
 
-            if capstone_detail_is_call(&detail) {
-                flush_candidate_run(&mut candidates, &mut run_start, run_end);
-                continue;
-            }
-            if backend.arch() == DetectedArch::X86_64
-                && capstone_detail_has_rip_relative_memory(&detail)
+            let role = if capstone_detail_is_call(&detail)
+                || (backend.arch() == DetectedArch::X86_64
+                    && capstone_detail_has_rip_relative_memory(&detail))
             {
-                flush_candidate_run(&mut candidates, &mut run_start, run_end);
-                continue;
-            }
+                WindowRole::Excluded
+            } else {
+                match backend.classify_candidate_instruction(instruction) {
+                    Ok(CandidateInstructionDisposition::StraightLine) => WindowRole::StraightLine,
+                    Ok(CandidateInstructionDisposition::Terminator) => WindowRole::Terminator,
+                    Err(_) => WindowRole::Excluded,
+                }
+            };
 
-            match backend.classify_candidate_instruction(instruction) {
-                Ok(CandidateInstructionDisposition::StraightLine) => {
-                    run_start.get_or_insert(instruction.address());
-                    run_end = instruction_end;
-                }
-                Ok(CandidateInstructionDisposition::Terminator) => {
-                    if run_start.is_some() {
-                        run_end = instruction_end;
-                    }
-                    flush_candidate_run(&mut candidates, &mut run_start, run_end);
-                }
-                Err(_) => {
-                    flush_candidate_run(&mut candidates, &mut run_start, run_end);
-                }
-            }
+            planned.push(WindowInstruction::new(
+                instruction.address(),
+                instruction_end,
+                role,
+            ));
         }
-        flush_candidate_run(&mut candidates, &mut run_start, run_end);
+
         section_results.push(SectionCandidateWindows {
+            candidates: plan_candidate_windows(&planned, &branch_targets),
             section,
-            candidates,
         });
     }
 
@@ -1363,20 +1348,6 @@ fn capstone_detail_direct_branch_targets(detail: &capstone::InsnDetail<'_>) -> V
             _ => None,
         })
         .collect()
-}
-
-#[cfg_attr(not(test), allow(dead_code))]
-fn flush_candidate_run(
-    candidates: &mut Vec<AddressWindow>,
-    run_start: &mut Option<u64>,
-    run_end: u64,
-) {
-    if let Some(start) = run_start.take() {
-        candidates.push(AddressWindow {
-            start,
-            end: run_end,
-        });
-    }
 }
 
 fn optimized_output_path(path: &Path) -> PathBuf {


### PR DESCRIPTION
## Goal — deepen a shallow, hard-to-test seam

Surfaced by the **improve-codebase-architecture** skill (scan weighted toward
`git log` hot spots): `src/main.rs` is the codebase's hottest file (14 of the
last 80 commits) and largest (6,939 lines), a shallow *God module* at the crate
root.

The most impactful deepening in it is the **ADR-0009 candidate-window
planner**. The whole-binary `--auto` driver spends its *entire* risk budget on
window selection — a window rewritten when it should not have been produces a
wrong binary — yet the run-splitting rules lived inline in the binary-only
`find_candidate_windows_with_backend`, interleaved with Capstone iteration and
`ElfPatcher` I/O. Living at the crate root, the state machine
(`run_start`/`run_end`/`flush_candidate_run`) was invisible to
`cargo test --lib` and lib coverage, and — critically — **covered only
indirectly**: the only tests that exercised the split rules each build an
in-memory ELF fixture and drive Capstone, so adding a case meant hand-assembling
bytes.

## What changed

Lift the algorithm into a pure library **seam**:

```rust
candidate_windows::plan_candidate_windows(
    &[WindowInstruction],   // { address, end, role }
    &HashSet<u64>,          // global direct-branch targets
) -> Vec<AddressWindow>
```

The adapter in `main.rs` classifies each decoded instruction into a lightweight
`WindowInstruction` descriptor — the Capstone group/operand inspection and the
overflow-checked `end` computation stay in the adapter — and the planner applies
the split rules with **no knowledge of Capstone, `ElfPatcher`, or byte layout**.
`flush_candidate_run` is gone from `main.rs`; its logic is now internal to the
planner. Net: `main.rs` −54 lines, and the soundness-critical logic reads
top-to-bottom in one deep module.

## Seam under test

The TDD skill requires naming the seam and confirming it; with no interactive
user, it is declared here: **`candidate_windows::plan_candidate_windows`** — the
public function is the only surface the tests touch.

## TDD evidence (red → green)

1. **RED** — created the module with the descriptor types and a stub returning
   `Vec::new()`, then wrote behavioral unit tests at the seam. `cargo test --lib`
   → **7 behavioral failures** against the stub (2 that legitimately expect empty
   output passed).
2. **GREEN** — implemented the run-splitting algorithm → **9/9 pass**.

The nine tests are fixture-free specs, one per ADR-0009 rule, each asserting
hand-derived `(start, end)` window bounds (independent of the algorithm, not
recomputed by it): contiguous run, inclusive terminator, lone terminator →
nothing, excluded-instruction split, interior branch-target pre-split,
window-may-begin-at-target, terminator-at-interior-target ordering, and a
mixed multi-run stream.

## Behavior preservation

- The three "flush the run and drop this instruction" cases — a call, an x86-64
  RIP-relative memory operand, and an unsupported mnemonic — collapse to
  `WindowRole::Excluded`, which the original code already handled **identically**
  (all three flushed at the unchanged `run_end` and contributed nothing).
- The **12 existing ELF-fixture integration tests** in `cli_helper_tests`
  (exact-boundary assertions across calls, RIP-relative ops, unsupported
  instructions, interior/cross-section branch targets, terminator-only-at-end,
  and partial-decode fail-closed) are **unchanged** and pass — they guard the
  refactor.

## Verification

`./ci_check.sh` passes end-to-end: `cargo fmt --check`, build, AArch64/x86 test
binaries, full `cargo test` (**1614 lib + 135 bin + 57 integration = 1806 tests,
0 failures**), and `test_all.sh`. `cargo clippy` clean on the changed crates.

## Other deepening candidates (from the architecture review, declined here)

Reported as follow-ups; not pursued in this focused change:

| # | Candidate | Strength | Why not now |
|---|-----------|----------|-------------|
| 2 | Search-result reporting module (`fmt_*`/`format_*`/`print_*`) | Worth exploring | Already pure & already tested — a move, not a new capability |
| 3 | CLI surface module (`Args`/`Commands`/`Cli*` + conversions, ~330 lines) | Worth exploring | Biggest line win, but shallow adapters; touches `main()` dispatch |
| 4 | Equivalence-report builder (`build_equiv_report`) | Speculative | Pure but AArch64-coupled; bundle with #2 later |

## Notes

- The skill's Step 2 HTML report was written to
  `/tmp/architecture-review-20260731T011236.html` (OS temp, ephemeral by design)
  — its candidate table is mirrored above.
- The skill's Step 3 grilling loop is interactive and was skipped in this
  unattended run; the top-recommendation choice is recorded here instead.