### PR TITLE
fix(security): harden repository Claude permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,6 @@
       "Bash(just run)",
       "Bash(cargo run:*)",
       "Bash(aarch64-linux-gnu-gcc:*)",
-      "Bash(chmod:*)",
       "Bash(./build_tests.sh:*)",
       "Bash(just analyze:*)",
       "Bash(just help:*)",
@@ -19,7 +18,6 @@
       "Bash(mkdir:*)",
       "Bash(just build)",
       "Bash(z3:*)",
-      "Bash(sudo pacman:*)",
       "Bash(cargo test)",
       "Bash(cargo clean:*)",
       "Bash(cargo build:*)",
@@ -32,11 +30,9 @@
       "Bash(cargo test:*)",
       "Bash(ls:*)",
       "Bash(RUST_BACKTRACE=1 cargo test integration::opt_test::test_opt_basic_functionality -- --nocapture)",
-      "Bash(rm:*)",
       "WebFetch(domain:censoredusername.github.io)",
       "Bash(RUST_BACKTRACE=1 cargo test test_mov_imm_encoding -- --nocapture)",
       "Bash(RUST_BACKTRACE=1 cargo test test_multiple_instructions -- --nocapture)",
-      "Bash(git checkout:*)",
       "mcp__github__create_pull_request",
       "mcp__github__get_file_contents",
       "Bash(cat:*)",
@@ -50,7 +46,12 @@
       "mcp__github__pull_request_read",
       "Bash(gh pr checks:*)"
     ],
-    "deny": []
+    "deny": [
+      "Bash(rm *)",
+      "Bash(sudo *)",
+      "Bash(chmod *)",
+      "Bash(git checkout *)"
+    ]
   },
   "enableAllProjectMcpServers": false
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,9 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
+    - name: Check Claude settings policy
+      run: python3 -m unittest discover -s scripts -p 'test_claude_settings_policy.py'
+
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,11 +48,12 @@ Standard Cargo commands also work:
 ### CI Checks
 
 **IMPORTANT**: Before committing and pushing, always run `./ci_check.sh` to ensure your code will pass CI. This script runs:
-1. Code formatting check (`cargo fmt -- --check`)
-2. Project build
-3. Unit tests
+1. Repository Claude permission-policy check (`python3 -m unittest discover -s scripts -p 'test_claude_settings_policy.py'`)
+2. Code formatting check (`cargo fmt -- --check`)
+3. Project build
 4. Test binary builds
-5. Full test suite
+5. Unit and integration tests
+6. Full test suite
 
 This prevents pushing code that will fail CI checks.
 
@@ -119,6 +120,7 @@ The project requires:
 - Capstone engine (usually installed via system package manager) — auto-detects x86 and arm64 modes
 - Z3 SMT solver and development libraries (for semantic equivalence checking)
 - `just` command runner for running build tasks (required by test_all.sh)
+- Python 3 (standard library only, for the repository Claude permission-policy check)
 - For building x86 test binaries via `build_tests.sh`:
   - Host `gcc` for x86-64 (produced into `binaries/x86_64/`)
   - `gcc -m32` for x86-32 (requires `gcc-multilib`; gracefully skipped if absent)

--- a/ci_check.sh
+++ b/ci_check.sh
@@ -23,37 +23,43 @@ print_status() {
     fi
 }
 
-# 1. Check formatting
-echo "1. Checking code formatting..."
+# 1. Check the tracked Claude Code permission policy
+echo "1. Checking Claude settings policy..."
+python3 -m unittest discover -s scripts -p 'test_claude_settings_policy.py'
+print_status "Claude settings policy"
+echo
+
+# 2. Check formatting
+echo "2. Checking code formatting..."
 cargo fmt -- --check
 print_status "Code formatting"
 echo
 
-# 2. Build project
-echo "2. Building project..."
+# 3. Build project
+echo "3. Building project..."
 cargo build --verbose
 print_status "Build"
 echo
 
