### PR TITLE
fix(mutants): honor wrapper timeout configuration

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -6,13 +6,12 @@
 # I/O / CLI plumbing or known infinite-loop-prone code.
 
 # Allow each mutant 5x the baseline test runtime for direct `cargo mutants`
-# invocations that run a baseline outside the source tree. Some mutants
-# intentionally cause unbounded loops (e.g. mutating loop bounds in
-# src/search/).
+# invocations that actually measure a baseline. Some mutants intentionally
+# cause unbounded loops (e.g. mutating loop bounds in src/search/).
 #
 # This setting cannot govern `just mutants`: the official wrapper deliberately
-# uses `--baseline=skip` and `--in-place`, which are incompatible with a
-# baseline-derived multiplier, and defaults to an explicit 180-second timeout.
+# runs with `--in-place` and `--baseline=skip`, so there is no baseline runtime
+# to multiply, and it defaults to an explicit 180-second timeout instead.
 # Override that policy with `just mutants --timeout SECONDS`.
 timeout_multiplier = 5.0
 

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -5,18 +5,18 @@
 # exclude_re_in_file once the first nightly identifies modules dominated by
 # I/O / CLI plumbing or known infinite-loop-prone code.
 
-# Allow each mutant 5x the baseline test runtime before declaring timeout.
-# Integration tests take ~1-2 min and some mutants intentionally cause
-# unbounded loops (e.g. mutating loop bounds in src/search/).
+# Allow each mutant 5x the baseline test runtime for direct `cargo mutants`
+# invocations that run a baseline outside the source tree. Some mutants
+# intentionally cause unbounded loops (e.g. mutating loop bounds in
+# src/search/).
 #
-# Note: the CI workflows pass `--timeout 180` explicitly, which overrides
-# this multiplier in CI. The multiplier still governs `just mutants` and any
-# other invocation that doesn't pass `--timeout`.
+# This setting cannot govern `just mutants`: the official wrapper deliberately
+# uses `--baseline=skip` and `--in-place`, which are incompatible with a
+# baseline-derived multiplier, and defaults to an explicit 180-second timeout.
+# Override that policy with `just mutants --timeout SECONDS`.
 timeout_multiplier = 5.0
 
