### PR TITLE
feat(auto): refuse indirect control-flow target windows

### DIFF
--- a/src/candidate_windows.rs
+++ b/src/candidate_windows.rs
@@ -129,6 +129,44 @@ pub fn plan_candidate_windows(
     candidates
 }
 
+/// Result of applying ADR-0009's conservative indirect-target refusal rule to
+/// already-planned candidate windows.
+#[derive(Debug)]
+pub struct IndirectTargetFilterResult {
+    /// Candidate windows that contain no indirect target in their interior.
+    pub admitted: Vec<AddressWindow>,
+    /// Number of complete windows suppressed for indirect-target reasons.
+    pub refused: usize,
+}
+
+/// Refuse every candidate whose strict interior contains an indirect target.
+///
+/// Direct targets split runs at known instruction boundaries. Indirect targets
+/// are deliberately different: ADR-0009 Decision 5 requires conservative
+/// refusal, so the entire candidate is dropped rather than split. A target at
+/// `window.start` is safe because that address remains fixed; a target at the
+/// exclusive `window.end` is outside the window.
+pub fn refuse_windows_with_interior_targets(
+    candidates: Vec<AddressWindow>,
+    indirect_targets: &HashSet<u64>,
+) -> IndirectTargetFilterResult {
+    let mut admitted = Vec::with_capacity(candidates.len());
+    let mut refused = 0usize;
+
+    for candidate in candidates {
+        let contains_indirect_target = indirect_targets
+            .iter()
+            .any(|target| candidate.start < *target && *target < candidate.end);
+        if contains_indirect_target {
+            refused += 1;
+        } else {
+            admitted.push(candidate);
+        }
+    }
+
+    IndirectTargetFilterResult { admitted, refused }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -242,5 +280,24 @@ mod tests {
             bounds(&plan_candidate_windows(&stream, &targets(&[]))),
             vec![(0x1000, 0x1008), (0x100c, 0x1014), (0x1018, 0x101c)],
         );
+    }
+
+    #[test]
+    fn indirect_interior_target_refuses_whole_window_and_counts_it() {
+        let candidates = vec![
+            AddressWindow {
+                start: 0x1000,
+                end: 0x1010,
+            },
+            AddressWindow {
+                start: 0x2000,
+                end: 0x2010,
+            },
+        ];
+
+        let result = refuse_windows_with_interior_targets(candidates, &targets(&[0x1004, 0x2000]));
+
+        assert_eq!(result.refused, 1);
+        assert_eq!(bounds(&result.admitted), vec![(0x2000, 0x2010)]);
     }
 }

--- a/src/elf_patcher/mod.rs
+++ b/src/elf_patcher/mod.rs
@@ -1,4 +1,11 @@
-use elf::{ElfBytes, endian::AnyEndian};
+use elf::ElfBytes;
+use elf::endian::{AnyEndian, EndianParse};
+use elf::file::Class;
+use elf::parse::ParseAt;
+use elf::relocation::{Rel, Rela};
+use elf::section::{SectionHeader, SectionHeaderTable};
+use elf::symbol::{Symbol, SymbolTable};
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 
@@ -17,6 +24,10 @@ const X86_NOP_TABLE: [&[u8]; 10] = [
     &[0x0f, 0x1f, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00],
     &[0x66, 0x0f, 0x1f, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00],
 ];
+
+/// Standard compact relative-relocation section type. `elf` 0.8 predates the
+/// public `SHT_RELR` constant even though contemporary toolchains emit it.
+const SHT_RELR: u32 = 19;
 
 /// Architecture detected from the ELF `e_machine` field. Drives
 /// per-arch behaviours: instruction alignment for window validation
@@ -160,6 +171,129 @@ impl ElfPatcher {
         Ok(text_sections)
     }
 
