### PR TITLE
fix(ci): make test failures authoritative

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,10 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
-    - name: Check Claude settings policy
-      run: python3 -m unittest discover -s scripts -p 'test_claude_settings_policy.py'
+    - name: Check repository CI policy
+      run: |
+        python3 -m unittest discover -s scripts -p 'test_*_policy.py'
+        ./scripts/test_test_all.sh
 
     - name: Install dependencies
       run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Standard Cargo commands also work:
 ### CI Checks
 
 **IMPORTANT**: Before committing and pushing, always run `./ci_check.sh` to ensure your code will pass CI. This script runs:
-1. Repository Claude permission-policy check (`python3 -m unittest discover -s scripts -p 'test_claude_settings_policy.py'`)
+1. Repository CI-policy checks (`python3 -m unittest discover -s scripts -p 'test_*_policy.py'` and `./scripts/test_test_all.sh`)
 2. Code formatting check (`cargo fmt -- --check`)
 3. Project build
 4. Test binary builds
@@ -120,7 +120,7 @@ The project requires:
 - Capstone engine (usually installed via system package manager) — auto-detects x86 and arm64 modes
 - Z3 SMT solver and development libraries (for semantic equivalence checking)
 - `just` command runner for running build tasks (required by test_all.sh)
-- Python 3 (standard library only, for the repository Claude permission-policy check)
+- Python 3 (standard library only, for the repository CI-policy checks)
 - For building x86 test binaries via `build_tests.sh`:
   - Host `gcc` for x86-64 (produced into `binaries/x86_64/`)
   - `gcc -m32` for x86-32 (requires `gcc-multilib`; gracefully skipped if absent)

--- a/ci_check.sh
+++ b/ci_check.sh
@@ -23,10 +23,12 @@ print_status() {
     fi
 }
 
-# 1. Check the tracked Claude Code permission policy
-echo "1. Checking Claude settings policy..."
-python3 -m unittest discover -s scripts -p 'test_claude_settings_policy.py'
-print_status "Claude settings policy"
+# 1. Check repository CI policies and their shell regressions
+echo "1. Checking repository CI policy..."
+python3 -m unittest discover -s scripts -p 'test_*_policy.py'
+print_status "Repository CI policy"
+./scripts/test_test_all.sh
+print_status "Analyzer script regressions"
 echo
 
 # 2. Check formatting