-# 3. Build test binaries (if build_tests.sh exists)
+# 4. Build test binaries (if build_tests.sh exists)
 # Must run before `cargo test` because integration tests under tests/integration/
 # load the cross-compiled AArch64 binaries from binaries/.
 if [ -f "./build_tests.sh" ]; then
-    echo "3. Building test binaries..."
+    echo "4. Building test binaries..."
     ./build_tests.sh
     print_status "Test binary build"
     echo
 fi
 
-# 4. Run unit + integration tests
-echo "4. Running tests..."
+# 5. Run unit + integration tests
+echo "5. Running tests..."
 cargo test --verbose
 print_status "Tests"
 echo
 
-# 5. Run all tests (if test_all.sh exists)
+# 6. Run all tests (if test_all.sh exists)
 if [ -f "./test_all.sh" ]; then
-    echo "5. Running all tests..."
+    echo "6. Running all tests..."
     ./test_all.sh
     print_status "All tests"
     echo

--- a/scripts/test_claude_settings_policy.py
+++ b/scripts/test_claude_settings_policy.py
@@ -1,0 +1,71 @@
+"""Regression checks for the tracked Claude Code permission policy.
+
+Run with:
+    python3 -m unittest discover -s scripts -p 'test_claude_settings_policy.py'
+"""
+
+import json
+from pathlib import Path
+import unittest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+SETTINGS_PATH = REPOSITORY_ROOT / ".claude" / "settings.json"
+
+REQUIRED_DENY_RULES = frozenset(
+    {
+        "Bash(rm *)",
+        "Bash(sudo *)",
+        "Bash(chmod *)",
+        "Bash(git checkout *)",
+    }
+)
+
+
+def normalize_trailing_wildcard(rule: str) -> str:
+    """Return the canonical spelling for a trailing Claude Bash wildcard."""
+    if rule.endswith(":*)"):
+        return f"{rule[:-3]} *)"
+    return rule
+
+
+def is_dangerous_shared_allow(rule: str) -> bool:
+    """Identify broad destructive or host-mutating shared Bash grants."""
+    normalized = normalize_trailing_wildcard(rule)
+    if normalized == "Bash(sudo)" or normalized.startswith("Bash(sudo "):
+        return True
+    return normalized in REQUIRED_DENY_RULES
+
+
+class TestClaudeSettingsPolicy(unittest.TestCase):
+    def test_shared_policy_denies_destructive_shell_families(self):
+        settings = json.loads(SETTINGS_PATH.read_text(encoding="utf-8"))
+        permissions = settings.get("permissions", {})
+
+        dangerous_allows = sorted(
+            rule
+            for rule in permissions.get("allow", [])
+            if is_dangerous_shared_allow(rule)
+        )
+        normalized_denies = {
+            normalize_trailing_wildcard(rule)
+            for rule in permissions.get("deny", [])
+        }
+        missing_denies = sorted(REQUIRED_DENY_RULES - normalized_denies)
+
+        failures = []
+        if dangerous_allows:
+            failures.append(
+                "dangerous rules must not be allowed by shared settings: "
+                + ", ".join(dangerous_allows)
+            )
+        if missing_denies:
+            failures.append(
+                "shared settings must explicitly deny: " + ", ".join(missing_denies)
+            )
+
+        self.assertFalse(failures, "\n".join(failures))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- remove broad shared grants for rm, sudo, chmod, and git checkout and add explicit project denies
- add an actionable standard-library policy regression test that understands both wildcard spellings
- fail local and hosted CI early when the tracked policy regresses

## Testing

- `python3 -m unittest discover -s scripts -p 'test_*.py'`
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --all` (after the documented `build_tests.sh` fixture prerequisite)
- `./ci_check.sh`

The implementation-stage template names `scripts/full_test.sh`, which is absent in this repository. The repository-authoritative `./ci_check.sh` was used instead; it runs `build_tests.sh`, Cargo tests, and `test_all.sh`.

Closes #213

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**