### PR TITLE
fix(opt): guard output writes against alias races

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -74,7 +74,11 @@ rules live behind the pure `src/output_path.rs` seam, whose single entry point i
 `resolve_output_path`; the `opt` driver in `src/main.rs` is a thin adapter that
 passes the input path and optional `-o` through it. Deriving the sibling name is
 fallible — a stem-less or non-UTF-8 input yields an error the driver reports
-rather than a panic.
+rather than a panic. Because optimization can run after that early check,
+`ElfPatcher::create_patched_copy` is the authoritative in-place guard: it pins
+the exact input and output file handles, compares their identities before
+truncation, and writes through the already-checked output handle so a concurrent
+pathname swap cannot redirect the destructive write to the input.
 
 ### Subset hint (intentionally absent)
 The LLM prompt does **not** enumerate the maintained AArch64 subset s11's parser accepts (see [docs/capability.md](docs/capability.md)). The model is invited to use any AArch64 mnemonic it knows. Outputs that use unsupported instructions are recorded as a research signal (which mnemonics the model "wanted" to reach for), not treated as wasted calls. See ADR-0003.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,6 +937,7 @@ dependencies = [
  "rand 0.10.2",
  "rand_chacha 0.10.0",
  "rayon",
+ "same-file",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ crossbeam-channel = "0.5"
 num_cpus = "1.16"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+same-file = "1.0"
 tempfile = "3.27"
 
 [dev-dependencies]

--- a/src/elf_patcher/mod.rs
+++ b/src/elf_patcher/mod.rs
@@ -5,8 +5,10 @@ use elf::parse::ParseAt;
 use elf::relocation::{Rel, Rela};
 use elf::section::{SectionHeader, SectionHeaderTable};
 use elf::symbol::{Symbol, SymbolTable};
+use same_file::Handle;
 use std::collections::HashSet;
-use std::fs;
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
 use std::path::Path;
 
 /// Intel SDM canonical multi-byte NOP sequences, indexed by length.
@@ -109,6 +111,7 @@ impl DetectedArch {
 pub struct ElfPatcher {
     file_data: Vec<u8>,
     arch: DetectedArch,
+    input_handle: Handle,
 }
 
 #[derive(Debug, Clone)]
@@ -127,7 +130,9 @@ pub struct TextSection {
 
 impl ElfPatcher {
     pub fn new(path: &Path) -> Result<Self, Box<dyn std::error::Error>> {
-        let file_data = fs::read(path)?;
+        let input_handle = Handle::from_file(File::open(path)?)?;
+        let mut file_data = Vec::new();
+        input_handle.as_file().read_to_end(&mut file_data)?;
         let elf = ElfBytes::<AnyEndian>::minimal_parse(&file_data)?;
         let arch = DetectedArch::from_e_machine(elf.ehdr.e_machine).ok_or_else(|| {
             format!(
@@ -135,7 +140,11 @@ impl ElfPatcher {
                 elf.ehdr.e_machine
             )
         })?;
-        Ok(Self { file_data, arch })
+        Ok(Self {
+            file_data,
+            arch,
+            input_handle,
+        })
     }
 
     pub fn arch(&self) -> DetectedArch {
@@ -398,8 +407,26 @@ impl ElfPatcher {
             }
         }
 
-        // Write the patched file
-        fs::write(output_path, patched_data)?;
+        // Opening with truncation would clobber an alias before its identity is
+        // checked. Do not reopen this path after the check: truncate and write
+        // through the same pinned handle so a later pathname swap is harmless.
+        let output = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(output_path)?;
+        let mut output_handle = Handle::from_file(output)?;
+        if self.input_handle == output_handle {
+            return Err(format!(
+                "output path '{}' resolves to the input binary; refusing to optimize in place (choose a different -o/--output)",
+                output_path.display()
+            )
+            .into());
+        }
+
+        let output = output_handle.as_file_mut();
+        output.set_len(0)?;
+        output.write_all(&patched_data)?;
 
         Ok(())
     }
@@ -1291,6 +1318,42 @@ mod tests {
 
         assert!(targets.contains(&0x1000), "direct RELR address is named");
         assert!(targets.contains(&0x1008), "RELR bitmap address is named");
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn create_patched_copy_refuses_output_replaced_by_hard_link_to_input() {
+        let text_vaddr = 0x100000;
+        let text_bytes = [0xc3u8; 8];
+        let elf_bytes = build_minimal_x86_64_elf(&text_bytes, text_vaddr);
+        let temp = tempfile::tempdir().expect("temporary directory should be created");
+        let input = temp.path().join("input.elf");
+        let requested_output = temp.path().join("output.elf");
+        std::fs::write(&input, &elf_bytes).expect("input ELF should be written");
+
+        let patcher = ElfPatcher::new(&input).expect("patcher should accept minimal ELF");
+        let output = crate::output_path::resolve_output_path(&input, Some(&requested_output))
+            .expect("nonexistent output should pass the early in-place guard");
+
+        std::fs::hard_link(&input, &output)
+            .expect("output should be replaceable with a hard link to the input");
+
+        let window = AddressWindow {
+            start: text_vaddr,
+            end: text_vaddr + text_bytes.len() as u64,
+        };
+        let result = patcher.create_patched_copy(&output, &window, &[0x90]);
+
+        let err = result.expect_err("late output alias must be refused before writing");
+        assert!(
+            err.to_string().contains("refusing to optimize in place"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(
+            std::fs::read(&input).expect("input should remain readable"),
+            elf_bytes,
+            "refusing the late alias must leave the input byte-for-byte unchanged"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- retain the identity of the exact input handle used to read the ELF
- open output paths without truncation, reject input aliases, then truncate and write through the validated handle
- cover a hard-link swap after early output-path resolution with a deterministic regression test

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`
- `./ci_check.sh`

Closes #687

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**