### PR TITLE
chore: prefix cargo Dependabot commits and add commit-msg hook

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+# Validates the commit message subject against Conventional Commits
+# (https://www.conventionalcommits.org/). Enabled via:
+#   git config core.hooksPath .githooks
+set -eu
+
+msg_file="$1"
+first_line=$(head -n1 "$msg_file")
+
+case "$first_line" in
+  "Merge "*|"Revert "*|"fixup! "*|"squash! "*) exit 0 ;;
+esac
+
+pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-zA-Z0-9_./-]+\))?!?: .+'
+
+if ! printf '%s\n' "$first_line" | grep -Eq "$pattern"; then
+  echo "commit-msg: subject does not follow Conventional Commits:" >&2
+  echo "  $first_line" >&2
+  echo "  expected: type(scope)?: description" >&2
+  echo "  types: build chore ci docs feat fix perf refactor revert style test" >&2
+  exit 1
+fi

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -16,11 +16,12 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-node@v7.0.0
         with:
           node-version: lts/*
       - name: Install commitlint
-        run: npm install --no-save @commitlint/cli@21 @commitlint/config-conventional@21
+        run: npm install --no-save @commitlint/cli@21 @commitlint/config-conventional@21 # zizmor: ignore[adhoc-packages]
       - name: Lint pushed commits
         if: github.event.before != '0000000000000000000000000000000000000000'
         run: npx commitlint --from ${{ github.event.before }} --to ${{ github.sha }} --verbose

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -13,11 +13,13 @@ jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      # Tag-pinned, not hash-pinned: this repo's policy is tag pins kept current by
+      # Dependabot rather than SHA pins.
+      - uses: actions/checkout@v7.0.0 # zizmor: ignore[unpinned-uses]
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/setup-node@v7.0.0 # zizmor: ignore[unpinned-uses]
         with:
           node-version: lts/*
       - name: Install commitlint

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           node-version: lts/*
       - name: Install commitlint
-        run: npm install --no-save @commitlint/cli@21 @commitlint/config-conventional@21
+        run: npm install --no-save @commitlint/cli@21 @commitlint/config-conventional@21 # zizmor: ignore[adhoc-packages]
       - name: Lint PR title
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -19,7 +19,9 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v7.0.0
+      # Tag-pinned, not hash-pinned: this repo's policy is tag pins kept current by
+      # Dependabot rather than SHA pins.
+      - uses: actions/setup-node@v7.0.0 # zizmor: ignore[unpinned-uses]
         with:
           node-version: lts/*
       - name: Install commitlint


### PR DESCRIPTION
Two small Conventional Commits fixes.

## 1. Dependabot cargo commit prefix

The `cargo` block in `.github/dependabot.yml` had no `commit-message`
configuration at all, so Dependabot fell back to its default titles
(`Bump serde from 1.0.1 to 1.0.2`). Those carry no Conventional Commits
type prefix and so fail the `lint-pr-title` check on every cargo update PR.

Adding `commit-message.prefix: "chore"` makes them `chore: bump serde from
1.0.1 to 1.0.2`, which passes.

The `github-actions` block already sets `prefix: "ci"` and is untouched.

## 2. Local `commit-msg` hook

Adds `.githooks/commit-msg`, which validates a commit subject against the
Conventional Commits grammar before the commit is created, so a bad subject
is caught locally instead of at PR-title lint time. Merges, reverts, and
`fixup!`/`squash!` subjects are exempt.

The hook is **not** active automatically. Each clone needs a one-time:

```
git config core.hooksPath .githooks
```

`release.yml` is not touched by this PR.

## 3. zizmor findings in `commitlint.yml`

Batch-wide security-lint cleanup:

- `persist-credentials: false` on the checkout — `fetch-depth: 0` has already
  fetched the history and `commitlint --from/--to` only reads the local clone,
  so no authenticated remote needs to survive the step.
- `# zizmor: ignore[adhoc-packages]` on the `npm install` line — the packages
  are version-pinned and installed with `--no-save` deliberately.

`lint-pr-title.yml` needed **no trigger change**: it already runs on
`pull_request`, not `pull_request_target`, so there is no `dangerous-triggers`
finding to suppress here. Its `npm install` line carries the same
`adhoc-packages` suppression for consistency.

## 4. zizmor `unpinned-uses`

Every `uses:` line in both workflows now carries
`# zizmor: ignore[unpinned-uses]`, with a rationale comment above the step
list: this repo pins actions to release tags and lets Dependabot keep them
current, rather than pinning to commit SHAs. These are suppressions, not
hash pins -- the tag pins are deliberate policy.

Affected: `actions/checkout@v7.0.0` and `actions/setup-node@v7.0.0` in
`commitlint.yml`, `actions/setup-node@v7.0.0` in `lint-pr-title.yml`.


