### PR TITLE
refactor(driver): extract x86 window search inputs into a pure tested seam

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod report;
 pub mod search;
 pub mod semantics;
 pub mod validation;
+pub mod x86_search_inputs;
 
 #[cfg(test)]
 #[path = "test_utils.rs"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,9 @@ use s11::search::{EnumerativeSearch, SearchAlgorithm, StochasticSearch, Symbolic
 use s11::semantics::LiveOut;
 use s11::semantics::cost::CostMetric;
 #[allow(unused_imports)]
-use s11::{assembler, elf_patcher, ir, isa, parser, search, semantics, validation};
+use s11::{
+    assembler, elf_patcher, ir, isa, parser, search, semantics, validation, x86_search_inputs,
+};
 
 // --- Command Line Arguments ---
 
@@ -934,7 +936,7 @@ impl ElfOptimizationBackend for X86OptimizationBackend {
     }
 
     fn validate_window_ir(&self, ir: &[Self::Instruction]) -> Result<(), String> {
-        validate_x86_window_terminator_placement(ir)
+        x86_search_inputs::validate_terminator_placement(ir)
     }
 
     fn optimization_context(
@@ -1766,7 +1768,7 @@ fn build_x86_base_search_config(
         .with_solver_timeout(options.solver_timeout)
         .with_timeout_option(options.timeout)
         .with_verbose(options.verbose)
-        .with_x86_registers(x86_registers_from_target(target))
+        .with_x86_registers(x86_search_inputs::registers_from_target(target))
         .with_immediates(isa::x86::default_x86_immediates())
 }
 
@@ -2167,122 +2169,9 @@ fn validate_basic_block(ir: &[Instruction]) -> Result<(), String> {
 // live in `parser::x86`. The Capstone bridge (`convert_to_x86_ir`,
 // `convert_x86_capstone_op_for_optimization`) lives in `capstone_bridge_x86`.
 // This file keeps only the length-1 enumerator used by the enumerative x86
-// pipeline plus the window terminator/live-out helpers.
-
-/// Reject any non-terminal Jcc in an x86 optimization window. The
-/// optimizer only special-cases a trailing Jcc (peeled by
-/// `split_terminator_x86`, displacement preserved by
-/// `reassemble_x86_prefix_with_pinned_terminator`). A Jcc anywhere
-/// else in the window would be modelled as a data-state no-op by
-/// both the concrete and SMT executors, so the equivalence check
-/// could accept a rewrite that silently drops or rewrites the branch.
-fn validate_x86_window_terminator_placement(ir: &[isa::x86::X86Instruction]) -> Result<(), String> {
-    for (idx, instr) in ir.iter().enumerate() {
-        if matches!(instr, isa::x86::X86Instruction::Jcc { .. }) && idx != ir.len() - 1 {
-            return Err(format!(
-                "x86 window contains a non-terminal conditional branch at position {} \
-                 (last position is {}). The optimizer only supports Jcc as the trailing \
-                 terminator of a window. Narrow --start-addr/--end-addr to exclude the \
-                 mid-window branch.",
-                idx,
-                ir.len() - 1
-            ));
-        }
-    }
-    Ok(())
-}
-
-/// Candidate register pool for x86 search, drawn from the target's original
-/// destinations. The trait refactor regressed coverage by defaulting to the
-/// fixed `default_x86_registers()` pool, so a window over R10-R15 had no
-/// representable rewrite. Source-only registers are deliberately excluded: the
-/// single candidate pool can place registers in writable positions, while
-/// live-out tracking only makes original destinations plus EFLAGS observable.
-/// `RSP` and `RBP` are also excluded so search never synthesizes stack/frame
-/// writes. Falls back to the default pool only for an empty target; a non-empty
-/// target with no usable destinations returns an empty pool so search does not
-/// introduce unrelated writable registers.
-fn x86_registers_from_target(target: &[isa::x86::X86Instruction]) -> Vec<isa::x86::X86Register> {
-    let mut pool: Vec<isa::x86::X86Register> = Vec::new();
-    let referenced = target
-        .iter()
-        .filter_map(|instr| instr.destination_operand());
-    for reg in referenced {
-        if matches!(
-            reg.canonical(),
-            isa::x86::X86Register::RSP | isa::x86::X86Register::RBP
-        ) {
-            continue;
-        }
-        if !pool.contains(&reg) {
-            pool.push(reg);
-        }
-    }
-    if target.is_empty() {
-        return isa::x86::default_x86_registers();
-    }
-    pool
-}
-
-/// Candidate immediate pool for the x86 enumerative path: the target's own
-/// immediates plus `0`, `1`, and `-1`. The fixed `default_x86_immediates()`
-/// pool holds no negatives, so the trait refactor lost rewrites like
-/// `mov rax, -1; mov rax, -1` → `mov rax, -1`.
-fn x86_enumerative_immediates_from_target(target: &[isa::x86::X86Instruction]) -> Vec<i64> {
-    use isa::x86::X86Instruction;
-    let mut imms = vec![0i64, 1, -1];
-    let referenced = target.iter().filter_map(|instr| match instr {
-        X86Instruction::MovImm { imm, .. }
-        | X86Instruction::AddImm { imm, .. }
-        | X86Instruction::SubImm { imm, .. }
-        | X86Instruction::AndImm { imm, .. }
-        | X86Instruction::OrImm { imm, .. }
-        | X86Instruction::XorImm { imm, .. }
-        | X86Instruction::CmpImm { imm, .. } => Some(*imm),
-        _ => None,
-    });
-    for imm in referenced {
-        if !imms.contains(&imm) {
-            imms.push(imm);
-        }
-    }
-    imms
-}
-
-/// Build the per-window x86 live-out contract.
-///
-/// EFLAGS liveness folds in the downstream flags scan (pre-existing). For
-/// registers (issue #621): when `downstream_live` is `Some(set)`, the
-/// window-written live-out set is narrowed to that proven-live subset;
-/// when `None` every written register stays live (the pre-#621 default).
-///
-/// **Conditional/branch soundness gate (defense in depth).** Like the AArch64
-/// builder, register narrowing applies only when the window has no terminator:
-/// the downstream scan follows only the linear fall-through successor, so a
-/// trailing Jcc (with its unscanned branch-taken target) vetoes narrowing.
-/// The backend already withholds the narrowed set in that case; this is a
-/// second, local guard so the function is sound regardless of caller.
-fn x86_live_out_for_optimization(
-    target: &[isa::x86::X86Instruction],
-    downstream_flags_live: bool,
-    downstream_live: Option<&semantics::live_out::RegisterSet<isa::x86::X86Register>>,
-) -> semantics::live_out::X86LiveOut {
-    let live_out = validation::live_out::x86_live_out_from_target(target);
-    let flags_live = live_out.flags_live() || downstream_flags_live;
-    let has_terminator = target.last().is_some_and(|i| i.is_terminator());
-    let narrowing = if has_terminator {
-        None
-    } else {
-        downstream_live
-    };
-    let narrowed = match narrowing {
-        Some(live) => {
-            semantics::live_out::RegisterSet::from_registers(live.iter().copied().collect())
-        }
-        None => live_out,
-    };
-    narrowed.with_flags(flags_live)
-}
+// pipeline. The per-window search inputs — candidate register/immediate pools,
+// the live-out contract, and the terminator-placement admissibility gate — live
+// in `x86_search_inputs`.
 
 /// Build the search config for the x86 *enumerative* path. Like stochastic and
 /// symbolic search, enumerative search draws candidates from the target's own
@@ -2295,7 +2184,9 @@ fn build_x86_enumerative_search_config(
     options: &OptimizationOptions,
 ) -> SearchConfig {
     build_x86_stochastic_search_config(target, options)
-        .with_immediates(x86_enumerative_immediates_from_target(target))
+        .with_immediates(x86_search_inputs::enumerative_immediates_from_target(
+            target,
+        ))
         .with_cores(options.cores)
 }
 
@@ -2310,7 +2201,11 @@ fn run_x86_enumerative(
     use search::SearchAlgorithm;
 
     let config = build_x86_enumerative_search_config(target, options);
-    let live_out = x86_live_out_for_optimization(target, downstream_flags_live, downstream_live);
+    let live_out = x86_search_inputs::live_out_for_optimization(
+        target,
+        downstream_flags_live,
+        downstream_live,
+    );
 
     let (optimized, statistics) = if width == 32 {
         let mut search: EnumerativeSearch<isa::X86_32> = EnumerativeSearch::new();
@@ -2356,7 +2251,11 @@ fn run_x86_stochastic(
     if config.x86_available_registers.is_empty() {
         return None;
     }
-    let live_out = x86_live_out_for_optimization(target, downstream_flags_live, downstream_live);
+    let live_out = x86_search_inputs::live_out_for_optimization(
+        target,
+        downstream_flags_live,
+        downstream_live,
+    );
 
     // Extract (optimized, statistics) in each width branch separately:
     // the two `SearchResultFor<X86_64>` / `SearchResultFor<X86_32>`
@@ -2401,7 +2300,11 @@ fn run_x86_symbolic(
     use search::symbolic::SymbolicSearch;
 
     let config = build_x86_symbolic_search_config(target, options, same_count_code_size_allowed);
-    let live_out = x86_live_out_for_optimization(target, downstream_flags_live, downstream_live);
+    let live_out = x86_search_inputs::live_out_for_optimization(
+        target,
+        downstream_flags_live,
+        downstream_live,
+    );
 
     let (optimized, statistics) = if width == 32 {
         let mut search: SymbolicSearch<isa::X86_32> = SymbolicSearch::new();
@@ -4617,58 +4520,6 @@ mod cli_helper_tests {
     }
 
     #[test]
-    fn x86_live_out_for_optimization_includes_downstream_flags() {
-        let mov_only = [X86Instruction::MovImm {
-            rd: X86Register::RAX,
-            imm: 0,
-        }];
-
-        assert!(!x86_live_out_for_optimization(&mov_only, false, None).flags_live());
-        assert!(x86_live_out_for_optimization(&mov_only, true, None).flags_live());
-
-        let flag_writer = [X86Instruction::XorReg {
-            rd: X86Register::RAX,
-            rs: X86Register::RAX,
-        }];
-        assert!(x86_live_out_for_optimization(&flag_writer, false, None).flags_live());
-    }
-
-    #[test]
-    fn x86_live_out_for_optimization_narrows_to_downstream_live_regs() {
-        use semantics::live_out::RegisterSet;
-
-        // Window writes RAX and RBX.
-        let window = [
-            X86Instruction::MovImm {
-                rd: X86Register::RAX,
-                imm: 0,
-            },
-            X86Instruction::MovImm {
-                rd: X86Register::RBX,
-                imm: 0,
-            },
-        ];
-
-        // Default (no downstream analysis): both written registers stay live.
-        let default = x86_live_out_for_optimization(&window, false, None);
-        assert!(default.contains(X86Register::RAX));
-        assert!(default.contains(X86Register::RBX));
-
-        // Downstream scan proved only RBX live (RAX dead). The contract must
-        // drop RAX and pin RBX.
-        let downstream_live = RegisterSet::from_registers(vec![X86Register::RBX]);
-        let narrowed = x86_live_out_for_optimization(&window, false, Some(&downstream_live));
-        assert!(
-            !narrowed.contains(X86Register::RAX),
-            "a provably-dead window register must be dropped from live-out"
-        );
-        assert!(
-            narrowed.contains(X86Register::RBX),
-            "a downstream-read window register must stay pinned"
-        );
-    }
-
-    #[test]
     fn live_out_for_optimization_prefix_narrows_to_downstream_live_regs() {
         // Prefix writes x0 and x1.
         let prefix = [
@@ -4740,31 +4591,6 @@ mod cli_helper_tests {
             live_out.contains(Register::X0),
             "x0 must stay live: a conditional terminator has a branch-taken successor \
              the fall-through scan never inspected, so register narrowing must not apply"
-        );
-    }
-
-    /// x86 sibling of the conditional-terminator soundness gate: a target
-    /// ending in a Jcc must not narrow even if the proven-live set excludes a
-    /// written register.
-    #[test]
-    fn x86_live_out_for_optimization_does_not_narrow_with_trailing_jcc() {
-        use isa::x86::X86Condition;
-        let target = [
-            X86Instruction::MovImm {
-                rd: X86Register::RAX,
-                imm: 7,
-            },
-            X86Instruction::Jcc {
-                cond: X86Condition::E,
-            },
-        ];
-        // Pretend the fall-through scan proved RAX dead (empty set).
-        let dead = semantics::live_out::RegisterSet::<X86Register>::empty();
-        let live_out = x86_live_out_for_optimization(&target, false, Some(&dead));
-        assert!(
-            live_out.contains(X86Register::RAX),
-            "RAX must stay live: a trailing Jcc has an unscanned branch-taken successor, \
-             so register narrowing must not apply"
         );
     }
 
@@ -5006,56 +4832,6 @@ mod cli_helper_tests {
         }
     }
 
-    #[test]
-    fn validate_x86_window_rejects_mid_window_jcc() {
-        use isa::x86::{X86Condition, X86Instruction, X86Register};
-        let ir = vec![
-            X86Instruction::CmpReg {
-                rn: X86Register::RAX,
-                rs: X86Register::RBX,
-            },
-            X86Instruction::Jcc {
-                cond: X86Condition::E,
-            },
-            X86Instruction::MovImm {
-                rd: X86Register::RAX,
-                imm: 0,
-            },
-        ];
-        let err = validate_x86_window_terminator_placement(&ir)
-            .expect_err("mid-window Jcc must be rejected");
-        assert!(
-            err.contains("non-terminal conditional branch") && err.contains("position 1"),
-            "unhelpful error: {}",
-            err
-        );
-    }
-
-    #[test]
-    fn validate_x86_window_accepts_trailing_jcc() {
-        use isa::x86::{X86Condition, X86Instruction, X86Register};
-        let ir = vec![
-            X86Instruction::CmpReg {
-                rn: X86Register::RAX,
-                rs: X86Register::RBX,
-            },
-            X86Instruction::Jcc {
-                cond: X86Condition::E,
-            },
-        ];
-        validate_x86_window_terminator_placement(&ir).expect("trailing Jcc must be accepted");
-    }
-
-    #[test]
-    fn validate_x86_window_accepts_no_jcc() {
-        use isa::x86::{X86Instruction, X86Register};
-        let ir = vec![X86Instruction::MovImm {
-            rd: X86Register::RAX,
-            imm: 0,
-        }];
-        validate_x86_window_terminator_placement(&ir).expect("Jcc-free window must be accepted");
-    }
-
     /// Regression: x86 enumerative search must preserve a trailing Jcc while
     /// optimizing the straight-line prefix.
     #[test]
@@ -5219,63 +4995,6 @@ mod cli_helper_tests {
             .expect("two identical R10 zeroing writes must collapse to one");
 
         assert_single_r10_rewrite(&optimized);
-    }
-
-    #[test]
-    fn x86_register_pool_is_destination_derived_and_empty_falls_back() {
-        let target = vec![
-            X86Instruction::CmpReg {
-                rn: X86Register::RSP,
-                rs: X86Register::R11,
-            },
-            X86Instruction::CmpReg {
-                rn: X86Register::RBP,
-                rs: X86Register::R12,
-            },
-            X86Instruction::MovReg {
-                rd: X86Register::R11,
-                rs: X86Register::R10,
-            },
-            X86Instruction::AddReg {
-                rd: X86Register::R12,
-                rs: X86Register::RSP,
-            },
-        ];
-
-        assert_eq!(
-            x86_registers_from_target(&target),
-            vec![X86Register::R11, X86Register::R12]
-        );
-        assert_eq!(
-            x86_registers_from_target(&[]),
-            isa::x86::default_x86_registers()
-        );
-        assert_eq!(
-            x86_registers_from_target(&[
-                X86Instruction::CmpImm {
-                    rn: X86Register::R10,
-                    imm: 1,
-                },
-                X86Instruction::CmpImm {
-                    rn: X86Register::R10,
-                    imm: 1,
-                },
-            ]),
-            Vec::<X86Register>::new()
-        );
-        assert_eq!(
-            x86_registers_from_target(&[
-                X86Instruction::CmpImm {
-                    rn: X86Register::RSP,
-                    imm: 1,
-                },
-                X86Instruction::CmpReg {
-                    rn: X86Register::RBP,
-                    rs: X86Register::RBP,
-                },
-            ]),
-            Vec::<X86Register>::new()
-        );
     }
 
     /// Regression (PR #384): the enumerative config must be target-derived and

--- a/src/x86_search_inputs.rs
+++ b/src/x86_search_inputs.rs
@@ -1,0 +1,383 @@
+//! Search inputs for a single x86 optimization window.
+//!
+//! [`candidate_windows`](crate::candidate_windows) *selects* which address
+//! ranges of a binary are rewritable. This module answers the next question for
+//! one already-selected window: given its Target (the window's instructions),
+//! what does x86 search see, and is the window even admissible? Four pure
+//! functions make up that seam:
+//!
+//! * [`registers_from_target`] — the Candidate register pool search may write.
+//! * [`enumerative_immediates_from_target`] — the Candidate immediate pool the
+//!   enumerative path draws from.
+//! * [`live_out_for_optimization`] — the per-window Live-out contract, including
+//!   the conditional-branch soundness veto on register narrowing.
+//! * [`validate_terminator_placement`] — the admissibility gate that rejects a
+//!   window the optimizer cannot soundly rewrite (a non-terminal `Jcc`).
+//!
+//! These rules used to live inline in the `run_x86_*` drivers in the binary's
+//! `main.rs`, interleaved with CLI parsing, ELF I/O, and Capstone bridging — a
+//! shallow arrangement where the only way to exercise "RSP/RBP are excluded from
+//! the pool" or "a trailing terminator vetoes narrowing" was to drive a whole
+//! search. Lifting them into a **pure seam** (library types in, library types
+//! out; no CLI, ELF, or Capstone) makes each rule a fixture-free unit test and
+//! keeps the drivers as a thin adapter. See the `CONTEXT.md` glossary for the
+//! domain terms used above (Target, Candidate, Live-out, Observable state); the
+//! narrowing/flags issue references live on the individual functions below.
+
+use crate::isa::x86::{X86Instruction, X86Register, default_x86_registers};
+use crate::semantics::live_out::{RegisterSet, X86LiveOut};
+use crate::validation::live_out::x86_live_out_from_target;
+
+/// Reject any non-terminal `Jcc` in an x86 optimization window. The optimizer
+/// only special-cases a trailing `Jcc` (peeled by `split_terminator_x86`,
+/// displacement preserved by `reassemble_x86_prefix_with_pinned_terminator`). A
+/// `Jcc` anywhere else in the window would be modelled as a data-state no-op by
+/// both the concrete and SMT executors, so the equivalence check could accept a
+/// rewrite that silently drops or rewrites the branch.
+pub fn validate_terminator_placement(ir: &[X86Instruction]) -> Result<(), String> {
+    for (idx, instr) in ir.iter().enumerate() {
+        if matches!(instr, X86Instruction::Jcc { .. }) && idx != ir.len() - 1 {
+            return Err(format!(
+                "x86 window contains a non-terminal conditional branch at position {} \
+                 (last position is {}). The optimizer only supports Jcc as the trailing \
+                 terminator of a window. Narrow --start-addr/--end-addr to exclude the \
+                 mid-window branch.",
+                idx,
+                ir.len() - 1
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Candidate register pool for x86 search, drawn from the target's original
+/// destinations. The trait refactor regressed coverage by defaulting to the
+/// fixed `default_x86_registers()` pool, so a window over R10-R15 had no
+/// representable rewrite. Source-only registers are deliberately excluded: the
+/// single candidate pool can place registers in writable positions, while
+/// live-out tracking only makes original destinations plus EFLAGS observable.
+/// `RSP` and `RBP` are also excluded so search never synthesizes stack/frame
+/// writes. Falls back to the default pool only for an empty target; a non-empty
+/// target with no usable destinations returns an empty pool so search does not
+/// introduce unrelated writable registers.
+pub fn registers_from_target(target: &[X86Instruction]) -> Vec<X86Register> {
+    let mut pool: Vec<X86Register> = Vec::new();
+    let referenced = target
+        .iter()
+        .filter_map(|instr| instr.destination_operand());
+    for reg in referenced {
+        if matches!(reg.canonical(), X86Register::RSP | X86Register::RBP) {
+            continue;
+        }
+        if !pool.contains(&reg) {
+            pool.push(reg);
+        }
+    }
+    if target.is_empty() {
+        return default_x86_registers();
+    }
+    pool
+}
+
+/// Candidate immediate pool for the x86 enumerative path: the target's own
+/// immediates plus `0`, `1`, and `-1`. The fixed `default_x86_immediates()`
+/// pool holds no negatives, so the trait refactor lost rewrites like
+/// `mov rax, -1; mov rax, -1` → `mov rax, -1`.
+pub fn enumerative_immediates_from_target(target: &[X86Instruction]) -> Vec<i64> {
+    let mut imms = vec![0i64, 1, -1];
+    let referenced = target.iter().filter_map(|instr| match instr {
+        X86Instruction::MovImm { imm, .. }
+        | X86Instruction::AddImm { imm, .. }
+        | X86Instruction::SubImm { imm, .. }
+        | X86Instruction::AndImm { imm, .. }
+        | X86Instruction::OrImm { imm, .. }
+        | X86Instruction::XorImm { imm, .. }
+        | X86Instruction::CmpImm { imm, .. } => Some(*imm),
+        _ => None,
+    });
+    for imm in referenced {
+        if !imms.contains(&imm) {
+            imms.push(imm);
+        }
+    }
+    imms
+}
+
+/// Build the per-window x86 live-out contract.
+///
+/// EFLAGS liveness folds in the downstream flags scan (pre-existing). For
+/// registers (issue #621): when `downstream_live` is `Some(set)`, the
+/// window-written live-out set is narrowed to that proven-live subset;
+/// when `None` every written register stays live (the pre-#621 default).
+///
+/// **Conditional/branch soundness gate (defense in depth).** Like the AArch64
+/// builder, register narrowing applies only when the window has no terminator:
+/// the downstream scan follows only the linear fall-through successor, so a
+/// trailing Jcc (with its unscanned branch-taken target) vetoes narrowing.
+/// The backend already withholds the narrowed set in that case; this is a
+/// second, local guard so the function is sound regardless of caller.
+pub fn live_out_for_optimization(
+    target: &[X86Instruction],
+    downstream_flags_live: bool,
+    downstream_live: Option<&RegisterSet<X86Register>>,
+) -> X86LiveOut {
+    let live_out = x86_live_out_from_target(target);
+    let flags_live = live_out.flags_live() || downstream_flags_live;
+    let has_terminator = target.last().is_some_and(|i| i.is_terminator());
+    let narrowing = if has_terminator {
+        None
+    } else {
+        downstream_live
+    };
+    let narrowed = match narrowing {
+        Some(live) => RegisterSet::from_registers(live.iter().copied().collect()),
+        None => live_out,
+    };
+    narrowed.with_flags(flags_live)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::isa::x86::X86Condition;
+
+    // ===== enumerative_immediates_from_target (new coverage) =====
+
+    #[test]
+    fn enumerative_immediates_are_seeded_with_zero_one_minus_one() {
+        // No target immediates: the pool is exactly the fixed seeds.
+        assert_eq!(enumerative_immediates_from_target(&[]), vec![0, 1, -1]);
+    }
+
+    #[test]
+    fn enumerative_immediates_append_novel_target_immediates_in_order() {
+        // 42 and -5 are novel, so they follow the seeds in first-seen order.
+        let target = [
+            X86Instruction::MovImm {
+                rd: X86Register::RAX,
+                imm: 42,
+            },
+            X86Instruction::AddImm {
+                rd: X86Register::RBX,
+                imm: -5,
+            },
+        ];
+        assert_eq!(
+            enumerative_immediates_from_target(&target),
+            vec![0, 1, -1, 42, -5]
+        );
+    }
+
+    #[test]
+    fn enumerative_immediates_dedupe_against_seeds_and_repeats() {
+        // 1 duplicates a seed; the second 7 duplicates the first — neither repeats.
+        let target = [
+            X86Instruction::MovImm {
+                rd: X86Register::RAX,
+                imm: 1,
+            },
+            X86Instruction::CmpImm {
+                rn: X86Register::RAX,
+                imm: 7,
+            },
+            X86Instruction::SubImm {
+                rd: X86Register::RAX,
+                imm: 7,
+            },
+        ];
+        assert_eq!(
+            enumerative_immediates_from_target(&target),
+            vec![0, 1, -1, 7]
+        );
+    }
+
+    #[test]
+    fn enumerative_immediates_ignore_register_only_instructions() {
+        // A register-to-register move carries no immediate to harvest.
+        let target = [X86Instruction::MovReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RBX,
+        }];
+        assert_eq!(enumerative_immediates_from_target(&target), vec![0, 1, -1]);
+    }
+
+    // ===== registers_from_target (carried from main.rs) =====
+
+    #[test]
+    fn register_pool_is_destination_derived_and_empty_falls_back() {
+        let target = vec![
+            X86Instruction::CmpReg {
+                rn: X86Register::RSP,
+                rs: X86Register::R11,
+            },
+            X86Instruction::CmpReg {
+                rn: X86Register::RBP,
+                rs: X86Register::R12,
+            },
+            X86Instruction::MovReg {
+                rd: X86Register::R11,
+                rs: X86Register::R10,
+            },
+            X86Instruction::AddReg {
+                rd: X86Register::R12,
+                rs: X86Register::RSP,
+            },
+        ];
+
+        assert_eq!(
+            registers_from_target(&target),
+            vec![X86Register::R11, X86Register::R12]
+        );
+        assert_eq!(registers_from_target(&[]), default_x86_registers());
+        assert_eq!(
+            registers_from_target(&[
+                X86Instruction::CmpImm {
+                    rn: X86Register::R10,
+                    imm: 1,
+                },
+                X86Instruction::CmpImm {
+                    rn: X86Register::R10,
+                    imm: 1,
+                },
+            ]),
+            Vec::<X86Register>::new()
+        );
+        assert_eq!(
+            registers_from_target(&[
+                X86Instruction::CmpImm {
+                    rn: X86Register::RSP,
+                    imm: 1,
+                },
+                X86Instruction::CmpReg {
+                    rn: X86Register::RBP,
+                    rs: X86Register::RBP,
+                },
+            ]),
+            Vec::<X86Register>::new()
+        );
+    }
+
+    // ===== validate_terminator_placement (carried from main.rs) =====
+
+    #[test]
+    fn validate_rejects_mid_window_jcc() {
+        let ir = vec![
+            X86Instruction::CmpReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            X86Instruction::Jcc {
+                cond: X86Condition::E,
+            },
+            X86Instruction::MovImm {
+                rd: X86Register::RAX,
+                imm: 0,
+            },
+        ];
+        let err = validate_terminator_placement(&ir).expect_err("mid-window Jcc must be rejected");
+        assert!(
+            err.contains("non-terminal conditional branch") && err.contains("position 1"),
+            "unhelpful error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn validate_accepts_trailing_jcc() {
+        let ir = vec![
+            X86Instruction::CmpReg {
+                rn: X86Register::RAX,
+                rs: X86Register::RBX,
+            },
+            X86Instruction::Jcc {
+                cond: X86Condition::E,
+            },
+        ];
+        validate_terminator_placement(&ir).expect("trailing Jcc must be accepted");
+    }
+
+    #[test]
+    fn validate_accepts_no_jcc() {
+        let ir = vec![X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: 0,
+        }];
+        validate_terminator_placement(&ir).expect("Jcc-free window must be accepted");
+    }
+
+    // ===== live_out_for_optimization (carried from main.rs) =====
+
+    #[test]
+    fn live_out_includes_downstream_flags() {
+        let mov_only = [X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: 0,
+        }];
+
+        assert!(!live_out_for_optimization(&mov_only, false, None).flags_live());
+        assert!(live_out_for_optimization(&mov_only, true, None).flags_live());
+
+        let flag_writer = [X86Instruction::XorReg {
+            rd: X86Register::RAX,
+            rs: X86Register::RAX,
+        }];
+        assert!(live_out_for_optimization(&flag_writer, false, None).flags_live());
+    }
+
+    #[test]
+    fn live_out_narrows_to_downstream_live_regs() {
+        // Window writes RAX and RBX.
+        let window = [
+            X86Instruction::MovImm {
+                rd: X86Register::RAX,
+                imm: 0,
+            },
+            X86Instruction::MovImm {
+                rd: X86Register::RBX,
+                imm: 0,
+            },
+        ];
+
+        // Default (no downstream analysis): both written registers stay live.
+        let default = live_out_for_optimization(&window, false, None);
+        assert!(default.contains(X86Register::RAX));
+        assert!(default.contains(X86Register::RBX));
+
+        // Downstream scan proved only RBX live (RAX dead). The contract must
+        // drop RAX and pin RBX.
+        let downstream_live = RegisterSet::from_registers(vec![X86Register::RBX]);
+        let narrowed = live_out_for_optimization(&window, false, Some(&downstream_live));
+        assert!(
+            !narrowed.contains(X86Register::RAX),
+            "a provably-dead window register must be dropped from live-out"
+        );
+        assert!(
+            narrowed.contains(X86Register::RBX),
+            "a downstream-read window register must stay pinned"
+        );
+    }
+
+    /// x86 sibling of the conditional-terminator soundness gate: a target
+    /// ending in a Jcc must not narrow even if the proven-live set excludes a
+    /// written register.
+    #[test]
+    fn live_out_does_not_narrow_with_trailing_jcc() {
+        let target = [
+            X86Instruction::MovImm {
+                rd: X86Register::RAX,
+                imm: 7,
+            },
+            X86Instruction::Jcc {
+                cond: X86Condition::E,
+            },
+        ];
+        // Pretend the fall-through scan proved RAX dead (empty set).
+        let dead = RegisterSet::<X86Register>::empty();
+        let live_out = live_out_for_optimization(&target, false, Some(&dead));
+        assert!(
+            live_out.contains(X86Register::RAX),
+            "RAX must stay live: a trailing Jcc has an unscanned branch-taken successor, \
+             so register narrowing must not apply"
+        );
+    }
+}


### PR DESCRIPTION
## Goal

Continue carving the ~6.4k-line `src/main.rs` god-file into pure, independently-testable seams — the trajectory of the two most recent commits (`refactor(cli): extract report module` #743, `refactor(driver): extract candidate-window planner` #744). This slice lifts the **x86 optimization-window search inputs** out of the binary crate into a new deep library module, `src/x86_search_inputs.rs`.

## What moved

Four pure functions that decide what x86 search sees for one *already-selected* window (contrast with `candidate_windows`, which *selects* the address ranges):

| new (`x86_search_inputs::`) | was (`main.rs`) | role |
|---|---|---|
| `registers_from_target` | `x86_registers_from_target` | candidate register pool (RSP/RBP excluded, destination-derived) |
| `enumerative_immediates_from_target` | `x86_enumerative_immediates_from_target` | candidate immediate pool for the enumerative path |
| `live_out_for_optimization` | `x86_live_out_for_optimization` | per-window live-out contract + conditional-branch narrowing veto |
| `validate_terminator_placement` | `validate_x86_window_terminator_placement` | admissibility gate (rejects a non-terminal `Jcc`) |

They were pure and depended only on library types (`isa::x86`, `semantics::live_out`, `validation::live_out`), yet lived interleaved with CLI parsing, ELF I/O, and Capstone bridging — a shallow arrangement where the only way to exercise a rule like "a trailing terminator vetoes register narrowing" was to drive a whole search. The `run_x86_*` drivers are now the thin adapter that calls the seam.

**Impact:** `src/main.rs` 6417 → 6136 (−281 lines net; the extracted logic + its tests move to the new module). Behavior is unchanged.

## TDD

The task asked for test-first. This PR is honest about which part is genuinely red→green and which is a mechanical carry-over of already-proven tests:

- **(a) Genuinely red-first — new coverage.** `enumerative_immediates_from_target` had **zero** tests. I added four fixture-free tests (seed pool `[0, 1, -1]`, first-seen ordering, dedup against seeds *and* repeats, exclusion of register-only instructions), watched them fail against a deliberately-wrong stub, then implemented to green. Expected values are hand-derived literals, not recomputed from the implementation.
- **(b) Mechanical carry-over.** The other three functions already had fixture-free tests inline in `main.rs`; those tests moved with them into the library (out of the binary crate), so no coverage was lost and the terminator/narrowing/register-pool rules are still pinned.

New library module test count: **11** (`cargo test --lib x86_search_inputs`).

## Validation

- `./ci_check.sh` — full gate green: `cargo fmt --check`, build, cross-compiled AArch64 test binaries, unit + integration tests (lib 1637 passed, bin 117 passed), and `test_all.sh`.
- `cargo clippy --all-targets` — clean (only the pre-existing `proc-macro-error2` dependency future-incompat warning).

## Audit trail (architecture review)

Per the `improve-codebase-architecture` skill, the scan was scoped to the churn hot spot (`main.rs`: 29 touches in 120 commits, largest file). Candidates considered and why this one won:

1. **x86 window search inputs — chosen.** Highest leverage (soundness-critical, cohesive domain seam), lowest risk (pure, library-only deps), fills a real coverage gap, and lands as the natural next step after #743/#744.
2. `build_*_search_config` cluster — thin pass-throughs coupled to `OptimizationOptions`; relocating is churn without much deepening.
3. Output-path resolution (`resolve_output_path` et al.) — cohesive but already well-tested and filesystem-touching; a good follow-up.
4. Capstone-detail adapters / `ElfOptimizationBackend` — genuinely adapter-shaped (resist fixture-free tests); high-risk to move in one PR.
5. Reassembly pair (`reassemble_x86_prefix_with_pinned_terminator` + `append_nop_padding`) — **deferred**: conceptually part of x86 window handling, but depends on the main-local `X86Arch` enum, so a clean move needs `X86Arch` relocated too. Left as a focused follow-up so this PR stays reviewable.

## Notes

- This is an autonomous run, so the skill's interactive "which candidate would you like to explore?" prompt and the subsequent grilling loop were deliberately collapsed into the self-selected pick documented above, rather than skipped.
- The skill's HTML report was written to the OS temp dir (not the repo, not opened — headless run): `/tmp/architecture-review-20260816-120540.html`. Its substance is reproduced in the audit trail above.
