### PR TITLE
fix(ci): install libc6-dev-arm64-cross for the release AArch64 cross-link step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,12 @@ jobs:
       - name: Install system build deps
         run: |
           sudo apt-get update
+          # libc6-dev-arm64-cross is a Recommends (not a hard Depends) of
+          # gcc-aarch64-linux-gnu, so --no-install-recommends silently drops
+          # it — but it ships the crt objects (Scrt1.o, crti.o) build_tests.sh
+          # needs to link the AArch64 test binaries. List it explicitly.
           sudo apt-get install -y --no-install-recommends \
-            libcapstone-dev gcc-aarch64-linux-gnu z3 libz3-dev
+            libcapstone-dev gcc-aarch64-linux-gnu libc6-dev-arm64-cross z3 libz3-dev
           curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh \
             | sudo bash -s -- --to /usr/local/bin
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- Follow-up to #745. The `Release` workflow has never actually completed a release since semantic-release was introduced (~2026-06-21): every run with a releasable commit fails inside `prepare.sh`'s `ci_check.sh` gate, at the AArch64 cross-link step in `build_tests.sh`:
  ```
  /usr/lib/gcc-cross/aarch64-linux-gnu/13/.../ld: cannot find Scrt1.o: No such file or directory
  /usr/lib/gcc-cross/aarch64-linux-gnu/13/.../ld: cannot find crti.o: No such file or directory
  ```
- Root cause: `release.yml`'s `apt-get install` passes `--no-install-recommends`, which silently drops `libc6-dev-arm64-cross` — a Recommends-only (not a hard Depends) of `gcc-aarch64-linux-gnu` on Ubuntu. That package provides the crt objects (`Scrt1.o`, `crti.o`) needed to link the cross-compiled AArch64 test binaries. `test.yml`/`coverage.yml` don't pass `--no-install-recommends`, so they pull it in automatically and their identical cross-link step succeeds — confirmed by diffing the two workflows' install-step logs (`libc6-dev-arm64-cross` appears as an "additional package" in `test.yml`'s output, is entirely absent from `release.yml`'s).
- Fix: list `libc6-dev-arm64-cross` explicitly in `release.yml`'s install step instead of relying on recommends, keeping `--no-install-recommends` for everything else.
- Consequence of the bug: `Cargo.toml` is still `0.1.0` and no GitHub Release has ever been published. Once this merges, the first successful run will cut `1.0.0` per the accumulated Conventional Commits history, not a patch bump.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — parses cleanly.
- [ ] Confirm via `workflow_dispatch` (or the next scheduled/pushed run) that `prepare.sh` gets past the AArch64 link step and a real release is cut.