### PR TITLE
test(search): tighten product timeout assertion

### DIFF
--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -1737,7 +1737,9 @@ mod tests {
         );
         assert_eq!(
             cost_calls, 1,
-            "timeout should stop after exactly 1 cost call; saw {cost_calls}"
+            "timeout should be checked before the second product candidate; the first \
+             50ms cost call already exceeds the 25ms budget, so the length-three sweep \
+             stops one candidate in instead of running all 8"
         );
     }
 

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -1734,12 +1734,11 @@ mod tests {
             shared.stop.load(Ordering::Relaxed),
             "nested product loop should set stop after the timeout expires"
         );
-        // The deadline starts before Rayon dispatch and recursive polling, so zero calls is valid.
         let cost_calls = INNER_TIMEOUT_COST_CALLS.load(Ordering::Relaxed);
+        // The deadline starts before Rayon dispatch and recursive polling, so zero calls is valid.
         assert!(
             cost_calls < 2,
-            "nested timeout should prevent evaluating a second product candidate; saw \
-             {cost_calls} cost calls"
+            "nested timeout should prevent evaluating a second product candidate; saw {cost_calls} cost calls"
         );
     }
 

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -1735,9 +1735,9 @@ mod tests {
             shared.stop.load(Ordering::Relaxed),
             "nested product loop should set stop after the timeout expires"
         );
-        assert!(
-            cost_calls < 8,
-            "timeout should stop before the full length-three product sweep; saw {cost_calls} cost calls"
+        assert_eq!(
+            cost_calls, 1,
+            "timeout should stop after exactly 1 cost call; saw {cost_calls}"
         );
     }
 

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -1734,12 +1734,11 @@ mod tests {
             shared.stop.load(Ordering::Relaxed),
             "nested product loop should set stop after the timeout expires"
         );
-        assert_eq!(
-            INNER_TIMEOUT_COST_CALLS.load(Ordering::Relaxed),
-            1,
-            "timeout should be checked before the second product candidate; the first \
-             50ms cost call already exceeds the 25ms budget, so the length-three sweep \
-             stops one candidate in instead of running all 8"
+        let cost_calls = INNER_TIMEOUT_COST_CALLS.load(Ordering::Relaxed);
+        assert!(
+            cost_calls < 2,
+            "nested timeout should prevent evaluating a second product candidate; saw \
+             {cost_calls} cost calls"
         );
     }
 

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -1730,13 +1730,13 @@ mod tests {
             });
         });
 
-        let cost_calls = INNER_TIMEOUT_COST_CALLS.load(Ordering::Relaxed);
         assert!(
             shared.stop.load(Ordering::Relaxed),
             "nested product loop should set stop after the timeout expires"
         );
         assert_eq!(
-            cost_calls, 1,
+            INNER_TIMEOUT_COST_CALLS.load(Ordering::Relaxed),
+            1,
             "timeout should be checked before the second product candidate; the first \
              50ms cost call already exceeds the 25ms budget, so the length-three sweep \
              stops one candidate in instead of running all 8"

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -1734,6 +1734,7 @@ mod tests {
             shared.stop.load(Ordering::Relaxed),
             "nested product loop should set stop after the timeout expires"
         );
+        // The deadline starts before Rayon dispatch and recursive polling, so zero calls is valid.
         let cost_calls = INNER_TIMEOUT_COST_CALLS.load(Ordering::Relaxed);
         assert!(
             cost_calls < 2,


### PR DESCRIPTION
## Summary

- tighten the nested length-product timeout test to reject evaluating a second candidate
- allow zero cost calls when the deadline expires during Rayon dispatch or recursive polling
- preserve the separate assertion that the nested timeout sets the shared stop flag

## Testing

- targeted product and sibling timeout tests under the default harness
- both timeout tests under `cargo llvm-cov`
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`
- `./ci_check.sh`

Closes #530

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**