+    /// Collect executable addresses conservatively named by ELF metadata that
+    /// can describe indirect control-flow entry points (ADR-0009 Decision 5).
+    ///
+    /// Relocations can name code through several fields depending on ELF type
+    /// and relocation kind, so this deliberately considers the application
+    /// site, linked symbol, explicit addend, and symbol-plus-addend. Only values
+    /// inside an executable section survive. Malformed metadata is an error: a
+    /// partial exclusion set would make whole-binary candidate discovery
+    /// unsound.
+    pub fn indirect_control_flow_targets(
+        &self,
+    ) -> Result<HashSet<u64>, Box<dyn std::error::Error>> {
+        let elf = ElfBytes::<AnyEndian>::minimal_parse(&self.file_data)?;
+        let section_headers = elf
+            .section_headers()
+            .ok_or("indirect-target analysis requires ELF section headers")?;
+        let executable_ranges = executable_section_ranges(&section_headers)?;
+        let mut targets = HashSet::new();
+
+        for (section_index, relocation_section) in section_headers.iter().enumerate() {
+            match relocation_section.sh_type {
+                elf::abi::SHT_REL => {
+                    validate_table_layout::<Rel>(&elf, &relocation_section, section_index)?;
+                    let (data, compression) = elf.section_data(&relocation_section)?;
+                    if compression.is_some() {
+                        return Err(format!(
+                            "compressed relocation section {section_index} cannot be analyzed"
+                        )
+                        .into());
+                    }
+                    let mut offset = 0usize;
+                    while offset < data.len() {
+                        let relocation =
+                            Rel::parse_at(elf.ehdr.endianness, elf.ehdr.class, &mut offset, data)?;
+                        collect_relocation_targets(
+                            &elf,
+                            &section_headers,
+                            &relocation_section,
+                            relocation.r_offset,
+                            relocation.r_sym,
+                            None,
+                            &executable_ranges,
+                            &mut targets,
+                        )?;
+                    }
+                }
+                elf::abi::SHT_RELA => {
+                    validate_table_layout::<Rela>(&elf, &relocation_section, section_index)?;
+                    let (data, compression) = elf.section_data(&relocation_section)?;
+                    if compression.is_some() {
+                        return Err(format!(
+                            "compressed relocation section {section_index} cannot be analyzed"
+                        )
+                        .into());
+                    }
+                    let mut offset = 0usize;
+                    while offset < data.len() {
+                        let relocation =
+                            Rela::parse_at(elf.ehdr.endianness, elf.ehdr.class, &mut offset, data)?;
+                        collect_relocation_targets(
+                            &elf,
+                            &section_headers,
+                            &relocation_section,
+                            relocation.r_offset,
+                            relocation.r_sym,
+                            Some(relocation.r_addend),
+                            &executable_ranges,
+                            &mut targets,
+                        )?;
+                    }
+                }
+                SHT_RELR => {
+                    let (data, compression) = elf.section_data(&relocation_section)?;
+                    if compression.is_some() {
+                        return Err(format!(
+                            "compressed RELR section {section_index} cannot be analyzed"
+                        )
+                        .into());
+                    }
+                    collect_relr_targets(
+                        &elf,
+                        &section_headers,
+                        &relocation_section,
+                        section_index,
+                        data,
+                        &executable_ranges,
+                        &mut targets,
+                    )?;
+                }
+                _ => {}
+            }
+        }
+
+        let (_, section_names) = elf.section_headers_with_strtab()?;
+        let section_names = section_names
+            .ok_or("indirect-target analysis requires an ELF section-name string table")?;
+        for (section_index, section) in section_headers.iter().enumerate() {
+            let section_name = section_names
+                .get(section.sh_name as usize)
+                .map_err(|error| format!("section {section_index} has an invalid name: {error}"))?;
+            if !matches!(section_name, ".rodata" | ".data.rel.ro") {
+                continue;
+            }
+
+            let (data, compression) = elf.section_data(&section)?;
+            if compression.is_some() {
+                return Err(format!(
+                    "compressed pointer section '{section_name}' cannot be analyzed"
+                )
+                .into());
+            }
+            collect_pointer_values(
+                data,
+                elf.ehdr.class,
+                elf.ehdr.endianness,
+                &executable_ranges,
+                &mut targets,
+            )?;
+        }
+
+        Ok(targets)
+    }
+
     pub fn validate_address_window(&self, window: &AddressWindow) -> Result<TextSection, String> {
         let text_sections = self
             .get_text_sections()
@@ -269,6 +403,295 @@ impl ElfPatcher {
 
         Ok(())
     }
+}
+
+fn executable_section_ranges(
+    section_headers: &SectionHeaderTable<'_, AnyEndian>,
+) -> Result<Vec<std::ops::Range<u64>>, Box<dyn std::error::Error>> {
+    section_headers
+        .iter()
+        .filter(|section| {
+            section.sh_flags & elf::abi::SHF_EXECINSTR as u64 != 0 && section.sh_size > 0
+        })
+        .map(|section| {
+            let end = section
+                .sh_addr
+                .checked_add(section.sh_size)
+                .ok_or_else(|| {
+                    format!(
+                        "executable section range overflows: start 0x{:x}, size {}",
+                        section.sh_addr, section.sh_size
+                    )
+                })?;
+            Ok(section.sh_addr..end)
+        })
+        .collect()
+}
+
+fn validate_table_layout<P: ParseAt>(
+    elf: &ElfBytes<'_, AnyEndian>,
+    section: &SectionHeader,
+    section_index: usize,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let entry_size = P::validate_entsize(elf.ehdr.class, section.sh_entsize.try_into()?)?;
+    let section_size: usize = section.sh_size.try_into()?;
+    if !section_size.is_multiple_of(entry_size) {
+        return Err(format!(
+            "ELF table section {section_index} size {} is not a multiple of entry size {entry_size}",
+            section.sh_size
+        )
+        .into());
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_relocation_targets(
+    elf: &ElfBytes<'_, AnyEndian>,
+    section_headers: &SectionHeaderTable<'_, AnyEndian>,
+    relocation_section: &SectionHeader,
+    r_offset: u64,
+    r_sym: u32,
+    addend: Option<i64>,
+    executable_ranges: &[std::ops::Range<u64>],
+    targets: &mut HashSet<u64>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let relocation_site =
+        resolve_relocation_site(elf, section_headers, relocation_section, r_offset)?;
+    insert_executable_address(relocation_site, executable_ranges, targets);
+
+    let symbol_value = resolve_relocation_symbol(elf, section_headers, relocation_section, r_sym)?;
+    if let Some(value) = symbol_value {
+        insert_executable_address(value, executable_ranges, targets);
+    }
+
+    if let Some(addend) = addend {
+        if let Ok(value) = u64::try_from(addend) {
+            insert_executable_address(value, executable_ranges, targets);
+        }
+        if let Some(symbol_value) = symbol_value {
+            let relocated_value = symbol_value.checked_add_signed(addend).ok_or_else(|| {
+                format!(
+                    "relocation symbol-plus-addend overflows: symbol 0x{symbol_value:x}, addend {addend}"
+                )
+            })?;
+            insert_executable_address(relocated_value, executable_ranges, targets);
+        }
+    }
+
+    Ok(())
+}
+
+fn collect_relr_targets(
+    elf: &ElfBytes<'_, AnyEndian>,
+    section_headers: &SectionHeaderTable<'_, AnyEndian>,
+    relocation_section: &SectionHeader,
+    section_index: usize,
+    data: &[u8],
+    executable_ranges: &[std::ops::Range<u64>],
+    targets: &mut HashSet<u64>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (entry_size, word_bits) = match elf.ehdr.class {
+        Class::ELF32 => (4usize, 32u32),
+        Class::ELF64 => (8usize, 64u32),
+    };
+    if relocation_section.sh_entsize != entry_size as u64 {
+        return Err(format!(
+            "RELR section {section_index} has entry size {}, expected {entry_size}",
+            relocation_section.sh_entsize
+        )
+        .into());
+    }
+    if !data.len().is_multiple_of(entry_size) {
+        return Err(format!(
+            "RELR section {section_index} size {} is not a multiple of entry size {entry_size}",
+            data.len()
+        )
+        .into());
+    }
+
+    let mut next_bitmap_address = None;
+    for start in (0..data.len()).step_by(entry_size) {
+        let mut offset = start;
+        let entry = match elf.ehdr.class {
+            Class::ELF32 => u64::from(elf.ehdr.endianness.parse_u32_at(&mut offset, data)?),
+            Class::ELF64 => elf.ehdr.endianness.parse_u64_at(&mut offset, data)?,
+        };
+        if entry & 1 == 0 {
+            let relocation_site =
+                resolve_relocation_site(elf, section_headers, relocation_section, entry)?;
+            insert_executable_address(relocation_site, executable_ranges, targets);
+            next_bitmap_address = Some(
+                entry
+                    .checked_add(entry_size as u64)
+                    .ok_or_else(|| format!("RELR direct entry address overflows: 0x{entry:x}"))?,
+            );
+            continue;
+        }
+
+        let bitmap_base = next_bitmap_address
+            .ok_or_else(|| format!("RELR section {section_index} begins with a bitmap entry"))?;
+        let bitmap = entry >> 1;
+        for bit in 0..(word_bits - 1) {
+            if bitmap & (1u64 << bit) == 0 {
+                continue;
+            }
+            let byte_offset = u64::from(bit)
+                .checked_mul(entry_size as u64)
+                .ok_or("RELR bitmap byte offset overflow")?;
+            let raw_address = bitmap_base.checked_add(byte_offset).ok_or_else(|| {
+                format!(
+                    "RELR bitmap address overflows: base 0x{bitmap_base:x}, offset {byte_offset}"
+                )
+            })?;
+            let relocation_site =
+                resolve_relocation_site(elf, section_headers, relocation_section, raw_address)?;
+            insert_executable_address(relocation_site, executable_ranges, targets);
+        }
+        let bitmap_span = u64::from(word_bits - 1)
+            .checked_mul(entry_size as u64)
+            .ok_or("RELR bitmap span overflow")?;
+        next_bitmap_address = Some(bitmap_base.checked_add(bitmap_span).ok_or_else(|| {
+            format!("RELR bitmap base overflows: base 0x{bitmap_base:x}, span {bitmap_span}")
+        })?);
+    }
+
+    Ok(())
+}
+
+fn resolve_relocation_site(
+    elf: &ElfBytes<'_, AnyEndian>,
+    section_headers: &SectionHeaderTable<'_, AnyEndian>,
+    relocation_section: &SectionHeader,
+    r_offset: u64,
+) -> Result<u64, Box<dyn std::error::Error>> {
+    if elf.ehdr.e_type != elf::abi::ET_REL {
+        return Ok(r_offset);
+    }
+
+    let target_section = section_headers
+        .get(relocation_section.sh_info as usize)
+        .map_err(|error| {
+            format!(
+                "relocation target section {} is invalid: {error}",
+                relocation_section.sh_info
+            )
+        })?;
+    target_section.sh_addr.checked_add(r_offset).ok_or_else(|| {
+        format!(
+            "section-relative relocation offset overflows: base 0x{:x}, offset 0x{r_offset:x}",
+            target_section.sh_addr
+        )
+        .into()
+    })
+}
+
+fn resolve_relocation_symbol(
+    elf: &ElfBytes<'_, AnyEndian>,
+    section_headers: &SectionHeaderTable<'_, AnyEndian>,
+    relocation_section: &SectionHeader,
+    r_sym: u32,
+) -> Result<Option<u64>, Box<dyn std::error::Error>> {
+    if r_sym == 0 {
+        return Ok(None);
+    }
+
+    let symbol_section_index = relocation_section.sh_link as usize;
+    let symbol_section = section_headers.get(symbol_section_index).map_err(|error| {
+        format!("relocation-linked symbol table {symbol_section_index} is invalid: {error}")
+    })?;
+    if !matches!(
+        symbol_section.sh_type,
+        elf::abi::SHT_SYMTAB | elf::abi::SHT_DYNSYM
+    ) {
+        return Err(format!(
+            "relocation section links to section {symbol_section_index} of type {}, not a symbol table",
+            symbol_section.sh_type
+        )
+        .into());
+    }
+    validate_table_layout::<Symbol>(elf, &symbol_section, symbol_section_index)?;
+    let (symbol_data, compression) = elf.section_data(&symbol_section)?;
+    if compression.is_some() {
+        return Err(format!(
+            "compressed symbol table section {symbol_section_index} cannot be analyzed"
+        )
+        .into());
+    }
+    let symbol = SymbolTable::new(elf.ehdr.endianness, elf.ehdr.class, symbol_data)
+        .get(r_sym as usize)
+        .map_err(|error| format!("relocation symbol index {r_sym} is invalid: {error}"))?;
+    if symbol.is_undefined() {
+        return Ok(None);
+    }
+
+    let value = if elf.ehdr.e_type != elf::abi::ET_REL || symbol.st_shndx == elf::abi::SHN_ABS {
+        symbol.st_value
+    } else if symbol.st_shndx >= elf::abi::SHN_LORESERVE {
+        return Err(format!(
+            "relocatable symbol {r_sym} uses unsupported reserved section index 0x{:x}",
+            symbol.st_shndx
+        )
+        .into());
+    } else {
+        let defining_section = section_headers
+            .get(symbol.st_shndx as usize)
+            .map_err(|error| {
+                format!(
+                    "relocation symbol {r_sym} defining section {} is invalid: {error}",
+                    symbol.st_shndx
+                )
+            })?;
+        defining_section
+            .sh_addr
+            .checked_add(symbol.st_value)
+            .ok_or_else(|| {
+                format!(
+                    "section-relative symbol value overflows: base 0x{:x}, value 0x{:x}",
+                    defining_section.sh_addr, symbol.st_value
+                )
+            })?
+    };
+    Ok(Some(value))
+}
+
+fn insert_executable_address(
+    value: u64,
+    executable_ranges: &[std::ops::Range<u64>],
+    targets: &mut HashSet<u64>,
+) {
+    if executable_ranges.iter().any(|range| range.contains(&value)) {
+        targets.insert(value);
+    }
+}
+
+fn collect_pointer_values(
+    data: &[u8],
+    class: Class,
+    endianness: AnyEndian,
+    executable_ranges: &[std::ops::Range<u64>],
+    targets: &mut HashSet<u64>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let pointer_width = match class {
+        Class::ELF32 => 4,
+        Class::ELF64 => 8,
+    };
+    let Some(last_start) = data.len().checked_sub(pointer_width) else {
+        return Ok(());
+    };
+
+    // Scan at every byte offset rather than assuming natural alignment. This
+    // intentionally over-approximates: an unaligned code pointer must not evade
+    // the soundness gate, and false positives only suppress optimization.
+    for start in 0..=last_start {
+        let mut offset = start;
+        let value = match class {
+            Class::ELF32 => u64::from(endianness.parse_u32_at(&mut offset, data)?),
+            Class::ELF64 => endianness.parse_u64_at(&mut offset, data)?,
+        };
+        insert_executable_address(value, executable_ranges, targets);
+    }
+    Ok(())
 }
 
 pub fn parse_hex_address(addr_str: &str) -> Result<u64, String> {
@@ -511,6 +934,363 @@ mod tests {
 
     fn build_minimal_aarch64_elf(text_bytes: &[u8], text_vaddr: u64) -> Vec<u8> {
         build_minimal_elf64(text_bytes, text_vaddr, elf::abi::EM_AARCH64)
+    }
+
+    /// ELF64 fixture with `.text`, one `.rela.text` entry, and a linked
+    /// `.symtab`. The relocation names three independently useful values: its
+    /// application site, its symbol, and symbol-plus-addend.
+    fn build_x86_64_rela_fixture(
+        text_vaddr: u64,
+        relocation_offset: u64,
+        symbol_value: u64,
+        addend: i64,
+    ) -> Vec<u8> {
+        let elf_header_size = 64usize;
+        let shentsize = 64usize;
+        let shnum = 6usize;
+        let text = [0x90u8; 16];
+
+        let mut rela = Vec::with_capacity(24);
+        rela.extend_from_slice(&relocation_offset.to_le_bytes());
+        let r_info = (1u64 << 32) | u64::from(elf::abi::R_X86_64_64);
+        rela.extend_from_slice(&r_info.to_le_bytes());
+        rela.extend_from_slice(&addend.to_le_bytes());
+
+        let mut symtab = vec![0u8; 24];
+        symtab.extend_from_slice(&1u32.to_le_bytes()); // st_name -> "target"
+        symtab.push((elf::abi::STB_GLOBAL << 4) | elf::abi::STT_FUNC);
+        symtab.push(0); // st_other
+        symtab.extend_from_slice(&1u16.to_le_bytes()); // st_shndx -> .text
+        symtab.extend_from_slice(&symbol_value.to_le_bytes());
+        symtab.extend_from_slice(&0u64.to_le_bytes()); // st_size
+
+        let strtab = b"\0target\0";
+        let shstrtab = b"\0.text\0.rela.text\0.symtab\0.strtab\0.shstrtab\0";
+        let text_name = 1u64;
+        let rela_name = 7u64;
+        let symtab_name = 18u64;
+        let strtab_name = 26u64;
+        let shstrtab_name = 34u64;
+
+        let text_offset = elf_header_size;
+        let rela_offset = text_offset + text.len();
+        let symtab_offset = rela_offset + rela.len();
+        let strtab_offset = symtab_offset + symtab.len();
+        let shstrtab_offset = strtab_offset + strtab.len();
+        let shoff = shstrtab_offset + shstrtab.len();
+        let mut buf = vec![0u8; shoff + shentsize * shnum];
+
+        buf[0..4].copy_from_slice(b"\x7fELF");
+        buf[4] = elf::abi::ELFCLASS64;
+        buf[5] = elf::abi::ELFDATA2LSB;
+        buf[6] = elf::abi::EV_CURRENT;
+        buf[16..18].copy_from_slice(&elf::abi::ET_EXEC.to_le_bytes());
+        buf[18..20].copy_from_slice(&elf::abi::EM_X86_64.to_le_bytes());
+        buf[20..24].copy_from_slice(&(elf::abi::EV_CURRENT as u32).to_le_bytes());
+        buf[40..48].copy_from_slice(&(shoff as u64).to_le_bytes());
+        buf[52..54].copy_from_slice(&(elf_header_size as u16).to_le_bytes());
+        buf[58..60].copy_from_slice(&(shentsize as u16).to_le_bytes());
+        buf[60..62].copy_from_slice(&(shnum as u16).to_le_bytes());
+        buf[62..64].copy_from_slice(&5u16.to_le_bytes());
+
+        buf[text_offset..rela_offset].copy_from_slice(&text);
+        buf[rela_offset..symtab_offset].copy_from_slice(&rela);
+        buf[symtab_offset..strtab_offset].copy_from_slice(&symtab);
+        buf[strtab_offset..shstrtab_offset].copy_from_slice(strtab);
+        buf[shstrtab_offset..shoff].copy_from_slice(shstrtab);
+
+        let mut write_shdr = |index: usize, fields: [u64; 10]| {
+            let base = shoff + index * shentsize;
+            buf[base..base + 4].copy_from_slice(&(fields[0] as u32).to_le_bytes());
+            buf[base + 4..base + 8].copy_from_slice(&(fields[1] as u32).to_le_bytes());
+            buf[base + 8..base + 16].copy_from_slice(&fields[2].to_le_bytes());
+            buf[base + 16..base + 24].copy_from_slice(&fields[3].to_le_bytes());
+            buf[base + 24..base + 32].copy_from_slice(&fields[4].to_le_bytes());
+            buf[base + 32..base + 40].copy_from_slice(&fields[5].to_le_bytes());
+            buf[base + 40..base + 44].copy_from_slice(&(fields[6] as u32).to_le_bytes());
+            buf[base + 44..base + 48].copy_from_slice(&(fields[7] as u32).to_le_bytes());
+            buf[base + 48..base + 56].copy_from_slice(&fields[8].to_le_bytes());
+            buf[base + 56..base + 64].copy_from_slice(&fields[9].to_le_bytes());
+        };
+        write_shdr(0, [0; 10]);
+        write_shdr(
+            1,
+            [
+                text_name,
+                elf::abi::SHT_PROGBITS as u64,
+                (elf::abi::SHF_ALLOC | elf::abi::SHF_EXECINSTR) as u64,
+                text_vaddr,
+                text_offset as u64,
+                text.len() as u64,
+                0,
+                0,
+                1,
+                0,
+            ],
+        );
+        write_shdr(
+            2,
+            [
+                rela_name,
+                elf::abi::SHT_RELA as u64,
+                0,
+                0,
+                rela_offset as u64,
+                rela.len() as u64,
+                3, // linked symbol table
+                1, // target section: .text
+                8,
+                24,
+            ],
+        );
+        write_shdr(
+            3,
+            [
+                symtab_name,
+                elf::abi::SHT_SYMTAB as u64,
+                0,
+                0,
+                symtab_offset as u64,
+                symtab.len() as u64,
+                4, // linked .strtab
+                1,
+                8,
+                24,
+            ],
+        );
+        write_shdr(
+            4,
+            [
+                strtab_name,
+                elf::abi::SHT_STRTAB as u64,
+                0,
+                0,
+                strtab_offset as u64,
+                strtab.len() as u64,
+                0,
+                0,
+                1,
+                0,
+            ],
+        );
+        write_shdr(
+            5,
+            [
+                shstrtab_name,
+                elf::abi::SHT_STRTAB as u64,
+                0,
+                0,
+                shstrtab_offset as u64,
+                shstrtab.len() as u64,
+                0,
+                0,
+                1,
+                0,
+            ],
+        );
+
+        buf
+    }
+
+    fn build_x86_64_pointer_sections_fixture(
+        text_vaddr: u64,
+        rodata: &[u8],
+        data_rel_ro: &[u8],
+        relr: &[u8],
+    ) -> Vec<u8> {
+        let elf_header_size = 64usize;
+        let shentsize = 64usize;
+        let shnum = 6usize;
+        let text = [0x90u8; 16];
+        let shstrtab = b"\0.text\0.rodata\0.data.rel.ro\0.relr.dyn\0.shstrtab\0";
+
+        let text_offset = elf_header_size;
+        let rodata_offset = text_offset + text.len();
+        let data_rel_ro_offset = rodata_offset + rodata.len();
+        let relr_offset = data_rel_ro_offset + data_rel_ro.len();
+        let shstrtab_offset = relr_offset + relr.len();
+        let shoff = shstrtab_offset + shstrtab.len();
+        let mut buf = vec![0u8; shoff + shentsize * shnum];
+
+        buf[0..4].copy_from_slice(b"\x7fELF");
+        buf[4] = elf::abi::ELFCLASS64;
+        buf[5] = elf::abi::ELFDATA2LSB;
+        buf[6] = elf::abi::EV_CURRENT;
+        buf[16..18].copy_from_slice(&elf::abi::ET_EXEC.to_le_bytes());
+        buf[18..20].copy_from_slice(&elf::abi::EM_X86_64.to_le_bytes());
+        buf[20..24].copy_from_slice(&(elf::abi::EV_CURRENT as u32).to_le_bytes());
+        buf[40..48].copy_from_slice(&(shoff as u64).to_le_bytes());
+        buf[52..54].copy_from_slice(&(elf_header_size as u16).to_le_bytes());
+        buf[58..60].copy_from_slice(&(shentsize as u16).to_le_bytes());
+        buf[60..62].copy_from_slice(&(shnum as u16).to_le_bytes());
+        buf[62..64].copy_from_slice(&5u16.to_le_bytes());
+
+        buf[text_offset..rodata_offset].copy_from_slice(&text);
+        buf[rodata_offset..data_rel_ro_offset].copy_from_slice(rodata);
+        buf[data_rel_ro_offset..relr_offset].copy_from_slice(data_rel_ro);
+        buf[relr_offset..shstrtab_offset].copy_from_slice(relr);
+        buf[shstrtab_offset..shoff].copy_from_slice(shstrtab);
+
+        let mut write_shdr = |index: usize, fields: [u64; 10]| {
+            let base = shoff + index * shentsize;
+            buf[base..base + 4].copy_from_slice(&(fields[0] as u32).to_le_bytes());
+            buf[base + 4..base + 8].copy_from_slice(&(fields[1] as u32).to_le_bytes());
+            buf[base + 8..base + 16].copy_from_slice(&fields[2].to_le_bytes());
+            buf[base + 16..base + 24].copy_from_slice(&fields[3].to_le_bytes());
+            buf[base + 24..base + 32].copy_from_slice(&fields[4].to_le_bytes());
+            buf[base + 32..base + 40].copy_from_slice(&fields[5].to_le_bytes());
+            buf[base + 40..base + 44].copy_from_slice(&(fields[6] as u32).to_le_bytes());
+            buf[base + 44..base + 48].copy_from_slice(&(fields[7] as u32).to_le_bytes());
+            buf[base + 48..base + 56].copy_from_slice(&fields[8].to_le_bytes());
+            buf[base + 56..base + 64].copy_from_slice(&fields[9].to_le_bytes());
+        };
+        write_shdr(0, [0; 10]);
+        write_shdr(
+            1,
+            [
+                1,
+                elf::abi::SHT_PROGBITS as u64,
+                (elf::abi::SHF_ALLOC | elf::abi::SHF_EXECINSTR) as u64,
+                text_vaddr,
+                text_offset as u64,
+                text.len() as u64,
+                0,
+                0,
+                1,
+                0,
+            ],
+        );
+        write_shdr(
+            2,
+            [
+                7,
+                elf::abi::SHT_PROGBITS as u64,
+                elf::abi::SHF_ALLOC as u64,
+                0x2000,
+                rodata_offset as u64,
+                rodata.len() as u64,
+                0,
+                0,
+                1,
+                0,
+            ],
+        );
+        write_shdr(
+            3,
+            [
+                15,
+                elf::abi::SHT_PROGBITS as u64,
+                (elf::abi::SHF_ALLOC | elf::abi::SHF_WRITE) as u64,
+                0x3000,
+                data_rel_ro_offset as u64,
+                data_rel_ro.len() as u64,
+                0,
+                0,
+                1,
+                0,
+            ],
+        );
+        write_shdr(
+            4,
+            [
+                28,
+                19, // SHT_RELR (not yet exposed by elf 0.8)
+                elf::abi::SHF_ALLOC as u64,
+                0x4000,
+                relr_offset as u64,
+                relr.len() as u64,
+                0,
+                0,
+                8,
+                8,
+            ],
+        );
+        write_shdr(
+            5,
+            [
+                38,
+                elf::abi::SHT_STRTAB as u64,
+                0,
+                0,
+                shstrtab_offset as u64,
+                shstrtab.len() as u64,
+                0,
+                0,
+                1,
+                0,
+            ],
+        );
+
+        buf
+    }
+
+    #[test]
+    fn indirect_targets_include_relocation_site_symbol_and_symbol_plus_addend() {
+        use crate::test_utils::TempFile;
+
+        let elf_bytes = build_x86_64_rela_fixture(0x1000, 0x1004, 0x1008, 4);
+        let input = TempFile::new_bytes("s11-elf-indirect-rela", "elf", &elf_bytes);
+        let patcher = ElfPatcher::new(input.path()).expect("fixture ELF should parse");
+
+        let targets = patcher
+            .indirect_control_flow_targets()
+            .expect("valid relocation metadata should be analyzed");
+
+        assert!(
+            targets.contains(&0x1004),
+            "relocation site must be excluded"
+        );
+        assert!(targets.contains(&0x1008), "linked symbol must be excluded");
+        assert!(
+            targets.contains(&0x100c),
+            "symbol-plus-addend value must be excluded"
+        );
+    }
+
+    #[test]
+    fn indirect_targets_include_code_pointers_from_rodata_and_data_rel_ro() {
+        use crate::test_utils::TempFile;
+
+        let mut rodata = vec![0xa5]; // force the first pointer to be unaligned
+        rodata.extend_from_slice(&0x1004u64.to_le_bytes());
+        rodata.extend_from_slice(&0xfeed_face_cafe_beefu64.to_le_bytes());
+        let data_rel_ro = 0x1008u64.to_le_bytes();
+        let elf_bytes = build_x86_64_pointer_sections_fixture(0x1000, &rodata, &data_rel_ro, &[]);
+        let input = TempFile::new_bytes("s11-elf-indirect-pointers", "elf", &elf_bytes);
+        let patcher = ElfPatcher::new(input.path()).expect("fixture ELF should parse");
+
+        let targets = patcher
+            .indirect_control_flow_targets()
+            .expect("valid pointer sections should be analyzed");
+
+        assert!(
+            targets.contains(&0x1004),
+            "unaligned .rodata code pointer must be excluded"
+        );
+        assert!(
+            targets.contains(&0x1008),
+            ".data.rel.ro code pointer must be excluded"
+        );
+        assert_eq!(targets.len(), 2, "non-code data values must be ignored");
+    }
+
+    #[test]
+    fn indirect_targets_include_compact_relr_direct_and_bitmap_addresses() {
+        use crate::test_utils::TempFile;
+
+        let mut relr = Vec::new();
+        relr.extend_from_slice(&0x1000u64.to_le_bytes()); // direct relocation
+        relr.extend_from_slice(&3u64.to_le_bytes()); // bitmap bit 1 -> 0x1008
+        let elf_bytes = build_x86_64_pointer_sections_fixture(0x1000, &[], &[], &relr);
+        let input = TempFile::new_bytes("s11-elf-indirect-relr", "elf", &elf_bytes);
+        let patcher = ElfPatcher::new(input.path()).expect("fixture ELF should parse");
+
+        let targets = patcher
+            .indirect_control_flow_targets()
+            .expect("valid RELR metadata should be analyzed");
+
+        assert!(targets.contains(&0x1000), "direct RELR address is named");
+        assert!(targets.contains(&0x1008), "RELR bitmap address is named");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,9 @@ use std::time::Duration;
 mod test_utils;
 
 use s11::assembler::AArch64Assembler;
-use s11::candidate_windows::{WindowInstruction, WindowRole, plan_candidate_windows};
+use s11::candidate_windows::{
+    WindowInstruction, WindowRole, plan_candidate_windows, refuse_windows_with_interior_targets,
+};
 use s11::capstone_bridge::{ConvertOutcome, convert_capstone_op};
 use s11::capstone_bridge_x86::{convert_to_x86_ir, convert_x86_capstone_op_for_optimization};
 use s11::disassembly::{self, DisassembledInstruction};
@@ -1045,6 +1047,7 @@ impl ElfOptimizationBackend for X86OptimizationBackend {
 struct SectionCandidateWindows {
     section: TextSection,
     candidates: Vec<AddressWindow>,
+    indirect_target_refusals: usize,
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
@@ -1068,6 +1071,7 @@ fn find_candidate_windows_with_backend<B: ElfOptimizationBackend>(
     patcher: &ElfPatcher,
 ) -> Result<Vec<SectionCandidateWindows>, Box<dyn std::error::Error>> {
     let cs = backend.disassembler()?;
+    let indirect_targets = patcher.indirect_control_flow_targets()?;
 
     // Phase 1: disassemble every executable section once, fail closed on any
     // partial decode, and accumulate every direct branch/call target across the
@@ -1205,13 +1209,30 @@ fn find_candidate_windows_with_backend<B: ElfOptimizationBackend>(
             ));
         }
 
+        let filtered = refuse_windows_with_interior_targets(
+            plan_candidate_windows(&planned, &branch_targets),
+            &indirect_targets,
+        );
         section_results.push(SectionCandidateWindows {
-            candidates: plan_candidate_windows(&planned, &branch_targets),
+            candidates: filtered.admitted,
+            indirect_target_refusals: filtered.refused,
             section,
         });
     }
 
+    let refused = section_results
+        .iter()
+        .map(|section| section.indirect_target_refusals)
+        .sum();
+    println!("{}", indirect_target_refusal_log(refused));
+
     Ok(section_results)
+}
+
+fn indirect_target_refusal_log(refused: usize) -> String {
+    format!(
+        "Auto candidate discovery: refused {refused} window(s) because indirect targets from relocations or .rodata/.data.rel.ro pointers fell inside them."
+    )
 }
 
 fn capstone_detail_is_call(detail: &capstone::InsnDetail<'_>) -> bool {
@@ -2490,10 +2511,7 @@ mod cli_helper_tests {
         assert_eq!(optimized[0].destination(), Some(X86Register::R10));
     }
 
-    fn build_elf64_with_executable_sections(
-        sections: &[(&str, &[u8], u64)],
-        machine: u16,
-    ) -> Vec<u8> {
+    fn build_elf64_with_sections(sections: &[(&str, &[u8], u64, u64)], machine: u16) -> Vec<u8> {
         let elf_header_size = 64usize;
         let shentsize = 64usize;
         let shnum = sections.len() + 2;
@@ -2501,7 +2519,7 @@ mod cli_helper_tests {
         let mut shstrtab = vec![0u8];
         let section_name_offsets: Vec<usize> = sections
             .iter()
-            .map(|(name, _, _)| {
+            .map(|(name, _, _, _)| {
                 let offset = shstrtab.len();
                 shstrtab.extend_from_slice(name.as_bytes());
                 shstrtab.push(0);
@@ -2514,7 +2532,7 @@ mod cli_helper_tests {
         let mut next_offset = elf_header_size;
         let section_file_offsets: Vec<usize> = sections
             .iter()
-            .map(|(_, bytes, _)| {
+            .map(|(_, bytes, _, _)| {
                 let offset = next_offset;
                 next_offset += bytes.len();
                 offset
@@ -2547,7 +2565,7 @@ mod cli_helper_tests {
                 .to_le_bytes(),
         );
 
-        for ((_, bytes, _), offset) in sections.iter().zip(&section_file_offsets) {
+        for ((_, bytes, _, _), offset) in sections.iter().zip(&section_file_offsets) {
             buf[*offset..*offset + bytes.len()].copy_from_slice(bytes);
         }
         buf[shstrtab_offset..shstrtab_offset + shstrtab.len()].copy_from_slice(&shstrtab);
@@ -2567,7 +2585,7 @@ mod cli_helper_tests {
         };
         write_shdr(0, [0; 10]);
 
-        for (index, (((_, bytes, virtual_addr), name_offset), file_offset)) in sections
+        for (index, (((_, bytes, virtual_addr, flags), name_offset), file_offset)) in sections
             .iter()
             .zip(&section_name_offsets)
             .zip(&section_file_offsets)
@@ -2578,7 +2596,7 @@ mod cli_helper_tests {
                 [
                     *name_offset as u64,
                     elf::abi::SHT_PROGBITS as u64,
-                    (elf::abi::SHF_ALLOC | elf::abi::SHF_EXECINSTR) as u64,
+                    *flags,
                     *virtual_addr,
                     *file_offset as u64,
                     bytes.len() as u64,
@@ -2606,6 +2624,24 @@ mod cli_helper_tests {
         );
 
         buf
+    }
+
+    fn build_elf64_with_executable_sections(
+        sections: &[(&str, &[u8], u64)],
+        machine: u16,
+    ) -> Vec<u8> {
+        let sections = sections
+            .iter()
+            .map(|(name, bytes, virtual_addr)| {
+                (
+                    *name,
+                    *bytes,
+                    *virtual_addr,
+                    (elf::abi::SHF_ALLOC | elf::abi::SHF_EXECINSTR) as u64,
+                )
+            })
+            .collect::<Vec<_>>();
+        build_elf64_with_sections(&sections, machine)
     }
 
     fn build_minimal_elf64(text_bytes: &[u8], text_vaddr: u64, machine: u16) -> Vec<u8> {
@@ -2662,6 +2698,51 @@ mod cli_helper_tests {
         assert_eq!(sections[0].candidates[0].end, 0x1004);
         assert_eq!(sections[0].candidates[1].start, 0x1005);
         assert_eq!(sections[0].candidates[1].end, 0x1009);
+    }
+
+    #[test]
+    fn candidate_window_straddling_switch_table_target_is_refused() {
+        // Three supported instructions form one candidate; the trailing
+        // register-indirect jump models switch dispatch and closes that run.
+        // The table's 0x1004 entry names the second instruction, so the whole
+        // [0x1000,0x100c) candidate must be refused rather than rewritten
+        // across an entry point that linear direct-branch scanning cannot see.
+        let text = [
+            0x48, 0x83, 0xc0, 0x01, // add rax, 1 @0x1000
+            0x48, 0x83, 0xc0, 0x01, // add rax, 1 @0x1004 <- table target
+            0x48, 0x83, 0xc0, 0x01, // add rax, 1 @0x1008
+            0xff, 0xe0, // jmp rax (indirect dispatch; excluded separator)
+        ];
+        let rodata = 0x1004u64.to_le_bytes();
+        let elf_bytes = build_elf64_with_sections(
+            &[
+                (
+                    ".text",
+                    &text,
+                    0x1000,
+                    (elf::abi::SHF_ALLOC | elf::abi::SHF_EXECINSTR) as u64,
+                ),
+                (".rodata", &rodata, 0x2000, elf::abi::SHF_ALLOC as u64),
+            ],
+            elf::abi::EM_X86_64,
+        );
+        let input = TempFile::new_bytes("s11-candidate-switch-table", "elf", &elf_bytes);
+        let patcher = ElfPatcher::new(input.path()).expect("x86-64 ELF should parse");
+
+        let sections =
+            find_candidate_windows(&patcher).expect("candidate discovery should succeed");
+
+        assert_eq!(sections.len(), 1);
+        assert!(sections[0].candidates.is_empty());
+        assert_eq!(sections[0].indirect_target_refusals, 1);
+    }
+
+    #[test]
+    fn indirect_target_refusal_log_reports_suppressed_window_count() {
+        assert_eq!(
+            indirect_target_refusal_log(7),
+            "Auto candidate discovery: refused 7 window(s) because indirect targets from relocations or .rodata/.data.rel.ro pointers fell inside them."
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- collect executable addresses named by REL, RELA, RELR, linked symbols/addends, and pointer-width values in `.rodata` / `.data.rel.ro`
- fail closed on malformed or ambiguous ELF metadata and conservatively reject whole candidate windows containing an indirect target
- report the number of auto-discovery windows suppressed for indirect-target soundness, with switch-table, relocation, data-pointer, and RELR coverage

## Validation

- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`
- `./ci_check.sh`
- `/bin/ls` metadata probe (130 conservative indirect-target candidates found)

`scripts/full_test.sh` is not present in this repository; `./ci_check.sh` is the repository-documented full local CI gate and passed.

Closes #619

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**
