### PR TITLE
test(enumerative): cover empty candidate pool exit

### DIFF
--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -1207,6 +1207,43 @@ mod tests {
     }
 
     #[test]
+    fn empty_instruction_set_returns_no_optimization_without_evaluating_candidates() {
+        use crate::isa::{RiscV64, RiscVInstruction, RiscVRegister};
+
+        let target = vec![
+            RiscVInstruction::Addi {
+                rd: RiscVRegister::X1,
+                rs1: RiscVRegister::X1,
+                imm: 1,
+            },
+            RiscVInstruction::Addi {
+                rd: RiscVRegister::X2,
+                rs1: RiscVRegister::X2,
+                imm: 1,
+            },
+        ];
+        let config = SearchConfig::default().with_timeout_option(None);
+        let mut search = EnumerativeSearch::<RiscV64>::new();
+
+        assert!(
+            search.candidate_pool_for_config(&config).is_empty(),
+            "precondition: the test RISC-V backend must generate no candidate instructions"
+        );
+
+        let result = search.search(&target, &(), &config);
+
+        assert!(!result.found_optimization);
+        assert!(result.optimized_sequence.is_none());
+        assert_eq!(result.original_sequence, target);
+        assert_eq!(result.statistics.candidates_evaluated, 0);
+        assert_eq!(result.statistics.smt_queries, 0);
+        assert_eq!(
+            result.statistics.best_cost_found,
+            result.statistics.original_cost
+        );
+    }
+
+    #[test]
     fn statistics_aggregate_smt_elapsed() {
         // Reuse the same length-2 target as `collapses_mov_add_into_single_add`:
         // it reaches the equivalent `add x0, x1, #1` candidate promptly while


### PR DESCRIPTION
Adds a regression test that drives the public enumerative search flow with the existing test-only RISC-V backend, whose generated candidate pool is empty.

The test verifies that a multi-instruction target exits without an optimization, retains the original sequence, evaluates no candidates, performs no SMT queries, and keeps the original cost as the best cost. Coverage confirms the `min_instruction_cost == None` guard is now exercised.

Checks:
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`
- `cargo llvm-cov --lib --text --show-missing-lines`
- `./ci_check.sh`

Closes #531

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**