### PR TITLE
test(aarch64): explain extended LDRS fixture exclusion

### DIFF
--- a/src/ir/instructions.rs
+++ b/src/ir/instructions.rs
@@ -2610,6 +2610,7 @@ mod tests {
                 width,
             },
         ];
+        // No LDRSX exists, so signed loads cannot use the extended width.
         if width != AccessWidth::Extended {
             instructions.push(Instruction::Ldrs {
                 rt: Register::X0,


### PR DESCRIPTION
## Summary

- explain why the `single_reg_instructions` helper skips `Ldrs` for `AccessWidth::Extended`
- document the architectural absence of `LDRSX` without changing test behavior

## Testing

- `cargo test --lib ir::instructions::tests::ldrs_rejects_extended_width`
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --all` (after generating the required test binaries)
- `./ci_check.sh`

Closes #513

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**
