### PR TITLE
feat(cli): guard opt outputs against clobbering

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -65,16 +65,10 @@ statistics, LLM timings, equivalence counterexamples), which lives in
 `src/report.rs`.
 
 ### Output-path resolution
-Where an `opt` run writes its result. With no explicit `-o/--output` the driver
-derives a `<stem>_optimized.<ext>` sibling of the input; an explicit output is
-honoured unless it resolves to the input binary itself, which is refused so the
-run never rewrites the source in place (the hard-link case is caught by a
-`(device, inode)` identity check a canonical-path comparison would miss). These
-rules live behind the pure `src/output_path.rs` seam, whose single entry point is
-`resolve_output_path`; the `opt` driver in `src/main.rs` is a thin adapter that
-passes the input path and optional `-o` through it. Deriving the sibling name is
-fallible — a stem-less or non-UTF-8 input yields an error the driver reports
-rather than a panic.
+Where an `opt` run materializes its result: either the explicit `-o/--output`
+target or a derived `<stem>_optimized.<ext>` sibling. The input itself is never
+an output, existing targets require `--force`, and a successful run with no
+improvement still produces an unchanged copy.
 
 ### Subset hint (intentionally absent)
 The LLM prompt does **not** enumerate the maintained AArch64 subset s11's parser accepts (see [docs/capability.md](docs/capability.md)). The model is invited to use any AArch64 mnemonic it knows. Outputs that use unsupported instructions are recorded as a research signal (which mnemonics the model "wanted" to reach for), not treated as wasted calls. See ADR-0003.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -76,8 +76,9 @@ search runs in between), existing targets require `--force`, a symlink or
 any other non-regular filesystem entry at the output path is refused outright,
 and a successful run always writes a result file — a byte copy of the input on
 x86 when nothing better is found. `ElfPatcher` retains the exact input handle it
-read, and the complete result is staged in the output's parent, given that
-handle's permissions, and then published with no-clobber or atomic-replace
+read, and the complete result is built inside a mode-0700 staging directory in
+the output's parent, given that handle's ordinary access permissions (never its
+setuid/setgid bits), and then published with no-clobber or atomic-replace
 semantics. There is no destructive open of the final path, so a raced
 final-component symlink is never followed and a partial executable is never
 exposed. Deriving the sibling name is fallible: an empty or

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -78,10 +78,11 @@ and a successful run always writes a result file — a byte copy of the input on
 x86 when nothing better is found. `ElfPatcher` retains the exact input handle it
 read, and the complete result is built inside a mode-0700 staging directory in
 the output's parent, given that handle's ordinary access permissions (never its
-setuid/setgid bits), and then published with no-clobber or atomic-replace
-semantics. There is no destructive open of the final path, so a raced
-final-component symlink is never followed and a partial executable is never
-exposed. Deriving the sibling name is fallible: an empty or
+setuid/setgid bits), and then published with no-clobber semantics or an atomic
+exchange that validates the displaced entry before accepting it. Unsafe
+displaced entries are atomically restored. There is no destructive open of the
+final path, so a raced final-component symlink is never followed and a partial
+executable is never exposed. Deriving the sibling name is fallible: an empty or
 separator-terminated explicit path, or a stem-less or non-UTF-8 derived name,
 yields an error the driver reports rather than a panic.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -66,9 +66,17 @@ statistics, LLM timings, equivalence counterexamples), which lives in
 
 ### Output-path resolution
 Where an `opt` run materializes its result: either the explicit `-o/--output`
-target or a derived `<stem>_optimized.<ext>` sibling. The input itself is never
-an output, existing targets require `--force`, and a successful run with no
-improvement still produces an unchanged copy.
+target or a derived `<stem>_optimized.<ext>` sibling. The rules live behind the
+`src/output_path.rs` seam, whose single entry point `resolve_output_path`
+returns a `ResolvedOutput` carrying the overwrite policy into the final write;
+the `opt` driver in `src/main.rs` is a thin adapter over it. The input itself is
+never an output (the hard-link case is caught by a `(device, inode)` identity
+check a canonical-path comparison would miss, re-run at write time because the
+search runs in between), existing targets require `--force`, a symlink or
+directory at the output path is refused outright, and a successful run always
+writes a result file — a byte copy of the input on x86 when nothing better is
+found. Deriving the sibling name is fallible: a stem-less or non-UTF-8 input
+yields an error the driver reports rather than a panic.
 
 ### Subset hint (intentionally absent)
 The LLM prompt does **not** enumerate the maintained AArch64 subset s11's parser accepts (see [docs/capability.md](docs/capability.md)). The model is invited to use any AArch64 mnemonic it knows. Outputs that use unsupported instructions are recorded as a research signal (which mnemonics the model "wanted" to reach for), not treated as wasted calls. See ADR-0003.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -73,10 +73,14 @@ the `opt` driver in `src/main.rs` is a thin adapter over it. The input itself is
 never an output (the hard-link case is caught by a `(device, inode)` identity
 check a canonical-path comparison would miss, re-run at write time because the
 search runs in between), existing targets require `--force`, a symlink or
-directory at the output path is refused outright, and a successful run always
-writes a result file — a byte copy of the input on x86 when nothing better is
-found. Deriving the sibling name is fallible: a stem-less or non-UTF-8 input
-yields an error the driver reports rather than a panic.
+any other non-regular filesystem entry at the output path is refused outright,
+and a successful run always writes a result file — a byte copy of the input on
+x86 when nothing better is found. The complete result is staged in the output's
+parent, given the input ELF's permissions, and then published with no-clobber or
+atomic-replace semantics, so a raced final-component symlink is never followed
+and a partial executable is never exposed. Deriving the sibling name is
+fallible: an empty or separator-terminated explicit path, or a stem-less or
+non-UTF-8 derived name, yields an error the driver reports rather than a panic.
 
 ### Subset hint (intentionally absent)
 The LLM prompt does **not** enumerate the maintained AArch64 subset s11's parser accepts (see [docs/capability.md](docs/capability.md)). The model is invited to use any AArch64 mnemonic it knows. Outputs that use unsupported instructions are recorded as a research signal (which mnemonics the model "wanted" to reach for), not treated as wasted calls. See ADR-0003.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,6 +937,7 @@ dependencies = [
  "rand 0.10.2",
  "rand_chacha 0.10.0",
  "rayon",
+ "rustix",
  "same-file",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 same-file = "1.0"
 tempfile = "3.27"
+rustix = { version = "1.1", features = ["fs", "process"] }
 
 [dev-dependencies]
 proptest = "1.11"

