### PR TITLE
refactor(driver): extract output-path resolution into a tested seam

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -64,6 +64,18 @@ section with Capstone. This is distinct from the optimizer's result rendering (s
 statistics, LLM timings, equivalence counterexamples), which lives in
 `src/report.rs`.
 
+### Output-path resolution
+Where an `opt` run writes its result. With no explicit `-o/--output` the driver
+derives a `<stem>_optimized.<ext>` sibling of the input; an explicit output is
+honoured unless it resolves to the input binary itself, which is refused so the
+run never rewrites the source in place (the hard-link case is caught by a
+`(device, inode)` identity check a canonical-path comparison would miss). These
+rules live behind the pure `src/output_path.rs` seam, whose single entry point is
+`resolve_output_path`; the `opt` driver in `src/main.rs` is a thin adapter that
+passes the input path and optional `-o` through it. Deriving the sibling name is
+fallible — a stem-less or non-UTF-8 input yields an error the driver reports
+rather than a panic.
+
 ### Subset hint (intentionally absent)
 The LLM prompt does **not** enumerate the maintained AArch64 subset s11's parser accepts (see [docs/capability.md](docs/capability.md)). The model is invited to use any AArch64 mnemonic it knows. Outputs that use unsupported instructions are recorded as a research signal (which mnemonics the model "wanted" to reach for), not treated as wasted calls. See ADR-0003.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod docs_support;
 pub mod elf_patcher;
 pub mod ir;
 pub mod isa;
+pub mod output_path;
 pub mod parser;
 pub mod report;
 pub mod search;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use s11::disassembly::{self, DisassembledInstruction};
 use s11::elf_patcher::{AddressWindow, DetectedArch, ElfPatcher, TextSection, parse_hex_address};
 use s11::ir::instructions::split_terminator;
 use s11::ir::{Instruction, Register};
+use s11::output_path::resolve_output_path;
 use s11::report;
 use s11::search::config::{
     Algorithm, LlmConfig, SearchConfig, SearchMode, StochasticConfig, SymbolicConfig,
@@ -1284,75 +1285,6 @@ fn capstone_detail_direct_branch_targets(detail: &capstone::InsnDetail<'_>) -> V
             _ => None,
         })
         .collect()
-}
-
-fn optimized_output_path(path: &Path) -> PathBuf {
-    let mut new_path = path.to_path_buf();
-    let stem = new_path.file_stem().unwrap().to_str().unwrap();
-    let extension = new_path.extension().map(|e| e.to_str().unwrap());
-
-    let new_name = if let Some(ext) = extension {
-        format!("{}_optimized.{}", stem, ext)
-    } else {
-        format!("{}_optimized", stem)
-    };
-
-    new_path.set_file_name(new_name);
-    new_path
-}
-
-/// Resolve where an `opt` run writes its result.
-///
-/// With no explicit `-o/--output` the derived `<stem>_optimized.<ext>` sibling
-/// is preserved verbatim (the pre-#616 single-window behaviour). An explicit
-/// output is honoured, except when it resolves to the input binary itself: the
-/// driver never rewrites the input in place, so that request is rejected rather
-/// than silently clobbering the source.
-fn resolve_output_path(input: &Path, output: Option<&Path>) -> Result<PathBuf, String> {
-    match output {
-        Some(out) => {
-            if paths_point_to_same_file(input, out) {
-                Err(format!(
-                    "output path '{}' resolves to the input binary; refusing to optimize in place (choose a different -o/--output)",
-                    out.display()
-                ))
-            } else {
-                Ok(out.to_path_buf())
-            }
-        }
-        None => Ok(optimized_output_path(input)),
-    }
-}
-
-/// Whether `a` and `b` are the same file on disk.
-///
-/// On Unix this compares the `(device, inode)` pair, the only check that catches
-/// a **hard link**: two hard links to one inode are distinct directory entries
-/// with distinct canonical paths, so a canonical-path comparison would miss them
-/// and let an `-o` hard link to the input slip through the in-place guard and get
-/// truncated by `create_patched_copy`. `metadata` follows symlinks and requires
-/// the path to exist, so it subsumes the symlink and `./bin` vs `bin` cases too;
-/// a `-o` target that does not exist yet cannot alias the already-present input,
-/// so a failed stat means "different". Off Unix, fall back to comparing canonical
-/// paths (then literal paths when canonicalization fails, which only happens for
-/// a not-yet-created output that therefore cannot be the input).
-fn paths_point_to_same_file(a: &Path, b: &Path) -> bool {
-    #[cfg(unix)]
-    fn same_file(a: &Path, b: &Path) -> bool {
-        use std::os::unix::fs::MetadataExt;
-        match (std::fs::metadata(a), std::fs::metadata(b)) {
-            (Ok(ma), Ok(mb)) => ma.dev() == mb.dev() && ma.ino() == mb.ino(),
-            _ => false,
-        }
-    }
-    #[cfg(not(unix))]
-    fn same_file(a: &Path, b: &Path) -> bool {
-        match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
-            (Ok(ca), Ok(cb)) => ca == cb,
-            _ => a == b,
-        }
-    }
-    same_file(a, b)
 }
 
 /// Whole-binary `--auto` driver entry point.
