### PR TITLE
fix(aarch64): enumerate W32 logical candidates

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4992,11 +4992,11 @@ mod cli_helper_tests {
     fn run_optimization_uses_downstream_flags_dead_context() {
         let target = [
             Instruction::Cmp {
-                rn: Register::X0,
+                rn: Register::X1,
                 rm: Operand::Immediate(0),
             },
             Instruction::MovImm {
-                rd: Register::X1,
+                rd: Register::X0,
                 imm: 7,
             },
         ];

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -155,6 +155,11 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
             for &rm in registers {
                 if shifted_register_allows_rd_rn && rm != Register::SP {
                     for &amount in SHIFTED_OP_AMOUNTS {
+                        let logical_widths: &[RegisterWidth] = if amount <= 31 {
+                            &[RegisterWidth::X64, RegisterWidth::W32]
+                        } else {
+                            &[RegisterWidth::X64]
+                        };
                         for kind in [ShiftKind::Lsl, ShiftKind::Lsr, ShiftKind::Asr] {
                             let sr = Operand::ShiftedRegister {
                                 reg: rm,
@@ -169,24 +174,26 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
                             if amount <= 31 {
                                 instrs.push(Instruction::SubW { rd, rn, rm: sr });
                             }
-                            instrs.push(Instruction::And {
-                                rd,
-                                rn,
-                                rm: sr,
-                                width: RegisterWidth::X64,
-                            });
-                            instrs.push(Instruction::Orr {
-                                rd,
-                                rn,
-                                rm: sr,
-                                width: RegisterWidth::X64,
-                            });
-                            instrs.push(Instruction::Eor {
-                                rd,
-                                rn,
-                                rm: sr,
-                                width: RegisterWidth::X64,
-                            });
+                            for &width in logical_widths {
+                                instrs.push(Instruction::And {
+                                    rd,
+                                    rn,
+                                    rm: sr,
+                                    width,
+                                });
+                                instrs.push(Instruction::Orr {
+                                    rd,
+                                    rn,
+                                    rm: sr,
+                                    width,
+                                });
+                                instrs.push(Instruction::Eor {
+                                    rd,
+                                    rn,
+                                    rm: sr,
+                                    width,
+                                });
+                            }
                         }
                         // ROR — logical only.
                         let sr_ror = Operand::ShiftedRegister {
@@ -194,24 +201,26 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
                             kind: ShiftKind::Ror,
                             amount,
                         };
-                        instrs.push(Instruction::And {
-                            rd,
-                            rn,
-                            rm: sr_ror,
-                            width: RegisterWidth::X64,
-                        });
-                        instrs.push(Instruction::Orr {
-                            rd,
-                            rn,
-                            rm: sr_ror,
-                            width: RegisterWidth::X64,
-                        });
-                        instrs.push(Instruction::Eor {
-                            rd,
-                            rn,
-                            rm: sr_ror,
-                            width: RegisterWidth::X64,
-                        });
+                        for &width in logical_widths {
+                            instrs.push(Instruction::And {
+                                rd,
+                                rn,
+                                rm: sr_ror,
+                                width,
+                            });
+                            instrs.push(Instruction::Orr {
+                                rd,
+                                rn,
+                                rm: sr_ror,
+                                width,
+                            });
+                            instrs.push(Instruction::Eor {
+                                rd,
+                                rn,
+                                rm: sr_ror,
+                                width,
+                            });
+                        }
                     }
                 }
                 // Issue #60: extended-register form for ADD/SUB. Cmp/Cmn
@@ -1655,10 +1664,8 @@ mod tests {
 
     #[test]
     fn generate_encodable_instructions_contains_w_logical_register_forms() {
-        let instrs = generate_all_encodable_instructions(
-            &[Register::X0, Register::X1, Register::X2],
-            &[],
-        );
+        let instrs =
+            generate_all_encodable_instructions(&[Register::X0, Register::X1, Register::X2], &[]);
 
         for expected in [
             Instruction::And {
@@ -2555,28 +2562,48 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_all_instructions_includes_all_shifted_kinds_for_logical() {
-        let instrs = generate_all_instructions(&default_registers(), &default_immediates());
-        for kind in [
-            crate::ir::ShiftKind::Lsl,
-            crate::ir::ShiftKind::Lsr,
-            crate::ir::ShiftKind::Asr,
-            crate::ir::ShiftKind::Ror,
-        ] {
-            let has = instrs.iter().any(|i| {
-                matches!(
-                    i,
+    fn generate_encodable_instructions_contains_w_logical_shifted_register_forms() {
+        let instrs =
+            generate_all_encodable_instructions(&[Register::X0, Register::X1, Register::X2], &[]);
+
+        for width in [RegisterWidth::X64, RegisterWidth::W32] {
+            for kind in [
+                crate::ir::ShiftKind::Lsl,
+                crate::ir::ShiftKind::Lsr,
+                crate::ir::ShiftKind::Asr,
+                crate::ir::ShiftKind::Ror,
+            ] {
+                let rm = Operand::ShiftedRegister {
+                    reg: Register::X2,
+                    kind,
+                    amount: 1,
+                };
+                for expected in [
+                    Instruction::And {
+                        rd: Register::X0,
+                        rn: Register::X1,
+                        rm,
+                        width,
+                    },
                     Instruction::Orr {
-                        rm: Operand::ShiftedRegister { kind: k, .. }, ..
-                    } if *k == kind
-                )
-            });
-            assert!(
-                has,
-                "ORR must enumerate shifted-register form with {:?}",
-                kind
-            );
+                        rd: Register::X0,
+                        rn: Register::X1,
+                        rm,
+                        width,
+                    },
+                    Instruction::Eor {
+                        rd: Register::X0,
+                        rn: Register::X1,
+                        rm,
+                        width,
+                    },
+                ] {
+                    assert!(instrs.contains(&expected), "missing candidate: {expected}");
+                }
+            }
         }
+
+        assert!(instrs.iter().all(Instruction::is_encodable_aarch64));
     }
 
     #[test]
@@ -2661,10 +2688,27 @@ mod tests {
             }
         }
 
-        // 2 non-SP choices for each of rd/rn/rm, with 162 shifted-register
+        assert!(!instrs.iter().any(|instr| matches!(
+            instr,
+            Instruction::And {
+                rm: Operand::ShiftedRegister { amount: 32, .. },
+                width: RegisterWidth::W32,
+                ..
+            } | Instruction::Orr {
+                rm: Operand::ShiftedRegister { amount: 32, .. },
+                width: RegisterWidth::W32,
+                ..
+            } | Instruction::Eor {
+                rm: Operand::ShiftedRegister { amount: 32, .. },
+                width: RegisterWidth::W32,
+                ..
+            }
+        )));
+
+        // 2 non-SP choices for each of rd/rn/rm, with 234 shifted-register
         // binary candidates per tuple from the current AArch64 candidate matrix.
         assert_eq!(
-            shifted_count, 1296,
+            shifted_count, 1872,
             "enumeration must retain the expected shifted-register candidate count"
         );
     }

--- a/src/search/candidate.rs
+++ b/src/search/candidate.rs
@@ -80,24 +80,26 @@ pub fn generate_all_instructions(registers: &[Register], immediates: &[i64]) -> 
                 instrs.push(Instruction::AddW { rd, rn, rm: rm_op });
                 instrs.push(Instruction::Sub { rd, rn, rm: rm_op });
                 instrs.push(Instruction::SubW { rd, rn, rm: rm_op });
-                instrs.push(Instruction::And {
-                    rd,
-                    rn,
-                    rm: rm_op,
-                    width: RegisterWidth::X64,
-                });
-                instrs.push(Instruction::Orr {
-                    rd,
-                    rn,
-                    rm: rm_op,
-                    width: RegisterWidth::X64,
-                });
-                instrs.push(Instruction::Eor {
-                    rd,
-                    rn,
-                    rm: rm_op,
-                    width: RegisterWidth::X64,
-                });
+                for width in [RegisterWidth::X64, RegisterWidth::W32] {
+                    instrs.push(Instruction::And {
+                        rd,
+                        rn,
+                        rm: rm_op,
+                        width,
+                    });
+                    instrs.push(Instruction::Orr {
+                        rd,
+                        rn,
+                        rm: rm_op,
+                        width,
+                    });
+                    instrs.push(Instruction::Eor {
+                        rd,
+                        rn,
+                        rm: rm_op,
+                        width,
+                    });
+                }
                 instrs.push(Instruction::Lsl {
                     rd,
                     rn,
@@ -1648,6 +1650,38 @@ mod tests {
                 rm: Operand::Immediate(1)
             }
         )));
+        assert!(instrs.iter().all(Instruction::is_encodable_aarch64));
+    }
+
+    #[test]
+    fn generate_encodable_instructions_contains_w_logical_register_forms() {
+        let instrs = generate_all_encodable_instructions(
+            &[Register::X0, Register::X1, Register::X2],
+            &[],
+        );
+
+        for expected in [
+            Instruction::And {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Register(Register::X2),
+                width: RegisterWidth::W32,
+            },
+            Instruction::Orr {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Register(Register::X2),
+                width: RegisterWidth::W32,
+            },
+            Instruction::Eor {
+                rd: Register::X0,
+                rn: Register::X1,
+                rm: Operand::Register(Register::X2),
+                width: RegisterWidth::W32,
+            },
+        ] {
+            assert!(instrs.contains(&expected), "missing candidate: {expected}");
+        }
         assert!(instrs.iter().all(Instruction::is_encodable_aarch64));
     }
 

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -2072,7 +2072,9 @@ mod tests {
             .with_immediates(vec![0])
             .with_cores(Some(1))
             .with_solver_timeout(std::time::Duration::from_millis(250))
-            .with_timeout(std::time::Duration::from_secs(10));
+            // The finite pool terminates on its own. A wall-clock deadline makes
+            // this semantic regression load-sensitive as candidate coverage grows.
+            .with_timeout_option(None);
 
         let mut search = EnumerativeSearch::<crate::isa::AArch64>::new();
         let result = search.search(&target, &live_out, &config);


### PR DESCRIPTION
## Summary

- enumerate W32 `and`, `orr`, and `eor` plain-register candidates in the shared AArch64 pool
- enumerate W32 shifted-register forms for LSL, LSR, ASR, and ROR while enforcing the architectural shift limit of 31
- pin exact encodability/count coverage and remove candidate-order timing assumptions from affected enumerative and symbolic regressions

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`
- `./ci_check.sh`

Closes #602

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**