### PR TITLE
docs: document Conventional Commits requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,23 @@ Before pushing, run `./ci_check.sh` to mirror the test workflow locally:
 wrapper regression checks, fmt check, build, AArch64 test binaries, and the
 full test suite.
 
+## Contributing
+
+Commit subjects and pull request titles must follow the
+[Conventional Commits 1.0.0 specification]. Use the
+`type(scope)?: description` form; the scope is optional. For example:
+
+```
+feat(search): add cost-bounded enumeration
+fix(x86): reject invalid byte-register operands
+docs: explain benchmark setup
+```
+
+To validate commit messages locally with the repository's commit hook, run
+`git config core.hooksPath .githooks`.
+
+[Conventional Commits 1.0.0 specification]: https://www.conventionalcommits.org/en/v1.0.0/
+
 ## Using it
 
 ```

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ full test suite.
 
 Commit subjects and pull request titles must follow the
 [Conventional Commits 1.0.0 specification]. Use the
-`type(scope)?: description` form; the scope is optional. For example:
+`type(scope)?: description` form; the scope is optional. The accepted types are
+`build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`,
+`style`, and `test`. For example:
 
 ```
 feat(search): add cost-bounded enumeration


### PR DESCRIPTION
## Summary

- document that commit subjects and pull request titles must use Conventional Commits
- list the repository's exact accepted commit types, with the required subject shape and passing examples
- link the specification and explain how contributors can enable the tracked local commit-message hook

## Verification

- `./ci_check.sh`
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`
- `.githooks/commit-msg` accepts scoped and unscoped forms for all 11 documented types and rejects invalid subjects

Closes #695

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**
