### PR TITLE
test(parser): cover label before directive

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2636,6 +2636,14 @@ mod tests {
     }
 
     #[test]
+    fn parse_line_skips_inline_label_before_directive() {
+        assert!(matches!(
+            parse_line("_start: .text").unwrap(),
+            LineResult::Skip
+        ));
+    }
+
+    #[test]
     fn parse_line_accepts_multiple_inline_labels_before_instruction() {
         assert!(matches!(
             parse_line("outer: inner:").unwrap(),


### PR DESCRIPTION
Adds a focused parser regression proving that `_start: .text` is classified as `LineResult::Skip` after label stripping and directive recognition.

Closes #514

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**