### PR TITLE
fix(x86): reject REX-only byte registers in 32-bit mode

### DIFF
--- a/src/isa/x86/mod.rs
+++ b/src/isa/x86/mod.rs
@@ -392,19 +392,20 @@ impl X86Register {
         base.canonical().with_view(self.view)
     }
 
-    /// True when this GPR can be named as an operand while assembling in
-    /// `mode`. The extended registers R8..R15 require a REX prefix that does
-    /// not exist in 32-bit mode, so only the eight legacy GPRs are addressable
-    /// there; all sixteen are addressable in 64-bit mode. This is the shared
-    /// source of truth for the x86-32 register-legality constraint that the
-    /// search backends' register pools filter through; the assembler
-    /// `can_assemble` prefilter enforces the same rule via the width-aware
-    /// `x86_register_ok`.
+    /// True when this individual GPR view has an encoding in `mode`.
+    ///
+    /// In 32-bit mode, indices 0..=7 are available, but low-byte views are
+    /// limited to the legacy AL/CL/DL/BL encodings at indices 0..=3. In 64-bit
+    /// mode, all sixteen GPRs and the REX-only low-byte views SPL/BPL/SIL/DIL
+    /// are available. Whole-instruction constraints, such as pairing a legacy
+    /// high-byte register with a REX-requiring operand, remain the encoding
+    /// prefilter's responsibility.
     pub fn is_available_in(self, mode: crate::assembler::x86::X86Mode) -> bool {
-        match mode {
-            crate::assembler::x86::X86Mode::Mode64 => true,
-            crate::assembler::x86::X86Mode::Mode32 => self.index().is_some_and(|i| i < 8),
-        }
+        let mode_width = match mode {
+            crate::assembler::x86::X86Mode::Mode64 => 64,
+            crate::assembler::x86::X86Mode::Mode32 => 32,
+        };
+        encoding::x86_register_ok(self, mode_width)
     }
 }
 
@@ -2034,12 +2035,17 @@ mod tests {
     fn x86_register_availability_by_mode() {
         use crate::assembler::x86::X86Mode;
 
-        // 64-bit mode addresses all sixteen GPRs, including the extended file.
+        // 64-bit mode addresses all sixteen GPRs, including the extended file
+        // and the REX-only low-byte views.
         for r in [
             X86Register::RAX,
             X86Register::RDI,
             X86Register::R8,
             X86Register::R15,
+            X86Register::SPL,
+            X86Register::BPL,
+            X86Register::SIL,
+            X86Register::DIL,
         ] {
             assert!(
                 r.is_available_in(X86Mode::Mode64),
@@ -2048,9 +2054,18 @@ mod tests {
             );
         }
 
-        // 32-bit mode has no encoding for the extended registers R8..R15, but
-        // the eight legacy GPRs remain addressable.
-        for r in [X86Register::RAX, X86Register::RSP, X86Register::RDI] {
+        // 32-bit mode has no encoding for the extended registers R8..R15 or
+        // the REX-only low-byte views SPL/BPL/SIL/DIL. Native views of the
+        // eight legacy GPRs and the legacy low-byte views remain addressable.
+        for r in [
+            X86Register::RAX,
+            X86Register::RSP,
+            X86Register::RDI,
+            X86Register::AL,
+            X86Register::CL,
+            X86Register::DL,
+            X86Register::BL,
+        ] {
             assert!(
                 r.is_available_in(X86Mode::Mode32),
                 "{:?} must be available in 32-bit mode",
@@ -2062,6 +2077,10 @@ mod tests {
             X86Register::R9,
             X86Register::R12,
             X86Register::R15,
+            X86Register::SPL,
+            X86Register::BPL,
+            X86Register::SIL,
+            X86Register::DIL,
         ] {
             assert!(
                 !r.is_available_in(X86Mode::Mode32),


### PR DESCRIPTION
## Summary

- route `X86Register::is_available_in` through the shared encoding legality predicate
- reject SPL/BPL/SIL/DIL in x86-32 while preserving legacy low bytes and x86-64 behavior
- document the individual-register contract and add named-register regressions

## Tests

- `cargo test x86_register_availability_by_mode`
- `cargo test register_legality_tracks_rex_availability_per_mode`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`
- `./ci_check.sh`

The generic run contract referenced `scripts/full_test.sh`, but that Vow-specific path does not exist in this s11 repository; the repository-defined `./ci_check.sh` gate passed in full.

Closes #684

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**