### PR TITLE
refactor(driver): extract AArch64 window search inputs into a pure tested seam

### DIFF
--- a/src/aarch64_search_inputs.rs
+++ b/src/aarch64_search_inputs.rs
@@ -1,0 +1,411 @@
+//! Search inputs for a single AArch64 optimization window.
+//!
+//! [`candidate_windows`](crate::candidate_windows) *selects* which address
+//! ranges of a binary are rewritable. This module answers the next question for
+//! one already-selected AArch64 window: given its Target (the window's
+//! instructions) and the downstream liveness scan, what does the search see, and
+//! is the window even admissible? Three pure functions make up that seam:
+//!
+//! * [`aarch64_search_registers`] — the Candidate register pool the search may
+//!   write (the base general-purpose set plus every vector register the Target
+//!   already names).
+//! * [`live_out_for_optimization_prefix`] — the per-window Live-out contract,
+//!   including the terminator soundness veto on register narrowing.
+//! * [`validate_basic_block`] — the admissibility gate that rejects a window the
+//!   optimizer cannot soundly rewrite (a branch anywhere but the final slot,
+//!   issue #69 scope).
+//!
+//! These rules used to live inline in `run_optimization` and the AArch64 backend
+//! in the binary's `main.rs`, interleaved with CLI parsing, ELF I/O, and
+//! Capstone bridging — a shallow arrangement where the only way to exercise
+//! "a held-fixed terminator vetoes narrowing" or "a mid-block branch is
+//! rejected" was to drive a whole search. Lifting them into a **pure seam**
+//! (library types in, library types out; no CLI, ELF, or Capstone) makes each
+//! rule a fixture-free unit test and keeps the driver a thin adapter. This is
+//! the AArch64 mirror of [`x86_search_inputs`](crate::x86_search_inputs); see
+//! the `CONTEXT.md` glossary for the domain terms (Target, Candidate, Live-out).
+
+use crate::ir::{Instruction, Register};
+use crate::semantics::LiveOut;
+use crate::semantics::live_out::RegisterSet;
+
+/// The Live-out contract for an AArch64 optimization window.
+///
+/// A held-fixed terminator vetoes register narrowing: its other successor is
+/// never scanned, so a register the fall-through path proved dead may still be
+/// read on the taken path. Without a terminator, an available downstream-live
+/// set narrows live-out to (written ∩ proven-live); otherwise every
+/// window-written register stays live. A terminator's own source registers are
+/// always re-pinned so it can be reattached bit-identically, and a terminator
+/// keeps NZCV live for the same reason.
+pub fn live_out_for_optimization_prefix(
+    prefix: &[Instruction],
+    terminator: Option<&Instruction>,
+    downstream_flags_live: bool,
+    downstream_live: Option<&RegisterSet<Register>>,
+) -> LiveOut {
+    // A terminator vetoes register narrowing (its other successor is unscanned).
+    let narrowing = if terminator.is_some() {
+        None
+    } else {
+        downstream_live
+    };
+
+    let mut live_registers: Vec<Register> = match narrowing {
+        // Narrow to (written ∩ proven-live). The downstream set is already a
+        // subset of the window-written registers (it is computed from exactly
+        // that candidate set), so iterating it is sufficient.
+        Some(live) => live.iter().copied().collect(),
+        // No downstream analysis (or vetoed by a terminator): keep every
+        // written register live.
+        None => prefix
+            .iter()
+            .flat_map(|instr| instr.destinations())
+            .collect(),
+    };
+
+    if let Some(terminator) = terminator {
+        live_registers.extend(terminator.source_registers());
+    }
+
+    let flags_live = if terminator.is_some() {
+        true
+    } else {
+        downstream_flags_live
+    };
+
+    LiveOut::from_registers(live_registers).with_flags(flags_live)
+}
+
+/// The Candidate register pool AArch64 search may write for `target`.
+///
+/// The base general-purpose set (x0..x7) is always available; every vector
+/// register the Target already reads or writes joins the pool so a rewrite can
+/// reuse it. The pool is sorted for deterministic search behaviour.
+pub fn aarch64_search_registers(target: &[Instruction]) -> Vec<Register> {
+    let mut registers = vec![
+        Register::X0,
+        Register::X1,
+        Register::X2,
+        Register::X3,
+        Register::X4,
+        Register::X5,
+        Register::X6,
+        Register::X7,
+    ];
+
+    for register in target
+        .iter()
+        .flat_map(|instruction| instruction.source_registers().into_iter())
+        .chain(
+            target
+                .iter()
+                .flat_map(|instruction| instruction.destinations().into_iter()),
+        )
+        .filter(|register| register.vector().is_some())
+    {
+        if !registers.contains(&register) {
+            registers.push(register);
+        }
+    }
+    registers.sort_by_key(|register| register.sort_key());
+    registers
+}
+
+/// Reject any window that is not a single basic block ending in a terminator.
+///
+/// Issue #69 only supports rewriting the straight-line prefix of a window whose
+/// sole control-flow instruction (if any) is its last: a branch anywhere else
+/// would be modelled as a data-state no-op and the equivalence check could
+/// accept a rewrite that silently drops or reorders the branch.
+pub fn validate_basic_block(ir: &[Instruction]) -> Result<(), String> {
+    let last_idx = ir.len().saturating_sub(1);
+    for (i, instr) in ir.iter().enumerate() {
+        if i < last_idx && instr.is_terminator() {
+            return Err(format!(
+                "Region contains a branch at position {} ({}); only single basic blocks ending in a terminator are supported (issue #69 scope)",
+                i, instr
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::{self, Operand};
+    use crate::semantics;
+
+    // ===== Issue #69: validate_basic_block =====
+
+    #[test]
+    fn validate_basic_block_accepts_empty_sequence() {
+        assert!(validate_basic_block(&[]).is_ok());
+    }
+
+    #[test]
+    fn validate_basic_block_accepts_prefix_only_no_terminator() {
+        let seq = vec![
+            Instruction::MovImm {
+                rd: Register::X0,
+                imm: 1,
+            },
+            Instruction::Add {
+                rd: Register::X1,
+                rn: Register::X0,
+                rm: Operand::Immediate(2),
+            },
+        ];
+        assert!(validate_basic_block(&seq).is_ok());
+    }
+
+    #[test]
+    fn validate_basic_block_accepts_terminator_only() {
+        let seq = vec![Instruction::Ret { rn: Register::X30 }];
+        assert!(validate_basic_block(&seq).is_ok());
+    }
+
+    #[test]
+    fn validate_basic_block_accepts_prefix_plus_terminator() {
+        let seq = vec![
+            Instruction::MovImm {
+                rd: Register::X0,
+                imm: 1,
+            },
+            Instruction::Ret { rn: Register::X30 },
+        ];
+        assert!(validate_basic_block(&seq).is_ok());
+    }
+
+    #[test]
+    fn validate_basic_block_rejects_branch_mid_block() {
+        let seq = vec![
+            Instruction::MovImm {
+                rd: Register::X0,
+                imm: 1,
+            },
+            Instruction::B {
+                target: ir::LabelId(0x1000),
+            },
+            Instruction::Add {
+                rd: Register::X1,
+                rn: Register::X0,
+                rm: Operand::Immediate(2),
+            },
+        ];
+        let err = validate_basic_block(&seq).expect_err("branch at position 1 must be rejected");
+        assert!(
+            err.contains("position 1") && err.contains("issue #69"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    // ===== aarch64_search_registers =====
+
+    #[test]
+    fn aarch64_search_registers_include_vectors_used_by_target() {
+        let target = [
+            Instruction::VectorAdd {
+                vd: ir::VectorRegister::V0,
+                vn: ir::VectorRegister::V1,
+                vm: ir::VectorRegister::V2,
+                arrangement: ir::VectorArrangement::TwoD,
+            },
+            Instruction::MovFromVectorLane {
+                rd: Register::X0,
+                vn: ir::VectorRegister::V0,
+                lane: 0,
+            },
+        ];
+
+        let registers = aarch64_search_registers(&target);
+
+        assert!(registers.contains(&Register::Vector(ir::VectorRegister::V0)));
+        assert!(registers.contains(&Register::Vector(ir::VectorRegister::V1)));
+        assert!(registers.contains(&Register::Vector(ir::VectorRegister::V2)));
+        assert_eq!(
+            registers
+                .iter()
+                .filter(|reg| reg.vector().is_some())
+                .count(),
+            3
+        );
+    }
+
+    // ===== live_out_for_optimization_prefix =====
+
+    #[test]
+    fn live_out_for_optimization_prefix_narrows_to_downstream_live_regs() {
+        // Prefix writes x0 and x1.
+        let prefix = [
+            Instruction::MovImm {
+                rd: Register::X0,
+                imm: 0,
+            },
+            Instruction::MovImm {
+                rd: Register::X1,
+                imm: 0,
+            },
+        ];
+
+        // Default (no downstream analysis): both written registers stay live.
+        let default = live_out_for_optimization_prefix(&prefix, None, false, None);
+        assert!(default.contains(Register::X0));
+        assert!(default.contains(Register::X1));
+
+        // Downstream scan proved only x1 live (x0 dead): drop x0, pin x1.
+        let downstream_live = semantics::live_out::RegisterSet::from_registers(vec![Register::X1]);
+        let narrowed =
+            live_out_for_optimization_prefix(&prefix, None, false, Some(&downstream_live));
+        assert!(
+            !narrowed.contains(Register::X0),
+            "a provably-dead window register must be dropped from live-out"
+        );
+        assert!(
+            narrowed.contains(Register::X1),
+            "a downstream-live window register must stay pinned"
+        );
+    }
+
+    /// Soundness regression: a window whose held-fixed terminator is a
+    /// CONDITIONAL branch must NOT narrow window-written registers, even if the
+    /// linear fall-through suffix proved one dead. The downstream-regs scan only
+    /// follows the fall-through successor; the branch-TAKEN successor is never
+    /// inspected and may read the register's window value.
+    ///
+    /// Counterexample being guarded against:
+    ///   window:       mov x0, #7 ; b.eq TARGET
+    ///   fall-through: mov x0, #0 ; ret           (kills x0 -> scan says Dead)
+    ///   elsewhere:    TARGET: add x9, x0, #1     (READS x0 on the taken path)
+    /// If x0 were narrowed to dead, `mov x0, #7` could be deleted and the
+    /// b.eq-taken path would read a stale x0. `BCond::source_registers()` is
+    /// empty, so the terminator does not re-pin x0 either — the only correct
+    /// fix is to not narrow at all when a terminator is present.
+    #[test]
+    fn live_out_for_optimization_prefix_does_not_narrow_with_conditional_terminator() {
+        let prefix = [Instruction::MovImm {
+            rd: Register::X0,
+            imm: 7,
+        }];
+        let b_eq = Instruction::BCond {
+            target: ir::LabelId(0x2000),
+            cond: ir::Condition::EQ,
+        };
+
+        // The fall-through scan "proved" x0 dead (empty proven-live set).
+        let downstream_live_fall_through = semantics::live_out::RegisterSet::<Register>::empty();
+
+        let live_out = live_out_for_optimization_prefix(
+            &prefix,
+            Some(&b_eq),
+            false,
+            Some(&downstream_live_fall_through),
+        );
+
+        assert!(
+            live_out.contains(Register::X0),
+            "x0 must stay live: a conditional terminator has a branch-taken successor \
+             the fall-through scan never inspected, so register narrowing must not apply"
+        );
+    }
+
+    /// Same soundness gate for unconditional terminators: the instruction at
+    /// `end_addr` is not the real/only successor, so narrowing must not apply.
+    #[test]
+    fn live_out_for_optimization_prefix_does_not_narrow_with_unconditional_terminator() {
+        let prefix = [Instruction::MovImm {
+            rd: Register::X0,
+            imm: 7,
+        }];
+        let cases = [
+            Instruction::B {
+                target: ir::LabelId(0x2000),
+            },
+            Instruction::Ret { rn: Register::X30 },
+        ];
+        let dead = semantics::live_out::RegisterSet::<Register>::empty();
+        for terminator in cases {
+            let live_out =
+                live_out_for_optimization_prefix(&prefix, Some(&terminator), false, Some(&dead));
+            assert!(
+                live_out.contains(Register::X0),
+                "x0 must stay live with a {:?} terminator: narrowing must not apply",
+                terminator
+            );
+        }
+    }
+
+    #[test]
+    fn live_out_for_optimization_prefix_includes_registers_read_by_terminator() {
+        let prefix = [Instruction::MovImm {
+            rd: Register::X1,
+            imm: 1,
+        }];
+        let cases = [
+            (
+                Instruction::Cbz {
+                    rn: Register::X0,
+                    target: ir::LabelId(0x1000),
+                },
+                Register::X0,
+            ),
+            (
+                Instruction::Tbz {
+                    rt: Register::X2,
+                    bit: 5,
+                    target: ir::LabelId(0x1000),
+                },
+                Register::X2,
+            ),
+            (Instruction::Br { rn: Register::X16 }, Register::X16),
+            (Instruction::Ret { rn: Register::X30 }, Register::X30),
+        ];
+
+        for (terminator, source) in cases {
+            let live_out =
+                live_out_for_optimization_prefix(&prefix, Some(&terminator), false, None);
+            assert!(live_out.contains_register(Register::X1));
+            assert!(
+                live_out.contains_register(source),
+                "{:?} must keep {:?} live for the reattached terminator",
+                terminator,
+                source
+            );
+        }
+    }
+
+    #[test]
+    fn live_out_for_optimization_prefix_uses_downstream_flags_without_terminator() {
+        let prefix = [Instruction::MovImm {
+            rd: Register::X1,
+            imm: 1,
+        }];
+
+        let flags_dead = live_out_for_optimization_prefix(&prefix, None, false, None);
+        assert!(!flags_dead.flags_live());
+
+        let flags_live = live_out_for_optimization_prefix(&prefix, None, true, None);
+        assert!(flags_live.flags_live());
+    }
+
+    #[test]
+    fn live_out_for_optimization_prefix_keeps_flags_live_for_terminators() {
+        let prefix = [Instruction::MovImm {
+            rd: Register::X1,
+            imm: 1,
+        }];
+
+        let b_cond = Instruction::BCond {
+            target: ir::LabelId(0x1000),
+            cond: ir::Condition::EQ,
+        };
+        let live_out = live_out_for_optimization_prefix(&prefix, Some(&b_cond), false, None);
+        assert!(live_out.flags_live());
+
+        let ret = Instruction::Ret { rn: Register::X30 };
+        let live_out = live_out_for_optimization_prefix(&prefix, Some(&ret), false, None);
+        assert!(live_out.flags_live());
+    }
+}

--- a/src/aarch64_search_inputs.rs
+++ b/src/aarch64_search_inputs.rs
@@ -118,6 +118,9 @@ pub fn aarch64_search_registers(target: &[Instruction]) -> Vec<Register> {
 /// sole control-flow instruction (if any) is its last: a branch anywhere else
 /// would be modelled as a data-state no-op and the equivalence check could
 /// accept a rewrite that silently drops or reorders the branch.
+///
+/// Accepted shapes: `[]`, `[i1, ..., ik]` (no branch), `[t]` (terminator
+/// only), `[i1, ..., ik, t]` (prefix + terminator).
 pub fn validate_basic_block(ir: &[Instruction]) -> Result<(), String> {
     let last_idx = ir.len().saturating_sub(1);
     for (i, instr) in ir.iter().enumerate() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod aarch64_search_inputs;
 pub mod assembler;
 pub mod bench_support;
 pub mod candidate_windows;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,9 @@ use std::time::Duration;
 #[path = "test_utils.rs"]
 mod test_utils;
 
+use s11::aarch64_search_inputs::{
+    aarch64_search_registers, live_out_for_optimization_prefix, validate_basic_block,
+};
 use s11::assembler::AArch64Assembler;
 use s11::candidate_windows::{WindowInstruction, WindowRole, plan_candidate_windows};
 use s11::capstone_bridge::{ConvertOutcome, convert_capstone_op};
@@ -22,7 +25,6 @@ use s11::search::config::{
 };
 use s11::search::parallel::{ParallelConfig, run_parallel_search};
 use s11::search::{EnumerativeSearch, SearchAlgorithm, StochasticSearch, SymbolicSearch};
-use s11::semantics::LiveOut;
 use s11::semantics::cost::CostMetric;
 #[allow(unused_imports)]
 use s11::{
@@ -1612,45 +1614,6 @@ fn optimize_elf_binary_with_backend<B: ElfOptimizationBackend>(
 /// mirroring the `flags_live = if terminator.is_some() { true }` blanket. When
 /// a terminator is present we ignore `downstream_live` and keep every
 /// window-written register live.
-fn live_out_for_optimization_prefix(
-    prefix: &[Instruction],
-    terminator: Option<&Instruction>,
-    downstream_flags_live: bool,
-    downstream_live: Option<&semantics::live_out::RegisterSet<Register>>,
-) -> LiveOut {
-    // A terminator vetoes register narrowing (its other successor is unscanned).
-    let narrowing = if terminator.is_some() {
-        None
-    } else {
-        downstream_live
-    };
-
-    let mut live_registers: Vec<Register> = match narrowing {
-        // Narrow to (written ∩ proven-live). The downstream set is already a
-        // subset of the window-written registers (it is computed from exactly
-        // that candidate set), so iterating it is sufficient.
-        Some(live) => live.iter().copied().collect(),
-        // No downstream analysis (or vetoed by a terminator): keep every
-        // written register live.
-        None => prefix
-            .iter()
-            .flat_map(|instr| instr.destinations())
-            .collect(),
-    };
-
-    if let Some(terminator) = terminator {
-        live_registers.extend(terminator.source_registers());
-    }
-
-    let flags_live = if terminator.is_some() {
-        true
-    } else {
-        downstream_flags_live
-    };
-
-    LiveOut::from_registers(live_registers).with_flags(flags_live)
-}
-
 /// Shared base `SearchConfig` for the AArch64 stochastic/enumerative/hybrid/
 /// symbolic/LLM builders. Sets the fields every AArch64 algorithm configures
 /// identically — cost metric, overall and SMT solver timeouts, verbosity, and
@@ -1803,36 +1766,6 @@ fn build_x86_symbolic_search_config(
 /// scalar policy while adding every vector register referenced by the target.
 /// A target-local vector pool avoids the 32^3 candidate explosion of enabling
 /// the entire SIMD register file for small enumerative searches.
-fn aarch64_search_registers(target: &[Instruction]) -> Vec<Register> {
-    let mut registers = vec![
-        Register::X0,
-        Register::X1,
-        Register::X2,
-        Register::X3,
-        Register::X4,
-        Register::X5,
-        Register::X6,
-        Register::X7,
-    ];
-
-    for register in target
-        .iter()
-        .flat_map(|instruction| instruction.source_registers().into_iter())
-        .chain(
-            target
-                .iter()
-                .flat_map(|instruction| instruction.destinations().into_iter()),
-        )
-        .filter(|register| register.vector().is_some())
-    {
-        if !registers.contains(&register) {
-            registers.push(register);
-        }
-    }
-    registers.sort_by_key(|register| register.sort_key());
-    registers
-}
-
 /// Run optimization using the selected algorithm.
 ///
 /// Issue #69: if `target` ends in a terminator (branch / control-flow
@@ -2139,25 +2072,6 @@ fn optimization_context_for_backend(
     }
 
     OptimizationContext::default()
-}
-
-/// Validate that an IR sequence forms a single basic block: at most one
-/// terminator (branch / control-flow instruction), and only at the final
-/// position. Issue #69 scope — internal branches mid-block are rejected.
-///
-/// Accepted shapes: `[]`, `[i1, ..., ik]` (no branch), `[t]` (terminator
-/// only), `[i1, ..., ik, t]` (prefix + terminator).
-fn validate_basic_block(ir: &[Instruction]) -> Result<(), String> {
-    let last_idx = ir.len().saturating_sub(1);
-    for (i, instr) in ir.iter().enumerate() {
-        if i < last_idx && instr.is_terminator() {
-            return Err(format!(
-                "Region contains a branch at position {} ({}); only single basic blocks ending in a terminator are supported (issue #69 scope)",
-                i, instr
-            ));
-        }
-    }
-    Ok(())
 }
 
 // ============================================================================
@@ -4520,107 +4434,6 @@ mod cli_helper_tests {
     }
 
     #[test]
-    fn live_out_for_optimization_prefix_narrows_to_downstream_live_regs() {
-        // Prefix writes x0 and x1.
-        let prefix = [
-            Instruction::MovImm {
-                rd: Register::X0,
-                imm: 0,
-            },
-            Instruction::MovImm {
-                rd: Register::X1,
-                imm: 0,
-            },
-        ];
-
-        // Default (no downstream analysis): both written registers stay live.
-        let default = live_out_for_optimization_prefix(&prefix, None, false, None);
-        assert!(default.contains(Register::X0));
-        assert!(default.contains(Register::X1));
-
-        // Downstream scan proved only x1 live (x0 dead): drop x0, pin x1.
-        let downstream_live = semantics::live_out::RegisterSet::from_registers(vec![Register::X1]);
-        let narrowed =
-            live_out_for_optimization_prefix(&prefix, None, false, Some(&downstream_live));
-        assert!(
-            !narrowed.contains(Register::X0),
-            "a provably-dead window register must be dropped from live-out"
-        );
-        assert!(
-            narrowed.contains(Register::X1),
-            "a downstream-live window register must stay pinned"
-        );
-    }
-
-    /// Soundness regression: a window whose held-fixed terminator is a
-    /// CONDITIONAL branch must NOT narrow window-written registers, even if the
-    /// linear fall-through suffix proved one dead. The downstream-regs scan only
-    /// follows the fall-through successor; the branch-TAKEN successor is never
-    /// inspected and may read the register's window value.
-    ///
-    /// Counterexample being guarded against:
-    ///   window:       mov x0, #7 ; b.eq TARGET
-    ///   fall-through: mov x0, #0 ; ret           (kills x0 -> scan says Dead)
-    ///   elsewhere:    TARGET: add x9, x0, #1     (READS x0 on the taken path)
-    /// If x0 were narrowed to dead, `mov x0, #7` could be deleted and the
-    /// b.eq-taken path would read a stale x0. `BCond::source_registers()` is
-    /// empty, so the terminator does not re-pin x0 either — the only correct
-    /// fix is to not narrow at all when a terminator is present.
-    #[test]
-    fn live_out_for_optimization_prefix_does_not_narrow_with_conditional_terminator() {
-        let prefix = [Instruction::MovImm {
-            rd: Register::X0,
-            imm: 7,
-        }];
-        let b_eq = Instruction::BCond {
-            target: s11::ir::LabelId(0x2000),
-            cond: s11::ir::Condition::EQ,
-        };
-
-        // The fall-through scan "proved" x0 dead (empty proven-live set).
-        let downstream_live_fall_through = semantics::live_out::RegisterSet::<Register>::empty();
-
-        let live_out = live_out_for_optimization_prefix(
-            &prefix,
-            Some(&b_eq),
-            false,
-            Some(&downstream_live_fall_through),
-        );
-
-        assert!(
-            live_out.contains(Register::X0),
-            "x0 must stay live: a conditional terminator has a branch-taken successor \
-             the fall-through scan never inspected, so register narrowing must not apply"
-        );
-    }
-
-    /// Same soundness gate for unconditional terminators: the instruction at
-    /// `end_addr` is not the real/only successor, so narrowing must not apply.
-    #[test]
-    fn live_out_for_optimization_prefix_does_not_narrow_with_unconditional_terminator() {
-        let prefix = [Instruction::MovImm {
-            rd: Register::X0,
-            imm: 7,
-        }];
-        let cases = [
-            Instruction::B {
-                target: s11::ir::LabelId(0x2000),
-            },
-            Instruction::Ret { rn: Register::X30 },
-        ];
-        let dead = semantics::live_out::RegisterSet::<Register>::empty();
-        for terminator in cases {
-            let live_out =
-                live_out_for_optimization_prefix(&prefix, Some(&terminator), false, Some(&dead));
-            assert!(
-                live_out.contains(Register::X0),
-                "x0 must stay live with a {:?} terminator: narrowing must not apply",
-                terminator
-            );
-        }
-    }
-
-    #[test]
     fn x86_symbolic_code_size_preserves_downstream_flags_live() {
         let mut opts = options_for(Algorithm::Symbolic);
         opts.timeout = Some(Duration::from_secs(5));
@@ -5213,36 +5026,6 @@ mod cli_helper_tests {
         assert_eq!(config.cores, SearchConfig::default().cores);
     }
 
-    #[test]
-    fn aarch64_search_registers_include_vectors_used_by_target() {
-        let target = [
-            Instruction::VectorAdd {
-                vd: ir::VectorRegister::V0,
-                vn: ir::VectorRegister::V1,
-                vm: ir::VectorRegister::V2,
-                arrangement: ir::VectorArrangement::TwoD,
-            },
-            Instruction::MovFromVectorLane {
-                rd: Register::X0,
-                vn: ir::VectorRegister::V0,
-                lane: 0,
-            },
-        ];
-
-        let registers = aarch64_search_registers(&target);
-
-        assert!(registers.contains(&Register::Vector(ir::VectorRegister::V0)));
-        assert!(registers.contains(&Register::Vector(ir::VectorRegister::V1)));
-        assert!(registers.contains(&Register::Vector(ir::VectorRegister::V2)));
-        assert_eq!(
-            registers
-                .iter()
-                .filter(|reg| reg.vector().is_some())
-                .count(),
-            3
-        );
-    }
-
     /// Regression for issue #243, generalised: every AArch64 algorithm builder
     /// must propagate the shared base fields (`--timeout`, `--solver-timeout`,
     /// cost metric, verbosity, register/immediate pools) identically. They all
@@ -5526,47 +5309,6 @@ mod cli_helper_tests {
         run_llm_opt(llm_asm.path(), "x0", 0, "test-model", 0, true).unwrap();
     }
 
-    // ===== Issue #69: validate_basic_block =====
-
-    #[test]
-    fn validate_basic_block_accepts_empty_sequence() {
-        assert!(validate_basic_block(&[]).is_ok());
-    }
-
-    #[test]
-    fn validate_basic_block_accepts_prefix_only_no_terminator() {
-        let seq = vec![
-            Instruction::MovImm {
-                rd: Register::X0,
-                imm: 1,
-            },
-            Instruction::Add {
-                rd: Register::X1,
-                rn: Register::X0,
-                rm: Operand::Immediate(2),
-            },
-        ];
-        assert!(validate_basic_block(&seq).is_ok());
-    }
-
-    #[test]
-    fn validate_basic_block_accepts_terminator_only() {
-        let seq = vec![Instruction::Ret { rn: Register::X30 }];
-        assert!(validate_basic_block(&seq).is_ok());
-    }
-
-    #[test]
-    fn validate_basic_block_accepts_prefix_plus_terminator() {
-        let seq = vec![
-            Instruction::MovImm {
-                rd: Register::X0,
-                imm: 1,
-            },
-            Instruction::Ret { rn: Register::X30 },
-        ];
-        assert!(validate_basic_block(&seq).is_ok());
-    }
-
     #[test]
     fn split_terminator_returns_full_slice_when_no_terminator() {
         let seq = vec![Instruction::MovImm {
@@ -5590,78 +5332,6 @@ mod cli_helper_tests {
         let (prefix, term) = split_terminator(&seq);
         assert_eq!(prefix.len(), 1);
         assert_eq!(term, Some(&Instruction::Ret { rn: Register::X30 }));
-    }
-
-    #[test]
-    fn live_out_for_optimization_prefix_includes_registers_read_by_terminator() {
-        let prefix = [Instruction::MovImm {
-            rd: Register::X1,
-            imm: 1,
-        }];
-        let cases = [
-            (
-                Instruction::Cbz {
-                    rn: Register::X0,
-                    target: s11::ir::LabelId(0x1000),
-                },
-                Register::X0,
-            ),
-            (
-                Instruction::Tbz {
-                    rt: Register::X2,
-                    bit: 5,
-                    target: s11::ir::LabelId(0x1000),
-                },
-                Register::X2,
-            ),
-            (Instruction::Br { rn: Register::X16 }, Register::X16),
-            (Instruction::Ret { rn: Register::X30 }, Register::X30),
-        ];
-
-        for (terminator, source) in cases {
-            let live_out =
-                live_out_for_optimization_prefix(&prefix, Some(&terminator), false, None);
-            assert!(live_out.contains_register(Register::X1));
-            assert!(
-                live_out.contains_register(source),
-                "{:?} must keep {:?} live for the reattached terminator",
-                terminator,
-                source
-            );
-        }
-    }
-
-    #[test]
-    fn live_out_for_optimization_prefix_uses_downstream_flags_without_terminator() {
-        let prefix = [Instruction::MovImm {
-            rd: Register::X1,
-            imm: 1,
-        }];
-
-        let flags_dead = live_out_for_optimization_prefix(&prefix, None, false, None);
-        assert!(!flags_dead.flags_live());
-
-        let flags_live = live_out_for_optimization_prefix(&prefix, None, true, None);
-        assert!(flags_live.flags_live());
-    }
-
-    #[test]
-    fn live_out_for_optimization_prefix_keeps_flags_live_for_terminators() {
-        let prefix = [Instruction::MovImm {
-            rd: Register::X1,
-            imm: 1,
-        }];
-
-        let b_cond = Instruction::BCond {
-            target: s11::ir::LabelId(0x1000),
-            cond: s11::ir::Condition::EQ,
-        };
-        let live_out = live_out_for_optimization_prefix(&prefix, Some(&b_cond), false, None);
-        assert!(live_out.flags_live());
-
-        let ret = Instruction::Ret { rn: Register::X30 };
-        let live_out = live_out_for_optimization_prefix(&prefix, Some(&ret), false, None);
-        assert!(live_out.flags_live());
     }
 
     // (The standalone `find_shorter_equivalent_preserves_terminator_bit_identical`
@@ -5818,30 +5488,6 @@ mod cli_helper_tests {
             "candidate that clobbers x0 must be rejected because the \
              reattached cbz reads x0; got {:?}",
             result,
-        );
-    }
-
-    #[test]
-    fn validate_basic_block_rejects_branch_mid_block() {
-        let seq = vec![
-            Instruction::MovImm {
-                rd: Register::X0,
-                imm: 1,
-            },
-            Instruction::B {
-                target: s11::ir::LabelId(0x1000),
-            },
-            Instruction::Add {
-                rd: Register::X1,
-                rn: Register::X0,
-                rm: Operand::Immediate(2),
-            },
-        ];
-        let err = validate_basic_block(&seq).expect_err("branch at position 1 must be rejected");
-        assert!(
-            err.contains("position 1") && err.contains("issue #69"),
-            "unexpected error: {}",
-            err
         );
     }
 

--- a/tests/integration/aarch64_search_inputs.rs
+++ b/tests/integration/aarch64_search_inputs.rs
@@ -1,0 +1,132 @@
+//! Integration coverage for the extracted `s11::aarch64_search_inputs` module.
+//!
+//! Before the AArch64 per-window search-inputs cluster moved out of `main.rs`
+//! these functions lived in the binary crate and were unreachable from an
+//! integration test — the only way to exercise the register-narrowing veto or
+//! the single-basic-block gate was to drive a whole optimization run. Extracting
+//! them into `s11::aarch64_search_inputs` makes the pure seam testable from
+//! outside the crate, mirroring the `s11::x86_search_inputs` sibling (#752).
+//!
+//! Expected values are the known-good literals from the seam's own unit tests.
+
+use s11::aarch64_search_inputs::{
+    aarch64_search_registers, live_out_for_optimization_prefix, validate_basic_block,
+};
+use s11::ir::{
+    Condition, Instruction, LabelId, Operand, Register, VectorArrangement, VectorRegister,
+};
+use s11::semantics::live_out::RegisterSet;
+
+#[test]
+fn live_out_narrows_to_the_downstream_live_registers() {
+    let prefix = [
+        Instruction::MovImm {
+            rd: Register::X0,
+            imm: 0,
+        },
+        Instruction::MovImm {
+            rd: Register::X1,
+            imm: 0,
+        },
+    ];
+
+    // No downstream analysis: every written register stays live.
+    let default = live_out_for_optimization_prefix(&prefix, None, false, None);
+    assert!(default.contains(Register::X0));
+    assert!(default.contains(Register::X1));
+
+    // Downstream scan proved only x1 live: x0 is dropped, x1 is pinned.
+    let downstream_live = RegisterSet::from_registers(vec![Register::X1]);
+    let narrowed = live_out_for_optimization_prefix(&prefix, None, false, Some(&downstream_live));
+    assert!(!narrowed.contains(Register::X0));
+    assert!(narrowed.contains(Register::X1));
+}
+
+#[test]
+fn live_out_does_not_narrow_when_a_terminator_is_held_fixed() {
+    // Soundness gate: a held-fixed conditional terminator has a branch-taken
+    // successor the fall-through scan never inspects, so narrowing must not
+    // apply even when the fall-through "proved" the register dead.
+    let prefix = [Instruction::MovImm {
+        rd: Register::X0,
+        imm: 7,
+    }];
+    let b_eq = Instruction::BCond {
+        target: LabelId(0x2000),
+        cond: Condition::EQ,
+    };
+    let dead = RegisterSet::<Register>::empty();
+
+    let live_out = live_out_for_optimization_prefix(&prefix, Some(&b_eq), false, Some(&dead));
+    assert!(
+        live_out.contains(Register::X0),
+        "a held-fixed terminator vetoes register narrowing"
+    );
+    assert!(
+        live_out.flags_live(),
+        "a held-fixed terminator keeps NZCV live for reattachment"
+    );
+}
+
+#[test]
+fn validate_basic_block_rejects_a_mid_block_branch() {
+    let seq = [
+        Instruction::MovImm {
+            rd: Register::X0,
+            imm: 1,
+        },
+        Instruction::B {
+            target: LabelId(0x1000),
+        },
+        Instruction::Add {
+            rd: Register::X1,
+            rn: Register::X0,
+            rm: Operand::Immediate(2),
+        },
+    ];
+
+    let err = validate_basic_block(&seq).expect_err("a branch mid-block is out of #69 scope");
+    assert!(
+        err.contains("position 1") && err.contains("issue #69"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn validate_basic_block_accepts_a_prefix_ending_in_a_terminator() {
+    let seq = [
+        Instruction::MovImm {
+            rd: Register::X0,
+            imm: 1,
+        },
+        Instruction::Ret { rn: Register::X30 },
+    ];
+    assert!(validate_basic_block(&seq).is_ok());
+}
+
+#[test]
+fn aarch64_search_registers_expose_base_gprs_and_target_vectors() {
+    let target = [
+        Instruction::VectorAdd {
+            vd: VectorRegister::V0,
+            vn: VectorRegister::V1,
+            vm: VectorRegister::V2,
+            arrangement: VectorArrangement::TwoD,
+        },
+        Instruction::MovFromVectorLane {
+            rd: Register::X0,
+            vn: VectorRegister::V0,
+            lane: 0,
+        },
+    ];
+
+    let registers = aarch64_search_registers(&target);
+
+    // The base general-purpose pool (x0..x7) is always available.
+    assert!(registers.contains(&Register::X0));
+    assert!(registers.contains(&Register::X7));
+    // Every vector register named by the target joins the pool.
+    assert!(registers.contains(&Register::Vector(VectorRegister::V0)));
+    assert!(registers.contains(&Register::Vector(VectorRegister::V1)));
+    assert!(registers.contains(&Register::Vector(VectorRegister::V2)));
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,3 +1,4 @@
+mod aarch64_search_inputs;
 mod bump_version_test;
 mod carry_chain;
 mod disasm_test;


### PR DESCRIPTION
## Refactoring goal

Architecture audit (via the `improve-codebase-architecture` process) surfaced a recurring, high-leverage friction: soundness-critical logic stranded inside the `main.rs` **binary** crate, where it can only be exercised through inline unit tests and never through the integration-test surface. This PR takes the single best candidate: extract the AArch64 per-window **search-inputs** seam.

The three functions
- `validate_basic_block` — the single-basic-block admissibility gate (issue #69 scope),
- `aarch64_search_registers` — the Candidate register pool,
- `live_out_for_optimization_prefix` — the Live-out contract, including the **terminator soundness veto** on register narrowing,

move out of `main.rs` into a new `s11::aarch64_search_inputs` library module. This is the **direct AArch64 mirror** of the already-blessed `s11::x86_search_inputs` module (#752), closing a named asymmetry: the x86 seam was lifted into the library while its AArch64 counterpart stayed in the binary.

This is a **deepening** move: the seam takes library types in and returns library types out (no CLI, ELF, or Capstone), so each soundness rule becomes a fixture-free unit test and the driver stays a thin adapter. The change is behaviour-preserving — functions and their names are unchanged; the three driver call sites are byte-identical.

## Audit summary — candidates considered

Ranked by (leverage × safety) for a single-session, must-pass-CI, TDD refactor:

1. **AArch64 search-inputs seam → `aarch64_search_inputs.rs`** ✅ *(this PR)* — live, soundness-critical logic; self-contained (only lib types); mirrors a merged sibling; large testability gain (binary → library seam).
2. **`capstone_detail_*` → `capstone_detail.rs`** — strong and safe, but its only callers (`find_candidate_windows*`) are `#[cfg_attr(not(test), allow(dead_code))]` behind a `--auto` stub, so extraction buys navigability, not new testability of live logic. Good next PR.
3. **Search-config builder family → `search_config.rs`** — high leverage but needs a design decision first (it would push the CLI-shaped `OptimizationOptions` into the library). Deferred.
4. **`print_*` wrappers** — a *delete-the-layer* cleanup, not an extraction. Separate PR.
5. **`ElfOptimizationBackend` trait + impls** — the eventual big move; ~470 lines welded to driver types. High blast radius; sequence after the small wins.

## Tests that validate it

- **12 migrated unit tests** move with the functions into `src/aarch64_search_inputs.rs::tests` (register-narrowing, the conditional/unconditional terminator soundness gates, terminator-read re-pinning, flags-live policy, the mid-block-branch rejection, vector-register pool).
- **New `tests/integration/aarch64_search_inputs.rs`** (5 tests) proves the seam is reachable from **outside the crate** — the capability that did not exist before this extraction. Expected values are the known-good literals from the unit tests.
- Full `./ci_check.sh` (fmt + build + unit + test-binary builds + full suite) passes; `cargo clippy --all-targets` is clean.

## Deferred follow-ups (kept out to preserve a behaviour-identical move)

- Rename to match the x86 sibling: `validate_basic_block` → `validate_terminator_placement`, `aarch64_search_registers` → `registers_from_target`, `live_out_for_optimization_prefix` → `live_out_for_optimization`.
- Make the AArch64 enumerative immediates target-derived, like `x86_search_inputs::enumerative_immediates_from_target`.
