### PR TITLE
refactor(driver): extract disassembly listing into a pure tested seam

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -53,6 +53,17 @@ A `SearchAlgorithm` impl that delegates candidate generation to the OpenAI Codex
 ### Flags-live-out (LLM-flow exclusion)
 AArch64 condition state (NZCV) is part of the equivalence contract via `LiveOut.flags_live` (set from the `;nzcv` suffix to `equiv --live-out` per ADR-0006). The fast and SMT equivalence paths both consume the bit. *Separately*, the LLM-assisted search flow statically refuses targets whose final state includes flag liveness (any flag-writing instruction in the sequence — see `flags_live_out` in `src/validation/live_out.rs`) and bails before invoking Codex. This is a conservative policy choice, not a soundness workaround, and is the only remaining surface on which ADR-0002 is authoritative. See ADR-0002 (as amended) and ADR-0006.
 
+### Disassembly listing
+The textual output of the `disasm` command: one
+`0x{addr}: {bytes} {mnemonic} {operands}` line per instruction, over every
+executable section of an ELF. The rules for *which* sections are disassembled
+(`section_is_executable`) and *how* each line renders (`format_disassembly`)
+live behind the pure `src/disassembly.rs` seam; the `disassemble_elf_binary`
+driver in `src/main.rs` is a thin adapter that parses the ELF and decodes each
+section with Capstone. This is distinct from the optimizer's result rendering (search
+statistics, LLM timings, equivalence counterexamples), which lives in
+`src/report.rs`.
+
 ### Subset hint (intentionally absent)
 The LLM prompt does **not** enumerate the maintained AArch64 subset s11's parser accepts (see [docs/capability.md](docs/capability.md)). The model is invited to use any AArch64 mnemonic it knows. Outputs that use unsupported instructions are recorded as a research signal (which mnemonics the model "wanted" to reach for), not treated as wasted calls. See ADR-0003.
 