@@ -3212,62 +3144,6 @@ mod cli_helper_tests {
     }
 
     #[test]
-    fn resolve_output_path_falls_back_to_derived_path() {
-        let input = Path::new("/some/dir/prog.elf");
-        assert_eq!(
-            resolve_output_path(input, None).unwrap(),
-            optimized_output_path(input)
-        );
-    }
-
-    #[test]
-    fn resolve_output_path_honors_explicit_output() {
-        let input = Path::new("/some/dir/prog.elf");
-        let out = Path::new("/other/place/out.bin");
-        assert_eq!(
-            resolve_output_path(input, Some(out)).unwrap(),
-            out.to_path_buf()
-        );
-    }
-
-    #[test]
-    fn resolve_output_path_rejects_in_place_output() {
-        // The same existing file addressed two ways (a `.` component): on Unix
-        // the guard fires via the (dev, ino) identity check, off-Unix via
-        // canonicalization — either way, not literal string comparison.
-        let input = TempFile::new_bytes("s11-resolve-inplace", "elf", &[0u8; 4]);
-        let aliased = input
-            .path()
-            .parent()
-            .unwrap()
-            .join(".")
-            .join(input.path().file_name().unwrap());
-        let err = resolve_output_path(input.path(), Some(&aliased))
-            .expect_err("output resolving to the input binary must be rejected");
-        assert!(
-            err.contains("refusing to optimize in place"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn resolve_output_path_rejects_hard_link_to_input() {
-        // A hard link shares the input's inode but has a distinct canonical
-        // path, so only a (dev, ino) comparison — not canonicalize — catches it.
-        let input = TempFile::new_bytes("s11-resolve-hardlink", "elf", &[0u8; 8]);
-        let link = input.path().with_extension("hardlink");
-        std::fs::hard_link(input.path(), &link).expect("create hard link to input");
-        let result = resolve_output_path(input.path(), Some(&link));
-        let _ = std::fs::remove_file(&link);
-        let err = result.expect_err("a hard link to the input binary must be rejected");
-        assert!(
-            err.contains("refusing to optimize in place"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
     fn run_auto_optimization_is_not_yet_implemented() {
         let elf = build_minimal_elf64(&[0x90], 0x1000, elf::abi::EM_X86_64);
         let input = TempFile::new_bytes("s11-auto-guard", "elf", &elf);
@@ -4104,7 +3980,7 @@ mod cli_helper_tests {
         opts.timeout = Some(Duration::from_secs(5));
         opts.cost_metric = CostMetric::CodeSize;
 
-        let output = optimized_output_path(input.path());
+        let output = resolve_output_path(input.path(), None).unwrap();
         optimize_elf_binary(&patcher, input.path(), 0x1000, 0x100a, &output, &opts)
             .expect("narrow register aliases should reach search");
     }
@@ -4212,7 +4088,7 @@ mod cli_helper_tests {
         opts.timeout = Some(Duration::from_secs(5));
         opts.cost_metric = CostMetric::CodeSize;
 
-        let output = optimized_output_path(input.path());
+        let output = resolve_output_path(input.path(), None).unwrap();
         let err = optimize_elf_binary(&patcher, input.path(), 0x1000, 0x1006, &output, &opts)
             .expect_err("architectural byte SETcc should be rejected before search");
         let msg = err.to_string();

--- a/src/output_path.rs
+++ b/src/output_path.rs
@@ -1,0 +1,203 @@
+//! Output-path resolution — the pure seam deciding where an `opt` run writes.
+//!
+//! `s11 opt` never rewrites the input binary in place: with no explicit
+//! `-o/--output` it writes a derived `<stem>_optimized.<ext>` sibling, and an
+//! explicit output that resolves to the input itself is rejected rather than
+//! silently clobbering the source. Those rules — deriving the sibling name and
+//! the in-place guard (including the hard-link identity check that a
+//! canonical-path comparison would miss) — used to live inline in the driver
+//! (`main`'s `opt` arm), a shallow arrangement where the only way to exercise
+//! "a hard link to the input is refused" or "a stem-less input yields an error"
+//! was to drive the whole command.
+//!
+//! This module lifts those rules into a pure seam: paths in, a resolved
+//! `PathBuf` or an error message out, with a single public entry point
+//! ([`resolve_output_path`]). The derive step is fallible — a caller-supplied
+//! path with no usable (UTF-8) file name yields an `Err` the driver reports,
+//! never a panic. The two helpers behind the seam
+//! (`optimized_output_path`, `paths_point_to_same_file`) stay private because
+//! the whole point of the module is that callers only need the one decision.
+//! See the `CONTEXT.md` glossary for the domain terms.
+
+use std::path::{Path, PathBuf};
+
+/// Resolve where an `opt` run writes its result.
+///
+/// With no explicit `-o/--output` the derived `<stem>_optimized.<ext>` sibling
+/// is preserved verbatim (the pre-#616 single-window behaviour). An explicit
+/// output is honoured, except when it resolves to the input binary itself: the
+/// driver never rewrites the input in place, so that request is rejected rather
+/// than silently clobbering the source. A `None` output over an input with no
+/// usable file name (a stem-less or non-UTF-8 path) yields an error instead of
+/// panicking, so the driver can report it and exit cleanly.
+pub fn resolve_output_path(input: &Path, output: Option<&Path>) -> Result<PathBuf, String> {
+    match output {
+        Some(out) => {
+            if paths_point_to_same_file(input, out) {
+                Err(format!(
+                    "output path '{}' resolves to the input binary; refusing to optimize in place (choose a different -o/--output)",
+                    out.display()
+                ))
+            } else {
+                Ok(out.to_path_buf())
+            }
+        }
+        None => optimized_output_path(input),
+    }
+}
+
+/// Derive the default `<stem>_optimized.<ext>` sibling for `path`.
+///
+/// Fallible on purpose: `path` originates from the CLI, so it may have no file
+/// stem (`..`, `/`) or a non-UTF-8 name (arbitrary bytes on Linux). Rather than
+/// `unwrap` those away — which panicked the driver — surface an error the
+/// caller turns into a clean message pointing at `-o/--output`.
+fn optimized_output_path(path: &Path) -> Result<PathBuf, String> {
+    let mut new_path = path.to_path_buf();
+    let stem = new_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| {
+            format!(
+                "cannot derive an output path from input '{}': it has no usable (UTF-8) file name (pass an explicit -o/--output)",
+                path.display()
+            )
+        })?;
+    let extension = match new_path.extension() {
+        Some(ext) => Some(ext.to_str().ok_or_else(|| {
+            format!(
+                "cannot derive an output path from input '{}': its extension is not valid UTF-8 (pass an explicit -o/--output)",
+                path.display()
+            )
+        })?),
+        None => None,
+    };
+
+    let new_name = if let Some(ext) = extension {
+        format!("{}_optimized.{}", stem, ext)
+    } else {
+        format!("{}_optimized", stem)
+    };
+
+    new_path.set_file_name(new_name);
+    Ok(new_path)
+}
+
+/// Whether `a` and `b` are the same file on disk.
+///
+/// On Unix this compares the `(device, inode)` pair, the only check that catches
+/// a **hard link**: two hard links to one inode are distinct directory entries
+/// with distinct canonical paths, so a canonical-path comparison would miss them
+/// and let an `-o` hard link to the input slip through the in-place guard and get
+/// truncated by `create_patched_copy`. `metadata` follows symlinks and requires
+/// the path to exist, so it subsumes the symlink and `./bin` vs `bin` cases too;
+/// a `-o` target that does not exist yet cannot alias the already-present input,
+/// so a failed stat means "different". Off Unix, fall back to comparing canonical
+/// paths (then literal paths when canonicalization fails, which only happens for
+/// a not-yet-created output that therefore cannot be the input).
+fn paths_point_to_same_file(a: &Path, b: &Path) -> bool {
+    #[cfg(unix)]
+    fn same_file(a: &Path, b: &Path) -> bool {
+        use std::os::unix::fs::MetadataExt;
+        match (std::fs::metadata(a), std::fs::metadata(b)) {
+            (Ok(ma), Ok(mb)) => ma.dev() == mb.dev() && ma.ino() == mb.ino(),
+            _ => false,
+        }
+    }
+    #[cfg(not(unix))]
+    fn same_file(a: &Path, b: &Path) -> bool {
+        match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
+            (Ok(ca), Ok(cb)) => ca == cb,
+            _ => a == b,
+        }
+    }
+    same_file(a, b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::TempFile;
+
+    #[test]
+    fn resolve_output_path_falls_back_to_derived_path() {
+        let input = Path::new("/some/dir/prog.elf");
+        assert_eq!(
+            resolve_output_path(input, None).unwrap(),
+            optimized_output_path(input).unwrap()
+        );
+    }
+
+    #[test]
+    fn resolve_output_path_honors_explicit_output() {
+        let input = Path::new("/some/dir/prog.elf");
+        let out = Path::new("/other/place/out.bin");
+        assert_eq!(
+            resolve_output_path(input, Some(out)).unwrap(),
+            out.to_path_buf()
+        );
+    }
+
+    #[test]
+    fn resolve_output_path_rejects_in_place_output() {
+        // The same existing file addressed two ways (a `.` component): on Unix
+        // the guard fires via the (dev, ino) identity check, off-Unix via
+        // canonicalization — either way, not literal string comparison.
+        let input = TempFile::new_bytes("s11-resolve-inplace", "elf", &[0u8; 4]);
+        let aliased = input
+            .path()
+            .parent()
+            .unwrap()
+            .join(".")
+            .join(input.path().file_name().unwrap());
+        let err = resolve_output_path(input.path(), Some(&aliased))
+            .expect_err("output resolving to the input binary must be rejected");
+        assert!(
+            err.contains("refusing to optimize in place"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_output_path_rejects_hard_link_to_input() {
+        // A hard link shares the input's inode but has a distinct canonical
+        // path, so only a (dev, ino) comparison — not canonicalize — catches it.
+        let input = TempFile::new_bytes("s11-resolve-hardlink", "elf", &[0u8; 8]);
+        let link = input.path().with_extension("hardlink");
+        std::fs::hard_link(input.path(), &link).expect("create hard link to input");
+        let result = resolve_output_path(input.path(), Some(&link));
+        let _ = std::fs::remove_file(&link);
+        let err = result.expect_err("a hard link to the input binary must be rejected");
+        assert!(
+            err.contains("refusing to optimize in place"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_output_path_errors_on_stem_less_input() {
+        // `..` / `/` have no file stem; the derived-name step must surface an
+        // error the driver can report, not panic on an `unwrap`.
+        for input in [Path::new(".."), Path::new("/")] {
+            let err = resolve_output_path(input, None)
+                .expect_err("an input path with no file stem must yield an error, not a panic");
+            assert!(
+                err.contains("output path"),
+                "unexpected error for {input:?}: {err}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_output_path_errors_on_non_utf8_input() {
+        // Linux filenames are arbitrary bytes; a non-UTF-8 name must not panic
+        // when the driver derives `<stem>_optimized`.
+        use std::os::unix::ffi::OsStrExt;
+        let input = std::path::PathBuf::from(std::ffi::OsStr::from_bytes(b"bin\xffname"));
+        let err = resolve_output_path(&input, None)
+            .expect_err("a non-UTF-8 input path must yield an error, not a panic");
+        assert!(err.contains("output path"), "unexpected error: {err}");
+    }
+}


### PR DESCRIPTION
## Architecture audit → chosen refactor

Ran the `improve-codebase-architecture` skill (informed by `codebase-design` and
`CONTEXT.md`) against the codebase. The hot spot is unambiguous: `src/main.rs`
changed in 15 of the last 60 commits and the recent history (#758, #759, #760) is a
deliberate campaign of pulling **pure, tested seams** out of the 5.5k-line driver.
I continued that campaign.

**Candidates surfaced:**

| Candidate | Depth / friction | Why not (this PR) |
|---|---|---|
| **Output-path resolution** (`optimized_output_path`, `resolve_output_path`, `paths_point_to_same_file`) | One real entry point hiding derive-name + never-optimize-in-place guard + hard-link identity check. Zero project-type coupling. Deletion test passes: delete it and the in-place/hard-link guard scatters back to the `opt` driver. | **Chosen.** |
| Search-config builders (`build_*_search_config`, ~11 fns) | Larger, central concern, biggest test cluster. | Coupled to `OptimizationOptions` (25 refs in main.rs); a clean lift means moving a CLI-shaped struct into the lib — worse depth-per-risk for one PR. Good runner-up. |
| `find_candidate_windows` (~15 tests) | Richest logic. | The *pure* planner is already extracted as `src/candidate_windows.rs`; the main.rs function is the Capstone/backend adapter — not duplication, correctly placed. |

## What changed

Lifted output-path resolution into a new pure seam `src/output_path.rs` — a single
public entry point `resolve_output_path`, with the derive and same-file helpers kept
private. The `opt` driver becomes a thin adapter that passes the input path and
optional `-o` through it. Registered in `lib.rs`; added the **Output-path
resolution** glossary entry to `CONTEXT.md`, mirroring the disassembly-listing seam
(#759).

## Bug fixed (the TDD red phase)

`optimized_output_path` unwrapped `file_stem()` and `to_str()`, so `s11 opt` **panicked**
on any input path with no file stem (`..`, `/`) or a non-UTF-8 filename (arbitrary
bytes on Linux) — reachable straight through the `opt` arm at the derive step. The
derive is now fallible and `resolve_output_path` propagates the error, which the
driver already turns into a clean `Error: ...` exit (no interface change:
`resolve_output_path` still returns `Result<PathBuf, String>`).

## Tests (TDD, red → green → refactor)

Followed the `tdd` skill:

1. **Red** — added `resolve_output_path_errors_on_stem_less_input` and
   `resolve_output_path_errors_on_non_utf8_input`, asserting `Err` (not panic).
   Confirmed both panicked at `src/main.rs:1291` against the old code.
2. **Green** — made the derive fallible; both pass.
3. **Refactor** — moved the cluster + all six tests into `src/output_path.rs`
   (the four pre-existing path tests unchanged), so the seam is tested through its
   own interface.

All six tests pass in the new module; `./ci_check.sh` is green (fmt, build, unit +
integration suites). New code is clippy-clean (the two remaining clippy warnings are
pre-existing in `x86_window_reassembly.rs`).

## Impact

`src/main.rs` −127 lines net; the derive panic is closed; the in-place / hard-link
safety guard now lives behind a small, directly testable interface.
