### PR TITLE
test: port search-input regression tests dropped by duplicate-PR merges

### DIFF
--- a/src/aarch64_search_inputs.rs
+++ b/src/aarch64_search_inputs.rs
@@ -166,7 +166,33 @@ mod tests {
         );
     }
 
+    #[test]
+    fn default_immediates_span_zero_to_the_imm12_ceiling() {
+        let imms = default_immediates();
+        assert!(imms.contains(&0));
+        assert!(imms.contains(&1));
+        // 4095 = 0xFFF is the largest value an unshifted imm12 can encode; the
+        // pool must reach it (cf. #720's imm12 sampling contract) and never
+        // exceed it, since a larger literal is not directly encodable.
+        assert_eq!(imms.iter().copied().max(), Some(4095));
+        assert!(imms.iter().all(|&imm| (0..=4095).contains(&imm)));
+    }
+
     // ===== registers_from_target (new coverage + carried from main.rs) =====
+
+    #[test]
+    fn registers_from_target_does_not_admit_scalar_registers_beyond_x7() {
+        // Deliberate policy: a scalar register the target references above X7 is
+        // NOT added — only the fixed X0..X7 scalars plus target vector registers
+        // seed the pool. Pin it so it does not read as an omission bug.
+        let target = [Instruction::MovImm {
+            rd: Register::X9,
+            imm: 0,
+        }];
+        let pool = registers_from_target(&target);
+        assert!(!pool.contains(&Register::X9));
+        assert_eq!(pool.len(), 8);
+    }
 
     #[test]
     fn registers_from_target_seeds_scalar_x0_through_x7_sorted() {

--- a/src/x86_search_inputs.rs
+++ b/src/x86_search_inputs.rs
@@ -257,6 +257,19 @@ mod tests {
         );
     }
 
+    #[test]
+    fn register_pool_excludes_a_narrow_stack_pointer_view() {
+        // ESP is the dword view of the stack pointer (reg 4). The filter checks
+        // `canonical()`, so the narrow view is excluded just like RSP.
+        let target = [X86Instruction::MovImm {
+            rd: X86Register::ESP,
+            imm: 0,
+        }];
+        let pool = registers_from_target(&target);
+        assert!(!pool.contains(&X86Register::ESP));
+        assert!(!pool.contains(&X86Register::RSP));
+    }
+
     // ===== validate_terminator_placement (carried from main.rs) =====
 
     #[test]


### PR DESCRIPTION
## Summary
- `refactor/extract-search-inputs-seam` (PR #751) independently duplicated two refactors that landed on `main` first: the x86 search-input seam (#752) and the AArch64 search-input seam (#754). #751 is closed as superseded.
- This PR salvages the 3 regression tests that existed only on that branch and aren't covered by #752/#754's versions:
  - `registers_from_target_does_not_admit_scalar_registers_beyond_x7` — pins that the AArch64 register pool stays X0..X7 plus target vector registers (no scalar admitted beyond X7).
  - `default_immediates_span_zero_to_the_imm12_ceiling` — pins that the AArch64 immediate pool stays within `0..=4095` (the imm12 ceiling).
  - `register_pool_excludes_a_narrow_stack_pointer_view` — pins that the x86 register pool excludes ESP (the dword view of RSP) as well as RSP itself.

## Test plan
- [x] `cargo build --lib`
- [x] `cargo fmt -- --check`
- [x] `cargo test --lib` (new tests pass)
- [x] `./ci_check.sh`