--- a/src/elf_patcher/mod.rs
+++ b/src/elf_patcher/mod.rs
@@ -720,6 +720,20 @@ mod tests {
     use super::*;
     use crate::output_path::resolve_output_path;
 
+    /// A [`ResolvedOutput`] over a not-yet-existing path in a fresh temp dir.
+    ///
+    /// The padding tests care about the bytes `create_patched_copy` writes, not
+    /// about overwrite policy, so resolving against an absent target keeps
+    /// `force` out of them entirely. The returned `TempDir` owns the cleanup and
+    /// must stay alive for as long as the output is used.
+    fn resolved_test_output(input: &Path) -> (tempfile::TempDir, ResolvedOutput) {
+        let dir = tempfile::tempdir().expect("create output directory");
+        let output = dir.path().join("patched.elf");
+        let resolved =
+            resolve_output_path(input, Some(&output), false).expect("resolve test output path");
+        (dir, resolved)
+    }
+
     #[test]
     fn detected_arch_alignment() {
         assert_eq!(DetectedArch::Aarch64.instruction_alignment(), 4);
@@ -1314,8 +1328,7 @@ mod tests {
         let elf_bytes = build_minimal_x86_64_elf(&text_bytes, text_vaddr);
 
         let input = TempFile::new_bytes("s11-elf-padding-in", "elf", &elf_bytes);
-        let output_file = TempFile::new_bytes("s11-elf-padding-out", "elf", &[]);
-        let output = resolve_output_path(input.path(), Some(output_file.path()), true).unwrap();
+        let (_output_dir, output) = resolved_test_output(input.path());
 
         let patcher = ElfPatcher::new(input.path()).expect("patcher should accept minimal ELF");
         assert_eq!(patcher.arch(), DetectedArch::X86_64);
@@ -1349,8 +1362,7 @@ mod tests {
         let elf_bytes = build_minimal_aarch64_elf(&text_bytes, text_vaddr);
 
         let input = TempFile::new_bytes("s11-elf-aarch64-padding-in", "elf", &elf_bytes);
-        let output_file = TempFile::new_bytes("s11-elf-aarch64-padding-out", "elf", &[]);
-        let output = resolve_output_path(input.path(), Some(output_file.path()), true).unwrap();
+        let (_output_dir, output) = resolved_test_output(input.path());
 
         let patcher = ElfPatcher::new(input.path()).expect("patcher should accept minimal ELF");
         assert_eq!(patcher.arch(), DetectedArch::Aarch64);
@@ -1384,8 +1396,7 @@ mod tests {
         let elf_bytes = build_minimal_aarch64_elf(&text_bytes, text_vaddr);
 
         let input = TempFile::new_bytes("s11-elf-aarch64-no-padding-in", "elf", &elf_bytes);
-        let output_file = TempFile::new_bytes("s11-elf-aarch64-no-padding-out", "elf", &[]);
-        let output = resolve_output_path(input.path(), Some(output_file.path()), true).unwrap();
+        let (_output_dir, output) = resolved_test_output(input.path());
 
         let patcher = ElfPatcher::new(input.path()).expect("patcher should accept minimal ELF");
 
@@ -1420,8 +1431,7 @@ mod tests {
         let elf_bytes = build_minimal_x86_64_elf(&text_bytes, text_vaddr);
 
         let input = TempFile::new_bytes("s11-elf-x86-no-padding-in", "elf", &elf_bytes);
-        let output_file = TempFile::new_bytes("s11-elf-x86-no-padding-out", "elf", &[]);
-        let output = resolve_output_path(input.path(), Some(output_file.path()), true).unwrap();
+        let (_output_dir, output) = resolved_test_output(input.path());
 
         let patcher = ElfPatcher::new(input.path()).expect("patcher should accept minimal ELF");
 
@@ -1453,8 +1463,7 @@ mod tests {
         let elf_bytes = build_minimal_x86_64_elf(&text_bytes, text_vaddr);
 
         let input = TempFile::new_bytes("s11-elf-padding-big-in", "elf", &elf_bytes);
-        let output_file = TempFile::new_bytes("s11-elf-padding-big-out", "elf", &[]);
-        let output = resolve_output_path(input.path(), Some(output_file.path()), true).unwrap();
+        let (_output_dir, output) = resolved_test_output(input.path());
 
         let patcher = ElfPatcher::new(input.path()).expect("patcher should accept minimal ELF");
 
@@ -1494,8 +1503,7 @@ mod tests {
         let elf_bytes = build_minimal_aarch64_elf(&text_bytes, text_vaddr);
 
         let input = TempFile::new_bytes("s11-elf-aarch64-padding-big-in", "elf", &elf_bytes);
-        let output_file = TempFile::new_bytes("s11-elf-aarch64-padding-big-out", "elf", &[]);
-        let output = resolve_output_path(input.path(), Some(output_file.path()), true).unwrap();
+        let (_output_dir, output) = resolved_test_output(input.path());
 
         let patcher = ElfPatcher::new(input.path()).expect("patcher should accept minimal ELF");
 

--- a/src/elf_patcher/mod.rs
+++ b/src/elf_patcher/mod.rs
@@ -9,6 +9,8 @@ use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 
+use crate::output_path::ResolvedOutput;
+
 /// Intel SDM canonical multi-byte NOP sequences, indexed by length.
 /// Index 0 is the empty slice; indices 1..=9
 /// are the recommended sequences from the Intel optimization reference.
@@ -352,7 +354,7 @@ impl ElfPatcher {
 
     pub fn create_patched_copy(
         &self,
-        output_path: &Path,
+        output: &ResolvedOutput,
         window: &AddressWindow,
         new_code: &[u8],
     ) -> Result<(), Box<dyn std::error::Error>> {
@@ -399,7 +401,16 @@ impl ElfPatcher {
         }
 
         // Write the patched file
-        fs::write(output_path, patched_data)?;
+        output.write(&patched_data)?;
+
+        Ok(())
+    }
+
+    pub fn create_unmodified_copy(
+        &self,
+        output: &ResolvedOutput,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        output.write(&self.file_data)?;
 
         Ok(())
     }
@@ -707,6 +718,7 @@ pub fn parse_hex_address(addr_str: &str) -> Result<u64, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::output_path::resolve_output_path;
 
     #[test]
     fn detected_arch_alignment() {
@@ -1302,7 +1314,8 @@ mod tests {
         let elf_bytes = build_minimal_x86_64_elf(&text_bytes, text_vaddr);
 
         let input = TempFile::new_bytes("s11-elf-padding-in", "elf", &elf_bytes);
-        let output = TempFile::new_bytes("s11-elf-padding-out", "elf", &[]);
+        let output_file = TempFile::new_bytes("s11-elf-padding-out", "elf", &[]);
+        let output = resolve_output_path(input.path(), Some(output_file.path()), true).unwrap();
 
         let patcher = ElfPatcher::new(input.path()).expect("patcher should accept minimal ELF");
         assert_eq!(patcher.arch(), DetectedArch::X86_64);
@@ -1313,7 +1326,7 @@ mod tests {
         };
         let payload = [0x90u8, 0x90, 0x90];
         patcher
-            .create_patched_copy(output.path(), &window, &payload)
+            .create_patched_copy(&output, &window, &payload)
             .expect("patch should succeed");
 
         let patched = std::fs::read(output.path()).expect("output should be readable");
@@ -1336,7 +1349,8 @@ mod tests {
         let elf_bytes = build_minimal_aarch64_elf(&text_bytes, text_vaddr);
 
         let input = TempFile::new_bytes("s11-elf-aarch64-padding-in", "elf", &elf_bytes);
-        let output = TempFile::new_bytes("s11-elf-aarch64-padding-out", "elf", &[]);
+        let output_file = TempFile::new_bytes("s11-elf-aarch64-padding-out", "elf", &[]);
+        let output = resolve_output_path(input.path(), Some(output_file.path()), true).unwrap();
 
         let patcher = ElfPatcher::new(input.path()).expect("patcher should accept minimal ELF");
         assert_eq!(patcher.arch(), DetectedArch::Aarch64);
@@ -1347,7 +1361,7 @@ mod tests {
         };
         let payload = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x11, 0x22];
         patcher
-            .create_patched_copy(output.path(), &window, &payload)
+            .create_patched_copy(&output, &window, &payload)
             .expect("patch should succeed");
 
         let patched = std::fs::read(output.path()).expect("output should be readable");
@@ -1370,7 +1384,8 @@ mod tests {
         let elf_bytes = build_minimal_aarch64_elf(&text_bytes, text_vaddr);
 
         let input = TempFile::new_bytes("s11-elf-aarch64-no-padding-in", "elf", &elf_bytes);
-        let output = TempFile::new_bytes("s11-elf-aarch64-no-padding-out", "elf", &[]);
+        let output_file = TempFile::new_bytes("s11-elf-aarch64-no-padding-out", "elf", &[]);
+        let output = resolve_output_path(input.path(), Some(output_file.path()), true).unwrap();
 
         let patcher = ElfPatcher::new(input.path()).expect("patcher should accept minimal ELF");
 
@@ -1383,7 +1398,7 @@ mod tests {
             0xab, 0xcd,
         ];
         patcher
-            .create_patched_copy(output.path(), &window, &payload)
+            .create_patched_copy(&output, &window, &payload)
             .expect("patch should succeed");
 
         let patched = std::fs::read(output.path()).expect("output should be readable");
@@ -1405,7 +1420,8 @@ mod tests {
         let elf_bytes = build_minimal_x86_64_elf(&text_bytes, text_vaddr);
 
         let input = TempFile::new_bytes("s11-elf-x86-no-padding-in", "elf", &elf_bytes);
-        let output = TempFile::new_bytes("s11-elf-x86-no-padding-out", "elf", &[]);
+        let output_file = TempFile::new_bytes("s11-elf-x86-no-padding-out", "elf", &[]);
+        let output = resolve_output_path(input.path(), Some(output_file.path()), true).unwrap();
 
         let patcher = ElfPatcher::new(input.path()).expect("patcher should accept minimal ELF");
 
@@ -1415,7 +1431,7 @@ mod tests {
         };
         let payload = [0xcc, 0x31, 0xc0, 0x48, 0x83, 0xc0, 0x01, 0xc3];
         patcher
-            .create_patched_copy(output.path(), &window, &payload)
+            .create_patched_copy(&output, &window, &payload)
             .expect("patch should succeed");
 
         let patched = std::fs::read(output.path()).expect("output should be readable");
@@ -1437,7 +1453,8 @@ mod tests {
         let elf_bytes = build_minimal_x86_64_elf(&text_bytes, text_vaddr);
 
         let input = TempFile::new_bytes("s11-elf-padding-big-in", "elf", &elf_bytes);
-        let output = TempFile::new_bytes("s11-elf-padding-big-out", "elf", &[]);
+        let output_file = TempFile::new_bytes("s11-elf-padding-big-out", "elf", &[]);
+        let output = resolve_output_path(input.path(), Some(output_file.path()), true).unwrap();
 
         let patcher = ElfPatcher::new(input.path()).expect("patcher should accept minimal ELF");
 
@@ -1447,7 +1464,7 @@ mod tests {
         };
         let payload = [0x90u8, 0x90, 0x90];
         patcher
-            .create_patched_copy(output.path(), &window, &payload)
+            .create_patched_copy(&output, &window, &payload)
             .expect("patch should succeed");
 
         let patched = std::fs::read(output.path()).expect("output should be readable");
@@ -1477,7 +1494,8 @@ mod tests {
         let elf_bytes = build_minimal_aarch64_elf(&text_bytes, text_vaddr);
 
         let input = TempFile::new_bytes("s11-elf-aarch64-padding-big-in", "elf", &elf_bytes);
-        let output = TempFile::new_bytes("s11-elf-aarch64-padding-big-out", "elf", &[]);
+        let output_file = TempFile::new_bytes("s11-elf-aarch64-padding-big-out", "elf", &[]);
+        let output = resolve_output_path(input.path(), Some(output_file.path()), true).unwrap();
 
         let patcher = ElfPatcher::new(input.path()).expect("patcher should accept minimal ELF");
 
@@ -1487,7 +1505,7 @@ mod tests {
         };
         let payload = [0xaa, 0xbb, 0xcc, 0xdd];
         patcher
-            .create_patched_copy(output.path(), &window, &payload)
+            .create_patched_copy(&output, &window, &payload)
             .expect("patch should succeed");
 
         let patched = std::fs::read(output.path()).expect("output should be readable");

--- a/src/elf_patcher/mod.rs
+++ b/src/elf_patcher/mod.rs
@@ -409,8 +409,7 @@ impl ElfPatcher {
             }
         }
 
-        let input_permissions = self.input_handle.as_file().metadata()?.permissions();
-        output.write_with_permissions(&patched_data, input_permissions)?;
+        output.write_from_input(&patched_data, &self.input_handle)?;
 
         Ok(())
     }
@@ -419,8 +418,7 @@ impl ElfPatcher {
         &self,
         output: &ResolvedOutput,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let input_permissions = self.input_handle.as_file().metadata()?.permissions();
-        output.write_with_permissions(&self.file_data, input_permissions)?;
+        output.write_from_input(&self.file_data, &self.input_handle)?;
 
         Ok(())
     }
@@ -1362,6 +1360,45 @@ mod tests {
             std::fs::read(&input).expect("input should remain readable"),
             elf_bytes,
             "refusing the late alias must leave the input byte-for-byte unchanged"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_patched_copy_tracks_input_inode_across_rename() {
+        let text_vaddr = 0x100000;
+        let text_bytes = [0xc3u8; 8];
+        let elf_bytes = build_minimal_x86_64_elf(&text_bytes, text_vaddr);
+        let temp = tempfile::tempdir().expect("temporary directory should be created");
+        let input = temp.path().join("input.elf");
+        let requested_output = temp.path().join("output.elf");
+        std::fs::write(&input, &elf_bytes).expect("input ELF should be written");
+        std::fs::write(&requested_output, b"stale output").expect("output should be seeded");
+
+        let patcher = ElfPatcher::new(&input).expect("patcher should accept minimal ELF");
+        let output = crate::output_path::resolve_output_path(&input, Some(&requested_output), true)
+            .expect("existing regular output should pass with force");
+
+        std::fs::rename(&input, &requested_output)
+            .expect("input inode should move onto the output path");
+        std::fs::write(&input, b"replacement input pathname")
+            .expect("input pathname should be replaced");
+
+        let window = AddressWindow {
+            start: text_vaddr,
+            end: text_vaddr + text_bytes.len() as u64,
+        };
+        let result = patcher.create_patched_copy(&output, &window, &[0x90]);
+
+        let err = result.expect_err("pinned input inode must never become the output");
+        assert!(
+            err.to_string().contains("refusing to optimize in place"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(
+            std::fs::read(&requested_output).expect("moved input should remain readable"),
+            elf_bytes,
+            "refusal must preserve the inode ElfPatcher actually read"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,8 +237,9 @@ enum Commands {
             "result file; when omitted the result is written next to the input as ",
             "<stem>_optimized.<ext>.\n\n",
             "Output policy: Existing output files are refused unless --force is passed; ",
-            "--force never permits replacing the input itself, and a symlink or directory ",
-            "at the output path is always refused. A successful run always writes the ",
+            "--force never permits replacing the input itself. Any non-regular filesystem entry ",
+            "(including a symlink or directory) at the output path is always refused. ",
+            "A successful run always writes the ",
             "result file; when no improvement is found the result is a byte copy of the ",
             "input on x86, and a re-encoding of the searched window on AArch64.\n\n",
             "Note: enumerative search scales with the generated instruction families ",
@@ -3295,6 +3296,10 @@ mod cli_helper_tests {
         assert!(
             opt_help.contains("Existing output files are refused unless --force is passed"),
             "opt help should document the overwrite policy:\n{opt_help}"
+        );
+        assert!(
+            opt_help.contains("Any non-regular filesystem entry"),
+            "opt help should document rejection of special output files:\n{opt_help}"
         );
         assert!(
             opt_help.contains("A successful run always writes the result file"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,9 +237,10 @@ enum Commands {
             "result file; when omitted the result is written next to the input as ",
             "<stem>_optimized.<ext>.\n\n",
             "Output policy: Existing output files are refused unless --force is passed; ",
-            "--force never permits replacing the input itself. A successful run always ",
-            "writes the result file, copying the input unchanged when no improvement is ",
-            "found.\n\n",
+            "--force never permits replacing the input itself, and a symlink or directory ",
+            "at the output path is always refused. A successful run always writes the ",
+            "result file; when no improvement is found the result is a byte copy of the ",
+            "input on x86, and a re-encoding of the searched window on AArch64.\n\n",
             "Note: enumerative search scales with the generated instruction families ",
             "in its candidate pool. At the default AArch64 8-register CLI scope, ",
             "multiply-accumulate and high-half multiply add 9,728 candidates per ",
@@ -3298,6 +3299,11 @@ mod cli_helper_tests {
         assert!(
             opt_help.contains("A successful run always writes the result file"),
             "opt help should document no-improvement copy-through:\n{opt_help}"
+        );
+        assert!(
+            opt_help.contains("a re-encoding of the searched window on AArch64"),
+            "opt help must not promise a byte copy on AArch64, whose no-improvement \
+             path re-assembles the window:\n{opt_help}"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use s11::disassembly::{self, DisassembledInstruction};
 use s11::elf_patcher::{AddressWindow, DetectedArch, ElfPatcher, TextSection, parse_hex_address};
 use s11::ir::instructions::split_terminator;
 use s11::ir::{Instruction, Register};
-use s11::output_path::resolve_output_path;
+use s11::output_path::{ResolvedOutput, resolve_output_path};
 use s11::report;
 use s11::search::config::{
     Algorithm, LlmConfig, SearchConfig, SearchMode, StochasticConfig, SymbolicConfig,
@@ -236,6 +236,10 @@ enum Commands {
             "exclusive with --start-addr/--end-addr. Use -o/--output to name the ",
             "result file; when omitted the result is written next to the input as ",
             "<stem>_optimized.<ext>.\n\n",
+            "Output policy: Existing output files are refused unless --force is passed; ",
+            "--force never permits replacing the input itself. A successful run always ",
+            "writes the result file, copying the input unchanged when no improvement is ",
+            "found.\n\n",
             "Note: enumerative search scales with the generated instruction families ",
             "in its candidate pool. At the default AArch64 8-register CLI scope, ",
             "multiply-accumulate and high-half multiply add 9,728 candidates per ",
@@ -258,6 +262,9 @@ enum Commands {
         /// Write the optimized binary to PATH (defaults to <stem>_optimized.<ext>)
         #[arg(long, short = 'o')]
         output: Option<PathBuf>,
+        /// Replace an existing output file (never permits optimizing the input in place)
+        #[arg(long)]
+        force: bool,
 
         // --- Architecture selection ---
         /// Target architecture (auto-detected from ELF if not specified)
@@ -975,7 +982,7 @@ impl ElfOptimizationBackend for X86OptimizationBackend {
     }
 
     fn no_optimization_message(&self) -> &'static str {
-        "No optimization found; not patching (input binary left untouched)."
+        "No optimization found; copying the input unchanged."
     }
 
     fn assemble_window(
@@ -1387,7 +1394,7 @@ fn optimize_elf_binary(
     path: &Path,
     start_addr: u64,
     end_addr: u64,
-    output_path: &Path,
+    output: &ResolvedOutput,
     options: &OptimizationOptions,
 ) -> Result<(), Box<dyn std::error::Error>> {
     match patcher.arch() {
@@ -1397,7 +1404,7 @@ fn optimize_elf_binary(
             path,
             start_addr,
             end_addr,
-            output_path,
+            output,
             options,
         ),
         DetectedArch::X86_64 | DetectedArch::X86_32 => optimize_elf_binary_with_backend(
@@ -1407,7 +1414,7 @@ fn optimize_elf_binary(
             path,
             start_addr,
             end_addr,
-            output_path,
+            output,
             options,
         ),
     }
@@ -1419,7 +1426,7 @@ fn optimize_elf_binary_with_backend<B: ElfOptimizationBackend>(
     path: &Path,
     start_addr: u64,
     end_addr: u64,
-    output_path: &Path,
+    output: &ResolvedOutput,
     options: &OptimizationOptions,
 ) -> Result<(), Box<dyn std::error::Error>> {
     println!("Optimizing ELF binary: {}", path.display());
@@ -1516,13 +1523,15 @@ fn optimize_elf_binary_with_backend<B: ElfOptimizationBackend>(
         start_addr,
     )?;
     let OptimizedWindowBytes::Patch(assembled_bytes) = assembled_bytes else {
+        patcher.create_unmodified_copy(output)?;
+        println!("Created unchanged binary: {}", output.path().display());
         return Ok(());
     };
     println!("Reassembled to {} bytes", assembled_bytes.len());
 
     // Create patched ELF file at the caller-resolved output path.
-    patcher.create_patched_copy(output_path, &window, &assembled_bytes)?;
-    println!("Created optimized binary: {}", output_path.display());
+    patcher.create_patched_copy(output, &window, &assembled_bytes)?;
+    println!("Created optimized binary: {}", output.path().display());
 
     Ok(())
 }
@@ -2336,6 +2345,7 @@ fn main() {
             end_addr,
             auto,
             output,
+            force,
             arch,
             algorithm,
             timeout,
@@ -2447,7 +2457,7 @@ fn main() {
                         std::process::exit(1);
                     }
                 };
-                let output_path = match resolve_output_path(&binary, output.as_deref()) {
+                let output_path = match resolve_output_path(&binary, output.as_deref(), force) {
                     Ok(path) => path,
                     Err(e) => {
                         eprintln!("Error: {e}");
@@ -3280,6 +3290,14 @@ mod cli_helper_tests {
         assert!(
             opt_help.contains("--output"),
             "opt help should document -o/--output:\n{opt_help}"
+        );
+        assert!(
+            opt_help.contains("Existing output files are refused unless --force is passed"),
+            "opt help should document the overwrite policy:\n{opt_help}"
+        );
+        assert!(
+            opt_help.contains("A successful run always writes the result file"),
+            "opt help should document no-improvement copy-through:\n{opt_help}"
         );
     }
 
@@ -4206,7 +4224,7 @@ mod cli_helper_tests {
         opts.timeout = Some(Duration::from_secs(5));
         opts.cost_metric = CostMetric::CodeSize;
 
-        let output = resolve_output_path(input.path(), None).unwrap();
+        let output = resolve_output_path(input.path(), None, false).unwrap();
         optimize_elf_binary(&patcher, input.path(), 0x1000, 0x100a, &output, &opts)
             .expect("narrow register aliases should reach search");
     }
@@ -4314,7 +4332,7 @@ mod cli_helper_tests {
         opts.timeout = Some(Duration::from_secs(5));
         opts.cost_metric = CostMetric::CodeSize;
 
-        let output = resolve_output_path(input.path(), None).unwrap();
+        let output = resolve_output_path(input.path(), None, false).unwrap();
         let err = optimize_elf_binary(&patcher, input.path(), 0x1000, 0x1006, &output, &opts)
             .expect_err("architectural byte SETcc should be rejected before search");
         let msg = err.to_string();

--- a/src/output_path.rs
+++ b/src/output_path.rs
@@ -101,6 +101,18 @@ impl ResolvedOutput {
         mut staged: tempfile::NamedTempFile,
         input: &Handle,
     ) -> io::Result<()> {
+        // Creation needs no replacement primitive. Trying no-clobber first
+        // lets `--force` remain portable when the target is absent, while an
+        // AlreadyExists result returns ownership of the staged file so the
+        // atomic replacement path below can still handle a raced entry.
+        match staged.persist_noclobber(&self.path) {
+            Ok(_) => return Ok(()),
+            Err(error) if error.error.kind() == io::ErrorKind::AlreadyExists => {
+                staged = error.file;
+            }
+            Err(error) => return Err(self.write_error(&error.error)),
+        }
+
         match exchange_paths(staged.path(), &self.path) {
             Ok(()) => match self.validate_displaced_target(staged.path(), input) {
                 Ok(()) => {
@@ -221,12 +233,7 @@ pub fn resolve_output_path(
     // must not re-derive it, or the diagnostic and the check can disagree.
     match std::fs::symlink_metadata(&output) {
         Ok(existing) => validate_existing_output(&output, &existing, force)?,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => {
-            validate_output_parent(&output)?;
-            if force {
-                validate_atomic_replacement(&output)?;
-            }
-        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => validate_output_parent(&output)?,
         Err(error) => {
             return Err(format!(
                 "cannot inspect output path '{}': {error}",
@@ -765,6 +772,25 @@ mod tests {
             std::fs::read(&output).expect("read racing output"),
             sentinel,
             "racing output must remain unchanged"
+        );
+    }
+
+    #[test]
+    fn forced_write_creates_a_missing_output_without_replacement() {
+        let dir = tempfile::tempdir().expect("create output directory");
+        let input = dir.path().join("input.elf");
+        let output = dir.path().join("output.elf");
+        std::fs::write(&input, b"original input binary").expect("seed input");
+
+        let resolved = resolve_output_path(&input, Some(&output), true)
+            .expect("force must not require replacement support for a missing target");
+        resolved
+            .write(b"optimized ELF")
+            .expect("force should create a missing output with no-clobber publication");
+
+        assert_eq!(
+            std::fs::read(output).expect("read created output"),
+            b"optimized ELF"
         );
     }
 

--- a/src/output_path.rs
+++ b/src/output_path.rs
@@ -13,12 +13,11 @@
 //! [`resolve_output_path`] returns a [`ResolvedOutput`] that carries the policy
 //! into the final write, which repeats it: the preflight runs before a
 //! potentially long search, so it cannot be the last word. Writes are staged in
-//! the destination directory, inherit the input's permissions, and are then
-//! published without exposing a partial result. Deriving a sibling remains
-//! fallible for stem-less or non-UTF-8 input names. See the `CONTEXT.md`
-//! glossary for the domain term.
+//! a private directory under the destination, inherit the input's ordinary
+//! access permissions, and are then published without exposing a partial
+//! result. Deriving a sibling remains fallible for stem-less or non-UTF-8 input
+//! names. See the `CONTEXT.md` glossary for the domain term.
 
-use std::fs::OpenOptions;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
@@ -61,18 +60,19 @@ impl ResolvedOutput {
         bytes: &[u8],
         input_permissions: std::fs::Permissions,
     ) -> io::Result<()> {
-        // Build the complete result privately in the destination directory, so
-        // publishing it is a same-filesystem rename rather than a destructive
-        // open of the final path.
+        // Build the complete result in a mode-0700 staging directory under the
+        // destination. Another user with write access to the shared parent
+        // cannot replace the named staging inode before publication, while the
+        // nested location still guarantees a same-filesystem rename.
         let parent = output_parent(&self.path);
-        let mut staged =
-            tempfile::NamedTempFile::new_in(parent).map_err(|error| self.write_error(&error))?;
+        let (_staging_dir, mut staged) =
+            create_staged_output(parent).map_err(|error| self.write_error(&error))?;
         staged
             .write_all(bytes)
             .map_err(|error| self.write_error(&error))?;
         staged
             .as_file()
-            .set_permissions(input_permissions)
+            .set_permissions(sanitize_output_permissions(input_permissions))
             .map_err(|error| self.write_error(&error))?;
 
         if self.overwrite {
@@ -191,16 +191,10 @@ fn validate_existing_output(
             output.display()
         ));
     }
-    OpenOptions::new()
-        .write(true)
-        .open(output)
-        .map_err(|error| {
-            format!(
-                "output path '{}' is not writable: {error}",
-                output.display()
-            )
-        })?;
-    Ok(())
+    // Atomic replacement renames a new inode into the directory; the old
+    // inode's mode is irrelevant, while parent publication permission is
+    // essential and must fail before search.
+    validate_output_parent(output)
 }
 
 /// Reject every existing target that cannot safely become a regular result.
@@ -249,6 +243,35 @@ fn output_parent(output: &Path) -> &Path {
         .unwrap_or_else(|| Path::new("."))
 }
 
+fn create_staged_output(parent: &Path) -> io::Result<(tempfile::TempDir, tempfile::NamedTempFile)> {
+    let mut builder = tempfile::Builder::new();
+    builder.prefix(".s11-output-");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // Apply this at creation time, not with a later chmod: no other user
+        // may get a window in which they can enter the staging directory.
+        builder.permissions(std::fs::Permissions::from_mode(0o700));
+    }
+    let staging_dir = builder.tempdir_in(parent)?;
+    let staged = tempfile::NamedTempFile::new_in(staging_dir.path())?;
+    Ok((staging_dir, staged))
+}
+
+#[cfg(unix)]
+fn sanitize_output_permissions(input: std::fs::Permissions) -> std::fs::Permissions {
+    use std::os::unix::fs::PermissionsExt;
+    // The staged inode belongs to the current user, which may differ from the
+    // input owner. Copy only ordinary access bits so a privileged invocation
+    // can never manufacture a setuid/setgid executable owned by itself.
+    std::fs::Permissions::from_mode(input.mode() & 0o777)
+}
+
+#[cfg(not(unix))]
+fn sanitize_output_permissions(input: std::fs::Permissions) -> std::fs::Permissions {
+    input
+}
+
 fn validate_output_parent(output: &Path) -> Result<(), String> {
     let parent = output_parent(output);
     // One stat answers both questions; `Path::exists` and `Path::is_dir` are
@@ -268,7 +291,10 @@ fn validate_output_parent(output: &Path) -> Result<(), String> {
         }
         Ok(_) => {}
     }
-    tempfile::tempfile_in(parent).map_err(|error| {
+    // Exercise the exact directory-and-file creation used by publication. This
+    // proves parent writability without depending on the mode of an old target
+    // inode, which atomic replacement never opens.
+    create_staged_output(parent).map_err(|error| {
         format!(
             "output parent directory '{}' is not writable: {error}",
             parent.display()
@@ -543,15 +569,15 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn resolved_output_preserves_input_permissions() {
+    fn resolved_output_preserves_access_permissions_without_privilege_bits() {
         use std::os::unix::fs::PermissionsExt;
 
         let dir = tempfile::tempdir().expect("create output directory");
         let input = dir.path().join("input.elf");
         let output = dir.path().join("output.elf");
         std::fs::write(&input, b"original input binary").expect("seed input");
-        std::fs::set_permissions(&input, std::fs::Permissions::from_mode(0o751))
-            .expect("set executable input mode");
+        std::fs::set_permissions(&input, std::fs::Permissions::from_mode(0o6751))
+            .expect("set executable input mode with privilege bits");
 
         let resolved = resolve_output_path(&input, Some(&output), false)
             .expect("missing output should pass preflight");
@@ -562,7 +588,10 @@ mod tests {
             .permissions()
             .mode()
             & 0o7777;
-        assert_eq!(output_mode, 0o751, "output must inherit the input mode");
+        assert_eq!(
+            output_mode, 0o751,
+            "output must inherit access bits without becoming setuid or setgid"
+        );
     }
 
     #[cfg(unix)]
@@ -709,5 +738,95 @@ mod tests {
                 "non-regular output diagnostic must not advertise --force: {err}"
             );
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_forced_output_requires_writable_parent() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("create fixture directory");
+        let input = dir.path().join("input.elf");
+        std::fs::write(&input, b"input").expect("seed input");
+        let parent = dir.path().join("read-only");
+        std::fs::create_dir(&parent).expect("create output parent");
+        let output = parent.join("output.elf");
+        std::fs::write(&output, b"stale output").expect("seed existing output");
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o555))
+            .expect("make output parent read-only");
+
+        if tempfile::tempfile_in(&parent).is_ok() {
+            std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o755))
+                .expect("restore output parent permissions");
+            eprintln!(
+                "Skipping forced-parent test: read-only mode not enforced (running as root?)"
+            );
+            return;
+        }
+
+        let result = resolve_output_path(&input, Some(&output), true);
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o755))
+            .expect("restore output parent permissions");
+        let err = result.expect_err("forced replacement requires writable parent directory");
+        assert!(
+            err.contains("output parent directory") && err.contains("not writable"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_forced_output_does_not_require_old_inode_writability() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("create fixture directory");
+        let input = dir.path().join("input.elf");
+        let output = dir.path().join("read-only-output.elf");
+        std::fs::write(&input, b"input").expect("seed input");
+        std::fs::write(&output, b"stale output").expect("seed existing output");
+        std::fs::set_permissions(&output, std::fs::Permissions::from_mode(0o444))
+            .expect("make old output inode read-only");
+
+        if std::fs::OpenOptions::new()
+            .write(true)
+            .open(&output)
+            .is_ok()
+        {
+            eprintln!("Skipping read-only-inode test: mode not enforced (running as root?)");
+            return;
+        }
+
+        resolve_output_path(&input, Some(&output), true)
+            .expect("atomic replacement should depend on parent, not old inode, writability");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn staged_output_is_nested_in_a_private_directory() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let parent = tempfile::tempdir().expect("create output parent");
+        let (staging_dir, staged) =
+            create_staged_output(parent.path()).expect("create staged output");
+
+        assert_eq!(
+            staging_dir.path().parent(),
+            Some(parent.path()),
+            "staging directory must share the destination filesystem"
+        );
+        assert_eq!(
+            staged.path().parent(),
+            Some(staging_dir.path()),
+            "named staging file must not be exposed directly in a shared parent"
+        );
+        let staging_mode = std::fs::metadata(staging_dir.path())
+            .expect("stat staging directory")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            staging_mode, 0o700,
+            "other users must not be able to replace the staged inode"
+        );
     }
 }

--- a/src/output_path.rs
+++ b/src/output_path.rs
@@ -7,17 +7,14 @@
 //! are checked before search so a bad target fails cheaply.
 //!
 //! An output that already exists as a **symlink** or a **directory** is refused
-//! outright, with or without `--force`: following a symlink would truncate a
-//! file at a path the user never named (the clobber this seam exists to
-//! prevent), and a directory can never become the result file, so advertising
-//! `--force` for either would be a dead end.
+//! outright, with or without `--force` — see `validate_existing_output` for why
+//! `--force` cannot help in either case.
 //!
 //! [`resolve_output_path`] returns a [`ResolvedOutput`] that carries the policy
-//! into the final write. Default writes use exclusive creation, closing the
-//! race where another file appears during a long search; forced writes reopen
-//! without truncation, recheck the input identity, and only then replace the
-//! target. Deriving a sibling remains fallible for stem-less or non-UTF-8 input
-//! names. See the `CONTEXT.md` glossary for the domain term.
+//! into the final write, which repeats it: the preflight runs before a
+//! potentially long search, so it cannot be the last word. Deriving a sibling
+//! remains fallible for stem-less or non-UTF-8 input names. See the
+//! `CONTEXT.md` glossary for the domain term.
 
 use std::fs::{File, OpenOptions};
 use std::io::{self, Write};
@@ -26,9 +23,8 @@ use std::path::{Path, PathBuf};
 /// A validated `opt` output target together with its overwrite policy.
 ///
 /// Callers resolve this once before starting a potentially long search, then
-/// pass it to the ELF writer. The final write repeats the safety policy:
-/// default writes use exclusive creation, while forced writes may truncate a
-/// distinct existing target but still refuse an alias of the input binary.
+/// pass it to the ELF writer, whose write re-applies the policy against the
+/// state of the filesystem at the end of that search.
 #[derive(Debug)]
 pub struct ResolvedOutput {
     input: PathBuf,
@@ -43,41 +39,42 @@ impl ResolvedOutput {
     }
 
     pub(crate) fn write(&self, bytes: &[u8]) -> io::Result<()> {
-        let mut options = OpenOptions::new();
-        options.write(true);
-        if self.overwrite {
-            options.create(true);
-        } else {
-            options.create_new(true);
-        }
-
-        // The search that produced `bytes` may have run for hours, so an open
-        // failure here has to name the path and the way out — the bare
-        // `File exists (os error 17)` an unwrapped `create_new` yields tells
-        // the user neither.
-        let mut file = options.open(&self.path).map_err(|error| {
-            let context = if error.kind() == io::ErrorKind::AlreadyExists {
-                format!(
-                    "output path '{}' appeared while the search was running; refusing to replace it (pass --force to replace it)",
-                    self.path.display()
-                )
-            } else {
-                format!("cannot write output path '{}': {error}", self.path.display())
-            };
-            io::Error::new(error.kind(), context)
-        })?;
-        if self.overwrite {
-            if self.opened_target_aliases_input(&file) {
-                return Err(io::Error::new(
-                    io::ErrorKind::PermissionDenied,
+        // `create_new` wins over `create` when both are set, so the two flags
+        // are the whole policy: exclusive creation by default, open-or-create
+        // under `--force`.
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(self.overwrite)
+            .create_new(!self.overwrite)
+            .open(&self.path)
+            .map_err(|error| {
+                // The search that produced `bytes` may have run for hours, so an
+                // open failure here has to name the path and the way out — the
+                // bare `File exists (os error 17)` an unwrapped `create_new`
+                // yields tells the user neither.
+                let context = if error.kind() == io::ErrorKind::AlreadyExists {
                     format!(
-                        "output path '{}' resolves to the input binary; refusing to optimize in place",
+                        "output path '{}' appeared while the search was running; refusing to replace it (pass --force to replace it)",
                         self.path.display()
-                    ),
-                ));
-            }
-            file.set_len(0)?;
+                    )
+                } else {
+                    format!("cannot write output path '{}': {error}", self.path.display())
+                };
+                io::Error::new(error.kind(), context)
+            })?;
+
+        // Unconditional, though it can only fire under `--force`: the default
+        // path just created this file exclusively, so it cannot already share
+        // the input's inode. Stating the guard once beats gating it on the same
+        // flag the open mode already encodes.
+        if self.opened_target_aliases_input(&file) {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                in_place_refusal(&self.path),
+            ));
         }
+        // Also a no-op on the default path: a freshly created file is empty.
+        file.set_len(0)?;
         file.write_all(bytes)
     }
 
@@ -88,10 +85,7 @@ impl ResolvedOutput {
     /// link to the input can appear at the output path in between.
     #[cfg(unix)]
     fn opened_target_aliases_input(&self, file: &File) -> bool {
-        match (file.metadata(), std::fs::metadata(&self.input)) {
-            (Ok(target), Ok(input)) => same_file_ids(&target, &input),
-            _ => false,
-        }
+        same_file_ids(file.metadata(), std::fs::metadata(&self.input))
     }
 
     #[cfg(not(unix))]
@@ -119,10 +113,7 @@ pub fn resolve_output_path(
     };
 
     if paths_point_to_same_file(input, &output) {
-        return Err(format!(
-            "output path '{}' resolves to the input binary; refusing to optimize in place (choose a different -o/--output)",
-            output.display()
-        ));
+        return Err(in_place_refusal(&output));
     }
 
     // One stat decides the whole existing-target policy; the branches below
@@ -194,17 +185,22 @@ fn validate_output_parent(output: &Path) -> Result<(), String> {
         .parent()
         .filter(|path| !path.as_os_str().is_empty())
         .unwrap_or_else(|| Path::new("."));
-    if !parent.exists() {
-        return Err(format!(
-            "output parent directory '{}' does not exist",
-            parent.display()
-        ));
-    }
-    if !parent.is_dir() {
-        return Err(format!(
-            "output parent path '{}' is not a directory",
-            parent.display()
-        ));
+    // One stat answers both questions; `Path::exists` and `Path::is_dir` are
+    // each a `metadata` call, so asking in turn would stat the same path twice.
+    match std::fs::metadata(parent) {
+        Err(_) => {
+            return Err(format!(
+                "output parent directory '{}' does not exist",
+                parent.display()
+            ));
+        }
+        Ok(metadata) if !metadata.is_dir() => {
+            return Err(format!(
+                "output parent path '{}' is not a directory",
+                parent.display()
+            ));
+        }
+        Ok(_) => {}
     }
     tempfile::tempfile_in(parent).map_err(|error| {
         format!(
@@ -254,40 +250,49 @@ fn optimized_output_path(path: &Path) -> Result<PathBuf, String> {
 
 /// Whether `a` and `b` are the same file on disk.
 ///
-/// On Unix this compares the `(device, inode)` pair, the only check that catches
-/// a **hard link**: two hard links to one inode are distinct directory entries
-/// with distinct canonical paths, so a canonical-path comparison would miss them
-/// and let an `-o` hard link to the input slip through the in-place guard and get
+/// Comparing the `(device, inode)` pair is the only check that catches a **hard
+/// link**: two hard links to one inode are distinct directory entries with
+/// distinct canonical paths, so a canonical-path comparison would miss them and
+/// let an `-o` hard link to the input slip through the in-place guard and get
 /// truncated by `create_patched_copy`. `metadata` follows symlinks and requires
-/// the path to exist, so it subsumes the symlink and `./bin` vs `bin` cases too;
-/// a `-o` target that does not exist yet cannot alias the already-present input,
-/// so a failed stat means "different". Off Unix, fall back to comparing canonical
-/// paths (then literal paths when canonicalization fails, which only happens for
-/// a not-yet-created output that therefore cannot be the input).
+/// the path to exist, so it subsumes the symlink and `./bin` vs `bin` cases too.
+#[cfg(unix)]
 fn paths_point_to_same_file(a: &Path, b: &Path) -> bool {
-    #[cfg(unix)]
-    fn same_file(a: &Path, b: &Path) -> bool {
-        match (std::fs::metadata(a), std::fs::metadata(b)) {
-            (Ok(ma), Ok(mb)) => same_file_ids(&ma, &mb),
-            _ => false,
-        }
+    same_file_ids(std::fs::metadata(a), std::fs::metadata(b))
+}
+
+/// Whether `a` and `b` are the same file on disk.
+///
+/// Without `(device, inode)` this compares canonical paths, then literal paths
+/// when canonicalization fails — which only happens for a not-yet-created
+/// output, which therefore cannot be the input.
+#[cfg(not(unix))]
+fn paths_point_to_same_file(a: &Path, b: &Path) -> bool {
+    match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
+        (Ok(ca), Ok(cb)) => ca == cb,
+        _ => a == b,
     }
-    #[cfg(not(unix))]
-    fn same_file(a: &Path, b: &Path) -> bool {
-        match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
-            (Ok(ca), Ok(cb)) => ca == cb,
-            _ => a == b,
-        }
-    }
-    same_file(a, b)
 }
 
 /// The single `(device, inode)` identity rule, shared by the preflight guard
 /// and the write-time recheck so the two can never drift apart.
+///
+/// Takes the `Result`s rather than the metadata so the "a failed stat means
+/// *different*" half of the rule is shared too: a `-o` target that does not
+/// exist yet cannot alias the already-present input.
 #[cfg(unix)]
-fn same_file_ids(a: &std::fs::Metadata, b: &std::fs::Metadata) -> bool {
+fn same_file_ids(a: io::Result<std::fs::Metadata>, b: io::Result<std::fs::Metadata>) -> bool {
     use std::os::unix::fs::MetadataExt;
-    a.dev() == b.dev() && a.ino() == b.ino()
+    matches!((a, b), (Ok(a), Ok(b)) if a.dev() == b.dev() && a.ino() == b.ino())
+}
+
+/// The one wording for "this output is the input binary", shared by the
+/// preflight guard and the write-time recheck that enforce the same rule.
+fn in_place_refusal(output: &Path) -> String {
+    format!(
+        "output path '{}' resolves to the input binary; refusing to optimize in place (choose a different -o/--output)",
+        output.display()
+    )
 }
 
 #[cfg(test)]

--- a/src/output_path.rs
+++ b/src/output_path.rs
@@ -71,7 +71,7 @@ impl ResolvedOutput {
         // cannot replace the named staging inode before publication, while the
         // nested location still guarantees a same-filesystem rename.
         let parent = output_parent(&self.path);
-        let (_staging_dir, mut staged) =
+        let (staging_dir, mut staged) =
             create_staged_output(parent).map_err(|error| self.write_error(&error))?;
         staged
             .write_all(bytes)
@@ -82,32 +82,70 @@ impl ResolvedOutput {
             .map_err(|error| self.write_error(&error))?;
 
         if self.overwrite {
-            // Search can run for hours after preflight. Refuse any unsafe entry
-            // now present at the target, then rename over a regular file (or a
-            // target that is still absent). Rename replaces a final-component
-            // symlink rather than following it if one appears after this check.
-            self.revalidate_forced_target(input)?;
+            return self.publish_forced(staging_dir, staged, input);
         }
 
-        let published = if self.overwrite {
-            staged.persist(&self.path)
-        } else {
-            staged.persist_noclobber(&self.path)
-        };
-        published
+        staged
+            .persist_noclobber(&self.path)
             .map(|_| ())
             .map_err(|error| self.persist_error(&error.error))
     }
 
-    fn revalidate_forced_target(&self, input: &Handle) -> io::Result<()> {
-        match std::fs::symlink_metadata(&self.path) {
-            Ok(existing) => validate_existing_output_kind(&self.path, &existing)
-                .map_err(|message| io::Error::new(io::ErrorKind::PermissionDenied, message))?,
-            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-            Err(error) => return Err(self.write_error(&error)),
+    /// Publish with one atomic exchange, then validate the entry displaced into
+    /// the protected staging directory. This binds validation to replacement:
+    /// no pathname race can substitute an input alias or special file between
+    /// the two operations because they are the same filesystem operation.
+    fn publish_forced(
+        &self,
+        mut staging_dir: tempfile::TempDir,
+        mut staged: tempfile::NamedTempFile,
+        input: &Handle,
+    ) -> io::Result<()> {
+        match exchange_paths(staged.path(), &self.path) {
+            Ok(()) => match self.validate_displaced_target(staged.path(), input) {
+                Ok(()) => {
+                    // `staged` now names the safe, displaced old output. Its
+                    // cleanup removes that inode; the open file it owns is the
+                    // newly published output and remains at `self.path`.
+                    drop(staged);
+                    drop(staging_dir);
+                    Ok(())
+                }
+                Err(refusal) => match exchange_paths(staged.path(), &self.path) {
+                    Ok(()) => Err(refusal),
+                    Err(rollback) => {
+                        // A hostile shared-directory writer may remove the new
+                        // output before rollback. Never let cleanup then unlink
+                        // the displaced original: leave it at a reported,
+                        // mode-0700 recovery path.
+                        let recovery = staged.path().to_path_buf();
+                        staged.disable_cleanup(true);
+                        staging_dir.disable_cleanup(true);
+                        Err(io::Error::new(
+                            rollback.kind(),
+                            format!(
+                                "{refusal}; rollback failed: {rollback}; displaced entry preserved at '{}'",
+                                recovery.display()
+                            ),
+                        ))
+                    }
+                },
+            },
+            Err(error) if error.kind() == io::ErrorKind::NotFound => staged
+                .persist_noclobber(&self.path)
+                .map(|_| ())
+                .map_err(|persist| self.write_error(&persist.error)),
+            Err(error) => Err(self.write_error(&error)),
         }
+    }
 
-        if path_points_to_handle(&self.path, input) {
+    fn validate_displaced_target(&self, displaced: &Path, input: &Handle) -> io::Result<()> {
+        let existing =
+            std::fs::symlink_metadata(displaced).map_err(|error| self.write_error(&error))?;
+        validate_existing_output_kind_at(displaced, &self.path, &existing)
+            .map_err(|message| io::Error::new(io::ErrorKind::PermissionDenied, message))?;
+
+        if path_points_to_handle(displaced, input) {
             return Err(io::Error::new(
                 io::ErrorKind::PermissionDenied,
                 in_place_refusal(&self.path),
@@ -183,7 +221,12 @@ pub fn resolve_output_path(
     // must not re-derive it, or the diagnostic and the check can disagree.
     match std::fs::symlink_metadata(&output) {
         Ok(existing) => validate_existing_output(&output, &existing, force)?,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => validate_output_parent(&output)?,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            validate_output_parent(&output)?;
+            if force {
+                validate_atomic_replacement(&output)?;
+            }
+        }
         Err(error) => {
             return Err(format!(
                 "cannot inspect output path '{}': {error}",
@@ -220,7 +263,9 @@ fn validate_existing_output(
     // Atomic replacement renames a new inode into the directory; the old
     // inode's mode is irrelevant, while parent publication permission is
     // essential and must fail before search.
-    validate_output_parent(output)
+    validate_output_parent(output)?;
+    validate_sticky_replacement(output, existing)?;
+    validate_atomic_replacement(output)
 }
 
 /// Reject every existing target that cannot safely become a regular result.
@@ -232,31 +277,42 @@ fn validate_existing_output_kind(
     output: &Path,
     existing: &std::fs::Metadata,
 ) -> Result<(), String> {
+    validate_existing_output_kind_at(output, output, existing)
+}
+
+/// Validate metadata read at `actual`, while diagnostics consistently name the
+/// user-selected `display` path. They differ after an atomic exchange, when the
+/// displaced entry is protected under the private staging directory.
+fn validate_existing_output_kind_at(
+    actual: &Path,
+    display: &Path,
+    existing: &std::fs::Metadata,
+) -> Result<(), String> {
     let file_type = existing.file_type();
     if file_type.is_symlink() {
-        return Err(match std::fs::read_link(output) {
+        return Err(match std::fs::read_link(actual) {
             Ok(target) => format!(
                 "output path '{}' is a symlink to '{}'; refusing to write through it (pass -o '{}' or remove the link)",
-                output.display(),
+                display.display(),
                 target.display(),
                 target.display()
             ),
             Err(_) => format!(
                 "output path '{}' is a symlink; refusing to write through it (remove the link or choose a different -o/--output)",
-                output.display()
+                display.display()
             ),
         });
     }
     if file_type.is_dir() {
         return Err(format!(
             "output path '{}' is an existing directory; choose a file path with -o/--output",
-            output.display()
+            display.display()
         ));
     }
     if !file_type.is_file() {
         return Err(format!(
             "output path '{}' is not a regular file; choose a regular file path with -o/--output",
-            output.display()
+            display.display()
         ));
     }
     Ok(())
@@ -282,6 +338,109 @@ fn create_staged_output(parent: &Path) -> io::Result<(tempfile::TempDir, tempfil
     let staging_dir = builder.tempdir_in(parent)?;
     let staged = tempfile::NamedTempFile::new_in(staging_dir.path())?;
     Ok((staging_dir, staged))
+}
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_vendor = "apple",
+    target_os = "redox"
+))]
+fn exchange_paths(a: &Path, b: &Path) -> io::Result<()> {
+    rustix::fs::renameat_with(
+        rustix::fs::CWD,
+        a,
+        rustix::fs::CWD,
+        b,
+        rustix::fs::RenameFlags::EXCHANGE,
+    )
+    .map_err(|error| io::Error::from_raw_os_error(error.raw_os_error()))
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    target_vendor = "apple",
+    target_os = "redox"
+)))]
+fn exchange_paths(_a: &Path, _b: &Path) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "this platform does not provide atomic pathname exchange",
+    ))
+}
+
+/// Probe the exact cross-directory atomic exchange used for forced
+/// publication. The destination-side probe file is owned by this process, so
+/// the operation is non-destructive; sticky-directory ownership is checked
+/// separately for the real existing target.
+fn validate_atomic_replacement(output: &Path) -> Result<(), String> {
+    let parent = output_parent(output);
+    let (_staging_dir, staged) = create_staged_output(parent).map_err(|error| {
+        format!(
+            "output parent directory '{}' is not writable: {error}",
+            parent.display()
+        )
+    })?;
+    let peer = tempfile::NamedTempFile::new_in(parent).map_err(|error| {
+        format!(
+            "output parent directory '{}' is not writable: {error}",
+            parent.display()
+        )
+    })?;
+    exchange_paths(staged.path(), peer.path()).map_err(|error| {
+        format!(
+            "output parent directory '{}' cannot atomically replace '{}': {error}",
+            parent.display(),
+            output.display()
+        )
+    })
+}
+
+#[cfg(unix)]
+fn validate_sticky_replacement(output: &Path, existing: &std::fs::Metadata) -> Result<(), String> {
+    use std::os::unix::fs::MetadataExt;
+
+    let parent = output_parent(output);
+    let parent_metadata = std::fs::metadata(parent).map_err(|error| {
+        format!(
+            "cannot inspect output parent directory '{}': {error}",
+            parent.display()
+        )
+    })?;
+    if parent_metadata.mode() & 0o1000 == 0 {
+        return Ok(());
+    }
+
+    let effective_uid = rustix::process::geteuid().as_raw();
+    if sticky_directory_allows_replacement(parent_metadata.uid(), existing.uid(), effective_uid) {
+        Ok(())
+    } else {
+        Err(format!(
+            "cannot replace output path '{}' in sticky directory '{}': output is owned by uid {}, current effective uid is {}",
+            output.display(),
+            parent.display(),
+            existing.uid(),
+            effective_uid
+        ))
+    }
+}
+
+#[cfg(not(unix))]
+fn validate_sticky_replacement(
+    _output: &Path,
+    _existing: &std::fs::Metadata,
+) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn sticky_directory_allows_replacement(
+    parent_uid: u32,
+    output_uid: u32,
+    effective_uid: u32,
+) -> bool {
+    effective_uid == 0 || effective_uid == parent_uid || effective_uid == output_uid
 }
 
 #[cfg(unix)]
@@ -668,6 +827,10 @@ mod tests {
             input_bytes,
             "input binary must survive the refused forced write"
         );
+        assert!(
+            paths_point_to_same_file(&input, &output),
+            "atomic refusal must restore the raced input link at the output path"
+        );
     }
 
     #[cfg(unix)]
@@ -700,6 +863,11 @@ mod tests {
             std::fs::read(&victim).expect("read unrelated file"),
             victim_bytes,
             "forced publication must not follow the raced symlink"
+        );
+        assert_eq!(
+            std::fs::read_link(&output).expect("raced symlink should be restored"),
+            victim,
+            "atomic refusal must restore the unsafe output entry"
         );
     }
 
@@ -840,6 +1008,18 @@ mod tests {
 
         resolve_output_path(&input, Some(&output), true)
             .expect("atomic replacement should depend on parent, not old inode, writability");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sticky_directory_replacement_policy_checks_ownership() {
+        assert!(sticky_directory_allows_replacement(10, 20, 0));
+        assert!(sticky_directory_allows_replacement(10, 20, 10));
+        assert!(sticky_directory_allows_replacement(10, 20, 20));
+        assert!(
+            !sticky_directory_allows_replacement(10, 20, 30),
+            "an unrelated user cannot replace another users file in a sticky directory"
+        );
     }
 
     #[cfg(unix)]

--- a/src/output_path.rs
+++ b/src/output_path.rs
@@ -21,6 +21,8 @@
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
+use same_file::Handle;
+
 /// A validated `opt` output target together with its overwrite policy.
 ///
 /// Callers resolve this once before starting a potentially long search, then
@@ -41,7 +43,19 @@ impl ResolvedOutput {
 
     #[cfg(test)]
     pub(crate) fn write(&self, bytes: &[u8]) -> io::Result<()> {
-        let input_permissions = std::fs::metadata(&self.input)
+        let input_handle = Handle::from_path(&self.input).map_err(|error| {
+            io::Error::new(
+                error.kind(),
+                format!("cannot open input '{}': {error}", self.input.display()),
+            )
+        })?;
+        self.write_from_input(bytes, &input_handle)
+    }
+
+    pub(crate) fn write_from_input(&self, bytes: &[u8], input: &Handle) -> io::Result<()> {
+        let input_permissions = input
+            .as_file()
+            .metadata()
             .map_err(|error| {
                 io::Error::new(
                     error.kind(),
@@ -52,14 +66,6 @@ impl ResolvedOutput {
                 )
             })?
             .permissions();
-        self.write_with_permissions(bytes, input_permissions)
-    }
-
-    pub(crate) fn write_with_permissions(
-        &self,
-        bytes: &[u8],
-        input_permissions: std::fs::Permissions,
-    ) -> io::Result<()> {
         // Build the complete result in a mode-0700 staging directory under the
         // destination. Another user with write access to the shared parent
         // cannot replace the named staging inode before publication, while the
@@ -80,7 +86,7 @@ impl ResolvedOutput {
             // now present at the target, then rename over a regular file (or a
             // target that is still absent). Rename replaces a final-component
             // symlink rather than following it if one appears after this check.
-            self.revalidate_forced_target()?;
+            self.revalidate_forced_target(input)?;
         }
 
         let published = if self.overwrite {
@@ -93,7 +99,7 @@ impl ResolvedOutput {
             .map_err(|error| self.persist_error(&error.error))
     }
 
-    fn revalidate_forced_target(&self) -> io::Result<()> {
+    fn revalidate_forced_target(&self, input: &Handle) -> io::Result<()> {
         match std::fs::symlink_metadata(&self.path) {
             Ok(existing) => validate_existing_output_kind(&self.path, &existing)
                 .map_err(|message| io::Error::new(io::ErrorKind::PermissionDenied, message))?,
@@ -101,7 +107,7 @@ impl ResolvedOutput {
             Err(error) => return Err(self.write_error(&error)),
         }
 
-        if paths_point_to_same_file(&self.input, &self.path) {
+        if path_points_to_handle(&self.path, input) {
             return Err(io::Error::new(
                 io::ErrorKind::PermissionDenied,
                 in_place_refusal(&self.path),
@@ -133,6 +139,20 @@ impl ResolvedOutput {
             ),
         )
     }
+}
+
+/// Whether `path` currently identifies the exact input inode held open by the
+/// optimizer, independent of what now exists at the original input pathname.
+#[cfg(unix)]
+fn path_points_to_handle(path: &Path, handle: &Handle) -> bool {
+    same_file_ids(handle.as_file().metadata(), std::fs::metadata(path))
+}
+
+/// Whether `path` currently identifies the exact input file held open by the
+/// optimizer, independent of what now exists at the original input pathname.
+#[cfg(not(unix))]
+fn path_points_to_handle(path: &Path, handle: &Handle) -> bool {
+    matches!(Handle::from_path(path), Ok(path_handle) if &path_handle == handle)
 }
 
 /// Resolve where an `opt` run writes its result.

--- a/src/output_path.rs
+++ b/src/output_path.rs
@@ -6,17 +6,19 @@
 //! permits an output that aliases the input. Parent existence and writability
 //! are checked before search so a bad target fails cheaply.
 //!
-//! An output that already exists as a **symlink** or a **directory** is refused
-//! outright, with or without `--force` — see `validate_existing_output` for why
-//! `--force` cannot help in either case.
+//! Any existing output that is not a regular file is refused outright, with or
+//! without `--force`: this includes symlinks, directories, sockets, FIFOs, and
+//! device nodes. See `validate_existing_output_kind` for the non-opening check.
 //!
 //! [`resolve_output_path`] returns a [`ResolvedOutput`] that carries the policy
 //! into the final write, which repeats it: the preflight runs before a
-//! potentially long search, so it cannot be the last word. Deriving a sibling
-//! remains fallible for stem-less or non-UTF-8 input names. See the
-//! `CONTEXT.md` glossary for the domain term.
+//! potentially long search, so it cannot be the last word. Writes are staged in
+//! the destination directory, inherit the input's permissions, and are then
+//! published without exposing a partial result. Deriving a sibling remains
+//! fallible for stem-less or non-UTF-8 input names. See the `CONTEXT.md`
+//! glossary for the domain term.
 
-use std::fs::{File, OpenOptions};
+use std::fs::OpenOptions;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
@@ -39,58 +41,88 @@ impl ResolvedOutput {
     }
 
     pub(crate) fn write(&self, bytes: &[u8]) -> io::Result<()> {
-        // `create_new` wins over `create` when both are set, so the two flags
-        // are the whole policy: exclusive creation by default, open-or-create
-        // under `--force`.
-        let mut file = OpenOptions::new()
-            .write(true)
-            .create(self.overwrite)
-            .create_new(!self.overwrite)
-            .open(&self.path)
+        // Build the complete result privately in the destination directory, so
+        // publishing it is a same-filesystem rename rather than a destructive
+        // open of the final path.
+        let parent = output_parent(&self.path);
+        let mut staged =
+            tempfile::NamedTempFile::new_in(parent).map_err(|error| self.write_error(&error))?;
+        staged
+            .write_all(bytes)
+            .map_err(|error| self.write_error(&error))?;
+        let input_permissions = std::fs::metadata(&self.input)
             .map_err(|error| {
-                // The search that produced `bytes` may have run for hours, so an
-                // open failure here has to name the path and the way out — the
-                // bare `File exists (os error 17)` an unwrapped `create_new`
-                // yields tells the user neither.
-                let context = if error.kind() == io::ErrorKind::AlreadyExists {
+                io::Error::new(
+                    error.kind(),
                     format!(
-                        "output path '{}' appeared while the search was running; refusing to replace it (pass --force to replace it)",
-                        self.path.display()
-                    )
-                } else {
-                    format!("cannot write output path '{}': {error}", self.path.display())
-                };
-                io::Error::new(error.kind(), context)
-            })?;
+                        "cannot read permissions from input '{}': {error}",
+                        self.input.display()
+                    ),
+                )
+            })?
+            .permissions();
+        staged
+            .as_file()
+            .set_permissions(input_permissions)
+            .map_err(|error| self.write_error(&error))?;
 
-        // Unconditional, though it can only fire under `--force`: the default
-        // path just created this file exclusively, so it cannot already share
-        // the input's inode. Stating the guard once beats gating it on the same
-        // flag the open mode already encodes.
-        if self.opened_target_aliases_input(&file) {
+        if self.overwrite {
+            // Search can run for hours after preflight. Refuse any unsafe entry
+            // now present at the target, then rename over a regular file (or a
+            // target that is still absent). Rename replaces a final-component
+            // symlink rather than following it if one appears after this check.
+            self.revalidate_forced_target()?;
+        }
+
+        let published = if self.overwrite {
+            staged.persist(&self.path)
+        } else {
+            staged.persist_noclobber(&self.path)
+        };
+        published
+            .map(|_| ())
+            .map_err(|error| self.persist_error(&error.error))
+    }
+
+    fn revalidate_forced_target(&self) -> io::Result<()> {
+        match std::fs::symlink_metadata(&self.path) {
+            Ok(existing) => validate_existing_output_kind(&self.path, &existing)
+                .map_err(|message| io::Error::new(io::ErrorKind::PermissionDenied, message))?,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(self.write_error(&error)),
+        }
+
+        if paths_point_to_same_file(&self.input, &self.path) {
             return Err(io::Error::new(
                 io::ErrorKind::PermissionDenied,
                 in_place_refusal(&self.path),
             ));
         }
-        // Also a no-op on the default path: a freshly created file is empty.
-        file.set_len(0)?;
-        file.write_all(bytes)
+        Ok(())
     }
 
-    /// Whether the file just opened at [`Self::path`] is the input binary.
-    ///
-    /// Re-checked at write time because the preflight identity guard in
-    /// [`resolve_output_path`] runs before a potentially long search: a hard
-    /// link to the input can appear at the output path in between.
-    #[cfg(unix)]
-    fn opened_target_aliases_input(&self, file: &File) -> bool {
-        same_file_ids(file.metadata(), std::fs::metadata(&self.input))
+    fn persist_error(&self, error: &io::Error) -> io::Error {
+        if !self.overwrite && error.kind() == io::ErrorKind::AlreadyExists {
+            io::Error::new(
+                error.kind(),
+                format!(
+                    "output path '{}' appeared while the search was running; refusing to replace it (pass --force to replace it)",
+                    self.path.display()
+                ),
+            )
+        } else {
+            self.write_error(error)
+        }
     }
 
-    #[cfg(not(unix))]
-    fn opened_target_aliases_input(&self, _file: &File) -> bool {
-        paths_point_to_same_file(&self.input, &self.path)
+    fn write_error(&self, error: &io::Error) -> io::Error {
+        io::Error::new(
+            error.kind(),
+            format!(
+                "cannot write output path '{}': {error}",
+                self.path.display()
+            ),
+        )
     }
 }
 
@@ -99,9 +131,9 @@ impl ResolvedOutput {
 /// With no explicit `-o/--output`, derive the
 /// `<stem>_optimized.<ext>` sibling. Unless `force` is true, an existing regular
 /// file at the target is rejected; even with force, an output resolving to the
-/// input binary — or to a symlink or directory — is always rejected. The parent
-/// directory must already exist and be writable. A stem-less or non-UTF-8 input
-/// name yields an error instead of panicking.
+/// input binary — or to any non-regular filesystem entry — is always rejected.
+/// The parent directory must already exist and be writable. A stem-less or
+/// non-UTF-8 input name yields an error instead of panicking.
 pub fn resolve_output_path(
     input: &Path,
     output: Option<&Path>,
@@ -111,6 +143,8 @@ pub fn resolve_output_path(
         Some(out) => out.to_path_buf(),
         None => optimized_output_path(input)?,
     };
+
+    validate_output_file_path(&output)?;
 
     if paths_point_to_same_file(input, &output) {
         return Err(in_place_refusal(&output));
@@ -132,14 +166,42 @@ pub fn resolve_output_path(
 
 /// Decide whether an already-present `output` may become the result file.
 ///
-/// Symlinks and directories are refused with or without `--force`: opening a
-/// symlink for writing truncates its *target*, a path the user never named, and
-/// a directory can never be replaced by a file — so neither may advertise
-/// `--force` as the way forward.
+/// Non-regular filesystem entries are refused with or without `--force`:
+/// opening a symlink for writing truncates its *target*, a path the user never
+/// named; opening a FIFO can block; and devices must not become output sinks.
+/// None may advertise `--force` as the way forward.
 fn validate_existing_output(
     output: &Path,
     existing: &std::fs::Metadata,
     force: bool,
+) -> Result<(), String> {
+    validate_existing_output_kind(output, existing)?;
+    if !force {
+        return Err(format!(
+            "output path already exists: '{}' (pass --force to replace it)",
+            output.display()
+        ));
+    }
+    OpenOptions::new()
+        .write(true)
+        .open(output)
+        .map_err(|error| {
+            format!(
+                "output path '{}' is not writable: {error}",
+                output.display()
+            )
+        })?;
+    Ok(())
+}
+
+/// Reject every existing target that cannot safely become a regular result.
+///
+/// This check only inspects directory-entry metadata; it never opens the path,
+/// so special files such as FIFOs cannot block preflight and device nodes can
+/// never become output sinks.
+fn validate_existing_output_kind(
+    output: &Path,
+    existing: &std::fs::Metadata,
 ) -> Result<(), String> {
     let file_type = existing.file_type();
     if file_type.is_symlink() {
@@ -162,29 +224,24 @@ fn validate_existing_output(
             output.display()
         ));
     }
-    if !force {
+    if !file_type.is_file() {
         return Err(format!(
-            "output path already exists: '{}' (pass --force to replace it)",
+            "output path '{}' is not a regular file; choose a regular file path with -o/--output",
             output.display()
         ));
     }
-    OpenOptions::new()
-        .write(true)
-        .open(output)
-        .map_err(|error| {
-            format!(
-                "output path '{}' is not writable: {error}",
-                output.display()
-            )
-        })?;
     Ok(())
 }
 
-fn validate_output_parent(output: &Path) -> Result<(), String> {
-    let parent = output
+fn output_parent(output: &Path) -> &Path {
+    output
         .parent()
         .filter(|path| !path.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."));
+        .unwrap_or_else(|| Path::new("."))
+}
+
+fn validate_output_parent(output: &Path) -> Result<(), String> {
+    let parent = output_parent(output);
     // One stat answers both questions; `Path::exists` and `Path::is_dir` are
     // each a `metadata` call, so asking in turn would stat the same path twice.
     match std::fs::metadata(parent) {
@@ -209,6 +266,43 @@ fn validate_output_parent(output: &Path) -> Result<(), String> {
         )
     })?;
     Ok(())
+}
+
+/// Reject path spellings that cannot denote a regular output file.
+///
+/// Inspect the raw OS string: [`Path`] accessors intentionally normalize away
+/// a trailing separator, which is precisely the distinction this preflight
+/// must preserve so the final create cannot fail only after search.
+fn validate_output_file_path(output: &Path) -> Result<(), String> {
+    if output.as_os_str().is_empty() || output_path_ends_with_separator(output) {
+        return Err(format!(
+            "output path '{}' must name a file, not an empty or separator-terminated path",
+            output.display()
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn output_path_ends_with_separator(output: &Path) -> bool {
+    use std::os::unix::ffi::OsStrExt;
+    output.as_os_str().as_bytes().last() == Some(&b'/')
+}
+
+#[cfg(windows)]
+fn output_path_ends_with_separator(output: &Path) -> bool {
+    use std::os::windows::ffi::OsStrExt;
+    matches!(
+        output.as_os_str().encode_wide().next_back(),
+        Some(last) if last == b'/' as u16 || last == b'\\' as u16
+    )
+}
+
+#[cfg(not(any(unix, windows)))]
+fn output_path_ends_with_separator(output: &Path) -> bool {
+    output
+        .to_string_lossy()
+        .ends_with(std::path::MAIN_SEPARATOR)
 }
 
 /// Derive the default `<stem>_optimized.<ext>` sibling for `path`.
@@ -324,6 +418,27 @@ mod tests {
     }
 
     #[test]
+    fn resolve_output_path_rejects_explicit_output_without_a_file_name() {
+        let dir = tempfile::tempdir().expect("create output directory");
+        let input = dir.path().join("prog.elf");
+        let mut trailing_separator = dir.path().join("result").into_os_string();
+        trailing_separator.push(std::path::MAIN_SEPARATOR_STR);
+
+        for output in [PathBuf::new(), PathBuf::from(trailing_separator)] {
+            let err = resolve_output_path(&input, Some(&output), false)
+                .expect_err("explicit output must name a file");
+            assert!(
+                err.contains("output path") && err.contains("must name a file"),
+                "unexpected error for {output:?}: {err}"
+            );
+            assert!(
+                !err.contains("--force"),
+                "force cannot make an unusable file path valid: {err}"
+            );
+        }
+    }
+
+    #[test]
     fn resolve_output_path_rejects_in_place_output() {
         // The same existing file addressed two ways (a `.` component): on Unix
         // the guard fires via the (dev, ino) identity check, off-Unix via
@@ -395,6 +510,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("create output directory");
         let input = dir.path().join("input.elf");
         let output = dir.path().join("output.elf");
+        std::fs::write(&input, b"original input binary").expect("seed input");
         let resolved = resolve_output_path(&input, Some(&output), false)
             .expect("missing output should pass preflight");
         let sentinel = b"file created while optimization was running";
@@ -414,6 +530,30 @@ mod tests {
             sentinel,
             "racing output must remain unchanged"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolved_output_preserves_input_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("create output directory");
+        let input = dir.path().join("input.elf");
+        let output = dir.path().join("output.elf");
+        std::fs::write(&input, b"original input binary").expect("seed input");
+        std::fs::set_permissions(&input, std::fs::Permissions::from_mode(0o751))
+            .expect("set executable input mode");
+
+        let resolved = resolve_output_path(&input, Some(&output), false)
+            .expect("missing output should pass preflight");
+        resolved.write(b"optimized ELF").expect("write output");
+
+        let output_mode = std::fs::metadata(&output)
+            .expect("stat output")
+            .permissions()
+            .mode()
+            & 0o7777;
+        assert_eq!(output_mode, 0o751, "output must inherit the input mode");
     }
 
     #[cfg(unix)]
@@ -447,6 +587,39 @@ mod tests {
             std::fs::read(&input).expect("read input"),
             input_bytes,
             "input binary must survive the refused forced write"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn forced_write_refuses_symlink_created_after_preflight() {
+        let dir = tempfile::tempdir().expect("create output directory");
+        let input = dir.path().join("input.elf");
+        let output = dir.path().join("output.elf");
+        std::fs::write(&input, b"original input binary").expect("seed input");
+        std::fs::write(&output, b"stale output").expect("seed output");
+
+        let resolved =
+            resolve_output_path(&input, Some(&output), true).expect("forced output resolves");
+
+        let victim = dir.path().join("unrelated.txt");
+        let victim_bytes = b"unrelated file contents";
+        std::fs::write(&victim, victim_bytes).expect("seed unrelated file");
+        std::fs::remove_file(&output).expect("remove resolved output");
+        std::os::unix::fs::symlink(&victim, &output).expect("race a symlink into the output path");
+
+        let error = resolved
+            .write(b"optimized ELF")
+            .expect_err("forced writer must refuse a raced symlink");
+
+        assert!(
+            error.to_string().contains("is a symlink"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(
+            std::fs::read(&victim).expect("read unrelated file"),
+            victim_bytes,
+            "forced publication must not follow the raced symlink"
         );
     }
 
@@ -500,6 +673,31 @@ mod tests {
             assert!(
                 !err.contains("--force"),
                 "directory diagnostic must not advertise --force: {err}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_output_path_refuses_non_regular_output_without_opening_it() {
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().expect("create output directory");
+        let input = dir.path().join("input.elf");
+        std::fs::write(&input, b"input").expect("seed input");
+        let socket = dir.path().join("out.sock");
+        let _listener = UnixListener::bind(&socket).expect("bind output socket");
+
+        for force in [false, true] {
+            let err = resolve_output_path(&input, Some(&socket), force)
+                .expect_err("a non-regular output must be rejected");
+            assert!(
+                err.contains("is not a regular file"),
+                "unexpected error with force={force}: {err}"
+            );
+            assert!(
+                !err.contains("--force"),
+                "non-regular output diagnostic must not advertise --force: {err}"
             );
         }
     }

--- a/src/output_path.rs
+++ b/src/output_path.rs
@@ -6,6 +6,12 @@
 //! permits an output that aliases the input. Parent existence and writability
 //! are checked before search so a bad target fails cheaply.
 //!
+//! An output that already exists as a **symlink** or a **directory** is refused
+//! outright, with or without `--force`: following a symlink would truncate a
+//! file at a path the user never named (the clobber this seam exists to
+//! prevent), and a directory can never become the result file, so advertising
+//! `--force` for either would be a dead end.
+//!
 //! [`resolve_output_path`] returns a [`ResolvedOutput`] that carries the policy
 //! into the final write. Default writes use exclusive creation, closing the
 //! race where another file appears during a long search; forced writes reopen
@@ -45,9 +51,23 @@ impl ResolvedOutput {
             options.create_new(true);
         }
 
-        let mut file = options.open(&self.path)?;
+        // The search that produced `bytes` may have run for hours, so an open
+        // failure here has to name the path and the way out — the bare
+        // `File exists (os error 17)` an unwrapped `create_new` yields tells
+        // the user neither.
+        let mut file = options.open(&self.path).map_err(|error| {
+            let context = if error.kind() == io::ErrorKind::AlreadyExists {
+                format!(
+                    "output path '{}' appeared while the search was running; refusing to replace it (pass --force to replace it)",
+                    self.path.display()
+                )
+            } else {
+                format!("cannot write output path '{}': {error}", self.path.display())
+            };
+            io::Error::new(error.kind(), context)
+        })?;
         if self.overwrite {
-            if opened_file_points_to_path(&file, &self.input, &self.path) {
+            if self.opened_target_aliases_input(&file) {
                 return Err(io::Error::new(
                     io::ErrorKind::PermissionDenied,
                     format!(
@@ -60,15 +80,34 @@ impl ResolvedOutput {
         }
         file.write_all(bytes)
     }
+
+    /// Whether the file just opened at [`Self::path`] is the input binary.
+    ///
+    /// Re-checked at write time because the preflight identity guard in
+    /// [`resolve_output_path`] runs before a potentially long search: a hard
+    /// link to the input can appear at the output path in between.
+    #[cfg(unix)]
+    fn opened_target_aliases_input(&self, file: &File) -> bool {
+        match (file.metadata(), std::fs::metadata(&self.input)) {
+            (Ok(target), Ok(input)) => same_file_ids(&target, &input),
+            _ => false,
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn opened_target_aliases_input(&self, _file: &File) -> bool {
+        paths_point_to_same_file(&self.input, &self.path)
+    }
 }
 
 /// Resolve where an `opt` run writes its result.
 ///
 /// With no explicit `-o/--output`, derive the
-/// `<stem>_optimized.<ext>` sibling. Unless `force` is true, any existing target
-/// is rejected; even with force, an output resolving to the input binary is
-/// always rejected. The parent directory must already exist and be writable.
-/// A stem-less or non-UTF-8 input name yields an error instead of panicking.
+/// `<stem>_optimized.<ext>` sibling. Unless `force` is true, an existing regular
+/// file at the target is rejected; even with force, an output resolving to the
+/// input binary — or to a symlink or directory — is always rejected. The parent
+/// directory must already exist and be writable. A stem-less or non-UTF-8 input
+/// name yields an error instead of panicking.
 pub fn resolve_output_path(
     input: &Path,
     output: Option<&Path>,
@@ -80,55 +119,74 @@ pub fn resolve_output_path(
     };
 
     if paths_point_to_same_file(input, &output) {
-        Err(format!(
+        return Err(format!(
             "output path '{}' resolves to the input binary; refusing to optimize in place (choose a different -o/--output)",
             output.display()
-        ))
-    } else if std::fs::symlink_metadata(&output).is_ok() && !force {
-        Err(format!(
+        ));
+    }
+
+    // One stat decides the whole existing-target policy; the branches below
+    // must not re-derive it, or the diagnostic and the check can disagree.
+    match std::fs::symlink_metadata(&output) {
+        Ok(existing) => validate_existing_output(&output, &existing, force)?,
+        Err(_) => validate_output_parent(&output)?,
+    }
+
+    Ok(ResolvedOutput {
+        input: input.to_path_buf(),
+        path: output,
+        overwrite: force,
+    })
+}
+
+/// Decide whether an already-present `output` may become the result file.
+///
+/// Symlinks and directories are refused with or without `--force`: opening a
+/// symlink for writing truncates its *target*, a path the user never named, and
+/// a directory can never be replaced by a file — so neither may advertise
+/// `--force` as the way forward.
+fn validate_existing_output(
+    output: &Path,
+    existing: &std::fs::Metadata,
+    force: bool,
+) -> Result<(), String> {
+    let file_type = existing.file_type();
+    if file_type.is_symlink() {
+        return Err(match std::fs::read_link(output) {
+            Ok(target) => format!(
+                "output path '{}' is a symlink to '{}'; refusing to write through it (pass -o '{}' or remove the link)",
+                output.display(),
+                target.display(),
+                target.display()
+            ),
+            Err(_) => format!(
+                "output path '{}' is a symlink; refusing to write through it (remove the link or choose a different -o/--output)",
+                output.display()
+            ),
+        });
+    }
+    if file_type.is_dir() {
+        return Err(format!(
+            "output path '{}' is an existing directory; choose a file path with -o/--output",
+            output.display()
+        ));
+    }
+    if !force {
+        return Err(format!(
             "output path already exists: '{}' (pass --force to replace it)",
             output.display()
-        ))
-    } else {
-        validate_output_writable(&output)?;
-        Ok(ResolvedOutput {
-            input: input.to_path_buf(),
-            path: output,
-            overwrite: force,
-        })
+        ));
     }
-}
-
-#[cfg(unix)]
-fn opened_file_points_to_path(file: &File, input: &Path, _output: &Path) -> bool {
-    use std::os::unix::fs::MetadataExt;
-
-    match (file.metadata(), std::fs::metadata(input)) {
-        (Ok(output), Ok(input)) => output.dev() == input.dev() && output.ino() == input.ino(),
-        _ => false,
-    }
-}
-
-#[cfg(not(unix))]
-fn opened_file_points_to_path(_file: &File, input: &Path, output: &Path) -> bool {
-    paths_point_to_same_file(input, output)
-}
-
-fn validate_output_writable(output: &Path) -> Result<(), String> {
-    if std::fs::symlink_metadata(output).is_ok() {
-        std::fs::OpenOptions::new()
-            .write(true)
-            .open(output)
-            .map_err(|error| {
-                format!(
-                    "output path '{}' is not writable: {error}",
-                    output.display()
-                )
-            })?;
-        Ok(())
-    } else {
-        validate_output_parent(output)
-    }
+    OpenOptions::new()
+        .write(true)
+        .open(output)
+        .map_err(|error| {
+            format!(
+                "output path '{}' is not writable: {error}",
+                output.display()
+            )
+        })?;
+    Ok(())
 }
 
 fn validate_output_parent(output: &Path) -> Result<(), String> {
@@ -209,9 +267,8 @@ fn optimized_output_path(path: &Path) -> Result<PathBuf, String> {
 fn paths_point_to_same_file(a: &Path, b: &Path) -> bool {
     #[cfg(unix)]
     fn same_file(a: &Path, b: &Path) -> bool {
-        use std::os::unix::fs::MetadataExt;
         match (std::fs::metadata(a), std::fs::metadata(b)) {
-            (Ok(ma), Ok(mb)) => ma.dev() == mb.dev() && ma.ino() == mb.ino(),
+            (Ok(ma), Ok(mb)) => same_file_ids(&ma, &mb),
             _ => false,
         }
     }
@@ -223,6 +280,14 @@ fn paths_point_to_same_file(a: &Path, b: &Path) -> bool {
         }
     }
     same_file(a, b)
+}
+
+/// The single `(device, inode)` identity rule, shared by the preflight guard
+/// and the write-time recheck so the two can never drift apart.
+#[cfg(unix)]
+fn same_file_ids(a: &std::fs::Metadata, b: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    a.dev() == b.dev() && a.ino() == b.ino()
 }
 
 #[cfg(test)]
@@ -335,10 +400,102 @@ mod tests {
             .expect_err("default writer must refuse the racing output");
 
         assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        assert!(
+            error.to_string().contains("output.elf") && error.to_string().contains("--force"),
+            "racing-output diagnostic must name the path and the override: {error}"
+        );
         assert_eq!(
             std::fs::read(&output).expect("read racing output"),
             sentinel,
             "racing output must remain unchanged"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn forced_write_refuses_hard_link_to_input_created_after_preflight() {
+        // The write-time identity recheck is the only thing standing between a
+        // `--force` run and a truncated input when a hard link appears at the
+        // output path during the search.
+        let dir = tempfile::tempdir().expect("create output directory");
+        let input = dir.path().join("input.elf");
+        let output = dir.path().join("output.elf");
+        let input_bytes = b"original input binary";
+        std::fs::write(&input, input_bytes).expect("seed input");
+        std::fs::write(&output, b"stale output").expect("seed output");
+
+        let resolved =
+            resolve_output_path(&input, Some(&output), true).expect("forced output resolves");
+
+        std::fs::remove_file(&output).expect("remove resolved output");
+        std::fs::hard_link(&input, &output).expect("race a hard link into the output path");
+
+        let error = resolved
+            .write(b"optimized ELF")
+            .expect_err("forced writer must refuse a hard link to the input");
+
+        assert!(
+            error.to_string().contains("refusing to optimize in place"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(
+            std::fs::read(&input).expect("read input"),
+            input_bytes,
+            "input binary must survive the refused forced write"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_output_path_refuses_symlink_output_even_with_force() {
+        // Opening a symlink for writing truncates its target — a path the user
+        // never named — so neither the default nor the forced policy may follow
+        // one. Regression for the clobber this seam exists to prevent.
+        let dir = tempfile::tempdir().expect("create output directory");
+        let input = dir.path().join("input.elf");
+        std::fs::write(&input, b"input").expect("seed input");
+        let victim = dir.path().join("unrelated.txt");
+        let victim_bytes = b"unrelated file contents";
+        std::fs::write(&victim, victim_bytes).expect("seed unrelated file");
+        let link = dir.path().join("out.elf");
+        std::os::unix::fs::symlink(&victim, &link).expect("create symlink output");
+
+        for force in [false, true] {
+            let err = resolve_output_path(&input, Some(&link), force)
+                .expect_err("a symlink output must be rejected");
+            assert!(
+                err.contains("is a symlink") && err.contains("unrelated.txt"),
+                "diagnostic should name the symlink target with force={force}: {err}"
+            );
+        }
+        assert_eq!(
+            std::fs::read(&victim).expect("read unrelated file"),
+            victim_bytes,
+            "the symlink target must be untouched"
+        );
+    }
+
+    #[test]
+    fn resolve_output_path_refuses_directory_output_without_advertising_force() {
+        // `--force` can never turn a directory into the result file, so the
+        // diagnostic must not send the user down that dead end.
+        let dir = tempfile::tempdir().expect("create output directory");
+        let input = dir.path().join("input.elf");
+        std::fs::write(&input, b"input").expect("seed input");
+        let output_dir = dir.path().join("out.d");
+        std::fs::create_dir(&output_dir).expect("create directory output");
+
+        for force in [false, true] {
+            let err = resolve_output_path(&input, Some(&output_dir), force)
+                .expect_err("a directory output must be rejected");
+            assert!(
+                err.contains("is an existing directory"),
+                "unexpected error with force={force}: {err}"
+            );
+            assert!(
+                !err.contains("--force"),
+                "directory diagnostic must not advertise --force: {err}"
+            );
+        }
     }
 }

--- a/src/output_path.rs
+++ b/src/output_path.rs
@@ -347,12 +347,7 @@ fn create_staged_output(parent: &Path) -> io::Result<(tempfile::TempDir, tempfil
     Ok((staging_dir, staged))
 }
 
-#[cfg(any(
-    target_os = "linux",
-    target_os = "android",
-    target_vendor = "apple",
-    target_os = "redox"
-))]
+#[cfg(any(target_os = "linux", target_os = "android", target_vendor = "apple"))]
 fn exchange_paths(a: &Path, b: &Path) -> io::Result<()> {
     rustix::fs::renameat_with(
         rustix::fs::CWD,
@@ -364,12 +359,7 @@ fn exchange_paths(a: &Path, b: &Path) -> io::Result<()> {
     .map_err(|error| io::Error::from_raw_os_error(error.raw_os_error()))
 }
 
-#[cfg(not(any(
-    target_os = "linux",
-    target_os = "android",
-    target_vendor = "apple",
-    target_os = "redox"
-)))]
+#[cfg(not(any(target_os = "linux", target_os = "android", target_vendor = "apple")))]
 fn exchange_paths(_a: &Path, _b: &Path) -> io::Result<()> {
     Err(io::Error::new(
         io::ErrorKind::Unsupported,

--- a/src/output_path.rs
+++ b/src/output_path.rs
@@ -163,7 +163,13 @@ pub fn resolve_output_path(
     // must not re-derive it, or the diagnostic and the check can disagree.
     match std::fs::symlink_metadata(&output) {
         Ok(existing) => validate_existing_output(&output, &existing, force)?,
-        Err(_) => validate_output_parent(&output)?,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => validate_output_parent(&output)?,
+        Err(error) => {
+            return Err(format!(
+                "cannot inspect output path '{}': {error}",
+                output.display()
+            ));
+        }
     }
 
     Ok(ResolvedOutput {
@@ -471,6 +477,22 @@ mod tests {
                 "force cannot make an unusable file path valid: {err}"
             );
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_output_path_reports_metadata_errors_before_search() {
+        let dir = tempfile::tempdir().expect("create output directory");
+        let input = dir.path().join("prog.elf");
+        let output = dir.path().join("x".repeat(256));
+
+        let err = resolve_output_path(&input, Some(&output), false)
+            .expect_err("an invalid final component must fail during preflight");
+
+        assert!(
+            err.contains("cannot inspect output path"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/src/output_path.rs
+++ b/src/output_path.rs
@@ -1,49 +1,160 @@
-//! Output-path resolution — the pure seam deciding where an `opt` run writes.
+//! Output-path resolution — the seam deciding and enforcing where `opt` writes.
 //!
 //! `s11 opt` never rewrites the input binary in place: with no explicit
-//! `-o/--output` it writes a derived `<stem>_optimized.<ext>` sibling, and an
-//! explicit output that resolves to the input itself is rejected rather than
-//! silently clobbering the source. Those rules — deriving the sibling name and
-//! the in-place guard (including the hard-link identity check that a
-//! canonical-path comparison would miss) — used to live inline in the driver
-//! (`main`'s `opt` arm), a shallow arrangement where the only way to exercise
-//! "a hard link to the input is refused" or "a stem-less input yields an error"
-//! was to drive the whole command.
+//! `-o/--output` it derives a `<stem>_optimized.<ext>` sibling. Existing explicit
+//! or derived targets are refused unless `--force` was passed, but force never
+//! permits an output that aliases the input. Parent existence and writability
+//! are checked before search so a bad target fails cheaply.
 //!
-//! This module lifts those rules into a pure seam: paths in, a resolved
-//! `PathBuf` or an error message out, with a single public entry point
-//! ([`resolve_output_path`]). The derive step is fallible — a caller-supplied
-//! path with no usable (UTF-8) file name yields an `Err` the driver reports,
-//! never a panic. The two helpers behind the seam
-//! (`optimized_output_path`, `paths_point_to_same_file`) stay private because
-//! the whole point of the module is that callers only need the one decision.
-//! See the `CONTEXT.md` glossary for the domain terms.
+//! [`resolve_output_path`] returns a [`ResolvedOutput`] that carries the policy
+//! into the final write. Default writes use exclusive creation, closing the
+//! race where another file appears during a long search; forced writes reopen
+//! without truncation, recheck the input identity, and only then replace the
+//! target. Deriving a sibling remains fallible for stem-less or non-UTF-8 input
+//! names. See the `CONTEXT.md` glossary for the domain term.
 
+use std::fs::{File, OpenOptions};
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+
+/// A validated `opt` output target together with its overwrite policy.
+///
+/// Callers resolve this once before starting a potentially long search, then
+/// pass it to the ELF writer. The final write repeats the safety policy:
+/// default writes use exclusive creation, while forced writes may truncate a
+/// distinct existing target but still refuse an alias of the input binary.
+#[derive(Debug)]
+pub struct ResolvedOutput {
+    input: PathBuf,
+    path: PathBuf,
+    overwrite: bool,
+}
+
+impl ResolvedOutput {
+    /// The path where the result will be materialized.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub(crate) fn write(&self, bytes: &[u8]) -> io::Result<()> {
+        let mut options = OpenOptions::new();
+        options.write(true);
+        if self.overwrite {
+            options.create(true);
+        } else {
+            options.create_new(true);
+        }
+
+        let mut file = options.open(&self.path)?;
+        if self.overwrite {
+            if opened_file_points_to_path(&file, &self.input, &self.path) {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    format!(
+                        "output path '{}' resolves to the input binary; refusing to optimize in place",
+                        self.path.display()
+                    ),
+                ));
+            }
+            file.set_len(0)?;
+        }
+        file.write_all(bytes)
+    }
+}
 
 /// Resolve where an `opt` run writes its result.
 ///
-/// With no explicit `-o/--output` the derived `<stem>_optimized.<ext>` sibling
-/// is preserved verbatim (the pre-#616 single-window behaviour). An explicit
-/// output is honoured, except when it resolves to the input binary itself: the
-/// driver never rewrites the input in place, so that request is rejected rather
-/// than silently clobbering the source. A `None` output over an input with no
-/// usable file name (a stem-less or non-UTF-8 path) yields an error instead of
-/// panicking, so the driver can report it and exit cleanly.
-pub fn resolve_output_path(input: &Path, output: Option<&Path>) -> Result<PathBuf, String> {
-    match output {
-        Some(out) => {
-            if paths_point_to_same_file(input, out) {
-                Err(format!(
-                    "output path '{}' resolves to the input binary; refusing to optimize in place (choose a different -o/--output)",
-                    out.display()
-                ))
-            } else {
-                Ok(out.to_path_buf())
-            }
-        }
-        None => optimized_output_path(input),
+/// With no explicit `-o/--output`, derive the
+/// `<stem>_optimized.<ext>` sibling. Unless `force` is true, any existing target
+/// is rejected; even with force, an output resolving to the input binary is
+/// always rejected. The parent directory must already exist and be writable.
+/// A stem-less or non-UTF-8 input name yields an error instead of panicking.
+pub fn resolve_output_path(
+    input: &Path,
+    output: Option<&Path>,
+    force: bool,
+) -> Result<ResolvedOutput, String> {
+    let output = match output {
+        Some(out) => out.to_path_buf(),
+        None => optimized_output_path(input)?,
+    };
+
+    if paths_point_to_same_file(input, &output) {
+        Err(format!(
+            "output path '{}' resolves to the input binary; refusing to optimize in place (choose a different -o/--output)",
+            output.display()
+        ))
+    } else if std::fs::symlink_metadata(&output).is_ok() && !force {
+        Err(format!(
+            "output path already exists: '{}' (pass --force to replace it)",
+            output.display()
+        ))
+    } else {
+        validate_output_writable(&output)?;
+        Ok(ResolvedOutput {
+            input: input.to_path_buf(),
+            path: output,
+            overwrite: force,
+        })
     }
+}
+
+#[cfg(unix)]
+fn opened_file_points_to_path(file: &File, input: &Path, _output: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    match (file.metadata(), std::fs::metadata(input)) {
+        (Ok(output), Ok(input)) => output.dev() == input.dev() && output.ino() == input.ino(),
+        _ => false,
+    }
+}
+
+#[cfg(not(unix))]
+fn opened_file_points_to_path(_file: &File, input: &Path, output: &Path) -> bool {
+    paths_point_to_same_file(input, output)
+}
+
+fn validate_output_writable(output: &Path) -> Result<(), String> {
+    if std::fs::symlink_metadata(output).is_ok() {
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(output)
+            .map_err(|error| {
+                format!(
+                    "output path '{}' is not writable: {error}",
+                    output.display()
+                )
+            })?;
+        Ok(())
+    } else {
+        validate_output_parent(output)
+    }
+}
+
+fn validate_output_parent(output: &Path) -> Result<(), String> {
+    let parent = output
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    if !parent.exists() {
+        return Err(format!(
+            "output parent directory '{}' does not exist",
+            parent.display()
+        ));
+    }
+    if !parent.is_dir() {
+        return Err(format!(
+            "output parent path '{}' is not a directory",
+            parent.display()
+        ));
+    }
+    tempfile::tempfile_in(parent).map_err(|error| {
+        format!(
+            "output parent directory '{}' is not writable: {error}",
+            parent.display()
+        )
+    })?;
+    Ok(())
 }
 
 /// Derive the default `<stem>_optimized.<ext>` sibling for `path`.
@@ -121,20 +232,24 @@ mod tests {
 
     #[test]
     fn resolve_output_path_falls_back_to_derived_path() {
-        let input = Path::new("/some/dir/prog.elf");
+        let dir = tempfile::tempdir().expect("create output directory");
+        let input = dir.path().join("prog.elf");
         assert_eq!(
-            resolve_output_path(input, None).unwrap(),
-            optimized_output_path(input).unwrap()
+            resolve_output_path(&input, None, false).unwrap().path(),
+            dir.path().join("prog_optimized.elf")
         );
     }
 
     #[test]
     fn resolve_output_path_honors_explicit_output() {
-        let input = Path::new("/some/dir/prog.elf");
-        let out = Path::new("/other/place/out.bin");
+        let dir = tempfile::tempdir().expect("create output directory");
+        let input = dir.path().join("prog.elf");
+        let out = dir.path().join("out.bin");
         assert_eq!(
-            resolve_output_path(input, Some(out)).unwrap(),
-            out.to_path_buf()
+            resolve_output_path(&input, Some(&out), false)
+                .unwrap()
+                .path(),
+            out
         );
     }
 
@@ -150,12 +265,14 @@ mod tests {
             .unwrap()
             .join(".")
             .join(input.path().file_name().unwrap());
-        let err = resolve_output_path(input.path(), Some(&aliased))
-            .expect_err("output resolving to the input binary must be rejected");
-        assert!(
-            err.contains("refusing to optimize in place"),
-            "unexpected error: {err}"
-        );
+        for force in [false, true] {
+            let err = resolve_output_path(input.path(), Some(&aliased), force)
+                .expect_err("output resolving to the input binary must be rejected");
+            assert!(
+                err.contains("refusing to optimize in place"),
+                "unexpected error with force={force}: {err}"
+            );
+        }
     }
 
     #[cfg(unix)]
@@ -166,13 +283,15 @@ mod tests {
         let input = TempFile::new_bytes("s11-resolve-hardlink", "elf", &[0u8; 8]);
         let link = input.path().with_extension("hardlink");
         std::fs::hard_link(input.path(), &link).expect("create hard link to input");
-        let result = resolve_output_path(input.path(), Some(&link));
+        for force in [false, true] {
+            let err = resolve_output_path(input.path(), Some(&link), force)
+                .expect_err("a hard link to the input binary must be rejected");
+            assert!(
+                err.contains("refusing to optimize in place"),
+                "unexpected error with force={force}: {err}"
+            );
+        }
         let _ = std::fs::remove_file(&link);
-        let err = result.expect_err("a hard link to the input binary must be rejected");
-        assert!(
-            err.contains("refusing to optimize in place"),
-            "unexpected error: {err}"
-        );
     }
 
     #[test]
@@ -180,7 +299,7 @@ mod tests {
         // `..` / `/` have no file stem; the derived-name step must surface an
         // error the driver can report, not panic on an `unwrap`.
         for input in [Path::new(".."), Path::new("/")] {
-            let err = resolve_output_path(input, None)
+            let err = resolve_output_path(input, None, false)
                 .expect_err("an input path with no file stem must yield an error, not a panic");
             assert!(
                 err.contains("output path"),
@@ -196,8 +315,30 @@ mod tests {
         // when the driver derives `<stem>_optimized`.
         use std::os::unix::ffi::OsStrExt;
         let input = std::path::PathBuf::from(std::ffi::OsStr::from_bytes(b"bin\xffname"));
-        let err = resolve_output_path(&input, None)
+        let err = resolve_output_path(&input, None, false)
             .expect_err("a non-UTF-8 input path must yield an error, not a panic");
         assert!(err.contains("output path"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn resolved_output_refuses_target_created_after_preflight() {
+        let dir = tempfile::tempdir().expect("create output directory");
+        let input = dir.path().join("input.elf");
+        let output = dir.path().join("output.elf");
+        let resolved = resolve_output_path(&input, Some(&output), false)
+            .expect("missing output should pass preflight");
+        let sentinel = b"file created while optimization was running";
+        std::fs::write(&output, sentinel).expect("create racing output");
+
+        let error = resolved
+            .write(b"optimized ELF")
+            .expect_err("default writer must refuse the racing output");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        assert_eq!(
+            std::fs::read(&output).expect("read racing output"),
+            sentinel,
+            "racing output must remain unchanged"
+        );
     }
 }

--- a/tests/integration/opt_test.rs
+++ b/tests/integration/opt_test.rs
@@ -1468,12 +1468,12 @@ fn test_opt_custom_output_copies_input_when_no_improvement_is_found() {
             .expect("stat input")
             .permissions()
             .mode()
-            & 0o7777;
+            & 0o777;
         let output_mode = fs::metadata(&custom_output)
             .expect("stat unchanged output")
             .permissions()
             .mode()
-            & 0o7777;
+            & 0o777;
         assert_eq!(
             output_mode, input_mode,
             "no-improvement output should preserve executable permissions"

--- a/tests/integration/opt_test.rs
+++ b/tests/integration/opt_test.rs
@@ -270,6 +270,49 @@ fn assert_opt_arch_mismatch_rejected(test_elf: &Path, arch: &str, detected_arch:
     );
 }
 
+/// Run `opt` over a one-byte window and assert it is refused *before* the
+/// search starts, with a stderr diagnostic containing every string in
+/// `expected`.
+///
+/// Sibling of [`assert_opt_arch_mismatch_rejected`]: both pin "reject before
+/// search", so the stdout markers that prove the search never started live in
+/// one place rather than once per output-policy test.
+fn assert_opt_output_rejected_before_search(
+    input: &Path,
+    output_arg: Option<&Path>,
+    expected: &[&str],
+) {
+    let mut command = Command::new(get_binary_path());
+    command
+        .arg("opt")
+        .arg(input)
+        .arg("--start-addr")
+        .arg("0x0")
+        .arg("--end-addr")
+        .arg("0x1");
+    if let Some(path) = output_arg {
+        command.arg("-o").arg(path);
+    }
+    let output = command.output().expect("execute s11 opt");
+
+    assert!(
+        !output.status.success(),
+        "opt must fail for input {input:?} with -o {output_arg:?}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    for needle in expected {
+        assert!(
+            stderr.contains(needle),
+            "diagnostic should contain {needle:?}; stderr: {stderr}"
+        );
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("Optimizing ELF binary") && !stdout.contains("Optimizing x86 ELF binary"),
+        "bad output must fail before search; stdout: {stdout}"
+    );
+}
+
 #[test]
 fn test_opt_refuses_existing_explicit_output_before_search() {
     let binary = get_binary_path();
@@ -277,29 +320,12 @@ fn test_opt_refuses_existing_explicit_output_before_search() {
     let sentinel = b"unrelated file contents";
     fs::write(existing_output.path(), sentinel).expect("seed existing output");
 
-    let output = Command::new(&binary)
-        .arg("opt")
-        .arg(&binary)
-        .arg("--start-addr")
-        .arg("0x0")
-        .arg("--end-addr")
-        .arg("0x1")
-        .arg("-o")
-        .arg(existing_output.path())
-        .output()
-        .expect("execute s11 opt");
+    assert_opt_output_rejected_before_search(
+        &binary,
+        Some(existing_output.path()),
+        &["output path already exists", "--force"],
+    );
 
-    assert!(!output.status.success(), "existing output must be refused");
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("output path already exists") && stderr.contains("--force"),
-        "diagnostic should explain the safe override; stderr: {stderr}"
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        !stdout.contains("Optimizing ELF binary"),
-        "collision must fail before search; stdout: {stdout}"
-    );
     assert_eq!(
         fs::read(existing_output.path()).expect("read refused output"),
         sentinel,
@@ -317,27 +343,12 @@ fn test_opt_refuses_existing_derived_output_before_search() {
     let sentinel = b"previous optimization result";
     fs::write(&derived_output, sentinel).expect("seed derived output");
 
-    let output = Command::new(&binary)
-        .arg("opt")
-        .arg(&input)
-        .arg("--start-addr")
-        .arg("0x0")
-        .arg("--end-addr")
-        .arg("0x1")
-        .output()
-        .expect("execute s11 opt");
+    assert_opt_output_rejected_before_search(
+        &input,
+        None,
+        &["output path already exists", "--force"],
+    );
 
-    assert!(!output.status.success(), "existing output must be refused");
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("output path already exists") && stderr.contains("--force"),
-        "diagnostic should explain the safe override; stderr: {stderr}"
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        !stdout.contains("Optimizing ELF binary"),
-        "collision must fail before search; stdout: {stdout}"
-    );
     assert_eq!(
         fs::read(&derived_output).expect("read refused output"),
         sentinel,
@@ -351,29 +362,12 @@ fn test_opt_rejects_missing_output_parent_before_search() {
     let temp_dir = tempfile::tempdir().expect("create fixture directory");
     let output_path = temp_dir.path().join("missing").join("output.elf");
 
-    let output = Command::new(&binary)
-        .arg("opt")
-        .arg(&binary)
-        .arg("--start-addr")
-        .arg("0x0")
-        .arg("--end-addr")
-        .arg("0x1")
-        .arg("-o")
-        .arg(&output_path)
-        .output()
-        .expect("execute s11 opt");
+    assert_opt_output_rejected_before_search(
+        &binary,
+        Some(&output_path),
+        &["output parent directory", "does not exist"],
+    );
 
-    assert!(!output.status.success(), "missing parent must be rejected");
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("output parent directory") && stderr.contains("does not exist"),
-        "diagnostic should identify the missing parent; stderr: {stderr}"
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        !stdout.contains("Optimizing ELF binary"),
-        "bad output must fail before search; stdout: {stdout}"
-    );
     assert!(!output_path.exists(), "bad output must not be created");
 }
 
@@ -403,55 +397,36 @@ fn test_opt_rejects_unwritable_output_parent_before_search() {
 
     let output_path = read_only_dir.join("output.elf");
 
-    let output = Command::new(&binary)
-        .arg("opt")
-        .arg(&binary)
-        .arg("--start-addr")
-        .arg("0x0")
-        .arg("--end-addr")
-        .arg("0x1")
-        .arg("-o")
-        .arg(&output_path)
-        .output()
-        .expect("execute s11 opt");
+    assert_opt_output_rejected_before_search(
+        &binary,
+        Some(&output_path),
+        &["output parent directory", "not writable"],
+    );
 
-    assert!(
-        !output.status.success(),
-        "unwritable parent must be rejected"
-    );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("output parent directory") && stderr.contains("not writable"),
-        "diagnostic should identify the unwritable parent; stderr: {stderr}"
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        !stdout.contains("Optimizing ELF binary"),
-        "bad output must fail before search; stdout: {stdout}"
-    );
     assert!(!output_path.exists(), "bad output must not be created");
 }
 
 #[test]
 fn test_opt_basic_functionality() {
     let binary = get_binary_path();
-    let test_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    let source_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("binaries")
         .join("arrays_debug");
 
-    check_test_binary(&test_elf);
+    check_test_binary(&source_elf);
+
+    // Stage the fixture in a private tempdir: the run derives its output as a
+    // sibling of the input, so optimizing in place would write into the shared
+    // `binaries/` directory, where a leftover from an aborted run now fails
+    // every later run against the existing-output guard.
+    let tmp_dir = tempfile::tempdir().expect("create temp fixture dir");
+    let test_elf = tmp_dir.path().join("arrays_debug");
+    fs::copy(&source_elf, &test_elf).expect("copy AArch64 fixture to tmp");
+    let optimized_path = tmp_dir.path().join("arrays_debug_optimized");
 
     // Avoid the unsupported .init PAC instruction while still exercising a
     // parser-supported, straight-line multi-instruction optimization window.
     let (start_addr, end_addr) = find_supported_aarch64_instruction_window(&test_elf, 4);
-
-    // The derived sibling lives in the shared `binaries/` fixture directory and
-    // an existing output is now refused without --force, so a leftover from an
-    // aborted run would fail every later run with an unrelated diagnostic.
-    let optimized_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("binaries")
-        .join("arrays_debug_optimized");
-    let _ = fs::remove_file(&optimized_path);
 
     let output = Command::new(binary)
         .arg("opt")
@@ -472,8 +447,6 @@ fn test_opt_basic_functionality() {
         .expect("Failed to execute s11");
 
     if !output.status.success() {
-        // Clean up in case of failure and print debug info
-        let _ = fs::remove_file(&optimized_path);
         panic!(
             "Command failed with status: {:?}\nstderr: {}\nstdout: {}",
             output.status,
@@ -534,9 +507,6 @@ fn test_opt_basic_functionality() {
         "Optimized binary should be created at: {:?}",
         optimized_path
     );
-
-    // Clean up
-    let _ = fs::remove_file(optimized_path);
 }
 
 #[test]
@@ -1259,6 +1229,54 @@ fn x86_find_byte_sequence(path: &Path, needle: &[u8]) -> u64 {
     panic!("byte sequence {needle:02x?} not found in any executable section of {path:?}");
 }
 
+/// `mov rax, 5` == `48 c7 c0 05 00 00 00`, the instruction `dup_mov_imm`
+/// repeats. Kept beside [`stage_dup_mov_imm`] so the encoding and the fixture
+/// it is coupled to move together.
+const MOV_RAX_5: [u8; 7] = [0x48, 0xc7, 0xc0, 0x05, 0x00, 0x00, 0x00];
+
+/// Copy the `binaries/x86_64/dup_mov_imm` fixture into a private tempdir.
+///
+/// `None` means the fixture was never built (no host x86-64 gcc), which every
+/// caller treats as a skip rather than a failure. The returned `TempDir` owns
+/// the cleanup and must outlive the returned path; a private directory also
+/// keeps the derived `dup_mov_imm_optimized` sibling from colliding between
+/// concurrently running tests.
+fn stage_dup_mov_imm(label: &str) -> Option<(tempfile::TempDir, PathBuf)> {
+    let source_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("binaries")
+        .join("x86_64")
+        .join("dup_mov_imm");
+    if !source_elf.exists() {
+        eprintln!("Skipping {label}: {source_elf:?} not present (run build_tests.sh)");
+        return None;
+    }
+    let tmp_dir = tempfile::tempdir().expect("create temp fixture dir");
+    let test_elf = tmp_dir.path().join("dup_mov_imm");
+    fs::copy(&source_elf, &test_elf).expect("copy x86-64 fixture to tmp");
+    Some((tmp_dir, test_elf))
+}
+
+/// `s11 opt` over an x86-64 window with the settings the `dup_mov_imm` tests
+/// share. Enumerative search keeps the result deterministic; callers append
+/// their own `-o` / `--force` arguments.
+fn x86_opt_command(test_elf: &Path, start_addr: u64, end_addr: u64) -> Command {
+    let mut command = Command::new(get_binary_path());
+    command
+        .arg("opt")
+        .arg(test_elf)
+        .arg("--arch")
+        .arg("x86-64")
+        .arg("--algorithm")
+        .arg("enumerative")
+        .arg("--timeout")
+        .arg("30")
+        .arg("--start-addr")
+        .arg(format!("0x{start_addr:x}"))
+        .arg("--end-addr")
+        .arg(format!("0x{end_addr:x}"));
+    command
+}
+
 /// End-to-end x86-64 opt test (issue #91): run the `s11 opt` CLI on a real
 /// x86-64 ELF and assert a *known* one-instruction shortening is found and
 /// reported.
@@ -1276,47 +1294,22 @@ fn x86_find_byte_sequence(path: &Path, needle: &[u8]) -> u64 {
 /// rather than failing, matching the other x86 opt tests here.
 #[test]
 fn test_opt_x86_64_known_shortening() {
-    let binary = get_binary_path();
-    let source_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("binaries")
-        .join("x86_64")
-        .join("dup_mov_imm");
-    if !source_elf.exists() {
-        eprintln!(
-            "Skipping x86-64 known-shortening opt test: {:?} not present (run build_tests.sh)",
-            source_elf
-        );
+    let Some((tmp_dir, test_elf)) = stage_dup_mov_imm("x86-64 known-shortening opt test") else {
         return;
-    }
+    };
 
-    // `mov rax, 5` == 48 c7 c0 05 00 00 00; find the first of the redundant
-    // pair and take a 14-byte (two-instruction) window over both.
-    let mov_rax_5: [u8; 7] = [0x48, 0xc7, 0xc0, 0x05, 0x00, 0x00, 0x00];
-    let pair: Vec<u8> = mov_rax_5.iter().chain(mov_rax_5.iter()).copied().collect();
-    let start_addr = x86_find_byte_sequence(&source_elf, &pair);
+    // Find the first of the redundant pair and take a 14-byte
+    // (two-instruction) window over both.
+    let pair: Vec<u8> = MOV_RAX_5.iter().chain(MOV_RAX_5.iter()).copied().collect();
+    let start_addr = x86_find_byte_sequence(&test_elf, &pair);
     let end_addr = start_addr + pair.len() as u64;
 
-    // Copy to a unique tempdir and use an explicit output so this also pins the
-    // end-to-end `-o` write path requested by issue #685.
-    let tmp_dir = tempfile::tempdir().expect("create temp fixture dir");
-    let test_elf = tmp_dir.path().join("dup_mov_imm");
-    fs::copy(&source_elf, &test_elf).expect("copy x86-64 fixture to tmp");
+    // Use an explicit output so this also pins the end-to-end `-o` write path
+    // requested by issue #685.
     let optimized_path = tmp_dir.path().join("custom-optimized.elf");
     let derived_path = tmp_dir.path().join("dup_mov_imm_optimized");
 
-    let output = Command::new(&binary)
-        .arg("opt")
-        .arg(&test_elf)
-        .arg("--arch")
-        .arg("x86-64")
-        .arg("--algorithm")
-        .arg("enumerative")
-        .arg("--timeout")
-        .arg("30")
-        .arg("--start-addr")
-        .arg(format!("0x{start_addr:x}"))
-        .arg("--end-addr")
-        .arg(format!("0x{end_addr:x}"))
+    let output = x86_opt_command(&test_elf, start_addr, end_addr)
         .arg("-o")
         .arg(&optimized_path)
         .output()
@@ -1364,44 +1357,19 @@ fn test_opt_x86_64_known_shortening() {
 
 #[test]
 fn test_opt_force_overwrites_existing_custom_output() {
-    let binary = get_binary_path();
-    let source_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("binaries")
-        .join("x86_64")
-        .join("dup_mov_imm");
-    if !source_elf.exists() {
-        eprintln!(
-            "Skipping x86-64 forced-output opt test: {:?} not present (run build_tests.sh)",
-            source_elf
-        );
+    let Some((tmp_dir, test_elf)) = stage_dup_mov_imm("x86-64 forced-output opt test") else {
         return;
-    }
+    };
 
-    let mov_rax_5: [u8; 7] = [0x48, 0xc7, 0xc0, 0x05, 0x00, 0x00, 0x00];
-    let pair: Vec<u8> = mov_rax_5.iter().chain(mov_rax_5.iter()).copied().collect();
-    let start_addr = x86_find_byte_sequence(&source_elf, &pair);
+    let pair: Vec<u8> = MOV_RAX_5.iter().chain(MOV_RAX_5.iter()).copied().collect();
+    let start_addr = x86_find_byte_sequence(&test_elf, &pair);
     let end_addr = start_addr + pair.len() as u64;
 
-    let tmp_dir = tempfile::tempdir().expect("create temp fixture dir");
-    let test_elf = tmp_dir.path().join("dup_mov_imm");
-    fs::copy(&source_elf, &test_elf).expect("copy x86-64 fixture to tmp");
     let custom_output = tmp_dir.path().join("custom-output.elf");
     fs::write(&custom_output, b"unrelated file contents").expect("seed existing output");
     let derived_output = tmp_dir.path().join("dup_mov_imm_optimized");
 
-    let output = Command::new(&binary)
-        .arg("opt")
-        .arg(&test_elf)
-        .arg("--arch")
-        .arg("x86-64")
-        .arg("--algorithm")
-        .arg("enumerative")
-        .arg("--timeout")
-        .arg("30")
-        .arg("--start-addr")
-        .arg(format!("0x{start_addr:x}"))
-        .arg("--end-addr")
-        .arg(format!("0x{end_addr:x}"))
+    let output = x86_opt_command(&test_elf, start_addr, end_addr)
         .arg("--force")
         .arg("-o")
         .arg(&custom_output)
@@ -1439,42 +1407,19 @@ fn test_opt_force_overwrites_existing_custom_output() {
 
 #[test]
 fn test_opt_custom_output_copies_input_when_no_improvement_is_found() {
-    let binary = get_binary_path();
-    let source_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("binaries")
-        .join("x86_64")
-        .join("dup_mov_imm");
-    if !source_elf.exists() {
-        eprintln!(
-            "Skipping x86-64 no-improvement output test: {:?} not present (run build_tests.sh)",
-            source_elf
-        );
+    let Some((tmp_dir, test_elf)) = stage_dup_mov_imm("x86-64 no-improvement output test") else {
         return;
-    }
+    };
 
-    let mov_rax_5: [u8; 7] = [0x48, 0xc7, 0xc0, 0x05, 0x00, 0x00, 0x00];
-    let start_addr = x86_find_byte_sequence(&source_elf, &mov_rax_5);
-    let end_addr = start_addr + mov_rax_5.len() as u64;
+    // A single `mov rax, 5` window: already minimal, so the search finds
+    // nothing to shorten and the run must still materialize an output.
+    let start_addr = x86_find_byte_sequence(&test_elf, &MOV_RAX_5);
+    let end_addr = start_addr + MOV_RAX_5.len() as u64;
 
-    let tmp_dir = tempfile::tempdir().expect("create temp fixture dir");
-    let test_elf = tmp_dir.path().join("dup_mov_imm");
-    fs::copy(&source_elf, &test_elf).expect("copy x86-64 fixture to tmp");
     let custom_output = tmp_dir.path().join("unchanged-output.elf");
     let derived_output = tmp_dir.path().join("dup_mov_imm_optimized");
 
-    let output = Command::new(&binary)
-        .arg("opt")
-        .arg(&test_elf)
-        .arg("--arch")
-        .arg("x86-64")
-        .arg("--algorithm")
-        .arg("enumerative")
-        .arg("--timeout")
-        .arg("30")
-        .arg("--start-addr")
-        .arg(format!("0x{start_addr:x}"))
-        .arg("--end-addr")
-        .arg(format!("0x{end_addr:x}"))
+    let output = x86_opt_command(&test_elf, start_addr, end_addr)
         .arg("-o")
         .arg(&custom_output)
         .output()

--- a/tests/integration/opt_test.rs
+++ b/tests/integration/opt_test.rs
@@ -388,6 +388,19 @@ fn test_opt_rejects_unwritable_output_parent_before_search() {
     fs::create_dir(&read_only_dir).expect("create output parent");
     fs::set_permissions(&read_only_dir, fs::Permissions::from_mode(0o555))
         .expect("make output parent read-only");
+
+    // Root ignores the 0o555 mode, so the precondition this test needs does not
+    // hold there (containerized local runs are commonly root). Probe rather
+    // than assert a guard that cannot fire.
+    let probe = read_only_dir.join(".writability-probe");
+    if fs::File::create(&probe).is_ok() {
+        let _ = fs::remove_file(&probe);
+        eprintln!(
+            "Skipping unwritable-parent opt test: read-only mode not enforced (running as root?)"
+        );
+        return;
+    }
+
     let output_path = read_only_dir.join("output.elf");
 
     let output = Command::new(&binary)
@@ -432,6 +445,14 @@ fn test_opt_basic_functionality() {
     // parser-supported, straight-line multi-instruction optimization window.
     let (start_addr, end_addr) = find_supported_aarch64_instruction_window(&test_elf, 4);
 
+    // The derived sibling lives in the shared `binaries/` fixture directory and
+    // an existing output is now refused without --force, so a leftover from an
+    // aborted run would fail every later run with an unrelated diagnostic.
+    let optimized_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("binaries")
+        .join("arrays_debug_optimized");
+    let _ = fs::remove_file(&optimized_path);
+
     let output = Command::new(binary)
         .arg("opt")
         .arg(&test_elf)
@@ -449,11 +470,6 @@ fn test_opt_basic_functionality() {
         .arg(format!("0x{end_addr:x}"))
         .output()
         .expect("Failed to execute s11");
-
-    // Check that optimized binary was created first, before other assertions
-    let optimized_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("binaries")
-        .join("arrays_debug_optimized");
 
     if !output.status.success() {
         // Clean up in case of failure and print debug info

--- a/tests/integration/opt_test.rs
+++ b/tests/integration/opt_test.rs
@@ -271,6 +271,155 @@ fn assert_opt_arch_mismatch_rejected(test_elf: &Path, arch: &str, detected_arch:
 }
 
 #[test]
+fn test_opt_refuses_existing_explicit_output_before_search() {
+    let binary = get_binary_path();
+    let existing_output = tempfile::NamedTempFile::new().expect("create existing output");
+    let sentinel = b"unrelated file contents";
+    fs::write(existing_output.path(), sentinel).expect("seed existing output");
+
+    let output = Command::new(&binary)
+        .arg("opt")
+        .arg(&binary)
+        .arg("--start-addr")
+        .arg("0x0")
+        .arg("--end-addr")
+        .arg("0x1")
+        .arg("-o")
+        .arg(existing_output.path())
+        .output()
+        .expect("execute s11 opt");
+
+    assert!(!output.status.success(), "existing output must be refused");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("output path already exists") && stderr.contains("--force"),
+        "diagnostic should explain the safe override; stderr: {stderr}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("Optimizing ELF binary"),
+        "collision must fail before search; stdout: {stdout}"
+    );
+    assert_eq!(
+        fs::read(existing_output.path()).expect("read refused output"),
+        sentinel,
+        "refused output must remain unchanged"
+    );
+}
+
+#[test]
+fn test_opt_refuses_existing_derived_output_before_search() {
+    let binary = get_binary_path();
+    let temp_dir = tempfile::tempdir().expect("create fixture directory");
+    let input = temp_dir.path().join("program");
+    fs::copy(&binary, &input).expect("copy input ELF");
+    let derived_output = temp_dir.path().join("program_optimized");
+    let sentinel = b"previous optimization result";
+    fs::write(&derived_output, sentinel).expect("seed derived output");
+
+    let output = Command::new(&binary)
+        .arg("opt")
+        .arg(&input)
+        .arg("--start-addr")
+        .arg("0x0")
+        .arg("--end-addr")
+        .arg("0x1")
+        .output()
+        .expect("execute s11 opt");
+
+    assert!(!output.status.success(), "existing output must be refused");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("output path already exists") && stderr.contains("--force"),
+        "diagnostic should explain the safe override; stderr: {stderr}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("Optimizing ELF binary"),
+        "collision must fail before search; stdout: {stdout}"
+    );
+    assert_eq!(
+        fs::read(&derived_output).expect("read refused output"),
+        sentinel,
+        "refused derived output must remain unchanged"
+    );
+}
+
+#[test]
+fn test_opt_rejects_missing_output_parent_before_search() {
+    let binary = get_binary_path();
+    let temp_dir = tempfile::tempdir().expect("create fixture directory");
+    let output_path = temp_dir.path().join("missing").join("output.elf");
+
+    let output = Command::new(&binary)
+        .arg("opt")
+        .arg(&binary)
+        .arg("--start-addr")
+        .arg("0x0")
+        .arg("--end-addr")
+        .arg("0x1")
+        .arg("-o")
+        .arg(&output_path)
+        .output()
+        .expect("execute s11 opt");
+
+    assert!(!output.status.success(), "missing parent must be rejected");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("output parent directory") && stderr.contains("does not exist"),
+        "diagnostic should identify the missing parent; stderr: {stderr}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("Optimizing ELF binary"),
+        "bad output must fail before search; stdout: {stdout}"
+    );
+    assert!(!output_path.exists(), "bad output must not be created");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_opt_rejects_unwritable_output_parent_before_search() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let binary = get_binary_path();
+    let temp_dir = tempfile::tempdir().expect("create fixture directory");
+    let read_only_dir = temp_dir.path().join("read-only");
+    fs::create_dir(&read_only_dir).expect("create output parent");
+    fs::set_permissions(&read_only_dir, fs::Permissions::from_mode(0o555))
+        .expect("make output parent read-only");
+    let output_path = read_only_dir.join("output.elf");
+
+    let output = Command::new(&binary)
+        .arg("opt")
+        .arg(&binary)
+        .arg("--start-addr")
+        .arg("0x0")
+        .arg("--end-addr")
+        .arg("0x1")
+        .arg("-o")
+        .arg(&output_path)
+        .output()
+        .expect("execute s11 opt");
+
+    assert!(
+        !output.status.success(),
+        "unwritable parent must be rejected"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("output parent directory") && stderr.contains("not writable"),
+        "diagnostic should identify the unwritable parent; stderr: {stderr}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("Optimizing ELF binary"),
+        "bad output must fail before search; stdout: {stdout}"
+    );
+    assert!(!output_path.exists(), "bad output must not be created");
+}
+
+#[test]
 fn test_opt_basic_functionality() {
     let binary = get_binary_path();
     let test_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -1131,12 +1280,13 @@ fn test_opt_x86_64_known_shortening() {
     let start_addr = x86_find_byte_sequence(&source_elf, &pair);
     let end_addr = start_addr + pair.len() as u64;
 
-    // Copy to a unique tempdir so concurrent `cargo test` runs don't collide
-    // on the `<input>_optimized` artifact the binary always writes.
+    // Copy to a unique tempdir and use an explicit output so this also pins the
+    // end-to-end `-o` write path requested by issue #685.
     let tmp_dir = tempfile::tempdir().expect("create temp fixture dir");
     let test_elf = tmp_dir.path().join("dup_mov_imm");
     fs::copy(&source_elf, &test_elf).expect("copy x86-64 fixture to tmp");
-    let optimized_path = tmp_dir.path().join("dup_mov_imm_optimized");
+    let optimized_path = tmp_dir.path().join("custom-optimized.elf");
+    let derived_path = tmp_dir.path().join("dup_mov_imm_optimized");
 
     let output = Command::new(&binary)
         .arg("opt")
@@ -1151,6 +1301,8 @@ fn test_opt_x86_64_known_shortening() {
         .arg(format!("0x{start_addr:x}"))
         .arg("--end-addr")
         .arg(format!("0x{end_addr:x}"))
+        .arg("-o")
+        .arg(&optimized_path)
         .output()
         .expect("Failed to execute s11");
 
@@ -1187,6 +1339,152 @@ fn test_opt_x86_64_known_shortening() {
         optimized_path.exists(),
         "optimized binary should be created at {:?}",
         optimized_path,
+    );
+    assert!(
+        !derived_path.exists(),
+        "explicit -o must not also create the derived sibling"
+    );
+}
+
+#[test]
+fn test_opt_force_overwrites_existing_custom_output() {
+    let binary = get_binary_path();
+    let source_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("binaries")
+        .join("x86_64")
+        .join("dup_mov_imm");
+    if !source_elf.exists() {
+        eprintln!(
+            "Skipping x86-64 forced-output opt test: {:?} not present (run build_tests.sh)",
+            source_elf
+        );
+        return;
+    }
+
+    let mov_rax_5: [u8; 7] = [0x48, 0xc7, 0xc0, 0x05, 0x00, 0x00, 0x00];
+    let pair: Vec<u8> = mov_rax_5.iter().chain(mov_rax_5.iter()).copied().collect();
+    let start_addr = x86_find_byte_sequence(&source_elf, &pair);
+    let end_addr = start_addr + pair.len() as u64;
+
+    let tmp_dir = tempfile::tempdir().expect("create temp fixture dir");
+    let test_elf = tmp_dir.path().join("dup_mov_imm");
+    fs::copy(&source_elf, &test_elf).expect("copy x86-64 fixture to tmp");
+    let custom_output = tmp_dir.path().join("custom-output.elf");
+    fs::write(&custom_output, b"unrelated file contents").expect("seed existing output");
+    let derived_output = tmp_dir.path().join("dup_mov_imm_optimized");
+
+    let output = Command::new(&binary)
+        .arg("opt")
+        .arg(&test_elf)
+        .arg("--arch")
+        .arg("x86-64")
+        .arg("--algorithm")
+        .arg("enumerative")
+        .arg("--timeout")
+        .arg("30")
+        .arg("--start-addr")
+        .arg(format!("0x{start_addr:x}"))
+        .arg("--end-addr")
+        .arg(format!("0x{end_addr:x}"))
+        .arg("--force")
+        .arg("-o")
+        .arg(&custom_output)
+        .output()
+        .expect("execute s11 opt");
+
+    assert!(
+        output.status.success(),
+        "forced custom output should succeed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Optimized to 1 instructions")
+            && stdout.contains(&custom_output.display().to_string()),
+        "known shortening should be written to the requested path; stdout: {stdout}"
+    );
+    let patched = fs::read(&custom_output).expect("read custom output");
+    assert_eq!(
+        patched.len(),
+        fs::metadata(&test_elf).expect("stat input").len() as usize,
+        "custom output should be a complete ELF copy"
+    );
+    assert_ne!(
+        patched,
+        fs::read(&test_elf).expect("read input"),
+        "known shortening should patch the custom output"
+    );
+    assert!(
+        !derived_output.exists(),
+        "explicit -o must not also create the derived sibling"
+    );
+}
+
+#[test]
+fn test_opt_custom_output_copies_input_when_no_improvement_is_found() {
+    let binary = get_binary_path();
+    let source_elf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("binaries")
+        .join("x86_64")
+        .join("dup_mov_imm");
+    if !source_elf.exists() {
+        eprintln!(
+            "Skipping x86-64 no-improvement output test: {:?} not present (run build_tests.sh)",
+            source_elf
+        );
+        return;
+    }
+
+    let mov_rax_5: [u8; 7] = [0x48, 0xc7, 0xc0, 0x05, 0x00, 0x00, 0x00];
+    let start_addr = x86_find_byte_sequence(&source_elf, &mov_rax_5);
+    let end_addr = start_addr + mov_rax_5.len() as u64;
+
+    let tmp_dir = tempfile::tempdir().expect("create temp fixture dir");
+    let test_elf = tmp_dir.path().join("dup_mov_imm");
+    fs::copy(&source_elf, &test_elf).expect("copy x86-64 fixture to tmp");
+    let custom_output = tmp_dir.path().join("unchanged-output.elf");
+    let derived_output = tmp_dir.path().join("dup_mov_imm_optimized");
+
+    let output = Command::new(&binary)
+        .arg("opt")
+        .arg(&test_elf)
+        .arg("--arch")
+        .arg("x86-64")
+        .arg("--algorithm")
+        .arg("enumerative")
+        .arg("--timeout")
+        .arg("30")
+        .arg("--start-addr")
+        .arg(format!("0x{start_addr:x}"))
+        .arg("--end-addr")
+        .arg(format!("0x{end_addr:x}"))
+        .arg("-o")
+        .arg(&custom_output)
+        .output()
+        .expect("execute s11 opt");
+
+    assert!(
+        output.status.success(),
+        "no-improvement custom output should succeed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("No optimization found")
+            && stdout.contains("Created unchanged binary")
+            && stdout.contains(&custom_output.display().to_string()),
+        "success should report the unchanged output artifact; stdout: {stdout}"
+    );
+    assert_eq!(
+        fs::read(&custom_output).expect("read unchanged output"),
+        fs::read(&test_elf).expect("read input"),
+        "no-improvement output should exactly copy the input ELF"
+    );
+    assert!(
+        !derived_output.exists(),
+        "explicit -o must not also create the derived sibling"
     );
 }
 

--- a/tests/integration/opt_test.rs
+++ b/tests/integration/opt_test.rs
@@ -371,6 +371,23 @@ fn test_opt_rejects_missing_output_parent_before_search() {
     assert!(!output_path.exists(), "bad output must not be created");
 }
 
+#[test]
+fn test_opt_rejects_trailing_separator_output_before_search() {
+    let binary = get_binary_path();
+    let temp_dir = tempfile::tempdir().expect("create fixture directory");
+    let mut output_arg = temp_dir.path().join("result").into_os_string();
+    output_arg.push(std::path::MAIN_SEPARATOR_STR);
+    let output_path = PathBuf::from(output_arg);
+
+    assert_opt_output_rejected_before_search(
+        &binary,
+        Some(&output_path),
+        &["output path", "must name a file"],
+    );
+
+    assert!(!output_path.exists(), "bad output must not be created");
+}
+
 #[cfg(unix)]
 #[test]
 fn test_opt_rejects_unwritable_output_parent_before_search() {
@@ -1443,6 +1460,25 @@ fn test_opt_custom_output_copies_input_when_no_improvement_is_found() {
         fs::read(&test_elf).expect("read input"),
         "no-improvement output should exactly copy the input ELF"
     );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let input_mode = fs::metadata(&test_elf)
+            .expect("stat input")
+            .permissions()
+            .mode()
+            & 0o7777;
+        let output_mode = fs::metadata(&custom_output)
+            .expect("stat unchanged output")
+            .permissions()
+            .mode()
+            & 0o7777;
+        assert_eq!(
+            output_mode, input_mode,
+            "no-improvement output should preserve executable permissions"
+        );
+    }
     assert!(
         !derived_output.exists(),
         "explicit -o must not also create the derived sibling"


### PR DESCRIPTION
## Summary

- refuse existing explicit and derived `opt` outputs by default, with a non-interactive `--force` override that never permits in-place or non-regular replacement
- reject unusable file paths, filesystem metadata errors, missing or unwritable parents, sticky-directory ownership failures, and unsupported existing-target exchange operations before search
- build complete outputs inside an atomically created mode-0700 staging directory, preserve ordinary input access bits while clearing setuid/setgid, and publish missing targets with no-clobber semantics or existing targets with atomic exchange
- validate the entry displaced by a forced atomic exchange inside the private staging directory, restoring it atomically when it aliases the pinned input or is not a regular file
- pass the exact input handle from `ElfPatcher` into publication, so pathname replacement cannot bypass alias checks and raced links cannot redirect writes
- always materialize the selected output, copying the input unchanged when x86 search finds no improvement
- document the policy in `opt --help` and cover explicit, derived, forced, invalid, special-file, race, metadata, permission, portability, and no-improvement paths

## Testing

- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --all` (1,898 tests passed; one doctest ignored)
- `./ci_check.sh` (repository policy, builds, tests, and end-to-end suite passed)

The generic implementation prompt named `scripts/full_test.sh`, which this repository does not contain; `./ci_check.sh` is the repository-defined full local gate.

Closes #685

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**