### PR TITLE
fix(ci): document mutants wrapper flags without separator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,9 @@ jobs:
         sudo apt-get install -y libcapstone-dev gcc-aarch64-linux-gnu z3 libz3-dev
         curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
 
+    - name: Check mutation-test wrapper invocations
+      run: ./scripts/test_mutants_invocation.sh
+
     - name: Setup Rust
       run: |
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable --component rustfmt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,8 +107,8 @@ and how to add a fixture.
 Mutation testing runs via [cargo-mutants](https://mutants.rs/) and is **informational only** — it does not gate merges. It is **not** wired into CI to keep GitHub Actions minutes for the test/clippy/CodeQL workflows.
 
 - `just mutants` — full run via `scripts/run-mutants.sh` (slow; expect >30 min).
-- `just mutants -- --diff` — mutants only on the local diff vs `origin/main`.
-- `just mutants -- --shard 0/8` — one shard of an 8-way split for parallel local runs.
+- `just mutants --diff` — mutants only on the local diff vs `origin/main`.
+- `just mutants --shard 0/8` — one shard of an 8-way split for parallel local runs.
 - Configuration lives in `.cargo/mutants.toml` (cargo-mutants reads this path automatically).
 - The wrapper prints a caught/missed/timeout/unviable summary via `scripts/mutants_summary.py`.
 

--- a/Justfile
+++ b/Justfile
@@ -80,7 +80,7 @@ llm-demo: build
 
 # Run cargo-mutants locally (slow; expect >30 min on a full run).
 # Thin wrapper around scripts/run-mutants.sh; pass `--diff` or `--shard`
-# arguments through with `just mutants -- --diff`.
+# arguments through with `just mutants --diff`.
 mutants *ARGS:
     ./scripts/run-mutants.sh {{ARGS}}
 

--- a/README.md
+++ b/README.md
@@ -170,10 +170,10 @@ minutes than the project can afford.
 cargo install --locked cargo-mutants
 
 just mutants                     # full run, expect >30 min
-just mutants -- --diff           # only mutants in the local diff vs origin/main
-just mutants -- --diff main      # diff vs an explicit base ref
-just mutants -- --shard 0/8      # one shard of an 8-way split
-just mutants -- -- --foo         # forward extra flags to cargo-mutants
+just mutants --diff              # only mutants in the local diff vs origin/main
+just mutants --diff main         # diff vs an explicit base ref
+just mutants --shard 0/8         # one shard of an 8-way split
+just mutants -- --foo            # forward extra flags to cargo-mutants
 ```
 
 The wrapper lives at `scripts/run-mutants.sh` and prints a

--- a/ci_check.sh
+++ b/ci_check.sh
@@ -31,37 +31,43 @@ print_status "Repository CI policy"
 print_status "Analyzer script regressions"
 echo
 
-# 2. Check formatting
-echo "2. Checking code formatting..."
+# 2. Check mutation-test wrapper invocations
+echo "2. Checking mutation-test wrapper invocations..."
+./scripts/test_mutants_invocation.sh
+print_status "Mutation-test wrapper invocations"
+echo
+
+# 3. Check formatting
+echo "3. Checking code formatting..."
 cargo fmt -- --check
 print_status "Code formatting"
 echo
 
-# 3. Build project
-echo "3. Building project..."
+# 4. Build project
+echo "4. Building project..."
 cargo build --verbose
 print_status "Build"
 echo
 
-# 4. Build test binaries (if build_tests.sh exists)
+# 5. Build test binaries (if build_tests.sh exists)
 # Must run before `cargo test` because integration tests under tests/integration/
 # load the cross-compiled AArch64 binaries from binaries/.
 if [ -f "./build_tests.sh" ]; then
-    echo "4. Building test binaries..."
+    echo "5. Building test binaries..."
     ./build_tests.sh
     print_status "Test binary build"
     echo
 fi
 
-# 5. Run unit + integration tests
-echo "5. Running tests..."
+# 6. Run unit + integration tests
+echo "6. Running tests..."
 cargo test --verbose
 print_status "Tests"
 echo
 
-# 6. Run all tests (if test_all.sh exists)
+# 7. Run all tests (if test_all.sh exists)
 if [ -f "./test_all.sh" ]; then
-    echo "6. Running all tests..."
+    echo "7. Running all tests..."
     ./test_all.sh
     print_status "All tests"
     echo

--- a/scripts/test_mutants_invocation.sh
+++ b/scripts/test_mutants_invocation.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$repo_root"
+
+assert_dry_run() {
+    local expected=$1
+    shift
+
+    local actual
+    actual=$(just --dry-run mutants "$@" 2>&1)
+    if [[ "$actual" != "$expected" ]]; then
+        echo "unexpected dry-run output for: just mutants $*" >&2
+        echo "expected: $expected" >&2
+        echo "actual:   $actual" >&2
+        exit 1
+    fi
+}
+
+assert_contains() {
+    local path=$1
+    local expected=$2
+
+    if ! grep -Fq -- "$expected" "$path"; then
+        echo "$path does not document: $expected" >&2
+        exit 1
+    fi
+}
+
+assert_absent() {
+    local path=$1
+    local stale=$2
+
+    if grep -Fq -- "$stale" "$path"; then
+        echo "$path still documents the invalid invocation: $stale" >&2
+        exit 1
+    fi
+}
+
+# Wrapper modes must reach run-mutants.sh without a leading separator.
+assert_dry_run './scripts/run-mutants.sh --diff' --diff
+assert_dry_run './scripts/run-mutants.sh --diff main' --diff main
+assert_dry_run './scripts/run-mutants.sh --shard 0/8' --shard 0/8
+
+# A separator remains required when intentionally forwarding cargo-mutants flags.
+assert_dry_run './scripts/run-mutants.sh -- --foo' -- --foo
+
+assert_contains Justfile 'just mutants --diff'
+assert_contains CLAUDE.md 'just mutants --diff'
+assert_contains CLAUDE.md 'just mutants --shard 0/8'
+assert_contains README.md 'just mutants --diff'
+assert_contains README.md 'just mutants --shard 0/8'
+assert_contains README.md 'just mutants -- --foo'
+
+for path in Justfile CLAUDE.md README.md; do
+    assert_absent "$path" 'just mutants -- --diff'
+    assert_absent "$path" 'just mutants -- --shard'
+    assert_absent "$path" 'just mutants -- -- --'
+done


### PR DESCRIPTION
## Summary

- document `--diff` and `--shard` as wrapper options without a leading separator
- preserve `just mutants -- --foo` as the intentional cargo-mutants passthrough form
- add a dry-run/documentation regression check to local and GitHub CI

## Validation

- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `./build_tests.sh && cargo test --all`
- `./ci_check.sh`

The Vow-stage command `scripts/full_test.sh` is not present in this s11 repository; `./ci_check.sh` ran the repository test suite through `test_all.sh` successfully.

Closes #219

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**