--- a/src/disassembly.rs
+++ b/src/disassembly.rs
@@ -1,0 +1,148 @@
+//! Disassembly listing — the pure presentation seam for `s11 disasm`.
+//!
+//! The `disasm` command reads an ELF, disassembles its executable sections with
+//! Capstone, and prints one `0x{addr}: {bytes} {mnemonic} {operands}` line per
+//! instruction. Deciding *which* sections to disassemble and *how* each line is
+//! rendered are pure rules that used to live inline in the `disasm` driver
+//! (`disassemble_elf_binary`) in the binary's `main.rs`, interleaved with file
+//! I/O, ELF parsing, and
+//! Capstone — a shallow arrangement where the only way to exercise "an
+//! `SHF_EXECINSTR` section with bytes is disassembled" or "a one-byte opcode is
+//! padded to the byte column" was to run the whole command and scrape stdout.
+//!
+//! This module lifts those rules into a pure seam: plain data in
+//! ([`DisassembledInstruction`]), `String`s out, no CLI, ELF, or Capstone in the
+//! interface. The driver stays a thin adapter that parses the ELF, decodes each
+//! executable section into [`DisassembledInstruction`]s, and prints the lines
+//! this module renders — mirroring how [`report`](crate::report) owns the
+//! optimizer's result rendering. It is a *separate* module from `report` on
+//! purpose: `report` renders search/optimization results (it speaks
+//! `SearchStatistics`, `LlmTimings`, equivalence counterexamples); this module
+//! renders a raw disassembly listing, a disjoint concern with disjoint inputs
+//! and no shared logic. See the `CONTEXT.md` glossary for the domain terms.
+
+/// One decoded instruction in a disassembly listing: the raw encoded bytes plus
+/// the resolved mnemonic and operand text.
+///
+/// Deliberately free of Capstone types so the listing renderer is a pure,
+/// fixture-free seam. The adapter resolves Capstone's optional mnemonic/operand
+/// strings (to `"???"` / `""` when absent) before building this value, so the
+/// renderer never has to know about Capstone's failure modes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DisassembledInstruction {
+    pub address: u64,
+    pub bytes: Vec<u8>,
+    pub mnemonic: String,
+    pub operands: String,
+}
+
+/// Whether a section should be disassembled by `disasm`: it must be flagged
+/// executable (`SHF_EXECINSTR`) and carry at least one byte.
+///
+/// Takes the raw `sh_flags` and `sh_size` header fields rather than an ELF
+/// section type so the rule stays a fixture-free unit — the driver reads the
+/// header, this decides. An executable-but-empty section (`sh_size == 0`) has
+/// nothing to decode and is skipped, matching the pre-refactor `disasm` filter.
+pub fn section_is_executable(sh_flags: u64, sh_size: u64) -> bool {
+    sh_flags & (elf::abi::SHF_EXECINSTR as u64) != 0 && sh_size > 0
+}
+
+/// Render a run of decoded instructions as the `disasm` command's listing: one
+/// `0x{addr}: {bytes} {mnemonic} {operands}` line per instruction, in order.
+///
+/// The byte column is the instruction's raw bytes as lowercase hex with no
+/// separators, left-justified in an 8-wide column (trailing spaces) so the
+/// mnemonic column stays aligned for both AArch64 (always four bytes, exactly
+/// eight hex digits) and shorter variable-length x86 opcodes.
+pub fn format_disassembly(instructions: &[DisassembledInstruction]) -> Vec<String> {
+    instructions
+        .iter()
+        .map(|instruction| {
+            let hex_bytes: String = instruction
+                .bytes
+                .iter()
+                .map(|byte| format!("{:02x}", byte))
+                .collect();
+            format!(
+                "0x{:x}: {:8} {} {}",
+                instruction.address, hex_bytes, instruction.mnemonic, instruction.operands
+            )
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_a_single_four_byte_instruction_line() {
+        let instructions = vec![DisassembledInstruction {
+            address: 0x1000,
+            bytes: vec![0xde, 0xad, 0xbe, 0xef],
+            mnemonic: "add".to_string(),
+            operands: "x0, x1, x2".to_string(),
+        }];
+
+        assert_eq!(
+            format_disassembly(&instructions),
+            vec!["0x1000: deadbeef add x0, x1, x2".to_string()],
+        );
+    }
+
+    #[test]
+    fn pads_short_byte_column_and_renders_empty_operands_and_order() {
+        let instructions = vec![
+            DisassembledInstruction {
+                address: 0x2000,
+                bytes: vec![0xcc],
+                mnemonic: "int3".to_string(),
+                operands: String::new(),
+            },
+            DisassembledInstruction {
+                address: 0x2004,
+                bytes: vec![0x01, 0x02, 0x03, 0x04],
+                mnemonic: "mov".to_string(),
+                operands: "rax, rbx".to_string(),
+            },
+        ];
+
+        // A one-byte opcode pads to the 8-wide byte column (so the mnemonic stays
+        // aligned) and empty operands leave a trailing space, exactly as the
+        // pre-refactor `disasm` listing printed. Lines keep input order.
+        assert_eq!(
+            format_disassembly(&instructions),
+            vec![
+                "0x2000: cc       int3 ".to_string(),
+                "0x2004: 01020304 mov rax, rbx".to_string(),
+            ],
+        );
+    }
+
+    #[test]
+    fn renders_no_lines_for_an_empty_section() {
+        assert_eq!(format_disassembly(&[]), Vec::<String>::new());
+    }
+
+    // SHF_EXECINSTR is 0x4; SHF_ALLOC|SHF_WRITE (a typical data section) is 0x3.
+    const SHF_EXECINSTR: u64 = 0x4;
+    const SHF_ALLOC_WRITE: u64 = 0x3;
+
+    #[test]
+    fn selects_executable_sections_with_bytes() {
+        // A `.text`-style section: executable and non-empty.
+        assert!(section_is_executable(SHF_EXECINSTR | 0x2, 128));
+    }
+
+    #[test]
+    fn skips_executable_but_empty_sections() {
+        // An executable section header with zero size has nothing to decode.
+        assert!(!section_is_executable(SHF_EXECINSTR, 0));
+    }
+
+    #[test]
+    fn skips_non_executable_sections() {
+        // A writable data section is never disassembled, even when it has bytes.
+        assert!(!section_is_executable(SHF_ALLOC_WRITE, 4096));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod bench_support;
 pub mod candidate_windows;
 pub mod capstone_bridge;
 pub mod capstone_bridge_x86;
+pub mod disassembly;
 pub mod docs_support;
 pub mod elf_patcher;
 pub mod ir;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use s11::assembler::AArch64Assembler;
 use s11::candidate_windows::{WindowInstruction, WindowRole, plan_candidate_windows};
 use s11::capstone_bridge::{ConvertOutcome, convert_capstone_op};
 use s11::capstone_bridge_x86::{convert_to_x86_ir, convert_x86_capstone_op_for_optimization};
+use s11::disassembly::{self, DisassembledInstruction};
 use s11::elf_patcher::{AddressWindow, DetectedArch, ElfPatcher, TextSection, parse_hex_address};
 use s11::ir::instructions::split_terminator;
 use s11::ir::{Instruction, Register};
@@ -138,14 +139,6 @@ impl SupportedArch {
             elf::abi::EM_X86_64 => Ok(Self::X86_64),
             elf::abi::EM_386 => Ok(Self::X86_32),
             m => Err(format!("Unsupported architecture (e_machine: {})", m).into()),
-        }
-    }
-
-    fn display_name(self) -> &'static str {
-        match self {
-            Self::Aarch64 => "AArch64",
-            Self::X86_64 => "x86-64",
-            Self::X86_32 => "x86-32",
         }
     }
 
@@ -453,19 +446,22 @@ fn resolve_opt_target(
     Ok(supported)
 }
 
-fn analyze_elf_binary(
+/// Disassemble every executable section of an ELF and print the `disasm`
+/// listing (one `0x{addr}: {bytes} {mnemonic} {operands}` line per instruction).
+///
+/// Architecture is auto-detected from `e_machine`; an explicit `expected_arch`
+/// (from `--arch`) is cross-checked and a mismatch is rejected before any
+/// disassembly. This is a thin adapter: ELF parsing and Capstone decoding stay
+/// here, while the executable-section rule and the listing format live behind
+/// the pure [`disassembly`](s11::disassembly) seam, so both are unit-testable
+/// without driving the command or scraping stdout. Sections are printed as they
+/// decode, so a decode failure in a later section still surfaces the listings
+/// already produced for earlier ones.
+fn disassemble_elf_binary(
     path: &Path,
-    disasm_mode: bool,
     expected_arch: Option<SupportedArch>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    if !disasm_mode {
-        println!("Analyzing ELF binary: {}", path.display());
-    }
-
-    // Read the file
     let file_data = fs::read(path)?;
-
-    // Parse ELF
     let elf = ElfBytes::<AnyEndian>::minimal_parse(&file_data)?;
 
     // Detect architecture; reject anything outside the supported set.
@@ -482,89 +478,37 @@ fn analyze_elf_binary(
         )
         .into());
     }
-    let arch = detected_arch.display_name();
-
-    if !disasm_mode {
-        println!("ELF Header:");
-        println!("  Architecture: {}", arch);
-        println!("  Entry point: 0x{:x}", elf.ehdr.e_entry);
-        println!(
-            "  Type: {}",
-            match elf.ehdr.e_type {
-                elf::abi::ET_EXEC => "Executable",
-                elf::abi::ET_DYN => "Shared object",
-                elf::abi::ET_REL => "Relocatable",
-                _ => "Other",
-            }
-        );
-    }
 
     // Initialize Capstone disassembler per architecture.
     let cs = detected_arch.build_capstone()?;
 
-    // Find and disassemble .text sections
     let section_headers = elf
         .section_headers()
         .ok_or("Failed to get section headers")?;
-    let (_, string_table) = elf.section_headers_with_strtab()?;
-    let string_table = string_table.ok_or("Failed to get string table")?;
-
-    if !disasm_mode {
-        println!("\nText sections:");
-    }
 
     for section_header in section_headers.iter() {
-        let section_name = string_table.get(section_header.sh_name as usize)?;
+        if !disassembly::section_is_executable(section_header.sh_flags, section_header.sh_size) {
+            continue;
+        }
 
-        // Look for executable sections (typically .text, .init, .fini, etc.)
-        if section_header.sh_flags & elf::abi::SHF_EXECINSTR as u64 != 0
-            && section_header.sh_size > 0
-        {
-            if !disasm_mode {
-                println!(
-                    "\nSection: {} (offset: 0x{:x}, size: {} bytes)",
-                    section_name, section_header.sh_offset, section_header.sh_size
-                );
-            }
+        let (data, _) = elf.section_data(&section_header)?;
+        if data.is_empty() {
+            continue;
+        }
 
-            // Get section data
-            let section_data = elf.section_data(&section_header)?;
-            let (data, _) = section_data;
+        let instructions = cs.disasm_all(data, section_header.sh_addr)?;
+        let decoded: Vec<DisassembledInstruction> = instructions
+            .iter()
+            .map(|instruction| DisassembledInstruction {
+                address: instruction.address(),
+                bytes: instruction.bytes().to_vec(),
+                mnemonic: instruction.mnemonic().unwrap_or("???").to_string(),
+                operands: instruction.op_str().unwrap_or("").to_string(),
+            })
+            .collect();
 
-            if !data.is_empty() {
-                if !disasm_mode {
-                    println!("Disassembly:");
-                }
-
-                // Disassemble the section
-                let instructions = cs.disasm_all(data, section_header.sh_addr)?;
-
-                for instruction in instructions.iter() {
-                    if disasm_mode {
-                        // Format: address: bytes  mnemonic operands
-                        let bytes = instruction.bytes();
-                        let hex_bytes: String = bytes
-                            .iter()
-                            .map(|b| format!("{:02x}", b))
-                            .collect::<Vec<_>>()
-                            .join("");
-                        println!(
-                            "0x{:x}: {:8} {} {}",
-                            instruction.address(),
-                            hex_bytes,
-                            instruction.mnemonic().unwrap_or("???"),
-                            instruction.op_str().unwrap_or("")
-                        );
-                    } else {
-                        println!(
-                            "  0x{:08x}: {}\t{}",
-                            instruction.address(),
-                            instruction.mnemonic().unwrap_or("???"),
-                            instruction.op_str().unwrap_or("")
-                        );
-                    }
-                }
-            }
+        for line in disassembly::format_disassembly(&decoded) {
+            println!("{line}");
         }
     }
 
@@ -2357,11 +2301,11 @@ fn main() {
 
     match args.command {
         Commands::Disasm { binary, arch } => {
-            // Disassemble mode. `analyze_elf_binary` auto-detects the
+            // Disassemble mode. `disassemble_elf_binary` auto-detects the
             // architecture from e_machine and picks the right Capstone
             // backend. The optional `--arch` still early-rejects RISC-V, but
-            // supported hints are cross-checked inside the analyzer after its
-            // single ELF read/parse.
+            // supported hints are cross-checked inside the disassembler after
+            // its single ELF read/parse.
             let arch = match arch.map(SupportedArch::try_from).transpose() {
                 Ok(arch) => arch,
                 Err(message) => {
@@ -2369,7 +2313,7 @@ fn main() {
                     std::process::exit(1);
                 }
             };
-            match analyze_elf_binary(&binary, true, arch) {
+            match disassemble_elf_binary(&binary, arch) {
                 Ok(()) => {}
                 Err(e) => {
                     let message = e.to_string();
@@ -3007,11 +2951,11 @@ mod cli_helper_tests {
     }
 
     #[test]
-    fn analyze_elf_binary_rejects_expected_arch_mismatch() {
+    fn disassemble_elf_binary_rejects_expected_arch_mismatch() {
         let elf_bytes = build_minimal_elf64(&[0xc3], 0x1000, elf::abi::EM_X86_64);
         let input = TempFile::new_bytes("s11-disasm-mismatch", "elf", &elf_bytes);
 
-        let err = analyze_elf_binary(input.path(), true, Some(SupportedArch::Aarch64))
+        let err = disassemble_elf_binary(input.path(), Some(SupportedArch::Aarch64))
             .expect_err("mismatched expected architecture should fail");
 
         let message = err.to_string();
@@ -3026,20 +2970,20 @@ mod cli_helper_tests {
     }
 
     #[test]
-    fn analyze_elf_binary_accepts_matching_expected_arch() {
+    fn disassemble_elf_binary_accepts_matching_expected_arch() {
         let elf_bytes = build_minimal_elf64(&[0xc3], 0x1000, elf::abi::EM_X86_64);
         let input = TempFile::new_bytes("s11-disasm-match", "elf", &elf_bytes);
 
-        analyze_elf_binary(input.path(), true, Some(SupportedArch::X86_64))
+        disassemble_elf_binary(input.path(), Some(SupportedArch::X86_64))
             .expect("matching expected architecture should disassemble");
     }
 
     #[test]
-    fn analyze_elf_binary_rejects_riscv_machine() {
+    fn disassemble_elf_binary_rejects_riscv_machine() {
         let elf_bytes = build_minimal_elf64(&[0x13, 0x00, 0x00, 0x00], 0x1000, elf::abi::EM_RISCV);
         let input = TempFile::new_bytes("s11-disasm-riscv", "elf", &elf_bytes);
 
-        let err = analyze_elf_binary(input.path(), true, None)
+        let err = disassemble_elf_binary(input.path(), None)
             .expect_err("RISC-V ELF disassembly should not be supported yet");
 
         assert_eq!(


### PR DESCRIPTION
## What & why

Architecture audit (via the `improve-codebase-architecture` skill's process) of the codebase's hot spot — `src/main.rs`, the driver, touched in **14 of the last 60 commits** and mid-way through a systematic program of *extracting pure tested seams out of the driver* (#732, #744, #752, #754, #758, …).

This PR continues that program on the last sizeable un-seamed, untested chunk in `main.rs`: the `disasm` command backend, `analyze_elf_binary`.

## Candidates considered (the audit result)

| Candidate | Why not (this PR) |
|---|---|
| **`disasm` backend `analyze_elf_binary`** (117 lines) — section selection + line formatting tangled with I/O/ELF/Capstone, untested, plus a **dead second renderer** behind `disasm_mode: bool` | **Chosen** — highest testability + tech-debt win at lowest risk; squarely on the established seam-extraction path |
| `mutate_opcode` (904 lines), `mutate_operand` (428) in `search/stochastic/mutation.rs` | Largest raw functions, but core MCMC semantics — subtle, high-risk, already densely tested; poor fit for a one-shot autonomous refactor |
| `generate_all_instructions` (704) in `search/candidate.rs` | Same risk profile as the mutators |
| `run_optimization` / `optimize_elf_binary_with_backend` in `main.rs` | Larger, more entangled with the search pipeline; better as its own focused PR |
| `find_candidate_windows_with_backend` (150) | Already delegates its soundness-critical logic to the `candidate_windows` seam — the residue is genuinely Capstone-adapter code |

### The friction fixed

`analyze_elf_binary` was a **shallow** driver: the executable-section rule (`SHF_EXECINSTR` + non-empty) and the per-instruction line format were interleaved with `fs::read`, ELF parsing, and Capstone — the only way to exercise them was to run the command and scrape stdout. It also carried a **dead second renderer**: a `disasm_mode: bool` gated an `analyze`-style report (ELF header block, `Text sections:` / `Section:` framing, a `0x{:08x}:\t` line format) that **no subcommand ever reaches** — `Commands` has no `Analyze` variant and the sole production caller (and all three unit tests) always passed `true`. Passes the deletion test outright.

## Change

- **New pure seam `src/disassembly.rs`** — plain data in (`DisassembledInstruction`), `String`s out; no CLI/ELF/Capstone in the interface, mirroring how `report` owns optimizer-result rendering (it is deliberately a separate module: `report` speaks `SearchStatistics`/`LlmTimings`/equivalence; this renders a raw disassembly listing — disjoint inputs, no shared logic).
  - `section_is_executable(sh_flags, sh_size) -> bool`
  - `format_disassembly(&[DisassembledInstruction]) -> Vec<String>`
- **Deleted** the unreachable analyze branch and its now-orphaned `SupportedArch::display_name`.
- **`disassemble_elf_binary`** (renamed from `analyze_elf_binary`, `disasm_mode` dropped) is now a ~50-line adapter that decodes each executable section and prints the rendered lines — preserving the old loop's streaming order and error propagation.
- Added the **Disassembly listing** term to `CONTEXT.md`.

`main.rs`: **−98 / +42** lines.

## Tests (TDD, red → green at the seam)

New `src/disassembly.rs` unit tests, fixture-free, with **literal** expected strings (independently derived, not recomputed via the code's `format!`):

- renders a four-byte instruction line
- pads a one-byte opcode to the 8-wide byte column + empty operands (trailing space) + multi-instruction ordering
- empty section → no lines
- executable-section truth table (exec+bytes ✓, exec+empty ✗, non-exec+bytes ✗)

The pre-existing arch-validation tests moved to the new name. Disasm output is **byte-for-byte unchanged**, verified end-to-end against a real x86-64 ELF (the `s11` binary itself):

```
0x8513f0: f30f1efa endbr64 
0x8513f4: 31ed     xor ebp, ebp
0x8513fd: 4883e4f0 and rsp, 0xfffffffffffffff0
```

## Verification

- `cargo fmt -- --check` ✓
- `cargo test --lib` → **1669 passed** (1663 + 6 new) ✓
- `cargo test --bins` → **99 passed** ✓
- Integration tests compile ✓

> Note: the ELF-driven `tests/integration/disasm_test.rs` cases need the gitignored `binaries/` fixtures (produced by `build_tests.sh`, absent in this environment), so they cannot run here; the fixture-free cases pass and the format contract they assert is verified above against a real binary. CI, which builds the fixtures, runs them normally.