### PR TITLE
refactor(driver): extract aarch64 window search inputs into a pure tested seam

### DIFF
--- a/src/aarch64_search_inputs.rs
+++ b/src/aarch64_search_inputs.rs
@@ -1,0 +1,469 @@
+//! Search inputs for a single AArch64 optimization window.
+//!
+//! [`plan_candidate_windows`](crate::candidate_windows) *selects* which address
+//! ranges of a binary are rewritable. This module answers the next question for
+//! one already-selected window: given its Target (the window's instructions),
+//! what does AArch64 search see, and is the window even admissible? Four pure
+//! functions make up that seam:
+//!
+//! * [`registers_from_target`] — the Candidate register pool search may write.
+//! * [`default_immediates`] — the fixed Candidate immediate pool every AArch64
+//!   algorithm draws from.
+//! * [`live_out_for_optimization_prefix`] — the per-window Live-out contract,
+//!   including the terminator soundness veto on register narrowing.
+//! * [`validate_basic_block`] — the admissibility gate that rejects a window the
+//!   optimizer cannot soundly rewrite (a non-terminal terminator, issue #69).
+//!
+//! These rules used to live inline in the `run_optimization` driver in the
+//! binary's `main.rs`, interleaved with CLI parsing, ELF I/O, and Capstone
+//! bridging — a shallow arrangement where the only way to exercise "X0..X7 plus
+//! the target's vector registers" or "a held-fixed terminator vetoes narrowing"
+//! was to drive a whole search. Lifting them into a **pure seam** (library types
+//! in, library types out; no CLI, ELF, or Capstone) makes each rule a
+//! fixture-free unit test and keeps the driver a thin adapter. This mirrors
+//! [`x86_search_inputs`](crate::x86_search_inputs), extracted for the x86 path
+//! in #752. See the `CONTEXT.md` glossary for the domain terms used above
+//! (Target, Candidate, Live-out, Observable state).
+
+use crate::ir::{Instruction, Register};
+use crate::semantics::{LiveOut, RegisterSet};
+
+/// Build the AArch64 search register pool, preserving the historical X0..X7
+/// scalar policy while adding every vector register referenced by the target.
+/// A target-local vector pool avoids the 32^3 candidate explosion of enabling
+/// the entire SIMD register file for small enumerative searches.
+pub fn registers_from_target(target: &[Instruction]) -> Vec<Register> {
+    let mut registers = vec![
+        Register::X0,
+        Register::X1,
+        Register::X2,
+        Register::X3,
+        Register::X4,
+        Register::X5,
+        Register::X6,
+        Register::X7,
+    ];
+
+    for register in target
+        .iter()
+        .flat_map(|instruction| instruction.source_registers().into_iter())
+        .chain(
+            target
+                .iter()
+                .flat_map(|instruction| instruction.destinations().into_iter()),
+        )
+        .filter(|register| register.vector().is_some())
+    {
+        if !registers.contains(&register) {
+            registers.push(register);
+        }
+    }
+    registers.sort_by_key(|register| register.sort_key());
+    registers
+}
+
+/// The fixed AArch64 Candidate immediate pool every algorithm draws from: small
+/// constants, powers of two and their neighbours, and encodable masks. Unlike
+/// the x86 pool it is not target-derived — it is a shared default handed to
+/// every AArch64 builder (stochastic/enumerative/hybrid/symbolic/LLM) via
+/// `run_optimization`.
+pub fn default_immediates() -> Vec<i64> {
+    vec![
+        0, 1, 2, 3, 4, 5, 7, 8, 10, 15, 16, 31, 32, 63, 64, 100, 255, 256, 1000, 4095,
+    ]
+}
+
+/// Build the per-window AArch64 Live-out contract over the window `prefix`.
+///
+/// Register liveness: when `downstream_live` is `Some(set)` *and* there is no
+/// held-fixed terminator, the window-written live-out set is narrowed to that
+/// proven-live subset; otherwise every written register stays live. Any
+/// register the reattached `terminator` reads is then pinned live. NZCV
+/// liveness comes from the terminator (always live) or the downstream
+/// fall-through scan.
+///
+/// **Terminator soundness veto.** A held-fixed terminator has an unscanned
+/// second successor (the branch-taken target), so its downstream register scan
+/// only covers the fall-through path. Register narrowing is therefore vetoed
+/// whenever a terminator is present, so a register live only on the taken path
+/// is never dropped. Mirrors the same guard in
+/// [`x86_search_inputs::live_out_for_optimization`](crate::x86_search_inputs::live_out_for_optimization).
+pub fn live_out_for_optimization_prefix(
+    prefix: &[Instruction],
+    terminator: Option<&Instruction>,
+    downstream_flags_live: bool,
+    downstream_live: Option<&RegisterSet<Register>>,
+) -> LiveOut {
+    // A terminator vetoes register narrowing (its other successor is unscanned).
+    let narrowing = if terminator.is_some() {
+        None
+    } else {
+        downstream_live
+    };
+
+    let mut live_registers: Vec<Register> = match narrowing {
+        // Narrow to (written ∩ proven-live). The downstream set is already a
+        // subset of the window-written registers (it is computed from exactly
+        // that candidate set), so iterating it is sufficient.
+        Some(live) => live.iter().copied().collect(),
+        // No downstream analysis (or vetoed by a terminator): keep every
+        // written register live.
+        None => prefix
+            .iter()
+            .flat_map(|instr| instr.destinations())
+            .collect(),
+    };
+
+    if let Some(terminator) = terminator {
+        live_registers.extend(terminator.source_registers());
+    }
+
+    let flags_live = if terminator.is_some() {
+        true
+    } else {
+        downstream_flags_live
+    };
+
+    LiveOut::from_registers(live_registers).with_flags(flags_live)
+}
+
+/// Admissibility gate for an AArch64 optimization window (issue #69): reject any
+/// window that contains a terminator anywhere but its final position. The
+/// optimizer only supports a single basic block whose trailing terminator is
+/// held fixed and reattached bit-identical; a mid-window branch would be modeled
+/// as a data-state no-op, so the equivalence check could accept a rewrite that
+/// silently drops it.
+pub fn validate_basic_block(ir: &[Instruction]) -> Result<(), String> {
+    let last_idx = ir.len().saturating_sub(1);
+    for (i, instr) in ir.iter().enumerate() {
+        if i < last_idx && instr.is_terminator() {
+            return Err(format!(
+                "Region contains a branch at position {} ({}); only single basic blocks ending in a terminator are supported (issue #69 scope)",
+                i, instr
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::{Condition, LabelId, Operand, VectorArrangement, VectorRegister};
+
+    // ===== default_immediates (new coverage) =====
+
+    #[test]
+    fn default_immediates_is_the_fixed_search_pool() {
+        // The AArch64 immediate pool is a fixed set of small constants and
+        // encodable masks. It used to be an untested literal inline in
+        // `run_optimization`; pinning it here guards silent edits to the pool.
+        assert_eq!(
+            default_immediates(),
+            vec![
+                0, 1, 2, 3, 4, 5, 7, 8, 10, 15, 16, 31, 32, 63, 64, 100, 255, 256, 1000, 4095
+            ]
+        );
+    }
+
+    // ===== registers_from_target (new coverage + carried from main.rs) =====
+
+    #[test]
+    fn registers_from_target_seeds_scalar_x0_through_x7_sorted() {
+        // With no vector registers referenced, the pool is exactly the
+        // historical X0..X7 scalar seed, in sort_key order.
+        let target = [Instruction::MovImm {
+            rd: Register::X0,
+            imm: 1,
+        }];
+        assert_eq!(
+            registers_from_target(&target),
+            vec![
+                Register::X0,
+                Register::X1,
+                Register::X2,
+                Register::X3,
+                Register::X4,
+                Register::X5,
+                Register::X6,
+                Register::X7,
+            ]
+        );
+        // No stray vector registers when the target is purely scalar.
+        assert!(
+            registers_from_target(&target)
+                .iter()
+                .all(|reg| reg.vector().is_none())
+        );
+    }
+
+    #[test]
+    fn registers_from_target_include_vectors_used_by_target() {
+        let target = [
+            Instruction::VectorAdd {
+                vd: VectorRegister::V0,
+                vn: VectorRegister::V1,
+                vm: VectorRegister::V2,
+                arrangement: VectorArrangement::TwoD,
+            },
+            Instruction::MovFromVectorLane {
+                rd: Register::X0,
+                vn: VectorRegister::V0,
+                lane: 0,
+            },
+        ];
+
+        let registers = registers_from_target(&target);
+
+        assert!(registers.contains(&Register::Vector(VectorRegister::V0)));
+        assert!(registers.contains(&Register::Vector(VectorRegister::V1)));
+        assert!(registers.contains(&Register::Vector(VectorRegister::V2)));
+        assert_eq!(
+            registers
+                .iter()
+                .filter(|reg| reg.vector().is_some())
+                .count(),
+            3
+        );
+    }
+
+    // ===== live_out_for_optimization_prefix (carried from main.rs) =====
+
+    #[test]
+    fn live_out_for_optimization_prefix_narrows_to_downstream_live_regs() {
+        // Prefix writes x0 and x1.
+        let prefix = [
+            Instruction::MovImm {
+                rd: Register::X0,
+                imm: 0,
+            },
+            Instruction::MovImm {
+                rd: Register::X1,
+                imm: 0,
+            },
+        ];
+
+        // Default (no downstream analysis): both written registers stay live.
+        let default = live_out_for_optimization_prefix(&prefix, None, false, None);
+        assert!(default.contains(Register::X0));
+        assert!(default.contains(Register::X1));
+
+        // Downstream scan proved only x1 live (x0 dead): drop x0, pin x1.
+        let downstream_live = RegisterSet::from_registers(vec![Register::X1]);
+        let narrowed =
+            live_out_for_optimization_prefix(&prefix, None, false, Some(&downstream_live));
+        assert!(
+            !narrowed.contains(Register::X0),
+            "a provably-dead window register must be dropped from live-out"
+        );
+        assert!(
+            narrowed.contains(Register::X1),
+            "a downstream-live window register must stay pinned"
+        );
+    }
+
+    /// Soundness regression: a window whose held-fixed terminator is a
+    /// CONDITIONAL branch must NOT narrow window-written registers, even if the
+    /// linear fall-through suffix proved one dead. The downstream-regs scan only
+    /// follows the fall-through successor; the branch-TAKEN successor is never
+    /// inspected and may read the register's window value.
+    ///
+    /// Counterexample being guarded against:
+    ///   window:       mov x0, #7 ; b.eq TARGET
+    ///   fall-through: mov x0, #0 ; ret           (kills x0 -> scan says Dead)
+    ///   elsewhere:    TARGET: add x9, x0, #1     (READS x0 on the taken path)
+    /// If x0 were narrowed to dead, `mov x0, #7` could be deleted and the
+    /// b.eq-taken path would read a stale x0. `BCond::source_registers()` is
+    /// empty, so the terminator does not re-pin x0 either — the only correct
+    /// fix is to not narrow at all when a terminator is present.
+    #[test]
+    fn live_out_for_optimization_prefix_does_not_narrow_with_conditional_terminator() {
+        let prefix = [Instruction::MovImm {
+            rd: Register::X0,
+            imm: 7,
+        }];
+        let b_eq = Instruction::BCond {
+            target: LabelId(0x2000),
+            cond: Condition::EQ,
+        };
+
+        // The fall-through scan "proved" x0 dead (empty proven-live set).
+        let downstream_live_fall_through = RegisterSet::<Register>::empty();
+
+        let live_out = live_out_for_optimization_prefix(
+            &prefix,
+            Some(&b_eq),
+            false,
+            Some(&downstream_live_fall_through),
+        );
+
+        assert!(
+            live_out.contains(Register::X0),
+            "x0 must stay live: a conditional terminator has a branch-taken successor \
+             the fall-through scan never inspected, so register narrowing must not apply"
+        );
+    }
+
+    /// Same soundness gate for unconditional terminators: the instruction at
+    /// `end_addr` is not the real/only successor, so narrowing must not apply.
+    #[test]
+    fn live_out_for_optimization_prefix_does_not_narrow_with_unconditional_terminator() {
+        let prefix = [Instruction::MovImm {
+            rd: Register::X0,
+            imm: 7,
+        }];
+        let cases = [
+            Instruction::B {
+                target: LabelId(0x2000),
+            },
+            Instruction::Ret { rn: Register::X30 },
+        ];
+        let dead = RegisterSet::<Register>::empty();
+        for terminator in cases {
+            let live_out =
+                live_out_for_optimization_prefix(&prefix, Some(&terminator), false, Some(&dead));
+            assert!(
+                live_out.contains(Register::X0),
+                "x0 must stay live with a {:?} terminator: narrowing must not apply",
+                terminator
+            );
+        }
+    }
+
+    #[test]
+    fn live_out_for_optimization_prefix_includes_registers_read_by_terminator() {
+        let prefix = [Instruction::MovImm {
+            rd: Register::X1,
+            imm: 1,
+        }];
+        let cases = [
+            (
+                Instruction::Cbz {
+                    rn: Register::X0,
+                    target: LabelId(0x1000),
+                },
+                Register::X0,
+            ),
+            (
+                Instruction::Tbz {
+                    rt: Register::X2,
+                    bit: 5,
+                    target: LabelId(0x1000),
+                },
+                Register::X2,
+            ),
+            (Instruction::Br { rn: Register::X16 }, Register::X16),
+            (Instruction::Ret { rn: Register::X30 }, Register::X30),
+        ];
+
+        for (terminator, source) in cases {
+            let live_out =
+                live_out_for_optimization_prefix(&prefix, Some(&terminator), false, None);
+            assert!(live_out.contains_register(Register::X1));
+            assert!(
+                live_out.contains_register(source),
+                "{:?} must keep {:?} live for the reattached terminator",
+                terminator,
+                source
+            );
+        }
+    }
+
+    #[test]
+    fn live_out_for_optimization_prefix_uses_downstream_flags_without_terminator() {
+        let prefix = [Instruction::MovImm {
+            rd: Register::X1,
+            imm: 1,
+        }];
+
+        let flags_dead = live_out_for_optimization_prefix(&prefix, None, false, None);
+        assert!(!flags_dead.flags_live());
+
+        let flags_live = live_out_for_optimization_prefix(&prefix, None, true, None);
+        assert!(flags_live.flags_live());
+    }
+
+    #[test]
+    fn live_out_for_optimization_prefix_keeps_flags_live_for_terminators() {
+        let prefix = [Instruction::MovImm {
+            rd: Register::X1,
+            imm: 1,
+        }];
+
+        let b_cond = Instruction::BCond {
+            target: LabelId(0x1000),
+            cond: Condition::EQ,
+        };
+        let live_out = live_out_for_optimization_prefix(&prefix, Some(&b_cond), false, None);
+        assert!(live_out.flags_live());
+
+        let ret = Instruction::Ret { rn: Register::X30 };
+        let live_out = live_out_for_optimization_prefix(&prefix, Some(&ret), false, None);
+        assert!(live_out.flags_live());
+    }
+
+    // ===== validate_basic_block (carried from main.rs, issue #69) =====
+
+    #[test]
+    fn validate_basic_block_accepts_empty_sequence() {
+        assert!(validate_basic_block(&[]).is_ok());
+    }
+
+    #[test]
+    fn validate_basic_block_accepts_prefix_only_no_terminator() {
+        let seq = vec![
+            Instruction::MovImm {
+                rd: Register::X0,
+                imm: 1,
+            },
+            Instruction::Add {
+                rd: Register::X1,
+                rn: Register::X0,
+                rm: Operand::Immediate(2),
+            },
+        ];
+        assert!(validate_basic_block(&seq).is_ok());
+    }
+
+    #[test]
+    fn validate_basic_block_accepts_terminator_only() {
+        let seq = vec![Instruction::Ret { rn: Register::X30 }];
+        assert!(validate_basic_block(&seq).is_ok());
+    }
+
+    #[test]
+    fn validate_basic_block_accepts_prefix_plus_terminator() {
+        let seq = vec![
+            Instruction::MovImm {
+                rd: Register::X0,
+                imm: 1,
+            },
+            Instruction::Ret { rn: Register::X30 },
+        ];
+        assert!(validate_basic_block(&seq).is_ok());
+    }
+
+    #[test]
+    fn validate_basic_block_rejects_branch_mid_block() {
+        let seq = vec![
+            Instruction::MovImm {
+                rd: Register::X0,
+                imm: 1,
+            },
+            Instruction::B {
+                target: LabelId(0x1000),
+            },
+            Instruction::Add {
+                rd: Register::X1,
+                rn: Register::X0,
+                rm: Operand::Immediate(2),
+            },
+        ];
+        let err = validate_basic_block(&seq).expect_err("branch at position 1 must be rejected");
+        assert!(
+            err.contains("position 1") && err.contains("issue #69"),
+            "unexpected error: {}",
+            err
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod aarch64_search_inputs;
 pub mod assembler;
 pub mod bench_support;
 pub mod candidate_windows;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,11 +22,11 @@ use s11::search::config::{
 };
 use s11::search::parallel::{ParallelConfig, run_parallel_search};
 use s11::search::{EnumerativeSearch, SearchAlgorithm, StochasticSearch, SymbolicSearch};
-use s11::semantics::LiveOut;
 use s11::semantics::cost::CostMetric;
 #[allow(unused_imports)]
 use s11::{
-    assembler, elf_patcher, ir, isa, parser, search, semantics, validation, x86_search_inputs,
+    aarch64_search_inputs, assembler, elf_patcher, ir, isa, parser, search, semantics, validation,
+    x86_search_inputs,
 };
 
 // --- Command Line Arguments ---
@@ -745,7 +745,7 @@ impl ElfOptimizationBackend for AArch64OptimizationBackend {
     }
 
     fn validate_window_ir(&self, ir: &[Self::Instruction]) -> Result<(), String> {
-        validate_basic_block(ir)
+        aarch64_search_inputs::validate_basic_block(ir)
     }
 
     fn optimization_context(
@@ -1612,45 +1612,6 @@ fn optimize_elf_binary_with_backend<B: ElfOptimizationBackend>(
 /// mirroring the `flags_live = if terminator.is_some() { true }` blanket. When
 /// a terminator is present we ignore `downstream_live` and keep every
 /// window-written register live.
-fn live_out_for_optimization_prefix(
-    prefix: &[Instruction],
-    terminator: Option<&Instruction>,
-    downstream_flags_live: bool,
-    downstream_live: Option<&semantics::live_out::RegisterSet<Register>>,
-) -> LiveOut {
-    // A terminator vetoes register narrowing (its other successor is unscanned).
-    let narrowing = if terminator.is_some() {
-        None
-    } else {
-        downstream_live
-    };
-
-    let mut live_registers: Vec<Register> = match narrowing {
-        // Narrow to (written ∩ proven-live). The downstream set is already a
-        // subset of the window-written registers (it is computed from exactly
-        // that candidate set), so iterating it is sufficient.
-        Some(live) => live.iter().copied().collect(),
-        // No downstream analysis (or vetoed by a terminator): keep every
-        // written register live.
-        None => prefix
-            .iter()
-            .flat_map(|instr| instr.destinations())
-            .collect(),
-    };
-
-    if let Some(terminator) = terminator {
-        live_registers.extend(terminator.source_registers());
-    }
-
-    let flags_live = if terminator.is_some() {
-        true
-    } else {
-        downstream_flags_live
-    };
-
-    LiveOut::from_registers(live_registers).with_flags(flags_live)
-}
-
 /// Shared base `SearchConfig` for the AArch64 stochastic/enumerative/hybrid/
 /// symbolic/LLM builders. Sets the fields every AArch64 algorithm configures
 /// identically — cost metric, overall and SMT solver timeouts, verbosity, and
@@ -1799,40 +1760,6 @@ fn build_x86_symbolic_search_config(
         .with_x86_same_count_code_size_allowed(same_count_code_size_allowed)
 }
 
-/// Build the AArch64 search register pool, preserving the historical X0..X7
-/// scalar policy while adding every vector register referenced by the target.
-/// A target-local vector pool avoids the 32^3 candidate explosion of enabling
-/// the entire SIMD register file for small enumerative searches.
-fn aarch64_search_registers(target: &[Instruction]) -> Vec<Register> {
-    let mut registers = vec![
-        Register::X0,
-        Register::X1,
-        Register::X2,
-        Register::X3,
-        Register::X4,
-        Register::X5,
-        Register::X6,
-        Register::X7,
-    ];
-
-    for register in target
-        .iter()
-        .flat_map(|instruction| instruction.source_registers().into_iter())
-        .chain(
-            target
-                .iter()
-                .flat_map(|instruction| instruction.destinations().into_iter()),
-        )
-        .filter(|register| register.vector().is_some())
-    {
-        if !registers.contains(&register) {
-            registers.push(register);
-        }
-    }
-    registers.sort_by_key(|register| register.sort_key());
-    registers
-}
-
 /// Run optimization using the selected algorithm.
 ///
 /// Issue #69: if `target` ends in a terminator (branch / control-flow
@@ -1859,16 +1786,14 @@ fn run_optimization(
 
     // Keep the historical scalar pool and add the target's vector registers
     // so every search backend can generate NEON candidates for NEON windows.
-    let available_registers = aarch64_search_registers(prefix);
-    let available_immediates = vec![
-        0, 1, 2, 3, 4, 5, 7, 8, 10, 15, 16, 31, 32, 63, 64, 100, 255, 256, 1000, 4095,
-    ];
+    let available_registers = aarch64_search_inputs::registers_from_target(prefix);
+    let available_immediates = aarch64_search_inputs::default_immediates();
 
     // Create live-out contract over the prefix (assume all modified registers
     // are live-out), plus any registers the fixed terminator reads after the
     // optimized prefix runs. NZCV liveness comes from the fixed terminator or
     // the known downstream fall-through context.
-    let live_out = live_out_for_optimization_prefix(
+    let live_out = aarch64_search_inputs::live_out_for_optimization_prefix(
         prefix,
         terminator,
         downstream_flags_live,
@@ -2139,25 +2064,6 @@ fn optimization_context_for_backend(
     }
 
     OptimizationContext::default()
-}
-
-/// Validate that an IR sequence forms a single basic block: at most one
-/// terminator (branch / control-flow instruction), and only at the final
-/// position. Issue #69 scope — internal branches mid-block are rejected.
-///
-/// Accepted shapes: `[]`, `[i1, ..., ik]` (no branch), `[t]` (terminator
-/// only), `[i1, ..., ik, t]` (prefix + terminator).
-fn validate_basic_block(ir: &[Instruction]) -> Result<(), String> {
-    let last_idx = ir.len().saturating_sub(1);
-    for (i, instr) in ir.iter().enumerate() {
-        if i < last_idx && instr.is_terminator() {
-            return Err(format!(
-                "Region contains a branch at position {} ({}); only single basic blocks ending in a terminator are supported (issue #69 scope)",
-                i, instr
-            ));
-        }
-    }
-    Ok(())
 }
 
 // ============================================================================
@@ -4520,107 +4426,6 @@ mod cli_helper_tests {
     }
 
     #[test]
-    fn live_out_for_optimization_prefix_narrows_to_downstream_live_regs() {
-        // Prefix writes x0 and x1.
-        let prefix = [
-            Instruction::MovImm {
-                rd: Register::X0,
-                imm: 0,
-            },
-            Instruction::MovImm {
-                rd: Register::X1,
-                imm: 0,
-            },
-        ];
-
-        // Default (no downstream analysis): both written registers stay live.
-        let default = live_out_for_optimization_prefix(&prefix, None, false, None);
-        assert!(default.contains(Register::X0));
-        assert!(default.contains(Register::X1));
-
-        // Downstream scan proved only x1 live (x0 dead): drop x0, pin x1.
-        let downstream_live = semantics::live_out::RegisterSet::from_registers(vec![Register::X1]);
-        let narrowed =
-            live_out_for_optimization_prefix(&prefix, None, false, Some(&downstream_live));
-        assert!(
-            !narrowed.contains(Register::X0),
-            "a provably-dead window register must be dropped from live-out"
-        );
-        assert!(
-            narrowed.contains(Register::X1),
-            "a downstream-live window register must stay pinned"
-        );
-    }
-
-    /// Soundness regression: a window whose held-fixed terminator is a
-    /// CONDITIONAL branch must NOT narrow window-written registers, even if the
-    /// linear fall-through suffix proved one dead. The downstream-regs scan only
-    /// follows the fall-through successor; the branch-TAKEN successor is never
-    /// inspected and may read the register's window value.
-    ///
-    /// Counterexample being guarded against:
-    ///   window:       mov x0, #7 ; b.eq TARGET
-    ///   fall-through: mov x0, #0 ; ret           (kills x0 -> scan says Dead)
-    ///   elsewhere:    TARGET: add x9, x0, #1     (READS x0 on the taken path)
-    /// If x0 were narrowed to dead, `mov x0, #7` could be deleted and the
-    /// b.eq-taken path would read a stale x0. `BCond::source_registers()` is
-    /// empty, so the terminator does not re-pin x0 either — the only correct
-    /// fix is to not narrow at all when a terminator is present.
-    #[test]
-    fn live_out_for_optimization_prefix_does_not_narrow_with_conditional_terminator() {
-        let prefix = [Instruction::MovImm {
-            rd: Register::X0,
-            imm: 7,
-        }];
-        let b_eq = Instruction::BCond {
-            target: s11::ir::LabelId(0x2000),
-            cond: s11::ir::Condition::EQ,
-        };
-
-        // The fall-through scan "proved" x0 dead (empty proven-live set).
-        let downstream_live_fall_through = semantics::live_out::RegisterSet::<Register>::empty();
-
-        let live_out = live_out_for_optimization_prefix(
-            &prefix,
-            Some(&b_eq),
-            false,
-            Some(&downstream_live_fall_through),
-        );
-
-        assert!(
-            live_out.contains(Register::X0),
-            "x0 must stay live: a conditional terminator has a branch-taken successor \
-             the fall-through scan never inspected, so register narrowing must not apply"
-        );
-    }
-
-    /// Same soundness gate for unconditional terminators: the instruction at
-    /// `end_addr` is not the real/only successor, so narrowing must not apply.
-    #[test]
-    fn live_out_for_optimization_prefix_does_not_narrow_with_unconditional_terminator() {
-        let prefix = [Instruction::MovImm {
-            rd: Register::X0,
-            imm: 7,
-        }];
-        let cases = [
-            Instruction::B {
-                target: s11::ir::LabelId(0x2000),
-            },
-            Instruction::Ret { rn: Register::X30 },
-        ];
-        let dead = semantics::live_out::RegisterSet::<Register>::empty();
-        for terminator in cases {
-            let live_out =
-                live_out_for_optimization_prefix(&prefix, Some(&terminator), false, Some(&dead));
-            assert!(
-                live_out.contains(Register::X0),
-                "x0 must stay live with a {:?} terminator: narrowing must not apply",
-                terminator
-            );
-        }
-    }
-
-    #[test]
     fn x86_symbolic_code_size_preserves_downstream_flags_live() {
         let mut opts = options_for(Algorithm::Symbolic);
         opts.timeout = Some(Duration::from_secs(5));
@@ -5213,36 +5018,6 @@ mod cli_helper_tests {
         assert_eq!(config.cores, SearchConfig::default().cores);
     }
 
-    #[test]
-    fn aarch64_search_registers_include_vectors_used_by_target() {
-        let target = [
-            Instruction::VectorAdd {
-                vd: ir::VectorRegister::V0,
-                vn: ir::VectorRegister::V1,
-                vm: ir::VectorRegister::V2,
-                arrangement: ir::VectorArrangement::TwoD,
-            },
-            Instruction::MovFromVectorLane {
-                rd: Register::X0,
-                vn: ir::VectorRegister::V0,
-                lane: 0,
-            },
-        ];
-
-        let registers = aarch64_search_registers(&target);
-
-        assert!(registers.contains(&Register::Vector(ir::VectorRegister::V0)));
-        assert!(registers.contains(&Register::Vector(ir::VectorRegister::V1)));
-        assert!(registers.contains(&Register::Vector(ir::VectorRegister::V2)));
-        assert_eq!(
-            registers
-                .iter()
-                .filter(|reg| reg.vector().is_some())
-                .count(),
-            3
-        );
-    }
-
     /// Regression for issue #243, generalised: every AArch64 algorithm builder
     /// must propagate the shared base fields (`--timeout`, `--solver-timeout`,
     /// cost metric, verbosity, register/immediate pools) identically. They all
@@ -5526,47 +5301,6 @@ mod cli_helper_tests {
         run_llm_opt(llm_asm.path(), "x0", 0, "test-model", 0, true).unwrap();
     }
 
-    // ===== Issue #69: validate_basic_block =====
-
-    #[test]
-    fn validate_basic_block_accepts_empty_sequence() {
-        assert!(validate_basic_block(&[]).is_ok());
-    }
-
-    #[test]
-    fn validate_basic_block_accepts_prefix_only_no_terminator() {
-        let seq = vec![
-            Instruction::MovImm {
-                rd: Register::X0,
-                imm: 1,
-            },
-            Instruction::Add {
-                rd: Register::X1,
-                rn: Register::X0,
-                rm: Operand::Immediate(2),
-            },
-        ];
-        assert!(validate_basic_block(&seq).is_ok());
-    }
-
-    #[test]
-    fn validate_basic_block_accepts_terminator_only() {
-        let seq = vec![Instruction::Ret { rn: Register::X30 }];
-        assert!(validate_basic_block(&seq).is_ok());
-    }
-
-    #[test]
-    fn validate_basic_block_accepts_prefix_plus_terminator() {
-        let seq = vec![
-            Instruction::MovImm {
-                rd: Register::X0,
-                imm: 1,
-            },
-            Instruction::Ret { rn: Register::X30 },
-        ];
-        assert!(validate_basic_block(&seq).is_ok());
-    }
-
     #[test]
     fn split_terminator_returns_full_slice_when_no_terminator() {
         let seq = vec![Instruction::MovImm {
@@ -5590,78 +5324,6 @@ mod cli_helper_tests {
         let (prefix, term) = split_terminator(&seq);
         assert_eq!(prefix.len(), 1);
         assert_eq!(term, Some(&Instruction::Ret { rn: Register::X30 }));
-    }
-
-    #[test]
-    fn live_out_for_optimization_prefix_includes_registers_read_by_terminator() {
-        let prefix = [Instruction::MovImm {
-            rd: Register::X1,
-            imm: 1,
-        }];
-        let cases = [
-            (
-                Instruction::Cbz {
-                    rn: Register::X0,
-                    target: s11::ir::LabelId(0x1000),
-                },
-                Register::X0,
-            ),
-            (
-                Instruction::Tbz {
-                    rt: Register::X2,
-                    bit: 5,
-                    target: s11::ir::LabelId(0x1000),
-                },
-                Register::X2,
-            ),
-            (Instruction::Br { rn: Register::X16 }, Register::X16),
-            (Instruction::Ret { rn: Register::X30 }, Register::X30),
-        ];
-
-        for (terminator, source) in cases {
-            let live_out =
-                live_out_for_optimization_prefix(&prefix, Some(&terminator), false, None);
-            assert!(live_out.contains_register(Register::X1));
-            assert!(
-                live_out.contains_register(source),
-                "{:?} must keep {:?} live for the reattached terminator",
-                terminator,
-                source
-            );
-        }
-    }
-
-    #[test]
-    fn live_out_for_optimization_prefix_uses_downstream_flags_without_terminator() {
-        let prefix = [Instruction::MovImm {
-            rd: Register::X1,
-            imm: 1,
-        }];
-
-        let flags_dead = live_out_for_optimization_prefix(&prefix, None, false, None);
-        assert!(!flags_dead.flags_live());
-
-        let flags_live = live_out_for_optimization_prefix(&prefix, None, true, None);
-        assert!(flags_live.flags_live());
-    }
-
-    #[test]
-    fn live_out_for_optimization_prefix_keeps_flags_live_for_terminators() {
-        let prefix = [Instruction::MovImm {
-            rd: Register::X1,
-            imm: 1,
-        }];
-
-        let b_cond = Instruction::BCond {
-            target: s11::ir::LabelId(0x1000),
-            cond: s11::ir::Condition::EQ,
-        };
-        let live_out = live_out_for_optimization_prefix(&prefix, Some(&b_cond), false, None);
-        assert!(live_out.flags_live());
-
-        let ret = Instruction::Ret { rn: Register::X30 };
-        let live_out = live_out_for_optimization_prefix(&prefix, Some(&ret), false, None);
-        assert!(live_out.flags_live());
     }
 
     // (The standalone `find_shorter_equivalent_preserves_terminator_bit_identical`
@@ -5736,7 +5398,8 @@ mod cli_helper_tests {
         let (prefix, term) = split_terminator(&seq);
         assert_eq!(term, Some(&terminator), "split must recognize ret");
 
-        let live_out = live_out_for_optimization_prefix(prefix, term, true, None);
+        let live_out =
+            aarch64_search_inputs::live_out_for_optimization_prefix(prefix, term, true, None);
         let config = SearchConfig::default()
             .with_registers(vec![Register::X0, Register::X1])
             .with_immediates(vec![0, 1]);
@@ -5800,7 +5463,8 @@ mod cli_helper_tests {
         ];
 
         let (prefix, term) = split_terminator(&target);
-        let live_out = live_out_for_optimization_prefix(prefix, term, true, None);
+        let live_out =
+            aarch64_search_inputs::live_out_for_optimization_prefix(prefix, term, true, None);
         assert!(
             live_out.contains_register(Register::X0),
             "live_out_for_optimization_prefix must mark x0 live when the \
@@ -5818,30 +5482,6 @@ mod cli_helper_tests {
             "candidate that clobbers x0 must be rejected because the \
              reattached cbz reads x0; got {:?}",
             result,
-        );
-    }
-
-    #[test]
-    fn validate_basic_block_rejects_branch_mid_block() {
-        let seq = vec![
-            Instruction::MovImm {
-                rd: Register::X0,
-                imm: 1,
-            },
-            Instruction::B {
-                target: s11::ir::LabelId(0x1000),
-            },
-            Instruction::Add {
-                rd: Register::X1,
-                rn: Register::X0,
-                rm: Operand::Immediate(2),
-            },
-        ];
-        let err = validate_basic_block(&seq).expect_err("branch at position 1 must be rejected");
-        assert!(
-            err.contains("position 1") && err.contains("issue #69"),
-            "unexpected error: {}",
-            err
         );
     }
 


### PR DESCRIPTION
## Goal

Deepen the `main.rs` binary driver by lifting the four **pure** AArch64 per-window *search input* rules into a dedicated library seam, `src/aarch64_search_inputs.rs`. This is the AArch64 twin of `src/x86_search_inputs.rs`, extracted for the x86 path two commits ago in #752 — that module's docs already name "the AArch64 builder" as a sibling seam that did not yet exist. This closes that parity gap.

The driver becomes a thin adapter that calls the seam; each rule is now a fixture-free unit test instead of requiring a whole search to exercise.

## Why this refactoring (candidates considered)

Audit followed the `improve-codebase-architecture` skill, scoped to the recent hot spots (`main.rs` led with 13 of the last 80 commits). Four candidates were assessed with `Explore` sub-agents against the deep-module *deletion test*:

| Candidate | Verdict | Why |
|---|---|---|
| **`main.rs` AArch64 search inputs** ✅ | **Strong** | Pure functions (library-in/library-out) buried in a 6136-line binary; direct precedent (#752); untested immediate pool; restores AArch64/x86 parity; hot-spot file where deepening pays off most. Mostly code motion + visibility → low risk. |
| `isa/x86.rs` encodability predicates | Worth exploring | Real seam (`x86_can_assemble_instruction` + `mode_width` predicates, ~41 refs) but no precedent to mirror and a broad, hot correctness path → higher blast radius. Good *next* step. |
| `assembler/mod.rs` | Speculative | Already deep; pure decision logic already lifted to free functions. Only a mechanical test-file split remains. |
| `ir/instructions.rs` | Speculative | Already deep; pure computations already seam-extracted and covered. Only cosmetic file-splitting remains. |

## What changed

Moved **verbatim** (name/visibility/doc only — behavior byte-identical) from `main.rs` into the new module:

- `registers_from_target` (was `aarch64_search_registers`) — the Candidate register pool (X0..X7 scalar seed + the target's vector registers).
- `live_out_for_optimization_prefix` — the per-window Live-out contract, including the held-fixed-terminator veto on register narrowing.
- `validate_basic_block` — the issue-#69 admissibility gate (single basic block, terminator only at the end).

Plus **`default_immediates()`**, which names and tests the fixed AArch64 immediate pool that was previously an untested literal inline in `run_optimization`.

`main.rs` shrinks by ~359 lines net; the `build_*_search_config` builders **stay** in `main.rs` because they depend on the binary-private `OptimizationOptions` — the same boundary #752 drew for the x86 builders. This is one step in an ongoing sequence of driver extractions, not a wholesale fix of `main.rs`.

## Tests (TDD)

Built test-first via the `tdd` skill. Because the interactive "confirm seams" step is unavailable in an autonomous run, the **seams under test** are stated here: the four public functions of `aarch64_search_inputs`, exercised purely through library types (no CLI/ELF/Capstone).

- **Genuine red→green slices (new coverage):**
  - `default_immediates_is_the_fixed_search_pool` — the pool had **zero** tests before.
  - `registers_from_target_seeds_scalar_x0_through_x7_sorted` — pins the X0..X7 base + `sort_key` ordering; only the vector case was covered before.
- **Carry-over (behavior-preservation):** the 12 existing unit tests for these functions moved with them. In Rust these "go red" only as compile errors and pass on first implementation — that is behavior preservation, not red-green, and is called out honestly here.
- Two integration tests in `main.rs` (`issue_69_acceptance_find_shorter_preserves_terminator`, `equivalence_rejects_prefix_candidate_that_clobbers_cbz_source`) now call the namespaced seam and continue to pass.

## Verification

- `./ci_check.sh` — all green (fmt, build, cross-compiled test binaries, `cargo test`, `test_all.sh`).
- `cargo test`: lib **1651 passed**, bin **105 passed**, integration **62 passed**, 0 failures.
- `cargo clippy --all-targets` — clean.