### PR TITLE
test(parser): cover ldrsw W-form addressing modes

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4137,9 +4137,13 @@ mod tests {
             ("ldrsh w0, [x1]", "ldrsh"),
             ("ldrsw w0, [x1]", "ldrsw"),
             ("ldrsb w0, [x1, #1]!", "ldrsb"),
+            ("ldrsw w0, [x1, #4]!", "ldrsw"),
             ("ldrsh w0, [x1], #2", "ldrsh"),
+            ("ldrsw w0, [x1], #4", "ldrsw"),
             ("ldrsb w0, [x1, x2]", "ldrsb"),
+            ("ldrsw w0, [x1, x2]", "ldrsw"),
             ("ldrsb w0, [x1, w2, sxtw]", "ldrsb"),
+            ("ldrsw w0, [x1, w2, sxtw #2]", "ldrsw"),
         ] {
             match parse_line(line) {
                 Err(ParseLineError::Other(msg)) => {


### PR DESCRIPTION
Summary:
- add pre-index and post-index `ldrsw` cases to W-form signed-load rejection coverage
- add register-offset and register-extend `ldrsw` cases using canonical word-load scaling
- keep parser behavior and validation ordering unchanged

Tests:
- `cargo test parse_line_rejects_w_form_signed_load_destinations`
- `cargo clippy --all -- -D warnings`
- `cargo test --all` (after `just build-tests`)
- `./ci_check.sh`

Closes #506

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**