### PR TITLE
refactor(cli): extract per-target search-input derivation into a tested seam

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod isa;
 pub mod parser;
 pub mod report;
 pub mod search;
+pub mod search_inputs;
 pub mod semantics;
 pub mod validation;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,11 @@ use s11::search::config::{
 };
 use s11::search::parallel::{ParallelConfig, run_parallel_search};
 use s11::search::{EnumerativeSearch, SearchAlgorithm, StochasticSearch, SymbolicSearch};
-use s11::semantics::LiveOut;
+use s11::search_inputs::{
+    aarch64_search_immediates, aarch64_search_registers, live_out_for_optimization_prefix,
+    x86_enumerative_immediates_from_target, x86_live_out_for_optimization,
+    x86_registers_from_target,
+};
 use s11::semantics::cost::CostMetric;
 #[allow(unused_imports)]
 use s11::{assembler, elf_patcher, ir, isa, parser, search, semantics, validation};
@@ -1610,45 +1614,6 @@ fn optimize_elf_binary_with_backend<B: ElfOptimizationBackend>(
 /// mirroring the `flags_live = if terminator.is_some() { true }` blanket. When
 /// a terminator is present we ignore `downstream_live` and keep every
 /// window-written register live.
-fn live_out_for_optimization_prefix(
-    prefix: &[Instruction],
-    terminator: Option<&Instruction>,
-    downstream_flags_live: bool,
-    downstream_live: Option<&semantics::live_out::RegisterSet<Register>>,
-) -> LiveOut {
-    // A terminator vetoes register narrowing (its other successor is unscanned).
-    let narrowing = if terminator.is_some() {
-        None
-    } else {
-        downstream_live
-    };
-
-    let mut live_registers: Vec<Register> = match narrowing {
-        // Narrow to (written ∩ proven-live). The downstream set is already a
-        // subset of the window-written registers (it is computed from exactly
-        // that candidate set), so iterating it is sufficient.
-        Some(live) => live.iter().copied().collect(),
-        // No downstream analysis (or vetoed by a terminator): keep every
-        // written register live.
-        None => prefix
-            .iter()
-            .flat_map(|instr| instr.destinations())
-            .collect(),
-    };
-
-    if let Some(terminator) = terminator {
-        live_registers.extend(terminator.source_registers());
-    }
-
-    let flags_live = if terminator.is_some() {
-        true
-    } else {
-        downstream_flags_live
-    };
-
-    LiveOut::from_registers(live_registers).with_flags(flags_live)
-}
-
 /// Shared base `SearchConfig` for the AArch64 stochastic/enumerative/hybrid/
 /// symbolic/LLM builders. Sets the fields every AArch64 algorithm configures
 /// identically — cost metric, overall and SMT solver timeouts, verbosity, and
@@ -1797,40 +1762,6 @@ fn build_x86_symbolic_search_config(
         .with_x86_same_count_code_size_allowed(same_count_code_size_allowed)
 }
 
-/// Build the AArch64 search register pool, preserving the historical X0..X7
-/// scalar policy while adding every vector register referenced by the target.
-/// A target-local vector pool avoids the 32^3 candidate explosion of enabling
-/// the entire SIMD register file for small enumerative searches.
-fn aarch64_search_registers(target: &[Instruction]) -> Vec<Register> {
-    let mut registers = vec![
-        Register::X0,
-        Register::X1,
-        Register::X2,
-        Register::X3,
-        Register::X4,
-        Register::X5,
-        Register::X6,
-        Register::X7,
-    ];
-
-    for register in target
-        .iter()
-        .flat_map(|instruction| instruction.source_registers().into_iter())
-        .chain(
-            target
-                .iter()
-                .flat_map(|instruction| instruction.destinations().into_iter()),
-        )
-        .filter(|register| register.vector().is_some())
-    {
-        if !registers.contains(&register) {
-            registers.push(register);
-        }
-    }
-    registers.sort_by_key(|register| register.sort_key());
-    registers
-}
-
 /// Run optimization using the selected algorithm.
 ///
 /// Issue #69: if `target` ends in a terminator (branch / control-flow
@@ -1858,9 +1789,7 @@ fn run_optimization(
     // Keep the historical scalar pool and add the target's vector registers
     // so every search backend can generate NEON candidates for NEON windows.
     let available_registers = aarch64_search_registers(prefix);
-    let available_immediates = vec![
-        0, 1, 2, 3, 4, 5, 7, 8, 10, 15, 16, 31, 32, 63, 64, 100, 255, 256, 1000, 4095,
-    ];
+    let available_immediates = aarch64_search_immediates();
 
     // Create live-out contract over the prefix (assume all modified registers
     // are live-out), plus any registers the fixed terminator reads after the
@@ -2202,88 +2131,6 @@ fn validate_x86_window_terminator_placement(ir: &[isa::x86::X86Instruction]) -> 
 /// writes. Falls back to the default pool only for an empty target; a non-empty
 /// target with no usable destinations returns an empty pool so search does not
 /// introduce unrelated writable registers.
-fn x86_registers_from_target(target: &[isa::x86::X86Instruction]) -> Vec<isa::x86::X86Register> {
-    let mut pool: Vec<isa::x86::X86Register> = Vec::new();
-    let referenced = target
-        .iter()
-        .filter_map(|instr| instr.destination_operand());
-    for reg in referenced {
-        if matches!(
-            reg.canonical(),
-            isa::x86::X86Register::RSP | isa::x86::X86Register::RBP
-        ) {
-            continue;
-        }
-        if !pool.contains(&reg) {
-            pool.push(reg);
-        }
-    }
-    if target.is_empty() {
-        return isa::x86::default_x86_registers();
-    }
-    pool
-}
-
-/// Candidate immediate pool for the x86 enumerative path: the target's own
-/// immediates plus `0`, `1`, and `-1`. The fixed `default_x86_immediates()`
-/// pool holds no negatives, so the trait refactor lost rewrites like
-/// `mov rax, -1; mov rax, -1` → `mov rax, -1`.
-fn x86_enumerative_immediates_from_target(target: &[isa::x86::X86Instruction]) -> Vec<i64> {
-    use isa::x86::X86Instruction;
-    let mut imms = vec![0i64, 1, -1];
-    let referenced = target.iter().filter_map(|instr| match instr {
-        X86Instruction::MovImm { imm, .. }
-        | X86Instruction::AddImm { imm, .. }
-        | X86Instruction::SubImm { imm, .. }
-        | X86Instruction::AndImm { imm, .. }
-        | X86Instruction::OrImm { imm, .. }
-        | X86Instruction::XorImm { imm, .. }
-        | X86Instruction::CmpImm { imm, .. } => Some(*imm),
-        _ => None,
-    });
-    for imm in referenced {
-        if !imms.contains(&imm) {
-            imms.push(imm);
-        }
-    }
-    imms
-}
-
-/// Build the per-window x86 live-out contract.
-///
-/// EFLAGS liveness folds in the downstream flags scan (pre-existing). For
-/// registers (issue #621): when `downstream_live` is `Some(set)`, the
-/// window-written live-out set is narrowed to that proven-live subset;
-/// when `None` every written register stays live (the pre-#621 default).
-///
-/// **Conditional/branch soundness gate (defense in depth).** Like the AArch64
-/// builder, register narrowing applies only when the window has no terminator:
-/// the downstream scan follows only the linear fall-through successor, so a
-/// trailing Jcc (with its unscanned branch-taken target) vetoes narrowing.
-/// The backend already withholds the narrowed set in that case; this is a
-/// second, local guard so the function is sound regardless of caller.
-fn x86_live_out_for_optimization(
-    target: &[isa::x86::X86Instruction],
-    downstream_flags_live: bool,
-    downstream_live: Option<&semantics::live_out::RegisterSet<isa::x86::X86Register>>,
-) -> semantics::live_out::X86LiveOut {
-    let live_out = validation::live_out::x86_live_out_from_target(target);
-    let flags_live = live_out.flags_live() || downstream_flags_live;
-    let has_terminator = target.last().is_some_and(|i| i.is_terminator());
-    let narrowing = if has_terminator {
-        None
-    } else {
-        downstream_live
-    };
-    let narrowed = match narrowing {
-        Some(live) => {
-            semantics::live_out::RegisterSet::from_registers(live.iter().copied().collect())
-        }
-        None => live_out,
-    };
-    narrowed.with_flags(flags_live)
-}
-
 /// Build the search config for the x86 *enumerative* path. Like stochastic and
 /// symbolic search, enumerative search draws candidates from the target's own
 /// registers via the shared x86 base; it additionally derives immediates from
@@ -4617,184 +4464,6 @@ mod cli_helper_tests {
     }
 
     #[test]
-    fn x86_live_out_for_optimization_includes_downstream_flags() {
-        let mov_only = [X86Instruction::MovImm {
-            rd: X86Register::RAX,
-            imm: 0,
-        }];
-
-        assert!(!x86_live_out_for_optimization(&mov_only, false, None).flags_live());
-        assert!(x86_live_out_for_optimization(&mov_only, true, None).flags_live());
-
-        let flag_writer = [X86Instruction::XorReg {
-            rd: X86Register::RAX,
-            rs: X86Register::RAX,
-        }];
-        assert!(x86_live_out_for_optimization(&flag_writer, false, None).flags_live());
-    }
-
-    #[test]
-    fn x86_live_out_for_optimization_narrows_to_downstream_live_regs() {
-        use semantics::live_out::RegisterSet;
-
-        // Window writes RAX and RBX.
-        let window = [
-            X86Instruction::MovImm {
-                rd: X86Register::RAX,
-                imm: 0,
-            },
-            X86Instruction::MovImm {
-                rd: X86Register::RBX,
-                imm: 0,
-            },
-        ];
-
-        // Default (no downstream analysis): both written registers stay live.
-        let default = x86_live_out_for_optimization(&window, false, None);
-        assert!(default.contains(X86Register::RAX));
-        assert!(default.contains(X86Register::RBX));
-
-        // Downstream scan proved only RBX live (RAX dead). The contract must
-        // drop RAX and pin RBX.
-        let downstream_live = RegisterSet::from_registers(vec![X86Register::RBX]);
-        let narrowed = x86_live_out_for_optimization(&window, false, Some(&downstream_live));
-        assert!(
-            !narrowed.contains(X86Register::RAX),
-            "a provably-dead window register must be dropped from live-out"
-        );
-        assert!(
-            narrowed.contains(X86Register::RBX),
-            "a downstream-read window register must stay pinned"
-        );
-    }
-
-    #[test]
-    fn live_out_for_optimization_prefix_narrows_to_downstream_live_regs() {
-        // Prefix writes x0 and x1.
-        let prefix = [
-            Instruction::MovImm {
-                rd: Register::X0,
-                imm: 0,
-            },
-            Instruction::MovImm {
-                rd: Register::X1,
-                imm: 0,
-            },
-        ];
-
-        // Default (no downstream analysis): both written registers stay live.
-        let default = live_out_for_optimization_prefix(&prefix, None, false, None);
-        assert!(default.contains(Register::X0));
-        assert!(default.contains(Register::X1));
-
-        // Downstream scan proved only x1 live (x0 dead): drop x0, pin x1.
-        let downstream_live = semantics::live_out::RegisterSet::from_registers(vec![Register::X1]);
-        let narrowed =
-            live_out_for_optimization_prefix(&prefix, None, false, Some(&downstream_live));
-        assert!(
-            !narrowed.contains(Register::X0),
-            "a provably-dead window register must be dropped from live-out"
-        );
-        assert!(
-            narrowed.contains(Register::X1),
-            "a downstream-live window register must stay pinned"
-        );
-    }
-
-    /// Soundness regression: a window whose held-fixed terminator is a
-    /// CONDITIONAL branch must NOT narrow window-written registers, even if the
-    /// linear fall-through suffix proved one dead. The downstream-regs scan only
-    /// follows the fall-through successor; the branch-TAKEN successor is never
-    /// inspected and may read the register's window value.
-    ///
-    /// Counterexample being guarded against:
-    ///   window:       mov x0, #7 ; b.eq TARGET
-    ///   fall-through: mov x0, #0 ; ret           (kills x0 -> scan says Dead)
-    ///   elsewhere:    TARGET: add x9, x0, #1     (READS x0 on the taken path)
-    /// If x0 were narrowed to dead, `mov x0, #7` could be deleted and the
-    /// b.eq-taken path would read a stale x0. `BCond::source_registers()` is
-    /// empty, so the terminator does not re-pin x0 either — the only correct
-    /// fix is to not narrow at all when a terminator is present.
-    #[test]
-    fn live_out_for_optimization_prefix_does_not_narrow_with_conditional_terminator() {
-        let prefix = [Instruction::MovImm {
-            rd: Register::X0,
-            imm: 7,
-        }];
-        let b_eq = Instruction::BCond {
-            target: s11::ir::LabelId(0x2000),
-            cond: s11::ir::Condition::EQ,
-        };
-
-        // The fall-through scan "proved" x0 dead (empty proven-live set).
-        let downstream_live_fall_through = semantics::live_out::RegisterSet::<Register>::empty();
-
-        let live_out = live_out_for_optimization_prefix(
-            &prefix,
-            Some(&b_eq),
-            false,
-            Some(&downstream_live_fall_through),
-        );
-
-        assert!(
-            live_out.contains(Register::X0),
-            "x0 must stay live: a conditional terminator has a branch-taken successor \
-             the fall-through scan never inspected, so register narrowing must not apply"
-        );
-    }
-
-    /// x86 sibling of the conditional-terminator soundness gate: a target
-    /// ending in a Jcc must not narrow even if the proven-live set excludes a
-    /// written register.
-    #[test]
-    fn x86_live_out_for_optimization_does_not_narrow_with_trailing_jcc() {
-        use isa::x86::X86Condition;
-        let target = [
-            X86Instruction::MovImm {
-                rd: X86Register::RAX,
-                imm: 7,
-            },
-            X86Instruction::Jcc {
-                cond: X86Condition::E,
-            },
-        ];
-        // Pretend the fall-through scan proved RAX dead (empty set).
-        let dead = semantics::live_out::RegisterSet::<X86Register>::empty();
-        let live_out = x86_live_out_for_optimization(&target, false, Some(&dead));
-        assert!(
-            live_out.contains(X86Register::RAX),
-            "RAX must stay live: a trailing Jcc has an unscanned branch-taken successor, \
-             so register narrowing must not apply"
-        );
-    }
-
-    /// Same soundness gate for unconditional terminators: the instruction at
-    /// `end_addr` is not the real/only successor, so narrowing must not apply.
-    #[test]
-    fn live_out_for_optimization_prefix_does_not_narrow_with_unconditional_terminator() {
-        let prefix = [Instruction::MovImm {
-            rd: Register::X0,
-            imm: 7,
-        }];
-        let cases = [
-            Instruction::B {
-                target: s11::ir::LabelId(0x2000),
-            },
-            Instruction::Ret { rn: Register::X30 },
-        ];
-        let dead = semantics::live_out::RegisterSet::<Register>::empty();
-        for terminator in cases {
-            let live_out =
-                live_out_for_optimization_prefix(&prefix, Some(&terminator), false, Some(&dead));
-            assert!(
-                live_out.contains(Register::X0),
-                "x0 must stay live with a {:?} terminator: narrowing must not apply",
-                terminator
-            );
-        }
-    }
-
-    #[test]
     fn x86_symbolic_code_size_preserves_downstream_flags_live() {
         let mut opts = options_for(Algorithm::Symbolic);
         opts.timeout = Some(Duration::from_secs(5));
@@ -5221,63 +4890,6 @@ mod cli_helper_tests {
         assert_single_r10_rewrite(&optimized);
     }
 
-    #[test]
-    fn x86_register_pool_is_destination_derived_and_empty_falls_back() {
-        let target = vec![
-            X86Instruction::CmpReg {
-                rn: X86Register::RSP,
-                rs: X86Register::R11,
-            },
-            X86Instruction::CmpReg {
-                rn: X86Register::RBP,
-                rs: X86Register::R12,
-            },
-            X86Instruction::MovReg {
-                rd: X86Register::R11,
-                rs: X86Register::R10,
-            },
-            X86Instruction::AddReg {
-                rd: X86Register::R12,
-                rs: X86Register::RSP,
-            },
-        ];
-
-        assert_eq!(
-            x86_registers_from_target(&target),
-            vec![X86Register::R11, X86Register::R12]
-        );
-        assert_eq!(
-            x86_registers_from_target(&[]),
-            isa::x86::default_x86_registers()
-        );
-        assert_eq!(
-            x86_registers_from_target(&[
-                X86Instruction::CmpImm {
-                    rn: X86Register::R10,
-                    imm: 1,
-                },
-                X86Instruction::CmpImm {
-                    rn: X86Register::R10,
-                    imm: 1,
-                },
-            ]),
-            Vec::<X86Register>::new()
-        );
-        assert_eq!(
-            x86_registers_from_target(&[
-                X86Instruction::CmpImm {
-                    rn: X86Register::RSP,
-                    imm: 1,
-                },
-                X86Instruction::CmpReg {
-                    rn: X86Register::RBP,
-                    rs: X86Register::RBP,
-                },
-            ]),
-            Vec::<X86Register>::new()
-        );
-    }
-
     /// Regression (PR #384): the enumerative config must be target-derived and
     /// must thread `--cores` (the trait-backed search is rayon-parallel and
     /// honours `config.cores`, but the old builder left it `None`).
@@ -5492,36 +5104,6 @@ mod cli_helper_tests {
         assert_eq!(config.available_immediates, imms);
         // No algorithm layer applied: cores is left at the SearchConfig default.
         assert_eq!(config.cores, SearchConfig::default().cores);
-    }
-
-    #[test]
-    fn aarch64_search_registers_include_vectors_used_by_target() {
-        let target = [
-            Instruction::VectorAdd {
-                vd: ir::VectorRegister::V0,
-                vn: ir::VectorRegister::V1,
-                vm: ir::VectorRegister::V2,
-                arrangement: ir::VectorArrangement::TwoD,
-            },
-            Instruction::MovFromVectorLane {
-                rd: Register::X0,
-                vn: ir::VectorRegister::V0,
-                lane: 0,
-            },
-        ];
-
-        let registers = aarch64_search_registers(&target);
-
-        assert!(registers.contains(&Register::Vector(ir::VectorRegister::V0)));
-        assert!(registers.contains(&Register::Vector(ir::VectorRegister::V1)));
-        assert!(registers.contains(&Register::Vector(ir::VectorRegister::V2)));
-        assert_eq!(
-            registers
-                .iter()
-                .filter(|reg| reg.vector().is_some())
-                .count(),
-            3
-        );
     }
 
     /// Regression for issue #243, generalised: every AArch64 algorithm builder
@@ -5871,78 +5453,6 @@ mod cli_helper_tests {
         let (prefix, term) = split_terminator(&seq);
         assert_eq!(prefix.len(), 1);
         assert_eq!(term, Some(&Instruction::Ret { rn: Register::X30 }));
-    }
-
-    #[test]
-    fn live_out_for_optimization_prefix_includes_registers_read_by_terminator() {
-        let prefix = [Instruction::MovImm {
-            rd: Register::X1,
-            imm: 1,
-        }];
-        let cases = [
-            (
-                Instruction::Cbz {
-                    rn: Register::X0,
-                    target: s11::ir::LabelId(0x1000),
-                },
-                Register::X0,
-            ),
-            (
-                Instruction::Tbz {
-                    rt: Register::X2,
-                    bit: 5,
-                    target: s11::ir::LabelId(0x1000),
-                },
-                Register::X2,
-            ),
-            (Instruction::Br { rn: Register::X16 }, Register::X16),
-            (Instruction::Ret { rn: Register::X30 }, Register::X30),
-        ];
-
-        for (terminator, source) in cases {
-            let live_out =
-                live_out_for_optimization_prefix(&prefix, Some(&terminator), false, None);
-            assert!(live_out.contains_register(Register::X1));
-            assert!(
-                live_out.contains_register(source),
-                "{:?} must keep {:?} live for the reattached terminator",
-                terminator,
-                source
-            );
-        }
-    }
-
-    #[test]
-    fn live_out_for_optimization_prefix_uses_downstream_flags_without_terminator() {
-        let prefix = [Instruction::MovImm {
-            rd: Register::X1,
-            imm: 1,
-        }];
-
-        let flags_dead = live_out_for_optimization_prefix(&prefix, None, false, None);
-        assert!(!flags_dead.flags_live());
-
-        let flags_live = live_out_for_optimization_prefix(&prefix, None, true, None);
-        assert!(flags_live.flags_live());
-    }
-
-    #[test]
-    fn live_out_for_optimization_prefix_keeps_flags_live_for_terminators() {
-        let prefix = [Instruction::MovImm {
-            rd: Register::X1,
-            imm: 1,
-        }];
-
-        let b_cond = Instruction::BCond {
-            target: s11::ir::LabelId(0x1000),
-            cond: s11::ir::Condition::EQ,
-        };
-        let live_out = live_out_for_optimization_prefix(&prefix, Some(&b_cond), false, None);
-        assert!(live_out.flags_live());
-
-        let ret = Instruction::Ret { rn: Register::X30 };
-        let live_out = live_out_for_optimization_prefix(&prefix, Some(&ret), false, None);
-        assert!(live_out.flags_live());
     }
 
     // (The standalone `find_shorter_equivalent_preserves_terminator_bit_identical`

--- a/src/search_inputs.rs
+++ b/src/search_inputs.rs
@@ -1,0 +1,679 @@
+//! Per-target search-input derivation — a pure seam shared by the AArch64 and
+//! x86 optimization drivers.
+//!
+//! Before a search runs it needs three things derived from the *target* (see
+//! `CONTEXT.md`): the **register pool** and **immediate pool** candidates may be
+//! drawn from, and the **live-out contract** a candidate must preserve. Those
+//! rules are policy, not plumbing:
+//!
+//! * the historical X0..X7 scalar pool, widened only by the target's own vector
+//!   registers, keeps small enumerative searches from exploding over the full
+//!   SIMD register file;
+//! * the x86 pool excludes the stack pointer / frame pointer and falls back to a
+//!   default pool for an empty target;
+//! * the live-out contract narrows to a proven-live downstream set **only when no
+//!   held-fixed terminator is present** — a terminator has an unscanned
+//!   branch-taken successor, so narrowing there would be unsound (ADR-0006 /
+//!   ADR-0008).
+//!
+//! These functions used to live inline in the 6,417-line binary crate
+//! (`src/main.rs`), where the only way to exercise them was through the binary's
+//! own `cli_helper_tests`. Lifting them into this library module — the
+//! search-input analogue of [`crate::candidate_windows`] — makes every rule a
+//! fixture-free unit test at a public seam, and lets `main.rs` shrink toward a
+//! thin adapter.
+
+use crate::ir::{Instruction, Register};
+use crate::semantics::LiveOut;
+use crate::semantics::live_out::{RegisterSet, X86LiveOut};
+
+/// Build the per-window AArch64 live-out contract over the optimized prefix.
+///
+/// A held-fixed terminator vetoes register narrowing: the downstream-regs scan
+/// follows only the linear fall-through successor, so a terminator's unscanned
+/// branch-taken successor may read a register the scan "proved" dead. When a
+/// terminator is present every written register stays live and its source
+/// registers are pinned; NZCV is forced live. Without a terminator the contract
+/// narrows to the proven-live downstream set (when supplied) and inherits the
+/// downstream flag liveness. See ADR-0006 / ADR-0008.
+pub fn live_out_for_optimization_prefix(
+    prefix: &[Instruction],
+    terminator: Option<&Instruction>,
+    downstream_flags_live: bool,
+    downstream_live: Option<&RegisterSet<Register>>,
+) -> LiveOut {
+    // A terminator vetoes register narrowing (its other successor is unscanned).
+    let narrowing = if terminator.is_some() {
+        None
+    } else {
+        downstream_live
+    };
+
+    let mut live_registers: Vec<Register> = match narrowing {
+        // Narrow to (written ∩ proven-live). The downstream set is already a
+        // subset of the window-written registers (it is computed from exactly
+        // that candidate set), so iterating it is sufficient.
+        Some(live) => live.iter().copied().collect(),
+        // No downstream analysis (or vetoed by a terminator): keep every
+        // written register live.
+        None => prefix
+            .iter()
+            .flat_map(|instr| instr.destinations())
+            .collect(),
+    };
+
+    if let Some(terminator) = terminator {
+        live_registers.extend(terminator.source_registers());
+    }
+
+    let flags_live = if terminator.is_some() {
+        true
+    } else {
+        downstream_flags_live
+    };
+
+    LiveOut::from_registers(live_registers).with_flags(flags_live)
+}
+
+/// Build the per-window x86 live-out contract.
+///
+/// EFLAGS liveness folds in the downstream flags scan. For registers: when
+/// `downstream_live` is `Some(set)`, the window-written live-out set is narrowed
+/// to that proven-live subset; when `None` every written register stays live.
+///
+/// **Conditional/branch soundness gate (defense in depth).** Like the AArch64
+/// builder, register narrowing applies only when the window has no terminator:
+/// the downstream scan follows only the linear fall-through successor, so a
+/// trailing Jcc (with its unscanned branch-taken target) vetoes narrowing.
+pub fn x86_live_out_for_optimization(
+    target: &[crate::isa::x86::X86Instruction],
+    downstream_flags_live: bool,
+    downstream_live: Option<&RegisterSet<crate::isa::x86::X86Register>>,
+) -> X86LiveOut {
+    let live_out = crate::validation::live_out::x86_live_out_from_target(target);
+    let flags_live = live_out.flags_live() || downstream_flags_live;
+    let has_terminator = target.last().is_some_and(|i| i.is_terminator());
+    let narrowing = if has_terminator {
+        None
+    } else {
+        downstream_live
+    };
+    let narrowed = match narrowing {
+        Some(live) => RegisterSet::from_registers(live.iter().copied().collect()),
+        None => live_out,
+    };
+    narrowed.with_flags(flags_live)
+}
+
+/// Build the AArch64 search register pool, preserving the historical X0..X7
+/// scalar policy while adding every vector register referenced by the target.
+/// A target-local vector pool avoids the 32^3 candidate explosion of enabling
+/// the entire SIMD register file for small enumerative searches.
+pub fn aarch64_search_registers(target: &[Instruction]) -> Vec<Register> {
+    let mut registers = vec![
+        Register::X0,
+        Register::X1,
+        Register::X2,
+        Register::X3,
+        Register::X4,
+        Register::X5,
+        Register::X6,
+        Register::X7,
+    ];
+
+    for register in target
+        .iter()
+        .flat_map(|instruction| instruction.source_registers().into_iter())
+        .chain(
+            target
+                .iter()
+                .flat_map(|instruction| instruction.destinations().into_iter()),
+        )
+        .filter(|register| register.vector().is_some())
+    {
+        if !registers.contains(&register) {
+            registers.push(register);
+        }
+    }
+    registers.sort_by_key(|register| register.sort_key());
+    registers
+}
+
+/// The default AArch64 candidate immediate pool. A small, hand-picked set that
+/// covers common small constants, power-of-two boundaries, and `4095` — the
+/// largest value an unshifted imm12 field can encode. Mirrors
+/// [`x86_enumerative_immediates_from_target`]'s role for the x86 path (which
+/// additionally seeds from the target); the AArch64 pool is target-independent.
+pub fn aarch64_search_immediates() -> Vec<i64> {
+    vec![
+        0, 1, 2, 3, 4, 5, 7, 8, 10, 15, 16, 31, 32, 63, 64, 100, 255, 256, 1000, 4095,
+    ]
+}
+
+/// Build the x86 search register pool from the target's own destination
+/// registers, excluding the stack and frame pointers. An *empty* target falls
+/// back to the default pool; a *non-empty* target whose instructions have no
+/// destination operands (e.g. only `cmp`s) deliberately yields an **empty**
+/// pool — the empty-target check runs after the derivation loop, so it does not
+/// fire here.
+pub fn x86_registers_from_target(
+    target: &[crate::isa::x86::X86Instruction],
+) -> Vec<crate::isa::x86::X86Register> {
+    use crate::isa::x86::X86Register;
+    let mut pool: Vec<X86Register> = Vec::new();
+    let referenced = target
+        .iter()
+        .filter_map(|instr| instr.destination_operand());
+    for reg in referenced {
+        if matches!(reg.canonical(), X86Register::RSP | X86Register::RBP) {
+            continue;
+        }
+        if !pool.contains(&reg) {
+            pool.push(reg);
+        }
+    }
+    if target.is_empty() {
+        return crate::isa::x86::default_x86_registers();
+    }
+    pool
+}
+
+/// Candidate immediate pool for the x86 enumerative path: the target's own
+/// immediates plus `0`, `1`, and `-1`. The fixed `default_x86_immediates()`
+/// pool holds no negatives, so the trait refactor lost rewrites like
+/// `mov rax, -1; mov rax, -1` → `mov rax, -1`.
+pub fn x86_enumerative_immediates_from_target(
+    target: &[crate::isa::x86::X86Instruction],
+) -> Vec<i64> {
+    use crate::isa::x86::X86Instruction;
+    let mut imms = vec![0i64, 1, -1];
+    let referenced = target.iter().filter_map(|instr| match instr {
+        X86Instruction::MovImm { imm, .. }
+        | X86Instruction::AddImm { imm, .. }
+        | X86Instruction::SubImm { imm, .. }
+        | X86Instruction::AndImm { imm, .. }
+        | X86Instruction::OrImm { imm, .. }
+        | X86Instruction::XorImm { imm, .. }
+        | X86Instruction::CmpImm { imm, .. } => Some(*imm),
+        _ => None,
+    });
+    for imm in referenced {
+        if !imms.contains(&imm) {
+            imms.push(imm);
+        }
+    }
+    imms
+}
+
+#[cfg(test)]
+mod tests {
+    #[allow(unused_imports)]
+    use super::*;
+    use crate::ir::{Instruction, Register, VectorArrangement, VectorRegister};
+
+    #[test]
+    fn aarch64_pool_is_exactly_x0_through_x7_for_a_scalar_target() {
+        // A purely scalar window contributes no vector registers, so the pool is
+        // the historical X0..X7 scalar policy and nothing else.
+        let target = [Instruction::Add {
+            rd: Register::X2,
+            rn: Register::X1,
+            rm: crate::ir::Operand::Register(Register::X0),
+        }];
+        assert_eq!(
+            aarch64_search_registers(&target),
+            vec![
+                Register::X0,
+                Register::X1,
+                Register::X2,
+                Register::X3,
+                Register::X4,
+                Register::X5,
+                Register::X6,
+                Register::X7,
+            ],
+        );
+    }
+
+    #[test]
+    fn aarch64_pool_does_not_admit_scalar_registers_beyond_x7() {
+        // Deliberate policy: a scalar register the target references above X7 is
+        // NOT added — only the fixed X0..X7 scalars plus target vector registers
+        // seed the pool. Pin it so it does not read as an omission bug.
+        let target = [Instruction::MovImm {
+            rd: Register::X9,
+            imm: 0,
+        }];
+        let pool = aarch64_search_registers(&target);
+        assert!(!pool.contains(&Register::X9));
+        assert_eq!(pool.len(), 8);
+    }
+
+    #[test]
+    fn aarch64_pool_appends_target_vector_registers_sorted_after_scalars() {
+        // A NEON window touching V1 widens the pool by exactly that vector
+        // register, ordered after the scalars by `sort_key` (V1 -> 65).
+        let target = [Instruction::VectorAdd {
+            vd: VectorRegister::V1,
+            vn: VectorRegister::V1,
+            vm: VectorRegister::V1,
+            arrangement: VectorArrangement::TwoD,
+        }];
+        assert_eq!(
+            aarch64_search_registers(&target),
+            vec![
+                Register::X0,
+                Register::X1,
+                Register::X2,
+                Register::X3,
+                Register::X4,
+                Register::X5,
+                Register::X6,
+                Register::X7,
+                Register::Vector(VectorRegister::V1),
+            ],
+        );
+    }
+
+    use crate::isa::x86::{X86Instruction, X86Register, default_x86_registers};
+
+    #[test]
+    fn x86_pool_excludes_a_narrow_stack_pointer_view() {
+        // ESP is the dword view of the stack pointer (reg 4). The filter checks
+        // `canonical()`, so the narrow view is excluded just like RSP. (Broader
+        // destination-derivation and empty-fallback behaviour is pinned by the
+        // relocated `x86_register_pool_is_destination_derived_and_empty_falls_back`
+        // regression below.)
+        let target = [X86Instruction::MovImm {
+            rd: X86Register::ESP,
+            imm: 0,
+        }];
+        let pool = x86_registers_from_target(&target);
+        assert!(!pool.contains(&X86Register::ESP));
+        assert!(!pool.contains(&X86Register::RSP));
+    }
+
+    #[test]
+    fn x86_enumerative_immediates_always_seed_zero_one_and_minus_one() {
+        assert_eq!(x86_enumerative_immediates_from_target(&[]), vec![0, 1, -1]);
+    }
+
+    #[test]
+    fn x86_enumerative_immediates_dedup_a_target_value_already_in_the_seed() {
+        // The doc-comment regression: `mov rax, -1; mov rax, -1`. -1 is already a
+        // seed, so it must not be appended twice.
+        let target = [
+            X86Instruction::MovImm {
+                rd: X86Register::RAX,
+                imm: -1,
+            },
+            X86Instruction::MovImm {
+                rd: X86Register::RAX,
+                imm: -1,
+            },
+        ];
+        assert_eq!(
+            x86_enumerative_immediates_from_target(&target),
+            vec![0, 1, -1],
+        );
+    }
+
+    #[test]
+    fn x86_enumerative_immediates_append_novel_target_values_after_the_seed() {
+        let target = [X86Instruction::AddImm {
+            rd: X86Register::RAX,
+            imm: 42,
+        }];
+        assert_eq!(
+            x86_enumerative_immediates_from_target(&target),
+            vec![0, 1, -1, 42],
+        );
+    }
+
+    #[test]
+    fn aarch64_immediate_pool_spans_zero_to_the_imm12_ceiling() {
+        let imms = aarch64_search_immediates();
+        assert!(imms.contains(&0));
+        assert!(imms.contains(&1));
+        // 4095 = 0xFFF is the largest value an unshifted imm12 can encode; the
+        // pool must reach it (cf. #720's imm12 sampling contract) and never
+        // exceed it, since a larger literal is not directly encodable.
+        assert_eq!(imms.iter().copied().max(), Some(4095));
+        assert!(imms.iter().all(|&imm| (0..=4095).contains(&imm)));
+    }
+
+    // --- Live-out contract regressions (relocated intact from the binary's
+    // cli_helper_tests; ADR-0006 / ADR-0008 soundness gates). ---
+
+    #[test]
+    fn x86_live_out_for_optimization_includes_downstream_flags() {
+        let mov_only = [X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: 0,
+        }];
+
+        assert!(!x86_live_out_for_optimization(&mov_only, false, None).flags_live());
+        assert!(x86_live_out_for_optimization(&mov_only, true, None).flags_live());
+
+        let flag_writer = [X86Instruction::XorReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RAX,
+        }];
+        assert!(x86_live_out_for_optimization(&flag_writer, false, None).flags_live());
+    }
+
+    #[test]
+    fn x86_live_out_for_optimization_narrows_to_downstream_live_regs() {
+        // Window writes RAX and RBX.
+        let window = [
+            X86Instruction::MovImm {
+                rd: X86Register::RAX,
+                imm: 0,
+            },
+            X86Instruction::MovImm {
+                rd: X86Register::RBX,
+                imm: 0,
+            },
+        ];
+
+        // Default (no downstream analysis): both written registers stay live.
+        let default = x86_live_out_for_optimization(&window, false, None);
+        assert!(default.contains(X86Register::RAX));
+        assert!(default.contains(X86Register::RBX));
+
+        // Downstream scan proved only RBX live (RAX dead). The contract must
+        // drop RAX and pin RBX.
+        let downstream_live = RegisterSet::from_registers(vec![X86Register::RBX]);
+        let narrowed = x86_live_out_for_optimization(&window, false, Some(&downstream_live));
+        assert!(
+            !narrowed.contains(X86Register::RAX),
+            "a provably-dead window register must be dropped from live-out"
+        );
+        assert!(
+            narrowed.contains(X86Register::RBX),
+            "a downstream-read window register must stay pinned"
+        );
+    }
+
+    #[test]
+    fn live_out_for_optimization_prefix_narrows_to_downstream_live_regs() {
+        // Prefix writes x0 and x1.
+        let prefix = [
+            Instruction::MovImm {
+                rd: Register::X0,
+                imm: 0,
+            },
+            Instruction::MovImm {
+                rd: Register::X1,
+                imm: 0,
+            },
+        ];
+
+        // Default (no downstream analysis): both written registers stay live.
+        let default = live_out_for_optimization_prefix(&prefix, None, false, None);
+        assert!(default.contains(Register::X0));
+        assert!(default.contains(Register::X1));
+
+        // Downstream scan proved only x1 live (x0 dead): drop x0, pin x1.
+        let downstream_live = RegisterSet::from_registers(vec![Register::X1]);
+        let narrowed =
+            live_out_for_optimization_prefix(&prefix, None, false, Some(&downstream_live));
+        assert!(
+            !narrowed.contains(Register::X0),
+            "a provably-dead window register must be dropped from live-out"
+        );
+        assert!(
+            narrowed.contains(Register::X1),
+            "a downstream-live window register must stay pinned"
+        );
+    }
+
+    /// Soundness regression: a window whose held-fixed terminator is a
+    /// CONDITIONAL branch must NOT narrow window-written registers, even if the
+    /// linear fall-through suffix proved one dead. The downstream-regs scan only
+    /// follows the fall-through successor; the branch-TAKEN successor is never
+    /// inspected and may read the register's window value.
+    ///
+    /// Counterexample being guarded against:
+    ///   window:       mov x0, #7 ; b.eq TARGET
+    ///   fall-through: mov x0, #0 ; ret           (kills x0 -> scan says Dead)
+    ///   elsewhere:    TARGET: add x9, x0, #1     (READS x0 on the taken path)
+    /// If x0 were narrowed to dead, `mov x0, #7` could be deleted and the
+    /// b.eq-taken path would read a stale x0. `BCond::source_registers()` is
+    /// empty, so the terminator does not re-pin x0 either — the only correct
+    /// fix is to not narrow at all when a terminator is present.
+    #[test]
+    fn live_out_for_optimization_prefix_does_not_narrow_with_conditional_terminator() {
+        let prefix = [Instruction::MovImm {
+            rd: Register::X0,
+            imm: 7,
+        }];
+        let b_eq = Instruction::BCond {
+            target: crate::ir::LabelId(0x2000),
+            cond: crate::ir::Condition::EQ,
+        };
+
+        // The fall-through scan "proved" x0 dead (empty proven-live set).
+        let downstream_live_fall_through = RegisterSet::<Register>::empty();
+
+        let live_out = live_out_for_optimization_prefix(
+            &prefix,
+            Some(&b_eq),
+            false,
+            Some(&downstream_live_fall_through),
+        );
+
+        assert!(
+            live_out.contains(Register::X0),
+            "x0 must stay live: a conditional terminator has a branch-taken successor \
+             the fall-through scan never inspected, so register narrowing must not apply"
+        );
+    }
+
+    /// x86 sibling of the conditional-terminator soundness gate: a target
+    /// ending in a Jcc must not narrow even if the proven-live set excludes a
+    /// written register.
+    #[test]
+    fn x86_live_out_for_optimization_does_not_narrow_with_trailing_jcc() {
+        use crate::isa::x86::X86Condition;
+        let target = [
+            X86Instruction::MovImm {
+                rd: X86Register::RAX,
+                imm: 7,
+            },
+            X86Instruction::Jcc {
+                cond: X86Condition::E,
+            },
+        ];
+        // Pretend the fall-through scan proved RAX dead (empty set).
+        let dead = RegisterSet::<X86Register>::empty();
+        let live_out = x86_live_out_for_optimization(&target, false, Some(&dead));
+        assert!(
+            live_out.contains(X86Register::RAX),
+            "RAX must stay live: a trailing Jcc has an unscanned branch-taken successor, \
+             so register narrowing must not apply"
+        );
+    }
+
+    /// Same soundness gate for unconditional terminators: the instruction at
+    /// `end_addr` is not the real/only successor, so narrowing must not apply.
+    #[test]
+    fn live_out_for_optimization_prefix_does_not_narrow_with_unconditional_terminator() {
+        let prefix = [Instruction::MovImm {
+            rd: Register::X0,
+            imm: 7,
+        }];
+        let cases = [
+            Instruction::B {
+                target: crate::ir::LabelId(0x2000),
+            },
+            Instruction::Ret { rn: Register::X30 },
+        ];
+        let dead = RegisterSet::<Register>::empty();
+        for terminator in cases {
+            let live_out =
+                live_out_for_optimization_prefix(&prefix, Some(&terminator), false, Some(&dead));
+            assert!(
+                live_out.contains(Register::X0),
+                "x0 must stay live with a {:?} terminator: narrowing must not apply",
+                terminator
+            );
+        }
+    }
+
+    #[test]
+    fn x86_register_pool_is_destination_derived_and_empty_falls_back() {
+        let target = vec![
+            X86Instruction::CmpReg {
+                rn: X86Register::RSP,
+                rs: X86Register::R11,
+            },
+            X86Instruction::CmpReg {
+                rn: X86Register::RBP,
+                rs: X86Register::R12,
+            },
+            X86Instruction::MovReg {
+                rd: X86Register::R11,
+                rs: X86Register::R10,
+            },
+            X86Instruction::AddReg {
+                rd: X86Register::R12,
+                rs: X86Register::RSP,
+            },
+        ];
+
+        assert_eq!(
+            x86_registers_from_target(&target),
+            vec![X86Register::R11, X86Register::R12]
+        );
+        assert_eq!(x86_registers_from_target(&[]), default_x86_registers());
+        assert_eq!(
+            x86_registers_from_target(&[
+                X86Instruction::CmpImm {
+                    rn: X86Register::R10,
+                    imm: 1,
+                },
+                X86Instruction::CmpImm {
+                    rn: X86Register::R10,
+                    imm: 1,
+                },
+            ]),
+            Vec::<X86Register>::new()
+        );
+        assert_eq!(
+            x86_registers_from_target(&[
+                X86Instruction::CmpImm {
+                    rn: X86Register::RSP,
+                    imm: 1,
+                },
+                X86Instruction::CmpReg {
+                    rn: X86Register::RBP,
+                    rs: X86Register::RBP,
+                },
+            ]),
+            Vec::<X86Register>::new()
+        );
+    }
+
+    #[test]
+    fn aarch64_search_registers_include_vectors_used_by_target() {
+        let target = [
+            Instruction::VectorAdd {
+                vd: VectorRegister::V0,
+                vn: VectorRegister::V1,
+                vm: VectorRegister::V2,
+                arrangement: VectorArrangement::TwoD,
+            },
+            Instruction::MovFromVectorLane {
+                rd: Register::X0,
+                vn: VectorRegister::V0,
+                lane: 0,
+            },
+        ];
+
+        let registers = aarch64_search_registers(&target);
+
+        assert!(registers.contains(&Register::Vector(VectorRegister::V0)));
+        assert!(registers.contains(&Register::Vector(VectorRegister::V1)));
+        assert!(registers.contains(&Register::Vector(VectorRegister::V2)));
+        assert_eq!(
+            registers
+                .iter()
+                .filter(|reg| reg.vector().is_some())
+                .count(),
+            3
+        );
+    }
+
+    #[test]
+    fn live_out_for_optimization_prefix_includes_registers_read_by_terminator() {
+        let prefix = [Instruction::MovImm {
+            rd: Register::X1,
+            imm: 1,
+        }];
+        let cases = [
+            (
+                Instruction::Cbz {
+                    rn: Register::X0,
+                    target: crate::ir::LabelId(0x1000),
+                },
+                Register::X0,
+            ),
+            (
+                Instruction::Tbz {
+                    rt: Register::X2,
+                    bit: 5,
+                    target: crate::ir::LabelId(0x1000),
+                },
+                Register::X2,
+            ),
+            (Instruction::Br { rn: Register::X16 }, Register::X16),
+            (Instruction::Ret { rn: Register::X30 }, Register::X30),
+        ];
+
+        for (terminator, source) in cases {
+            let live_out =
+                live_out_for_optimization_prefix(&prefix, Some(&terminator), false, None);
+            assert!(live_out.contains_register(Register::X1));
+            assert!(
+                live_out.contains_register(source),
+                "{:?} must keep {:?} live for the reattached terminator",
+                terminator,
+                source
+            );
+        }
+    }
+
+    #[test]
+    fn live_out_for_optimization_prefix_uses_downstream_flags_without_terminator() {
+        let prefix = [Instruction::MovImm {
+            rd: Register::X1,
+            imm: 1,
+        }];
+
+        let flags_dead = live_out_for_optimization_prefix(&prefix, None, false, None);
+        assert!(!flags_dead.flags_live());
+
+        let flags_live = live_out_for_optimization_prefix(&prefix, None, true, None);
+        assert!(flags_live.flags_live());
+    }
+
+    #[test]
+    fn live_out_for_optimization_prefix_keeps_flags_live_for_terminators() {
+        let prefix = [Instruction::MovImm {
+            rd: Register::X1,
+            imm: 1,
+        }];
+
+        let b_cond = Instruction::BCond {
+            target: crate::ir::LabelId(0x1000),
+            cond: crate::ir::Condition::EQ,
+        };
+        let live_out = live_out_for_optimization_prefix(&prefix, Some(&b_cond), false, None);
+        assert!(live_out.flags_live());
+
+        let ret = Instruction::Ret { rn: Register::X30 };
+        let live_out = live_out_for_optimization_prefix(&prefix, Some(&ret), false, None);
+        assert!(live_out.flags_live());
+    }
+}


### PR DESCRIPTION
## Refactoring goal

`src/main.rs` is the codebase's hot spot — 6,417 lines, changed 29× in the last 120 commits — and there's an active campaign lifting **pure tested seams** out of the binary crate (#743 report module, #744 candidate-window planner, #739 x86 Capstone bridge). This PR continues it.

The functions that derive a **search's inputs from the target** — the register pool and immediate pool candidates are drawn from, and the live-out contract a candidate must preserve — were trapped inline in the binary crate. They encode:

- **soundness-critical live-out policy**: a held-fixed terminator vetoes register narrowing because the downstream-liveness scan only follows the fall-through successor, never the branch-taken one (ADR-0006 / ADR-0008);
- **search-space policy**: the historical X0..X7 scalar pool widened only by the target's vector registers; the RSP/RBP-excluded x86 pool with an empty-target fallback; enumerative immediate seeding.

Because they lived in `main.rs`, the only way to exercise them was through the binary's own `cli_helper_tests`, and the three pool functions had **no direct test coverage at all**.

This extracts them into a new library module `src/search_inputs.rs` — the search-input analogue of `candidate_windows` — so every rule becomes a fixture-free unit test at a public seam. `main.rs` shrinks by ~490 lines (6,417 → 5,927) and becomes a thinner adapter.

## What moved

New `src/search_inputs.rs` with the pure functions:
`aarch64_search_registers`, `aarch64_search_immediates` (extracted from an inline literal for symmetry with the x86 path), `x86_registers_from_target`, `x86_enumerative_immediates_from_target`, `live_out_for_optimization_prefix`, `x86_live_out_for_optimization`.

`main.rs` imports the seam and deletes the local definitions; runtime behavior is unchanged (a pure move plus an identical immediate literal).

## Tests (TDD)

Developed the three previously-untested pool functions and the new `aarch64_search_immediates` **test-first**, one vertical slice each (red → green):

- `aarch64_pool_is_exactly_x0_through_x7_for_a_scalar_target`
- `aarch64_pool_does_not_admit_scalar_registers_beyond_x7` — pins the deliberate X0..X7 scalar policy so it doesn't read as an omission
- `aarch64_pool_appends_target_vector_registers_sorted_after_scalars`
- `x86_pool_excludes_a_narrow_stack_pointer_view` — ESP (dword view of RSP) is excluded via `canonical()`
- `x86_enumerative_immediates_{always_seed_zero_one_and_minus_one, dedup_a_target_value_already_in_the_seed, append_novel_target_values_after_the_seed}`
- `aarch64_immediate_pool_spans_zero_to_the_imm12_ceiling` — pins 4095 as the max unshifted imm12 (cf. #720)

**11 existing regressions relocated intact** from `main.rs` (not new TDD — a mechanical move), preserving the ADR-0006/ADR-0008 soundness gates: the conditional/unconditional-terminator narrowing vetoes, downstream register narrowing, terminator source-register pinning, flag-liveness, and x86 destination-derived pooling. The two end-to-end tests that exercise the enumerative-search / equivalence pipeline stay in `main.rs` and now call the imported functions.

## Verification (run synchronously)

- `cargo fmt -- --check` ✅
- `cargo build` ✅ (proves the binary still compiles against the new seam)
- `cargo test --lib` ✅ 1645 passed (incl. 19 in `search_inputs`)
- `cargo test --bin s11` ✅ 113 passed
- `cargo clippy --all-targets` ✅ clean (only a pre-existing dependency future-incompat note)
- `cargo test --no-run` ✅ all test targets compile
- Integration harness: the pure-Rust subset (`docs_capability`, 12 tests) passes. The ELF-dependent integration tests were **not** run — they require cross-compiled fixtures under `binaries/` (built by `build_tests.sh`, needing AArch64/x86-32 cross toolchains) that aren't present in this environment. This change is lib-additive and behavior-preserving, so it doesn't affect them.