### PR TITLE
fix(aarch64): normalize mov SP aliases to add zero

### DIFF
--- a/docs/capability.md
+++ b/docs/capability.md
@@ -41,6 +41,8 @@ Rewritable straight-line mnemonics accepted by the parser and Capstone bridge:
 - Data movement and aliases: `mov`, `mvn`, `neg`, `negs`, `movn`, `movz`,
   `movk`
   - Register `mov` supports both 64-bit `X` and 32-bit `W` forms.
+  - The 64-bit `mov <Xd|SP>, <Xn|SP>` aliases with an SP operand are
+    normalized to their encodable `add <Xd|SP>, <Xn|SP>, #0` form.
 - First NEON/SIMD vertical slice: `movi` with `Vn.2d|4s, #0`, lane-wise
   wrapping `add Vd.2d|4s, Vn.2d|4s, Vm.2d|4s`, and
   `mov Xd, Vn.d[0|1]`.

--- a/src/capstone_bridge.rs
+++ b/src/capstone_bridge.rs
@@ -192,7 +192,7 @@ pub fn convert_capstone_op(mnemonic: &str, op_str: &str) -> ConvertOutcome {
 #[cfg(test)]
 mod tests {
     use super::{ConvertOutcome, convert_capstone_op};
-    use crate::ir::{self, Instruction, Register};
+    use crate::ir::{self, Instruction, Operand, Register};
 
     #[test]
     fn convert_capstone_op_reencodes_wide_immediate_mov_as_movz() {
@@ -220,6 +220,27 @@ mod tests {
             match convert_capstone_op("mov", ops) {
                 ConvertOutcome::Instruction(instr) => assert_eq!(instr, expected),
                 other => panic!("expected MovZ for `mov {ops}`, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn convert_capstone_op_normalizes_mov_sp_aliases_as_add_zero() {
+        for (ops, rd, rn) in [
+            ("x29, sp", Register::X29, Register::SP),
+            ("sp, x0", Register::SP, Register::X0),
+            ("sp, sp", Register::SP, Register::SP),
+        ] {
+            match convert_capstone_op("mov", ops) {
+                ConvertOutcome::Instruction(instr) => assert_eq!(
+                    instr,
+                    Instruction::Add {
+                        rd,
+                        rn,
+                        rm: Operand::Immediate(0),
+                    }
+                ),
+                other => panic!("expected Add for `mov {ops}`, got {other:?}"),
             }
         }
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -406,7 +406,12 @@ fn split_operands(operands_str: &str) -> Vec<&str> {
     parts
 }
 
-/// Parse a MOV instruction
+/// Parse a MOV instruction.
+///
+/// The architectural register move uses an ORR encoding whose register slots
+/// do not admit SP. GNU/LLVM spell moves to or from SP as `mov` aliases for
+/// `add <Xd|SP>, <Xn|SP>, #0`, so lower those aliases before the encodability
+/// gate sees them.
 fn parse_mov(operands: &[&str]) -> Result<Instruction, String> {
     if operands.len() != 2 {
         return Err(format!("mov requires 2 operands, got {}", operands.len()));
@@ -441,6 +446,11 @@ fn parse_mov(operands: &[&str]) -> Result<Instruction, String> {
     let src = parse_operand(operands[1])?;
 
     match src {
+        Operand::Register(rn) if rd == Register::SP || rn == Register::SP => Ok(Instruction::Add {
+            rd,
+            rn,
+            rm: Operand::Immediate(0),
+        }),
         Operand::Register(rn) => Ok(Instruction::MovReg { rd, rn }),
         Operand::Immediate(imm) => Ok(Instruction::MovImm { rd, imm }),
         Operand::ShiftedRegister { .. } | Operand::ExtendedRegister { .. } => {
@@ -2574,6 +2584,21 @@ mod tests {
                 assert_eq!(imm, 42);
             }
             _ => panic!("expected MovImm"),
+        }
+    }
+
+    #[test]
+    fn parse_mov_to_sp_as_add_zero() {
+        match parse_line("mov sp, x0").unwrap() {
+            LineResult::Instruction(instr) => assert_eq!(
+                instr,
+                Instruction::Add {
+                    rd: Register::SP,
+                    rn: Register::X0,
+                    rm: Operand::Immediate(0),
+                }
+            ),
+            other => panic!("expected Add for `mov sp, x0`, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Summary

- lower 64-bit `mov` aliases with an SP operand to the encodable `add #0` IR form in the shared AArch64 parser
- cover direct parser and Capstone conversion paths, including source, destination, and SP-to-SP forms
- document the accepted alias normalization in the capability matrix

## Tests

- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`
- `./ci_check.sh`

Closes #510

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**
