### PR TITLE
refactor(x86): centralize sub-register legality validation

### DIFF
--- a/src/assembler/x86.rs
+++ b/src/assembler/x86.rs
@@ -17,7 +17,10 @@
 // disfiguring the macro invocations. Allow at module scope.
 #![allow(clippy::useless_conversion)]
 
-use crate::isa::x86::{X86Condition, X86Instruction, X86Register, X86RegisterView};
+use crate::isa::x86::{
+    X86Condition, X86Instruction, X86Register, X86RegisterView, x86_register_ok,
+    x86_register_pair_ok,
+};
 use dynasm::dynasm;
 use dynasmrt::DynasmApi;
 
@@ -56,16 +59,17 @@ impl X86Assembler {
 }
 
 fn reg_index(reg: X86Register) -> Result<u8, String> {
-    reg.index()
-        .ok_or_else(|| format!("register {:?} has no index", reg))
+    // X86Register construction is private and every value stores a valid GPR
+    // index. Keep Result here only so the encoder macros can use one `?`-based
+    // calling convention for index and immediate extraction.
+    Ok(reg
+        .index()
+        .expect("every X86Register has a construction-validated GPR index"))
 }
 
 fn reg_index_32(reg: X86Register) -> Result<u8, String> {
-    let i = reg_index(reg)?;
-    if i >= 8 {
-        return Err(format!("register {:?} not available in x86-32 mode", reg));
-    }
-    Ok(i)
+    validate_single_register(reg, 32)?;
+    reg_index(reg)
 }
 
 fn validate_register_pair(
@@ -75,38 +79,41 @@ fn validate_register_pair(
 ) -> Result<(), String> {
     validate_single_register(lhs, mode_width)?;
     validate_single_register(rhs, mode_width)?;
+
+    if x86_register_pair_ok(lhs, rhs, mode_width) {
+        return Ok(());
+    }
+
+    // The shared predicate above decides legality. The branches below only
+    // classify its remaining pair-specific failure for a useful diagnostic.
     if lhs.effective_width(mode_width) != rhs.effective_width(mode_width) {
         return Err(format!("register widths do not match: {} and {}", lhs, rhs));
     }
-    if (lhs.is_high_byte() || rhs.is_high_byte())
-        && (lhs.index().is_some_and(|index| index >= 4)
-            || rhs.index().is_some_and(|index| index >= 4))
-    {
-        return Err(format!(
-            "high-byte register cannot be encoded when a REX prefix is required: {}, {}",
-            lhs, rhs
-        ));
-    }
-    Ok(())
+    debug_assert!(lhs.is_high_byte() || rhs.is_high_byte());
+    Err(format!(
+        "high-byte register cannot be encoded when a REX prefix is required: {}, {}",
+        lhs, rhs
+    ))
 }
 
 fn validate_single_register(reg: X86Register, mode_width: u32) -> Result<(), String> {
-    if reg.effective_width(mode_width) > mode_width {
-        return Err(format!(
-            "register {} is not available in x86-{}",
-            reg, mode_width
-        ));
+    if x86_register_ok(reg, mode_width) {
+        return Ok(());
     }
-    if mode_width == 32
-        && reg.view() == X86RegisterView::LowByte
-        && reg.index().is_some_and(|index| index >= 4)
-    {
+
+    // The shared predicate is authoritative. A rejected low-byte operand in
+    // Mode32 necessarily belongs to the REX-only SPL..DIL/R8B..R15B family;
+    // distinguish that case solely to retain the actionable encoder message.
+    if mode_width == 32 && reg.view() == X86RegisterView::LowByte {
         return Err(format!(
             "register {} requires a REX prefix and is not available in x86-32",
             reg
         ));
     }
-    Ok(())
+    Err(format!(
+        "register {} is not available in x86-{}",
+        reg, mode_width
+    ))
 }
 
 fn validate_extension_move_registers(
@@ -1419,6 +1426,35 @@ mod tests {
             }])
             .expect_err("AH cannot be encoded in an instruction requiring REX");
         assert!(err.contains("high-byte"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn x86_32_rejects_rex_only_low_byte_registers_with_actionable_error() {
+        for reg in [
+            X86Register::SPL,
+            X86Register::BPL,
+            X86Register::SIL,
+            X86Register::DIL,
+        ] {
+            let err = X86Assembler::new_32()
+                .assemble_instructions(&[X86Instruction::MovImm { rd: reg, imm: 0 }])
+                .expect_err("x86-32 cannot encode the REX-only low-byte registers");
+            assert_eq!(
+                err,
+                format!("register {reg} requires a REX prefix and is not available in x86-32")
+            );
+        }
+    }
+
+    #[test]
+    fn assembler_rejects_mismatched_register_widths() {
+        let err = X86Assembler::new_64()
+            .assemble_instructions(&[X86Instruction::MovReg {
+                rd: X86Register::RAX,
+                rs: X86Register::EAX,
+            }])
+            .expect_err("x86 register operands must have matching widths");
+        assert_eq!(err, "register widths do not match: rax and eax");
     }
 
     #[test]

--- a/src/isa/x86/encoding.rs
+++ b/src/isa/x86/encoding.rs
@@ -201,21 +201,32 @@ mod tests {
     // the REX-only low bytes, while AL/CL/DL/BL remain addressable without REX.
     #[test]
     fn register_legality_tracks_rex_availability_per_mode() {
-        assert!(
-            !x86_register_ok(X86Register::R8, 32),
-            "R8 needs a REX prefix unavailable in 32-bit mode"
-        );
-        assert!(x86_register_ok(X86Register::R8, 64));
-        assert!(
-            !x86_register_ok(X86Register::SPL, 32),
-            "SPL is a REX-only low byte"
-        );
-        assert!(x86_register_ok(X86Register::SPL, 64));
-        assert!(
-            x86_register_ok(X86Register::AL, 32),
-            "AL is a legacy low byte, no REX required"
-        );
-        assert!(x86_register_ok(X86Register::RAX, 32));
+        for reg in [X86Register::R8, X86Register::R8D, X86Register::R8B] {
+            assert!(
+                !x86_register_ok(reg, 32),
+                "{reg} needs a REX prefix unavailable in 32-bit mode"
+            );
+            assert!(x86_register_ok(reg, 64), "{reg} is available in x86-64");
+        }
+        for reg in [
+            X86Register::SPL,
+            X86Register::BPL,
+            X86Register::SIL,
+            X86Register::DIL,
+        ] {
+            assert!(!x86_register_ok(reg, 32), "{reg} is a REX-only low byte");
+            assert!(x86_register_ok(reg, 64), "{reg} is available in x86-64");
+        }
+        for reg in [
+            X86Register::RAX,
+            X86Register::EAX,
+            X86Register::AX,
+            X86Register::AL,
+            X86Register::AH,
+        ] {
+            assert!(x86_register_ok(reg, 32), "{reg} is available without REX");
+            assert!(x86_register_ok(reg, 64), "{reg} is available in x86-64");
+        }
     }
 
     // A register pair must share an operand width and cannot mix a legacy high
@@ -230,6 +241,12 @@ mod tests {
         assert!(
             !x86_register_pair_ok(X86Register::R8, X86Register::RAX, 32),
             "an extended register drags the whole pair out of 32-bit legality"
+        );
+        assert!(x86_register_pair_ok(X86Register::AX, X86Register::BX, 32));
+        assert!(x86_register_pair_ok(X86Register::AL, X86Register::AH, 64));
+        assert!(
+            !x86_register_pair_ok(X86Register::EAX, X86Register::AX, 64),
+            "dword and word views cannot pair"
         );
     }
 

--- a/src/isa/x86/mod.rs
+++ b/src/isa/x86/mod.rs
@@ -382,18 +382,20 @@ impl X86Register {
 
     /// True when this individual GPR view has an encoding in `mode`.
     ///
-    /// In 32-bit mode, indices 0..=7 are available, but low-byte views are
-    /// limited to the legacy AL/CL/DL/BL encodings at indices 0..=3. In 64-bit
-    /// mode, all sixteen GPRs and the REX-only low-byte views SPL/BPL/SIL/DIL
-    /// are available. Whole-instruction constraints, such as pairing a legacy
-    /// high-byte register with a REX-requiring operand, remain the encoding
-    /// prefilter's responsibility.
+    /// This is the mode-typed spelling of [`x86_register_ok`] and delegates to
+    /// it, so the search backends' register pools filter through exactly the
+    /// rule the assembler enforces. In 32-bit mode, indices 0..=7 are
+    /// available, but low-byte views are limited to the legacy AL/CL/DL/BL
+    /// encodings at indices 0..=3. In 64-bit mode, all sixteen GPRs and the
+    /// REX-only low-byte views SPL/BPL/SIL/DIL are available. Whole-instruction
+    /// constraints, such as pairing a legacy high-byte register with a
+    /// REX-requiring operand, remain the encoding prefilter's responsibility.
     pub fn is_available_in(self, mode: crate::assembler::x86::X86Mode) -> bool {
         let mode_width = match mode {
             crate::assembler::x86::X86Mode::Mode64 => 64,
             crate::assembler::x86::X86Mode::Mode32 => 32,
         };
-        encoding::x86_register_ok(self, mode_width)
+        x86_register_ok(self, mode_width)
     }
 }
 
@@ -2102,13 +2104,17 @@ mod tests {
         }
 
         // 32-bit mode has no encoding for the extended registers R8..R15 or
-        // the REX-only low-byte views SPL/BPL/SIL/DIL. Native views of the
-        // eight legacy GPRs and the legacy low-byte views remain addressable.
+        // the REX-only low-byte views SPL/BPL/SIL/DIL. Every view of the eight
+        // legacy GPRs, including the legacy high and low bytes, remains
+        // addressable.
         for r in [
             X86Register::RAX,
             X86Register::RSP,
             X86Register::RDI,
+            X86Register::EAX,
+            X86Register::AX,
             X86Register::AL,
+            X86Register::AH,
             X86Register::CL,
             X86Register::DL,
             X86Register::BL,
@@ -2119,11 +2125,16 @@ mod tests {
                 r
             );
         }
+        // The REX-only low bytes are as unavailable in 32-bit mode as the
+        // extended file; `is_available_in` must not diverge from the
+        // assembler's `x86_register_ok`.
         for r in [
             X86Register::R8,
             X86Register::R9,
             X86Register::R12,
             X86Register::R15,
+            X86Register::R8D,
+            X86Register::R8B,
             X86Register::SPL,
             X86Register::BPL,
             X86Register::SIL,

--- a/src/isa/x86/mod.rs
+++ b/src/isa/x86/mod.rs
@@ -18,7 +18,7 @@
 
 mod encoding;
 mod stochastic;
-pub(crate) use encoding::x86_extension_source_ok;
+pub(crate) use encoding::{x86_extension_source_ok, x86_register_ok, x86_register_pair_ok};
 pub use stochastic::{
     X86InstructionGenerator, X86Mutator, default_x86_immediates, default_x86_registers,
 };
@@ -353,8 +353,8 @@ impl X86Register {
         self.view
     }
 
-    pub fn canonical(self) -> Self {
-        Self::from_index(self.index).expect("x86 register index is always valid")
+    pub const fn canonical(self) -> Self {
+        Self::new(self.index, X86RegisterView::Native)
     }
 
     pub const fn effective_width(self, mode_width: u32) -> u32 {
@@ -378,18 +378,6 @@ impl X86Register {
 
     pub const fn fully_overwrites_architectural_register(self) -> bool {
         matches!(self.view, X86RegisterView::Native | X86RegisterView::Dword)
-    }
-
-    pub fn with_view(self, view: X86RegisterView) -> Option<Self> {
-        if view == X86RegisterView::HighByte && self.index >= 4 {
-            None
-        } else {
-            Some(Self::new(self.index, view))
-        }
-    }
-
-    pub fn with_base(self, base: X86Register) -> Option<Self> {
-        base.canonical().with_view(self.view)
     }
 
     /// True when this individual GPR view has an encoding in `mode`.
@@ -1248,6 +1236,44 @@ mod tests {
     type RegImmForm = (&'static str, fn(X86Register, i64) -> X86Instruction);
 
     #[test]
+    fn register_views_share_a_canonical_architectural_gpr() {
+        for view in [
+            X86Register::RAX,
+            X86Register::EAX,
+            X86Register::AX,
+            X86Register::AL,
+            X86Register::AH,
+        ] {
+            assert_eq!(view.canonical(), X86Register::RAX, "unexpected view {view}");
+        }
+        for view in [
+            X86Register::R8,
+            X86Register::R8D,
+            X86Register::R8W,
+            X86Register::R8B,
+        ] {
+            assert_eq!(view.canonical(), X86Register::R8, "unexpected view {view}");
+        }
+    }
+
+    #[test]
+    fn register_view_width_and_high_byte_classification_are_explicit() {
+        for (reg, width64, width32, high_byte) in [
+            (X86Register::RAX, 64, 32, false),
+            (X86Register::EAX, 32, 32, false),
+            (X86Register::AX, 16, 16, false),
+            (X86Register::AL, 8, 8, false),
+            (X86Register::AH, 8, 8, true),
+            (X86Register::SPL, 8, 8, false),
+            (X86Register::R8B, 8, 8, false),
+        ] {
+            assert_eq!(reg.effective_width(64), width64, "x86-64 width for {reg}");
+            assert_eq!(reg.effective_width(32), width32, "x86-32 width for {reg}");
+            assert_eq!(reg.is_high_byte(), high_byte, "high-byte marker for {reg}");
+        }
+    }
+
+    #[test]
     fn x86_32_generic_encodability_rejects_extended_registers() {
         let seq = [X86Instruction::MovReg {
             rd: X86Register::R8,
@@ -1259,6 +1285,27 @@ mod tests {
         assert!(crate::search::candidate::is_sequence_encodable_for(
             &seq, &X86_64
         ));
+    }
+
+    #[test]
+    fn x86_search_encodability_rejects_high_byte_with_rex_register() {
+        let rex_conflict = [X86Instruction::MovReg {
+            rd: X86Register::AH,
+            rs: X86Register::R8B,
+        }];
+        assert!(
+            !crate::search::candidate::is_sequence_encodable_for(&rex_conflict, &X86_64),
+            "the search filter must drop high-byte candidates that require REX"
+        );
+
+        let legacy_pair = [X86Instruction::MovReg {
+            rd: X86Register::AH,
+            rs: X86Register::BL,
+        }];
+        assert!(
+            crate::search::candidate::is_sequence_encodable_for(&legacy_pair, &X86_64),
+            "the search filter must retain encodable legacy-byte pairs"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -963,6 +963,9 @@ impl ElfOptimizationBackend for X86OptimizationBackend {
                 options,
                 context.downstream_flags_live,
                 downstream_live.as_ref(),
+                // See docs/adr/0010-x86-register-views.md#decision: operand
+                // views remain precise through execution, costing, and
+                // assembly, so same-count code-size rewrites are safe here.
                 true,
             ),
             Algorithm::Hybrid | Algorithm::Llm => {

--- a/src/parser/x86.rs
+++ b/src/parser/x86.rs
@@ -1390,6 +1390,31 @@ mod tests {
     }
 
     #[test]
+    fn general_parser_rejects_legacy_high_byte_with_rex_only_register() {
+        for operands in ["ah, r8b", "dh, spl"] {
+            let err = x86_ir_from_mnemonic("mov", operands)
+                .expect_err("legacy high-byte operands cannot coexist with a REX prefix");
+            assert!(
+                err.contains("legacy high-byte register cannot be encoded with REX-byte operand"),
+                "unexpected error for mov {operands}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn mode32_parser_rejects_rex_only_low_byte_registers() {
+        for alias in ["spl", "bpl", "sil", "dil"] {
+            let operands = format!("{alias}, al");
+            let err = x86_ir_from_mnemonic_for_mode("mov", &operands, X86ParseMode::Mode32)
+                .expect_err("x86-32 has no REX prefix for low-byte aliases 4 through 7");
+            assert!(
+                err.contains("not encodable in this mode"),
+                "unexpected error for mov {operands}: {err}"
+            );
+        }
+    }
+
+    #[test]
     fn test_mnemonic_parses_reg_and_imm_forms_and_round_trips_display() {
         // `test rax, rbx` and `test rax, 5` parse to TestReg/TestImm, and the
         // Display output round-trips back through the parser to the same IR.

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -1290,14 +1290,23 @@ mod tests {
             check_equivalence_for::<crate::isa::X86_64>(&seq_mov_al, &seq_clear_low_byte, &cfg),
             EquivalenceResult::Equivalent
         );
+        let clobber_full_register = [X86Instruction::MovImm {
+            rd: X86Register::RAX,
+            imm: 0,
+        }];
+        assert!(matches!(
+            check_equivalence_for::<crate::isa::X86_64>(&seq_mov_al, &clobber_full_register, &cfg),
+            EquivalenceResult::NotEquivalent
+        ));
+        // The concrete pass above refutes this pair before SMT is reached, so
+        // repeat it with the fast path suppressed; otherwise a regression in
+        // the SMT partial-write model would go unnoticed here.
+        let smt_only = cfg.clone().random_tests(0);
         assert!(matches!(
             check_equivalence_for::<crate::isa::X86_64>(
                 &seq_mov_al,
-                &[X86Instruction::MovImm {
-                    rd: X86Register::RAX,
-                    imm: 0,
-                }],
-                &cfg
+                &clobber_full_register,
+                &smt_only
             ),
             EquivalenceResult::NotEquivalent
         ));

--- a/src/semantics/equivalence.rs
+++ b/src/semantics/equivalence.rs
@@ -1271,7 +1271,7 @@ mod tests {
     }
 
     #[test]
-    fn x86_64_smt_models_partial_byte_writes() {
+    fn x86_64_concrete_and_smt_model_partial_byte_writes() {
         let seq_mov_al = vec![X86Instruction::MovImm {
             rd: X86Register::AL,
             imm: 0,
@@ -1282,7 +1282,9 @@ mod tests {
         }];
         let cfg = EquivalenceConfigFor::<crate::isa::X86_64>::default()
             .live_out(X86LiveOut::from_registers(vec![X86Register::RAX]))
-            .random_tests(0);
+            // Exercise the concrete partial-write model before asking SMT for
+            // the all-input proof, so the two implementations stay in sync.
+            .random_tests(16);
 
         assert_eq!(
             check_equivalence_for::<crate::isa::X86_64>(&seq_mov_al, &seq_clear_low_byte, &cfg),
@@ -1329,7 +1331,7 @@ mod tests {
     }
 
     #[test]
-    fn x86_64_smt_models_dword_writes_as_zero_extending() {
+    fn x86_64_concrete_and_smt_model_dword_writes_as_zero_extending() {
         let seq_xor_eax = vec![X86Instruction::XorReg {
             rd: X86Register::EAX,
             rs: X86Register::EAX,
@@ -1340,7 +1342,8 @@ mod tests {
         }];
         let cfg = EquivalenceConfigFor::<crate::isa::X86_64>::default()
             .live_out(X86LiveOut::from_registers(vec![X86Register::RAX]).with_flags(true))
-            .random_tests(0);
+            // Exercise concrete dword zero-extension before the SMT proof.
+            .random_tests(16);
 
         assert_eq!(
             check_equivalence_for::<crate::isa::X86_64>(&seq_xor_eax, &seq_xor_rax, &cfg),


### PR DESCRIPTION
## Summary

- route assembler single-register and register-pair validation through the shared ISA encodability predicates while preserving actionable diagnostics; this also closes a latent gap where direct x86-32 single-register validation accepted R8-R15 until a later index check
- remove unreachable validation and unused register-view rebinding helpers, make canonicalization directly infallible, and cross-reference ADR-0010 at the frontend policy choice
- add dedicated helper, parser, assembler, concrete-vs-SMT, and search-filter regressions for x86 sub-register views

## Verification

- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --all` (after building the documented integration fixtures with `./build_tests.sh`)
- `./ci_check.sh`
- all GitHub checks pass, including tests, clippy, coverage/Codecov, CodeQL, title lint, and automated review

The generic implementation-stage prompt named `scripts/full_test.sh`, which does not exist in this s11 repository; `./ci_check.sh` is the repository-defined full-suite gate and passed, including `test_all.sh`.

Closes #680

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**