--- a/scripts/test_ci_policy.py
+++ b/scripts/test_ci_policy.py
@@ -1,0 +1,89 @@
+"""Regression checks for required Test workflow gates."""
+
+from pathlib import Path
+import unittest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+CI_CHECK_PATH = REPOSITORY_ROOT / "ci_check.sh"
+TEST_WORKFLOW_PATH = REPOSITORY_ROOT / ".github" / "workflows" / "test.yml"
+
+INTEGRATION_TEST_COMMAND = "cargo test --test integration_tests -- --nocapture"
+POLICY_DISCOVERY_COMMAND = (
+    "python3 -m unittest discover -s scripts -p 'test_*_policy.py'"
+)
+SHELL_REGRESSION_COMMAND = "./scripts/test_test_all.sh"
+
+
+def has_required_command(contents: str, command: str) -> bool:
+    """Return whether command appears on its own, without failure masking."""
+    return command in {line.strip() for line in contents.splitlines()}
+
+
+def workflow_step(contents: str, name: str) -> str:
+    """Extract a named workflow step without requiring a YAML dependency."""
+    lines = contents.splitlines()
+    marker = f"- name: {name}"
+
+    for start, line in enumerate(lines):
+        if line.strip() != marker:
+            continue
+
+        indentation = len(line) - len(line.lstrip())
+        end = len(lines)
+        for index in range(start + 1, len(lines)):
+            candidate = lines[index]
+            if not candidate.strip():
+                continue
+            candidate_indentation = len(candidate) - len(candidate.lstrip())
+            if candidate_indentation == indentation and candidate.lstrip().startswith("- "):
+                end = index
+                break
+        return "\n".join(lines[start:end])
+
+    raise ValueError(f"workflow step not found: {name}")
+
+
+class TestCiPolicy(unittest.TestCase):
+    def test_required_command_matcher_rejects_failure_masking(self):
+        masked_workflow = f"run: {INTEGRATION_TEST_COMMAND} || true"
+
+        self.assertFalse(
+            has_required_command(masked_workflow, INTEGRATION_TEST_COMMAND)
+        )
+
+    def test_integration_tests_are_a_required_gate(self):
+        workflow = TEST_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+        self.assertTrue(
+            has_required_command(workflow, INTEGRATION_TEST_COMMAND),
+            f"{INTEGRATION_TEST_COMMAND!r} must be present without failure masking",
+        )
+
+    def test_repository_policy_step_runs_all_regressions(self):
+        workflow = TEST_WORKFLOW_PATH.read_text(encoding="utf-8")
+        try:
+            policy_step = workflow_step(workflow, "Check repository CI policy")
+        except ValueError as error:
+            self.fail(str(error))
+
+        for command in (POLICY_DISCOVERY_COMMAND, SHELL_REGRESSION_COMMAND):
+            with self.subTest(command=command):
+                self.assertTrue(
+                    has_required_command(policy_step, command),
+                    f"repository CI policy step must run {command!r}",
+                )
+
+    def test_local_ci_gate_runs_all_regressions(self):
+        ci_check = CI_CHECK_PATH.read_text(encoding="utf-8")
+
+        for command in (POLICY_DISCOVERY_COMMAND, SHELL_REGRESSION_COMMAND):
+            with self.subTest(command=command):
+                self.assertTrue(
+                    has_required_command(ci_check, command),
+                    f"local CI gate must run {command!r}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_test_all.sh
+++ b/scripts/test_test_all.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+set -euo pipefail
+
+repository_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+temporary_root=$(mktemp -d)
+trap 'rm -rf "$temporary_root"' EXIT
+
+mkdir -p "$temporary_root/bin" "$temporary_root/work/binaries"
+
+cat >"$temporary_root/bin/just" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+
+cat >"$temporary_root/bin/cargo" <<'EOF'
+#!/bin/bash
+case "${STUB_CARGO_MODE:-fail}" in
+    fail)
+        echo "simulated analyzer failure" >&2
+        exit 42
+        ;;
+    empty)
+        exit 0
+        ;;
+    success)
+        echo "0x1000: 1f 20 03 d5 nop"
+        ;;
+    *)
+        echo "unknown STUB_CARGO_MODE: ${STUB_CARGO_MODE:-}" >&2
+        exit 64
+        ;;
+esac
+EOF
+
+chmod +x "$temporary_root/bin/just" "$temporary_root/bin/cargo"
+
+run_test_all() {
+    local cargo_mode="$1"
+
+    set +e
+    output=$(
+        cd "$temporary_root/work"
+        STUB_CARGO_MODE="$cargo_mode" PATH="$temporary_root/bin:$PATH" \
+            bash "$repository_root/test_all.sh" 2>&1
+    )
+    status=$?
+    set -e
+}
+
+run_test_all fail
+
+if [ "$status" -eq 0 ]; then
+    echo "test_all.sh succeeded after cargo run failed" >&2
+    echo "$output" >&2
+    exit 1
+fi
+
+if grep -Fq "The optimizer successfully analyzed all AArch64 binaries!" <<<"$output"; then
+    echo "test_all.sh printed its success banner after cargo run failed" >&2
+    echo "$output" >&2
+    exit 1
+fi
+
+echo "test_all.sh propagates analyzer command failures"
+
+run_test_all empty
+
+if [ "$status" -eq 0 ]; then
+    echo "test_all.sh succeeded without disassembly output" >&2
+    echo "$output" >&2
+    exit 1
+fi
+
+if grep -Fq "The optimizer successfully analyzed all AArch64 binaries!" <<<"$output"; then
+    echo "test_all.sh printed its success banner without disassembly output" >&2
+    echo "$output" >&2
+    exit 1
+fi
+
+echo "test_all.sh rejects empty analyzer output"
+
+run_test_all success
+
+if [ "$status" -ne 0 ]; then
+    echo "test_all.sh failed after valid disassembly output" >&2
+    echo "$output" >&2
+    exit 1
+fi
+
+banner_count=$(
+    grep -Fc "The optimizer successfully analyzed all AArch64 binaries!" \
+        <<<"$output" || true
+)
+if [ "$banner_count" -ne 1 ]; then
+    echo "test_all.sh printed its success banner $banner_count times; expected once" >&2
+    echo "$output" >&2
+    exit 1
+fi
+
+echo "test_all.sh accepts valid disassembly output"

--- a/test_all.sh
+++ b/test_all.sh
@@ -8,7 +8,7 @@
 # suite is the only one that runs; x86 tests live in the unit tests
 # inside concrete_x86.rs / smt_x86.rs / cost_x86.rs / the x86 trait
 # impls in src/isa/x86.rs.
-set -e
+set -euo pipefail
 
 echo "=== s11 Test Suite ==="
 echo
@@ -29,6 +29,8 @@ echo
 run_test() {
     local binary="$1"
     local name="$2"
+    local instructions
+    local output
     
     echo "=== Testing $name ==="
     echo "Binary: $binary"
@@ -36,9 +38,17 @@ run_test() {
     # Run the disassembler and show the last ~20 instructions of .text
     # (usually contains main). `s11 disasm` prints one
     # "addr: bytes mnemonic" line per instruction with no header.
-    cargo run -- disasm "$binary" 2>/dev/null | \
-        grep -E "0x[0-9a-f]+:" | \
-        tail -20
+    if ! output=$(cargo run -- disasm "$binary"); then
+        echo "Failed to analyze $name ($binary)." >&2
+        return 1
+    fi
+
+    if ! instructions=$(grep -E "0x[0-9a-f]+:" <<<"$output"); then
+        echo "No disassembly instructions found for $name ($binary)." >&2
+        return 1
+    fi
+
+    printf '%s\n' "$instructions" | tail -20
     echo
 }
 


### PR DESCRIPTION
Summary:
- propagate analyzer command failures and reject missing disassembly output in `test_all.sh`
- add process-level regressions for failed, empty, and successful analyzer runs
- pin the unmasked integration command and regression wiring in workflow policy tests
- keep the documented local CI gate aligned with GitHub Actions

Verification:
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `./build_tests.sh && cargo test --all`
- `./ci_check.sh`

Closes #216

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**