### PR TITLE
ci: batch releases on a weekly schedule

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,14 @@
 name: Release
 
-# Releases are cut by semantic-release: on every push to main it derives the
-# next version from Conventional Commit types, builds the Linux `s11` binary,
-# and publishes a GitHub Release (notes + CHANGELOG + tarball + checksums).
-# Replaces the previous manual workflow_dispatch pipeline.
+# Releases are cut by semantic-release on a weekly batch schedule (Sundays
+# 00:00 UTC): it derives the next version from Conventional Commit types
+# accumulated on main since the last release, builds the Linux `s11`
+# binary, and publishes a GitHub Release (notes + CHANGELOG + tarball +
+# checksums). No-op if nothing releasable landed that week. Use
+# workflow_dispatch to cut a release on demand between scheduled runs.
 on:
-  push:
-    branches: [main]
+  schedule:
+    - cron: "0 0 * * 0"
   workflow_dispatch: {}
 
 concurrency:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -2,20 +2,22 @@
 
 Releases are cut automatically by [semantic-release](https://semantic-release.org/),
 driven by the [`Release`](../.github/workflows/release.yml) GitHub Actions
-workflow. It runs on **every push to `main`**, derives the next version from
-[Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) types
-in the unreleased history, verifies the tree, builds a Linux release binary,
-tags the commit, and publishes a GitHub Release with generated notes and a
-`CHANGELOG.md` entry. There is no manual bump/draft/prerelease input — the
-version and whether a release happens at all are derived entirely from
-commit messages (see `.releaserc.json`).
+workflow. It runs on a **weekly schedule (Sundays 00:00 UTC)**, derives the
+next version from [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/)
+types accumulated on `main` since the last release, verifies the tree,
+builds a Linux release binary, tags the commit, and publishes a GitHub
+Release with generated notes and a `CHANGELOG.md` entry. It is a no-op if
+nothing releasable landed that week. There is no manual bump/draft/prerelease
+input — the version and whether a release happens at all are derived
+entirely from commit messages (see `.releaserc.json`).
 
 ## Cutting a release
 
 1. Merge commits with Conventional Commit prefixes (`feat:`, `fix:`, `perf:`,
    `BREAKING CHANGE:` in the footer, etc.) to `main`. Non-release-worthy
    types (`chore:`, `docs:`, `ci:`, ...) don't trigger a release on their own.
-2. That push is all it takes — the `Release` workflow runs automatically.
+2. The `Release` workflow runs automatically the following Sunday, or dispatch
+   it manually (Actions → Release → Run workflow) to cut a release sooner.
 3. On success you get:
    - a `vX.Y.Z` tag and GitHub Release with generated notes and the build
      artifacts (`s11-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz`, `SHA256SUMS.txt`),


### PR DESCRIPTION
## Summary
- Mirrors [pmatos/jsse#445](https://github.com/pmatos/jsse/pull/445): `release.yml` was triggering `semantic-release` on every push to `main`, so nearly every merged `fix`/`feat`/`perf` PR cut its own GitHub Release.
- Switch the trigger to a weekly cron (Sundays 00:00 UTC), batching accumulated releasable commits into one release/week. `workflow_dispatch` is kept for cutting a release on demand between scheduled runs.
- Updated `docs/RELEASING.md` to match the new cadence (s11 documents the trigger explicitly; jsse's PR only touched the workflow file).
- No changes to `.releaserc.json` — semantic-release's release-worthiness rules (commit-analyzer) are unaffected; only the cadence at which the workflow checks changes.

## This does not fix the release failure
While investigating, I found the `Release` workflow has never actually completed a release — every run since the semantic-release workflow was introduced (~June 21) has failed inside `prepare.sh`'s `ci_check.sh` gate, at the AArch64 cross-link step (`build_tests.sh`):

```
/usr/lib/gcc-cross/aarch64-linux-gnu/13/.../ld: cannot find Scrt1.o: No such file or directory
/usr/lib/gcc-cross/aarch64-linux-gnu/13/.../ld: cannot find crti.o: No such file or directory
```

Root cause: `release.yml`'s `apt-get install` uses `--no-install-recommends`, which skips `libc6-dev-arm64-cross` — a Recommends-only (not a hard Depends) of `gcc-aarch64-linux-gnu` on Ubuntu. `test.yml`/`coverage.yml` don't pass that flag, so they pull in `libc6-dev-arm64-cross` as an "additional package" and their AArch64 cross-link step succeeds. Confirmed by diffing the two workflows' install-step logs: `libc6-dev-arm64-cross` appears in `test.yml`'s install output and is entirely absent from `release.yml`'s.

Consequently `Cargo.toml` is still at `0.1.0` and no GitHub Release has ever been published — whenever this is fixed, the first successful run will cut `1.0.0` (per Conventional Commits history), not a patch bump.

This PR only changes the cadence (so a broken run fails once a week instead of on every push). I'll open a separate fix for the apt flag / missing package if wanted.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — parses cleanly.
- [ ] actionlint not available locally; not run.
- [ ] Confirm the scheduled run fires as expected on the next Sunday (or trigger manually via `workflow_dispatch` to sanity-check the job still runs — it will still fail at `prepare.sh` until the apt issue above is fixed).