-# Match the baseline (`cargo test --bins`) used in CI and `just mutants`. The
-# integration tests under tests/integration/ are flaky in our CI environment
-# (test.yml runs them with `|| true`), so including them in per-mutant runs
-# would mark every mutant as caught by the pre-existing flake instead of by
-# the mutation itself.
+# Match the unit-test baseline (`cargo test --bins`) used by `just mutants`.
+# Integration tests remain part of the normal quality gate; excluding them from
+# every per-mutant run keeps local informational mutation testing tractable.
 additional_cargo_test_args = ["--bins"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,9 @@ jobs:
         python3 -m unittest discover -s scripts -p 'test_*_policy.py'
         ./scripts/test_test_all.sh
 
+    - name: Check mutation-wrapper command construction
+      run: ./scripts/test_run_mutants.sh
+
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,8 @@ jobs:
         ./scripts/test_test_all.sh
 
     - name: Check mutation-wrapper command construction
-      run: ./scripts/test_run_mutants.sh
+      run: |
+        ./scripts/test_run_mutants.sh
 
     - name: Install dependencies
       run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,8 +114,8 @@ Mutation testing runs via [cargo-mutants](https://mutants.rs/) and is **informat
   per-mutant timeout.
 - Wrapper flags are written bare; only arguments after `--` are forwarded to
   cargo-mutants (`just mutants -- --foo`). `just` passes a literal `--` through
-  to the recipe, so `just mutants -- --diff` forwards `--diff` to cargo-mutants
-  instead of enabling the wrapper's diff mode.
+  to the recipe, so a leading separator forwards the flag after it to
+  cargo-mutants instead of enabling the wrapper's mode of the same name.
 - The wrapper uses `--in-place` (mutants are applied to the working tree, not a
   copy) and `--baseline=skip`. With no baseline run there is nothing for
   `.cargo/mutants.toml`'s `timeout_multiplier` to scale, so it applies only to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,14 +108,19 @@ and how to add a fixture.
 Mutation testing runs via [cargo-mutants](https://mutants.rs/) and is **informational only** — it does not gate merges. It is **not** wired into CI to keep GitHub Actions minutes for the test/clippy/CodeQL workflows.
 
 - `just mutants` — full run via `scripts/run-mutants.sh` (slow; expect >30 min).
-- `just mutants -- --diff` — mutants only on the local diff vs `origin/main`.
-- `just mutants -- --shard 0/8` — one shard of an 8-way split for parallel local runs.
+- `just mutants --diff` — mutants only on the local diff vs `origin/main`.
+- `just mutants --shard 0/8` — one shard of an 8-way split for parallel local runs.
 - `just mutants --timeout 45` — override the wrapper's default 180-second
   per-mutant timeout.
-- The wrapper uses `--baseline=skip` and `--in-place`, so
-  `.cargo/mutants.toml`'s `timeout_multiplier` applies only to compatible direct
-  `cargo mutants` runs; shared configuration such as
-  `additional_cargo_test_args` still applies.
+- Wrapper flags are written bare; only arguments after `--` are forwarded to
+  cargo-mutants (`just mutants -- --foo`). `just` passes a literal `--` through
+  to the recipe, so `just mutants -- --diff` forwards `--diff` to cargo-mutants
+  instead of enabling the wrapper's diff mode.
+- The wrapper uses `--in-place` (mutants are applied to the working tree, not a
+  copy) and `--baseline=skip`. With no baseline run there is nothing for
+  `.cargo/mutants.toml`'s `timeout_multiplier` to scale, so it applies only to
+  direct `cargo mutants` runs that measure a baseline. Shared configuration such
+  as `additional_cargo_test_args` still applies.
 - The wrapper prints a caught/missed/timeout/unviable summary via `scripts/mutants_summary.py`.
 
 ## Dependencies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,11 +49,12 @@ Standard Cargo commands also work:
 
 **IMPORTANT**: Before committing and pushing, always run `./ci_check.sh` to ensure your code will pass CI. This script runs:
 1. Repository CI-policy checks (`python3 -m unittest discover -s scripts -p 'test_*_policy.py'` and `./scripts/test_test_all.sh`)
-2. Code formatting check (`cargo fmt -- --check`)
-3. Project build
-4. Test binary builds
-5. Unit and integration tests
-6. Full test suite
+2. Mutation-wrapper command regression (`./scripts/test_run_mutants.sh`)
+3. Code formatting check (`cargo fmt -- --check`)
+4. Project build
+5. Test binary builds
+6. Unit and integration tests
+7. Full test suite
 
 This prevents pushing code that will fail CI checks.
 
@@ -109,7 +110,12 @@ Mutation testing runs via [cargo-mutants](https://mutants.rs/) and is **informat
 - `just mutants` — full run via `scripts/run-mutants.sh` (slow; expect >30 min).
 - `just mutants -- --diff` — mutants only on the local diff vs `origin/main`.
 - `just mutants -- --shard 0/8` — one shard of an 8-way split for parallel local runs.
-- Configuration lives in `.cargo/mutants.toml` (cargo-mutants reads this path automatically).
+- `just mutants --timeout 45` — override the wrapper's default 180-second
+  per-mutant timeout.
+- The wrapper uses `--baseline=skip` and `--in-place`, so
+  `.cargo/mutants.toml`'s `timeout_multiplier` applies only to compatible direct
+  `cargo mutants` runs; shared configuration such as
+  `additional_cargo_test_args` still applies.
 - The wrapper prints a caught/missed/timeout/unviable summary via `scripts/mutants_summary.py`.
 
 ## Dependencies

--- a/Justfile
+++ b/Justfile
@@ -79,8 +79,9 @@ llm-demo: build
     ./tests/data/llm_demo/run_demo.sh
 
 # Run cargo-mutants locally (slow; expect >30 min on a full run).
-# Thin wrapper around scripts/run-mutants.sh; pass `--diff` or `--shard`
-# arguments through with `just mutants -- --diff`.
+# Thin wrapper around scripts/run-mutants.sh; wrapper flags go through bare
+# (`just mutants --diff`, `just mutants --timeout 45`) and anything after `--`
+# is forwarded to cargo-mutants (`just mutants -- --foo`).
 mutants *ARGS:
     ./scripts/run-mutants.sh {{ARGS}}
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ just fmt           # cargo fmt
 ```
 
 Before pushing, run `./ci_check.sh` to mirror the test workflow locally:
-fmt check, build, AArch64 test binaries, full test suite.
+wrapper regression checks, fmt check, build, AArch64 test binaries, and the
+full test suite.
 
 ## Using it
 
@@ -173,13 +174,18 @@ just mutants                     # full run, expect >30 min
 just mutants -- --diff           # only mutants in the local diff vs origin/main
 just mutants -- --diff main      # diff vs an explicit base ref
 just mutants -- --shard 0/8      # one shard of an 8-way split
+just mutants --timeout 45        # override the 180-second per-mutant timeout
 just mutants -- -- --foo         # forward extra flags to cargo-mutants
 ```
 
 The wrapper lives at `scripts/run-mutants.sh` and prints a
 caught/missed/timeout/unviable summary at the end via
-`scripts/mutants_summary.py`. Configuration lives in
-`.cargo/mutants.toml`.
+`scripts/mutants_summary.py`. It runs cargo-mutants with `--baseline=skip` and
+`--in-place`, so it owns the timeout policy: 180 seconds per mutant by default,
+overridable with `--timeout SECONDS`. The `timeout_multiplier` in
+`.cargo/mutants.toml` applies only to compatible direct `cargo mutants` runs;
+shared settings such as `additional_cargo_test_args` still apply to the
+wrapper.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -180,8 +180,8 @@ just mutants -- --foo            # forward extra flags to cargo-mutants
 
 Bare flags are interpreted by the wrapper; everything after `--` is forwarded
 verbatim to cargo-mutants. `just` passes a literal `--` straight through to the
-recipe, so writing `just mutants -- --diff` forwards `--diff` to cargo-mutants
-instead of enabling the wrapper's diff mode.
+recipe, so a leading separator forwards the flag after it to cargo-mutants
+instead of enabling the wrapper's mode of the same name.
 
 The wrapper lives at `scripts/run-mutants.sh` and prints a
 caught/missed/timeout/unviable summary at the end via

--- a/README.md
+++ b/README.md
@@ -171,21 +171,27 @@ minutes than the project can afford.
 cargo install --locked cargo-mutants
 
 just mutants                     # full run, expect >30 min
-just mutants -- --diff           # only mutants in the local diff vs origin/main
-just mutants -- --diff main      # diff vs an explicit base ref
-just mutants -- --shard 0/8      # one shard of an 8-way split
+just mutants --diff              # only mutants in the local diff vs origin/main
+just mutants --diff main         # diff vs an explicit base ref
+just mutants --shard 0/8         # one shard of an 8-way split
 just mutants --timeout 45        # override the 180-second per-mutant timeout
-just mutants -- -- --foo         # forward extra flags to cargo-mutants
+just mutants -- --foo            # forward extra flags to cargo-mutants
 ```
+
+Bare flags are interpreted by the wrapper; everything after `--` is forwarded
+verbatim to cargo-mutants. `just` passes a literal `--` straight through to the
+recipe, so writing `just mutants -- --diff` forwards `--diff` to cargo-mutants
+instead of enabling the wrapper's diff mode.
 
 The wrapper lives at `scripts/run-mutants.sh` and prints a
 caught/missed/timeout/unviable summary at the end via
-`scripts/mutants_summary.py`. It runs cargo-mutants with `--baseline=skip` and
-`--in-place`, so it owns the timeout policy: 180 seconds per mutant by default,
-overridable with `--timeout SECONDS`. The `timeout_multiplier` in
-`.cargo/mutants.toml` applies only to compatible direct `cargo mutants` runs;
-shared settings such as `additional_cargo_test_args` still apply to the
-wrapper.
+`scripts/mutants_summary.py`. It runs cargo-mutants with `--in-place` (mutating
+the working tree rather than a copy) and `--baseline=skip`; because there is no
+baseline run, `.cargo/mutants.toml`'s `timeout_multiplier` has nothing to scale,
+so the wrapper owns the timeout policy: 180 seconds per mutant by default,
+overridable with `--timeout SECONDS`. The multiplier applies only to direct
+`cargo mutants` runs that do measure a baseline; shared settings such as
+`additional_cargo_test_args` still apply to the wrapper.
 
 ## License
 

--- a/ci_check.sh
+++ b/ci_check.sh
@@ -31,37 +31,43 @@ print_status "Repository CI policy"
 print_status "Analyzer script regressions"
 echo
 
-# 2. Check formatting
-echo "2. Checking code formatting..."
+# 2. Check mutation-wrapper command construction
+echo "2. Checking mutation-wrapper command construction..."
+./scripts/test_run_mutants.sh
+print_status "Mutation-wrapper command construction"
+echo
+
+# 3. Check formatting
+echo "3. Checking code formatting..."
 cargo fmt -- --check
 print_status "Code formatting"
 echo
 
-# 3. Build project
-echo "3. Building project..."
+# 4. Build project
+echo "4. Building project..."
 cargo build --verbose
 print_status "Build"
 echo
 
-# 4. Build test binaries (if build_tests.sh exists)
+# 5. Build test binaries (if build_tests.sh exists)
 # Must run before `cargo test` because integration tests under tests/integration/
 # load the cross-compiled AArch64 binaries from binaries/.
 if [ -f "./build_tests.sh" ]; then
-    echo "4. Building test binaries..."
+    echo "5. Building test binaries..."
     ./build_tests.sh
     print_status "Test binary build"
     echo
 fi
 
-# 5. Run unit + integration tests
-echo "5. Running tests..."
+# 6. Run unit + integration tests
+echo "6. Running tests..."
 cargo test --verbose
 print_status "Tests"
 echo
 
-# 6. Run all tests (if test_all.sh exists)
+# 7. Run all tests (if test_all.sh exists)
 if [ -f "./test_all.sh" ]; then
-    echo "6. Running all tests..."
+    echo "7. Running all tests..."
     ./test_all.sh
     print_status "All tests"
     echo

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -49,8 +49,9 @@ prepares that release.
    - `@semantic-release/exec` runs [`.github/semantic-release/prepare.sh`](../.github/semantic-release/prepare.sh),
      which bumps `Cargo.toml`/`Cargo.lock` via
      [`scripts/bump-version.sh`](../scripts/bump-version.sh), runs the full
-     [`ci_check.sh`](../ci_check.sh) gate (fmt check, build, `build_tests.sh`,
-     `cargo test`, `test_all.sh`) to verify the tree, then builds the release
+     [`ci_check.sh`](../ci_check.sh) gate (repository policy + shell
+     regressions, fmt check, build, `build_tests.sh`, `cargo test`,
+     `test_all.sh`) to verify the tree, then builds the release
      binary and stages the tarball + `SHA256SUMS.txt`.
    - `@semantic-release/github` creates the GitHub Release and attaches the
      staged artifacts.

--- a/scripts/run-mutants.sh
+++ b/scripts/run-mutants.sh
@@ -4,11 +4,12 @@
 # from a developer machine to avoid eating GitHub Actions minutes.
 #
 # Shared cargo-mutants configuration (including --bins) lives in
-# .cargo/mutants.toml. This wrapper defaults each mutant to 180s because its
-# --baseline=skip and --in-place execution mode cannot use timeout_multiplier;
-# pass --timeout SECONDS to override that default. Its baseline and per-mutant
-# runs use unit tests only (`cargo test --bins`); integration tests remain in
-# the normal project quality gate rather than every local mutation run.
+# .cargo/mutants.toml. This wrapper runs with --in-place and --baseline=skip,
+# so there is no baseline run for timeout_multiplier to scale; it therefore
+# defaults each mutant to 180s and takes --timeout SECONDS to override. Its
+# baseline and per-mutant runs use unit tests only (`cargo test --bins`);
+# integration tests remain in the normal project quality gate rather than
+# every local mutation run.
 
 set -euo pipefail
 
@@ -19,7 +20,7 @@ Usage:
   scripts/run-mutants.sh --diff          # only mutants in `git diff origin/main...`
   scripts/run-mutants.sh --diff main     # diff vs an explicit base ref
   scripts/run-mutants.sh --shard 0/8     # one shard of an 8-way split
-  scripts/run-mutants.sh --timeout 180   # per-mutant timeout in seconds
+  scripts/run-mutants.sh --timeout 45    # per-mutant timeout in seconds (default 180)
   scripts/run-mutants.sh -- --foo --bar  # forward extra flags to cargo-mutants
   scripts/run-mutants.sh -h | --help     # print this message
 EOF
@@ -58,6 +59,10 @@ while [[ $# -gt 0 ]]; do
         --timeout)
             if [[ $# -lt 2 ]]; then
                 echo "error: --timeout requires an argument (e.g. --timeout 180)" >&2
+                exit 2
+            fi
+            if [[ ! "$2" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+                echo "error: --timeout argument must be a number of seconds (e.g. --timeout 180)" >&2
                 exit 2
             fi
             timeout_seconds="$2"

--- a/scripts/run-mutants.sh
+++ b/scripts/run-mutants.sh
@@ -3,13 +3,12 @@
 # PR cargo-mutants CI workflows; mutation testing is now run on demand
 # from a developer machine to avoid eating GitHub Actions minutes.
 #
-# Configuration (timeout multiplier, --bins) lives in .cargo/mutants.toml.
-# The per-mutant timeout is forced to 180s here to match the previous CI
-# behaviour and keep wall-clock predictable. The baseline runs unit tests
-# only (`cargo test --bins`), matching the gating policy in
-# .github/workflows/test.yml which lets integration tests fail. Including
-# them would mark every mutant as "caught" by a pre-existing flake instead
-# of by the mutation itself.
+# Shared cargo-mutants configuration (including --bins) lives in
+# .cargo/mutants.toml. This wrapper defaults each mutant to 180s because its
+# --baseline=skip and --in-place execution mode cannot use timeout_multiplier;
+# pass --timeout SECONDS to override that default. Its baseline and per-mutant
+# runs use unit tests only (`cargo test --bins`); integration tests remain in
+# the normal project quality gate rather than every local mutation run.
 
 set -euo pipefail
 
@@ -20,6 +19,7 @@ Usage:
   scripts/run-mutants.sh --diff          # only mutants in `git diff origin/main...`
   scripts/run-mutants.sh --diff main     # diff vs an explicit base ref
   scripts/run-mutants.sh --shard 0/8     # one shard of an 8-way split
+  scripts/run-mutants.sh --timeout 180   # per-mutant timeout in seconds
   scripts/run-mutants.sh -- --foo --bar  # forward extra flags to cargo-mutants
   scripts/run-mutants.sh -h | --help     # print this message
 EOF
@@ -30,6 +30,7 @@ cd "$(dirname "$0")/.."
 mode="full"
 diff_base="origin/main"
 shard=""
+timeout_seconds="180"
 extra=()
 
 while [[ $# -gt 0 ]]; do
@@ -52,6 +53,14 @@ while [[ $# -gt 0 ]]; do
                 exit 2
             fi
             shard="$2"
+            shift 2
+            ;;
+        --timeout)
+            if [[ $# -lt 2 ]]; then
+                echo "error: --timeout requires an argument (e.g. --timeout 180)" >&2
+                exit 2
+            fi
+            timeout_seconds="$2"
             shift 2
             ;;
         --)
@@ -84,7 +93,7 @@ echo "==> Baseline build + unit tests"
 cargo build
 cargo test --bins
 
-args=(--baseline=skip --timeout 180 --in-place -vV)
+args=(--baseline=skip --timeout "$timeout_seconds" --in-place -vV)
 
 case "$mode" in
     diff)

--- a/scripts/test_ci_policy.py
+++ b/scripts/test_ci_policy.py
@@ -13,6 +13,8 @@ POLICY_DISCOVERY_COMMAND = (
     "python3 -m unittest discover -s scripts -p 'test_*_policy.py'"
 )
 SHELL_REGRESSION_COMMAND = "./scripts/test_test_all.sh"
+MUTANTS_REGRESSION_COMMAND = "./scripts/test_run_mutants.sh"
+MUTANTS_WORKFLOW_STEP = "Check mutation-wrapper command construction"
 
 
 def has_required_command(contents: str, command: str) -> bool:
@@ -74,10 +76,27 @@ class TestCiPolicy(unittest.TestCase):
                     f"repository CI policy step must run {command!r}",
                 )
 
+    def test_mutation_wrapper_regression_is_a_required_gate(self):
+        workflow = TEST_WORKFLOW_PATH.read_text(encoding="utf-8")
+        try:
+            wrapper_step = workflow_step(workflow, MUTANTS_WORKFLOW_STEP)
+        except ValueError as error:
+            self.fail(str(error))
+
+        self.assertTrue(
+            has_required_command(wrapper_step, MUTANTS_REGRESSION_COMMAND),
+            f"{MUTANTS_WORKFLOW_STEP!r} must run "
+            f"{MUTANTS_REGRESSION_COMMAND!r} without failure masking",
+        )
+
     def test_local_ci_gate_runs_all_regressions(self):
         ci_check = CI_CHECK_PATH.read_text(encoding="utf-8")
 
-        for command in (POLICY_DISCOVERY_COMMAND, SHELL_REGRESSION_COMMAND):
+        for command in (
+            POLICY_DISCOVERY_COMMAND,
+            SHELL_REGRESSION_COMMAND,
+            MUTANTS_REGRESSION_COMMAND,
+        ):
             with self.subTest(command=command):
                 self.assertTrue(
                     has_required_command(ci_check, command),

--- a/scripts/test_run_mutants.sh
+++ b/scripts/test_run_mutants.sh
@@ -32,14 +32,61 @@ run_wrapper() {
         "$FIXTURE/scripts/run-mutants.sh" "$@"
 }
 
-assert_mutants_command() {
+assert_logged_command() {
     local log_file="$1"
-    local expected="$2"
+    local pattern="$2"
+    local expected="$3"
     local actual
 
-    actual="$(grep '^cargo <mutants>' "$log_file")"
+    if ! actual="$(grep -- "$pattern" "$log_file")"; then
+        echo "expected a logged command matching '$pattern'; got:" >&2
+        cat "$log_file" >&2
+        exit 1
+    fi
+
     if [[ "$actual" != "$expected" ]]; then
         diff -u <(printf '%s\n' "$expected") <(printf '%s\n' "$actual")
+        exit 1
+    fi
+}
+
+assert_mutants_command() {
+    assert_logged_command "$1" '^cargo <mutants>' "$2"
+}
+
+# Rejected invocations must fail fast, before the (slow) build + baseline
+# preflight runs any cargo command.
+assert_rejected() {
+    local expected_message="$1"
+    shift
+    local log_file="$FIXTURE/rejected.log"
+    local stderr_file="$FIXTURE/rejected.stderr"
+    local status
+
+    : > "$log_file"
+    set +e
+    PATH="$FIXTURE/bin:$PATH" \
+        S11_MUTANTS_TEST_LOG="$log_file" \
+        "$FIXTURE/scripts/run-mutants.sh" "$@" \
+        > /dev/null 2> "$stderr_file"
+    status=$?
+    set -e
+
+    if [[ $status -ne 2 ]]; then
+        echo "expected '$*' to exit 2; got $status" >&2
+        cat "$stderr_file" >&2
+        exit 1
+    fi
+
+    if ! grep -Fq -- "$expected_message" "$stderr_file"; then
+        echo "expected a focused diagnostic for '$*'; got:" >&2
+        cat "$stderr_file" >&2
+        exit 1
+    fi
+
+    if [[ -s "$log_file" ]]; then
+        echo "expected '$*' to be rejected before the cargo preflight; got:" >&2
+        cat "$log_file" >&2
         exit 1
     fi
 }
@@ -49,6 +96,9 @@ run_wrapper "$default_log"
 assert_mutants_command \
     "$default_log" \
     'cargo <mutants> <--baseline=skip> <--timeout> <180> <--in-place> <-vV>'
+# The wrapper documents a unit-test-only baseline; pin it so a stray
+# integration-test flag can't creep back in.
+assert_logged_command "$default_log" '^cargo <test>' 'cargo <test> <--bins>'
 
 override_log="$FIXTURE/override.log"
 run_wrapper "$override_log" --timeout 45
@@ -56,30 +106,30 @@ assert_mutants_command \
     "$override_log" \
     'cargo <mutants> <--baseline=skip> <--timeout> <45> <--in-place> <-vV>'
 
-missing_log="$FIXTURE/missing.log"
-missing_stderr="$FIXTURE/missing.stderr"
-: > "$missing_log"
-set +e
-PATH="$FIXTURE/bin:$PATH" \
-    S11_MUTANTS_TEST_LOG="$missing_log" \
-    "$FIXTURE/scripts/run-mutants.sh" --timeout \
-    > /dev/null 2> "$missing_stderr"
-missing_status=$?
-set -e
+fractional_log="$FIXTURE/fractional.log"
+run_wrapper "$fractional_log" --timeout 2.5
+assert_mutants_command \
+    "$fractional_log" \
+    'cargo <mutants> <--baseline=skip> <--timeout> <2.5> <--in-place> <-vV>'
 
-if [[ $missing_status -ne 2 ]]; then
-    echo "expected a missing timeout value to exit 2; got $missing_status" >&2
-    exit 1
-fi
+shard_log="$FIXTURE/shard.log"
+run_wrapper "$shard_log" --timeout 45 --shard 0/8
+assert_mutants_command \
+    "$shard_log" \
+    'cargo <mutants> <--baseline=skip> <--timeout> <45> <--in-place> <-vV> <--no-shuffle> <--shard> <0/8> <--sharding> <round-robin>'
 
-if ! grep -Fq -- 'error: --timeout requires an argument (e.g. --timeout 180)' "$missing_stderr"; then
-    echo "expected a focused missing-timeout diagnostic; got:" >&2
-    cat "$missing_stderr" >&2
-    exit 1
-fi
+# The --diff branch needs a real git repository, so it is exercised by
+# `just mutants --diff` rather than by this fixture.
 
-if [[ -s "$missing_log" ]]; then
-    echo "expected missing-timeout validation before cargo preflight; got:" >&2
-    cat "$missing_log" >&2
-    exit 1
-fi
+assert_rejected \
+    'error: --timeout requires an argument (e.g. --timeout 180)' \
+    --timeout
+
+assert_rejected \
+    'error: --timeout argument must be a number of seconds (e.g. --timeout 180)' \
+    --timeout abc
+
+# A following flag must not be swallowed as the timeout value.
+assert_rejected \
+    'error: --timeout argument must be a number of seconds (e.g. --timeout 180)' \
+    --timeout --shard 0/8

--- a/scripts/test_run_mutants.sh
+++ b/scripts/test_run_mutants.sh
@@ -26,16 +26,25 @@ chmod +x \
 # The --diff branch shells out to git, so the fixture needs a real repository
 # with a base ref that differs from HEAD. `git diff BASE...` is commit-to-commit,
 # so the log files written here later do not perturb it.
-git init -q -b main "$FIXTURE"
-git -C "$FIXTURE" config user.name "s11 mutants regression"
-git -C "$FIXTURE" config user.email "mutants-regression@example.invalid"
-git -C "$FIXTURE" add -A
-git -C "$FIXTURE" -c commit.gpgsign=false commit -qm "fixture base"
-git -C "$FIXTURE" branch base
-git -C "$FIXTURE" update-ref refs/remotes/origin/main HEAD
+# Ambient global/system git config (core.hooksPath, init.templateDir,
+# commit.gpgsign) must not leak into the fixture repository.
+fixture_git() {
+    GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null \
+        git -C "$FIXTURE" \
+        -c user.name="s11 mutants regression" \
+        -c user.email="mutants-regression@example.invalid" \
+        "$@"
+}
+
+GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null \
+    git init -q -b main "$FIXTURE"
+fixture_git add -A
+fixture_git commit -qm "fixture base"
+fixture_git branch base
+fixture_git update-ref refs/remotes/origin/main HEAD
 printf 'mutated\n' > "$FIXTURE/changed.txt"
-git -C "$FIXTURE" add changed.txt
-git -C "$FIXTURE" -c commit.gpgsign=false commit -qm "fixture change"
+fixture_git add changed.txt
+fixture_git commit -qm "fixture change"
 
 run_wrapper() {
     local log_file="$1"
@@ -149,6 +158,14 @@ run_wrapper "$explicit_base_log" --diff base
 assert_mutants_command \
     "$explicit_base_log" \
     'cargo <mutants> <--baseline=skip> <--timeout> <180> <--in-place> <-vV> <--in-diff> <DIFF>'
+
+# Everything after `--` is forwarded verbatim to cargo-mutants, after the
+# wrapper's own flags.
+passthrough_log="$FIXTURE/passthrough.log"
+run_wrapper "$passthrough_log" --timeout 45 -- --foo --bar
+assert_mutants_command \
+    "$passthrough_log" \
+    'cargo <mutants> <--baseline=skip> <--timeout> <45> <--in-place> <-vV> <--foo> <--bar>'
 
 # The optional base ref must not swallow a following wrapper flag.
 diff_then_flag_log="$FIXTURE/diff-then-flag.log"

--- a/scripts/test_run_mutants.sh
+++ b/scripts/test_run_mutants.sh
@@ -23,6 +23,20 @@ chmod +x \
     "$FIXTURE/bin/cargo" \
     "$FIXTURE/scripts/run-mutants.sh"
 
+# The --diff branch shells out to git, so the fixture needs a real repository
+# with a base ref that differs from HEAD. `git diff BASE...` is commit-to-commit,
+# so the log files written here later do not perturb it.
+git init -q -b main "$FIXTURE"
+git -C "$FIXTURE" config user.name "s11 mutants regression"
+git -C "$FIXTURE" config user.email "mutants-regression@example.invalid"
+git -C "$FIXTURE" add -A
+git -C "$FIXTURE" -c commit.gpgsign=false commit -qm "fixture base"
+git -C "$FIXTURE" branch base
+git -C "$FIXTURE" update-ref refs/remotes/origin/main HEAD
+printf 'mutated\n' > "$FIXTURE/changed.txt"
+git -C "$FIXTURE" add changed.txt
+git -C "$FIXTURE" -c commit.gpgsign=false commit -qm "fixture change"
+
 run_wrapper() {
     local log_file="$1"
     shift
@@ -43,6 +57,10 @@ assert_logged_command() {
         cat "$log_file" >&2
         exit 1
     fi
+
+    # --diff mode passes a mktemp path; normalise it so assertions pin the
+    # flag rather than the random filename.
+    actual="$(printf '%s\n' "$actual" | sed -E 's|(<--in-diff> )<[^>]*>|\1<DIFF>|')"
 
     if [[ "$actual" != "$expected" ]]; then
         diff -u <(printf '%s\n' "$expected") <(printf '%s\n' "$actual")
@@ -118,8 +136,27 @@ assert_mutants_command \
     "$shard_log" \
     'cargo <mutants> <--baseline=skip> <--timeout> <45> <--in-place> <-vV> <--no-shuffle> <--shard> <0/8> <--sharding> <round-robin>'
 
-# The --diff branch needs a real git repository, so it is exercised by
-# `just mutants --diff` rather than by this fixture.
+diff_log="$FIXTURE/diff.log"
+run_wrapper "$diff_log" --diff
+assert_mutants_command \
+    "$diff_log" \
+    'cargo <mutants> <--baseline=skip> <--timeout> <180> <--in-place> <-vV> <--in-diff> <DIFF>'
+
+# An explicit base ref must be consumed as the base, not rejected as an
+# unknown argument.
+explicit_base_log="$FIXTURE/diff-base.log"
+run_wrapper "$explicit_base_log" --diff base
+assert_mutants_command \
+    "$explicit_base_log" \
+    'cargo <mutants> <--baseline=skip> <--timeout> <180> <--in-place> <-vV> <--in-diff> <DIFF>'
+
+# The optional base ref must not swallow a following wrapper flag.
+diff_then_flag_log="$FIXTURE/diff-then-flag.log"
+run_wrapper "$diff_then_flag_log" --diff --timeout 45
+assert_mutants_command \
+    "$diff_then_flag_log" \
+    'cargo <mutants> <--baseline=skip> <--timeout> <45> <--in-place> <-vV> <--in-diff> <DIFF>'
+
 
 assert_rejected \
     'error: --timeout requires an argument (e.g. --timeout 180)' \

--- a/scripts/test_run_mutants.sh
+++ b/scripts/test_run_mutants.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIXTURE="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+mkdir -p "$FIXTURE/bin" "$FIXTURE/scripts"
+cp "$ROOT/scripts/run-mutants.sh" "$FIXTURE/scripts/run-mutants.sh"
+
+printf '#!/usr/bin/env bash\nexit 0\n' > "$FIXTURE/build_tests.sh"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$FIXTURE/bin/cargo-mutants"
+printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'set -euo pipefail' \
+    'printf "cargo" >> "$S11_MUTANTS_TEST_LOG"' \
+    'printf " <%s>" "$@" >> "$S11_MUTANTS_TEST_LOG"' \
+    'printf "\\n" >> "$S11_MUTANTS_TEST_LOG"' \
+    > "$FIXTURE/bin/cargo"
+chmod +x \
+    "$FIXTURE/build_tests.sh" \
+    "$FIXTURE/bin/cargo-mutants" \
+    "$FIXTURE/bin/cargo" \
+    "$FIXTURE/scripts/run-mutants.sh"
+
+run_wrapper() {
+    local log_file="$1"
+    shift
+    : > "$log_file"
+    PATH="$FIXTURE/bin:$PATH" \
+        S11_MUTANTS_TEST_LOG="$log_file" \
+        "$FIXTURE/scripts/run-mutants.sh" "$@"
+}
+
+assert_mutants_command() {
+    local log_file="$1"
+    local expected="$2"
+    local actual
+
+    actual="$(grep '^cargo <mutants>' "$log_file")"
+    if [[ "$actual" != "$expected" ]]; then
+        diff -u <(printf '%s\n' "$expected") <(printf '%s\n' "$actual")
+        exit 1
+    fi
+}
+
+default_log="$FIXTURE/default.log"
+run_wrapper "$default_log"
+assert_mutants_command \
+    "$default_log" \
+    'cargo <mutants> <--baseline=skip> <--timeout> <180> <--in-place> <-vV>'
+
+override_log="$FIXTURE/override.log"
+run_wrapper "$override_log" --timeout 45
+assert_mutants_command \
+    "$override_log" \
+    'cargo <mutants> <--baseline=skip> <--timeout> <45> <--in-place> <-vV>'
+
+missing_log="$FIXTURE/missing.log"
+missing_stderr="$FIXTURE/missing.stderr"
+: > "$missing_log"
+set +e
+PATH="$FIXTURE/bin:$PATH" \
+    S11_MUTANTS_TEST_LOG="$missing_log" \
+    "$FIXTURE/scripts/run-mutants.sh" --timeout \
+    > /dev/null 2> "$missing_stderr"
+missing_status=$?
+set -e
+
+if [[ $missing_status -ne 2 ]]; then
+    echo "expected a missing timeout value to exit 2; got $missing_status" >&2
+    exit 1
+fi
+
+if ! grep -Fq -- 'error: --timeout requires an argument (e.g. --timeout 180)' "$missing_stderr"; then
+    echo "expected a focused missing-timeout diagnostic; got:" >&2
+    cat "$missing_stderr" >&2
+    exit 1
+fi
+
+if [[ -s "$missing_log" ]]; then
+    echo "expected missing-timeout validation before cargo preflight; got:" >&2
+    cat "$missing_log" >&2
+    exit 1
+fi


### PR DESCRIPTION
Summary:
- add a wrapper-level `--timeout SECONDS` override while retaining the 180-second default
- clarify that `timeout_multiplier` applies only to compatible direct cargo-mutants runs
- add an isolated command-construction regression and run it in local/hosted CI gates

Verification:
- `bash -n scripts/run-mutants.sh scripts/test_run_mutants.sh ci_check.sh`
- `./scripts/test_run_mutants.sh`
- `just --dry-run mutants --timeout 45`
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `./build_tests.sh && cargo test --all`
- `./ci_check.sh`

Closes #218

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**