### PR TITLE
fix(ci): pin workflow dependencies immutably

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,8 @@ updates:
     commit-message:
       prefix: "chore"
 
-  # GitHub Actions
+  # Keep immutable full-SHA workflow pins current. Same-line version comments in
+  # the workflows let Dependabot update their human-readable release labels too.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,13 +27,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@e5ad3c7725bc2459721893f88879fef9dbcf97b0 # v1.0.202
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
@@ -56,4 +56,3 @@ jobs:
           claude_args: |
             --model claude-sonnet-5
             --allowedTools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"
-

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -67,7 +67,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -96,6 +96,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -13,13 +13,12 @@ jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      # Tag-pinned, not hash-pinned: this repo's policy is tag pins kept current by
-      # Dependabot rather than SHA pins.
-      - uses: actions/checkout@v7.0.0 # zizmor: ignore[unpinned-uses]
+      # Dependabot keeps full-SHA pins current; version comments make updates reviewable.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-node@v7.0.0 # zizmor: ignore[unpinned-uses]
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: lts/*
       - name: Install commitlint

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install system dependencies
         run: |
@@ -40,10 +40,10 @@ jobs:
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Cache cargo registry and target
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@v2.86.5
+        uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518 # v2.86.5
         with:
           tool: cargo-llvm-cov
 
@@ -56,7 +56,7 @@ jobs:
             --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -19,9 +19,8 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      # Tag-pinned, not hash-pinned: this repo's policy is tag pins kept current by
-      # Dependabot rather than SHA pins.
-      - uses: actions/setup-node@v7.0.0 # zizmor: ignore[unpinned-uses]
+      # Dependabot keeps full-SHA pins current; version comments make updates reviewable.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: lts/*
       - name: Install commitlint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -46,25 +46,27 @@ jobs:
             libcapstone-dev gcc-aarch64-linux-gnu libc6-dev-arm64-cross z3 libz3-dev
           curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh \
             | sudo bash -s -- --to /usr/local/bin
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: rustfmt
-      - uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-node@v7.0.0
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: lts/*
       - name: Run semantic-release
-        uses: cycjimmy/semantic-release-action@v6.0.0
+        uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
         with:
+          # Inline npm dependencies are outside GitHub Actions Dependabot;
+          # keep exact patch versions and update them deliberately.
           extra_plugins: |
-            @semantic-release/changelog@6
-            @semantic-release/git@10
-            @semantic-release/exec@7
+            @semantic-release/changelog@6.0.3
+            @semantic-release/git@10.0.1
+            @semantic-release/exec@7.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload build artifacts (for debugging / reruns)
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-upload-${{ github.sha }}
           path: release-upload/

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -33,7 +33,7 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install dependencies
         run: |
@@ -46,7 +46,7 @@ jobs:
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Cache cargo registry and target
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Install required cargo
         run: cargo install clippy-sarif sarif-fmt
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload analysis results to GitHub
         if: ${{ !github.event.act }} # skip during local actions testing
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           sarif_file: rust-clippy-results.sarif
           wait-for-processing: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Check repository CI policy
       run: |
@@ -51,7 +51,7 @@ jobs:
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
     - name: Cache cargo registry and target
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
     - name: Check formatting
       run: cargo fmt -- --check

--- a/scripts/test_workflow_pinning_policy.py
+++ b/scripts/test_workflow_pinning_policy.py
@@ -1,6 +1,7 @@
 """Regression checks for immutable GitHub Actions workflow dependencies."""
 
 from collections.abc import Iterator
+from dataclasses import dataclass
 from pathlib import Path
 import re
 import unittest
@@ -13,13 +14,45 @@ DEPENDABOT_PATH = REPOSITORY_ROOT / ".github" / "dependabot.yml"
 
 FULL_COMMIT_SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
 VERSION_LABEL_PATTERN = re.compile(r"(?:v?\d+(?:\.\d+){0,2}|stable)(?:\s|$)")
+BLOCK_SCALAR_HEADER_PATTERN = re.compile(
+    r"(?P<style>[|>])(?:[1-9][+-]?|[+-][1-9]?)?"
+)
 SEMANTIC_RELEASE_PLUGIN_PATTERN = re.compile(
-    r"^\s+(?P<package>@semantic-release/[a-z0-9-]+)@(?P<version>\S+)\s*$",
-    re.MULTILINE,
+    r"(?P<package>@semantic-release/[a-z0-9-]+)@(?P<version>\S+)"
 )
 EXACT_SEMVER_PATTERN = re.compile(
     r"\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?"
 )
+DOUBLE_QUOTED_ESCAPES = {
+    "0": "\0",
+    "a": "\a",
+    "b": "\b",
+    "t": "\t",
+    "n": "\n",
+    "v": "\v",
+    "f": "\f",
+    "r": "\r",
+    "e": "\x1b",
+    " ": " ",
+    '"': '"',
+    "/": "/",
+    "\\": "\\",
+    "N": "\x85",
+    "_": "\xa0",
+    "L": "\u2028",
+    "P": "\u2029",
+}
+HEX_ESCAPE_LENGTHS = {"x": 2, "u": 4, "U": 8}
+
+
+@dataclass(frozen=True)
+class _MappingScalar:
+    """One line-numbered YAML mapping scalar relevant to policy checks."""
+
+    line_number: int
+    key: str
+    value: str | None
+    comment: str | None
 
 
 def _quoted_scalar_at(text: str, start: int) -> tuple[str, int] | None:
@@ -37,9 +70,23 @@ def _quoted_scalar_at(text: str, start: int) -> tuple[str, int] | None:
                 continue
             return "".join(value), index + 1
         if quote == '"' and character == "\\" and index + 1 < len(text):
-            value.append(text[index + 1])
-            index += 2
-            continue
+            escape = text[index + 1]
+            if escape in DOUBLE_QUOTED_ESCAPES:
+                value.append(DOUBLE_QUOTED_ESCAPES[escape])
+                index += 2
+                continue
+            if escape in HEX_ESCAPE_LENGTHS:
+                length = HEX_ESCAPE_LENGTHS[escape]
+                digits = text[index + 2 : index + 2 + length]
+                if len(digits) != length or re.fullmatch(r"[0-9A-Fa-f]+", digits) is None:
+                    return None
+                try:
+                    value.append(chr(int(digits, 16)))
+                except ValueError:
+                    return None
+                index += 2 + length
+                continue
+            return None
         value.append(character)
         index += 1
 
@@ -64,13 +111,19 @@ def _split_yaml_comment(line: str) -> tuple[str, str | None]:
     return line, None
 
 
-def _uses_value_at(text: str, boundary: int) -> str | None:
-    """Parse a uses mapping entry beginning at a known mapping boundary."""
+def _mapping_scalar_at(
+    text: str, boundary: int
+) -> tuple[str, str | None, str | None] | None:
+    """Parse one mapping scalar beginning at a known mapping boundary."""
     index = boundary
     while index < len(text) and text[index].isspace():
         index += 1
 
-    if index < len(text) and text[index] == "-":
+    if (
+        index < len(text)
+        and text[index] == "-"
+        and (index + 1 == len(text) or text[index + 1].isspace())
+    ):
         index += 1
         while index < len(text) and text[index].isspace():
             index += 1
@@ -91,75 +144,180 @@ def _uses_value_at(text: str, boundary: int) -> str | None:
 
     while index < len(text) and text[index].isspace():
         index += 1
-    if key != "uses" or index >= len(text) or text[index] != ":":
+    if not key or index >= len(text) or text[index] != ":":
         return None
 
     index += 1
     while index < len(text) and text[index].isspace():
         index += 1
     if index >= len(text):
-        return None
+        return key, None, None
 
     if text[index] in "'\"":
         scalar = _quoted_scalar_at(text, index)
-        return None if scalar is None else scalar[0]
+        if scalar is None:
+            return key, None, None
+        value, value_end = scalar
+        while value_end < len(text) and text[value_end] not in ",}]":
+            if not text[value_end].isspace():
+                return key, None, None
+            value_end += 1
+        return key, value, None
 
-    value_start = index
-    while index < len(text) and not text[index].isspace() and text[index] not in ",}]":
-        index += 1
-    return text[value_start:index] or None
+    value_end = index
+    while value_end < len(text) and text[value_end] not in ",}]":
+        value_end += 1
+    value = text[index:value_end].strip()
+    block_header = BLOCK_SCALAR_HEADER_PATTERN.fullmatch(value)
+    if block_header is not None:
+        return key, None, block_header.group("style")
+    if value.startswith(
+        ("*", "&", "!", "${{", "[", "{", "|", ">")
+    ) or value in {"~", "null", "Null", "NULL"}:
+        return key, None, None
+
+    return key, value or None, None
 
 
-def _uses_values(line: str) -> Iterator[str]:
-    """Yield uses values at block or flow mapping-entry boundaries."""
-    value = _uses_value_at(line, 0)
-    if value is not None:
-        yield value
+def _mapping_scalars_on_line(
+    text: str,
+) -> Iterator[tuple[str, str | None, str | None]]:
+    """Yield mapping scalars at block or flow mapping-entry boundaries."""
+    scalar = _mapping_scalar_at(text, 0)
+    if scalar is not None:
+        yield scalar
 
     index = 0
-    while index < len(line):
-        character = line[index]
+    while index < len(text):
+        character = text[index]
         if character in "'\"":
-            scalar = _quoted_scalar_at(line, index)
-            if scalar is None:
+            quoted = _quoted_scalar_at(text, index)
+            if quoted is None:
                 return
-            _, index = scalar
+            _, index = quoted
             continue
         if character in "{,":
-            value = _uses_value_at(line, index + 1)
-            if value is not None:
-                yield value
+            scalar = _mapping_scalar_at(text, index + 1)
+            if scalar is not None:
+                yield scalar
         index += 1
 
 
-def action_references(contents: str) -> Iterator[tuple[int, str, str | None]]:
-    """Yield line-numbered action specs and their same-line comments."""
-    for line_number, line in enumerate(contents.splitlines(), start=1):
-        mapping, comment = _split_yaml_comment(line)
-        for spec in _uses_values(mapping):
-            yield line_number, spec, comment
+def _block_scalar_body(
+    lines: list[str], header_index: int
+) -> tuple[list[str], int]:
+    """Return a de-indented block-scalar body and the next structural line."""
+    header = lines[header_index]
+    header_indentation = len(header) - len(header.lstrip(" "))
+    body = []
+    content_indentation = None
+    index = header_index + 1
+
+    while index < len(lines):
+        line = lines[index]
+        if not line.strip():
+            body.append("")
+            index += 1
+            continue
+
+        indentation = len(line) - len(line.lstrip(" "))
+        if indentation <= header_indentation:
+            break
+        if content_indentation is None:
+            content_indentation = indentation
+        if indentation < content_indentation:
+            break
+
+        body.append(line[content_indentation:])
+        index += 1
+
+    return body, index
+
+
+def _decode_block_scalar(style: str, body: list[str]) -> str:
+    """Decode the line folding needed by workflow dependency scalars."""
+    if style == "|":
+        return "\n".join(body)
+
+    value = []
+    for index, line in enumerate(body):
+        value.append(line)
+        if index + 1 == len(body):
+            continue
+        value.append(" " if line and body[index + 1] else "\n")
+    return "".join(value)
+
+
+def _mapping_scalars(contents: str) -> Iterator[_MappingScalar]:
+    """Yield decoded mapping scalars without rescanning block-scalar bodies."""
+    lines = contents.splitlines()
+    index = 0
+
+    while index < len(lines):
+        mapping, comment = _split_yaml_comment(lines[index])
+        scalars = list(_mapping_scalars_on_line(mapping))
+        block_scalar = next(
+            (scalar for scalar in scalars if scalar[2] is not None), None
+        )
+
+        if block_scalar is None:
+            for key, value, _ in scalars:
+                yield _MappingScalar(index + 1, key, value, comment)
+            index += 1
+            continue
+
+        body, next_index = _block_scalar_body(lines, index)
+        for key, value, style in scalars:
+            if style is not None:
+                value = _decode_block_scalar(style, body)
+            yield _MappingScalar(index + 1, key, value, comment)
+        index = next_index
 
 
 def remote_action_pinning_violations(contents: str) -> list[str]:
     """Return policy failures for remote action references in a workflow."""
     violations = []
 
-    for line_number, spec, label in action_references(contents):
-        if spec.startswith(("./", "docker://")) or "@" not in spec:
+    for scalar in _mapping_scalars(contents):
+        if scalar.key != "uses":
+            continue
+        if scalar.value is None or not scalar.value.strip():
+            violations.append(
+                f"line {scalar.line_number}: uses must be a decodable literal "
+                "action reference"
+            )
+            continue
+
+        spec = scalar.value.strip()
+        if spec.startswith(("./", "docker://")):
+            continue
+        if any(character.isspace() for character in spec) or "@" not in spec:
+            violations.append(
+                f"line {scalar.line_number}: uses must be a decodable literal "
+                "action reference"
+            )
             continue
 
         repository, reference = spec.rsplit("@", 1)
-        if "/" not in repository:
+        if "/" not in repository or not reference:
+            violations.append(
+                f"line {scalar.line_number}: uses must be a decodable literal "
+                "action reference"
+            )
             continue
 
         if FULL_COMMIT_SHA_PATTERN.fullmatch(reference) is None:
             violations.append(
-                f"line {line_number}: {spec} must use a full 40-character commit SHA"
+                f"line {scalar.line_number}: {spec} must use a full 40-character "
+                "commit SHA"
             )
 
-        if label is None or VERSION_LABEL_PATTERN.match(label) is None:
+        if (
+            scalar.comment is None
+            or VERSION_LABEL_PATTERN.match(scalar.comment) is None
+        ):
             violations.append(
-                f"line {line_number}: {spec} must include its tag or channel "
+                f"line {scalar.line_number}: {spec} must include its tag or channel "
                 "in a same-line comment"
             )
 
@@ -168,11 +326,27 @@ def remote_action_pinning_violations(contents: str) -> list[str]:
 
 def semantic_release_plugin_pinning_violations(contents: str) -> list[str]:
     """Return semantic-release plugin specs that do not use exact SemVer."""
-    return [
-        f"{match.group('package')}@{match.group('version')} must use an exact version"
-        for match in SEMANTIC_RELEASE_PLUGIN_PATTERN.finditer(contents)
-        if EXACT_SEMVER_PATTERN.fullmatch(match.group("version")) is None
-    ]
+    violations = []
+
+    for scalar in _mapping_scalars(contents):
+        if scalar.key != "extra_plugins":
+            continue
+        if scalar.value is None or not scalar.value.strip():
+            violations.append(
+                f"line {scalar.line_number}: extra_plugins must be a decodable "
+                "literal plugin list"
+            )
+            continue
+        for token in scalar.value.split():
+            if not token.startswith("@semantic-release/"):
+                continue
+            match = SEMANTIC_RELEASE_PLUGIN_PATTERN.fullmatch(token)
+            if match is None or EXACT_SEMVER_PATTERN.fullmatch(
+                match.group("version")
+            ) is None:
+                violations.append(f"{token} must use an exact version")
+
+    return violations
 
 
 def dependabot_update_block(contents: str, ecosystem: str) -> str:
@@ -281,6 +455,55 @@ class TestWorkflowPinningPolicy(unittest.TestCase):
             remote_action_pinning_violations(workflow),
         )
 
+    def test_remote_action_policy_rejects_folded_block_scalar_references(self):
+        workflow = """
+        - uses: >-
+            actions/checkout@v7
+        """
+
+        self.assertEqual(
+            [
+                "line 2: actions/checkout@v7 must use a full 40-character "
+                "commit SHA",
+                "line 2: actions/checkout@v7 must include its tag or channel "
+                "in a same-line comment",
+            ],
+            remote_action_pinning_violations(workflow),
+        )
+
+    def test_remote_action_policy_handles_block_scalar_references_and_bodies(self):
+        workflow = """
+        - uses: >- # v7.0.1
+            actions/checkout@0123456789012345678901234567890123456789
+        - uses: | # stable
+            dtolnay/rust-toolchain@abcdefabcdefabcdefabcdefabcdefabcdefabcd
+        - uses: >-
+            ./.github/actions/local
+        - uses: |
+            docker://alpine:3.23
+        - run: |
+            echo "uses: owner/action@v7"
+            uses: owner/action@v7
+        """
+
+        self.assertEqual([], remote_action_pinning_violations(workflow))
+
+    def test_remote_action_policy_rejects_undecodable_target_scalars(self):
+        workflow = """
+        - uses: *floating-action
+        - uses: "owner/action@v7
+        - run: *floating-action
+        - name: "uses: *floating-action"
+        """
+
+        self.assertEqual(
+            [
+                "line 2: uses must be a decodable literal action reference",
+                "line 3: uses must be a decodable literal action reference",
+            ],
+            remote_action_pinning_violations(workflow),
+        )
+
     def test_all_remote_workflow_actions_use_documented_full_shas(self):
         violations = []
         workflow_paths = sorted(WORKFLOW_DIRECTORY.glob("*.y*ml"))
@@ -293,6 +516,69 @@ class TestWorkflowPinningPolicy(unittest.TestCase):
                 violations.append(f"{relative_path}: {violation}")
 
         self.assertEqual([], violations, "\n".join(violations))
+
+    def test_semantic_release_plugin_policy_rejects_inline_mutable_versions(self):
+        workflow = "extra_plugins: '@semantic-release/changelog@6'"
+
+        self.assertEqual(
+            ["@semantic-release/changelog@6 must use an exact version"],
+            semantic_release_plugin_pinning_violations(workflow),
+        )
+
+    def test_semantic_release_plugin_policy_decodes_double_quoted_newlines(self):
+        workflow = (
+            r'extra_plugins: "@semantic-release/changelog@6.0.3\n'
+            r'@semantic-release/git@10"'
+        )
+
+        self.assertEqual(
+            ["@semantic-release/git@10 must use an exact version"],
+            semantic_release_plugin_pinning_violations(workflow),
+        )
+
+    def test_semantic_release_plugin_policy_handles_mapping_and_scalar_styles(self):
+        workflow = """
+        extra_plugins: '@semantic-release/changelog@6'
+        with: { extra_plugins: '@semantic-release/git@10' }
+        literal:
+          extra_plugins: |
+            @semantic-release/changelog@6.0.3
+            @semantic-release/git@10.0.1
+        folded:
+          extra_plugins: >-
+            @semantic-release/exec@7.1.0
+            @semantic-release/git@10.0.1
+        commands:
+          - run: |
+              extra_plugins: '@semantic-release/exec@7'
+          - run: "extra_plugins: '@semantic-release/exec@7'"
+        """
+
+        self.assertEqual(
+            [
+                "@semantic-release/changelog@6 must use an exact version",
+                "@semantic-release/git@10 must use an exact version",
+            ],
+            semantic_release_plugin_pinning_violations(workflow),
+        )
+
+    def test_semantic_release_plugin_policy_rejects_undecodable_target_scalars(self):
+        workflow = """
+        extra_plugins: *floating-plugins
+        extra_plugins: "@semantic-release/changelog@6
+        extra_plugins: >invalid
+        run: *floating-plugins
+        name: "extra_plugins: *floating-plugins"
+        """
+
+        self.assertEqual(
+            [
+                "line 2: extra_plugins must be a decodable literal plugin list",
+                "line 3: extra_plugins must be a decodable literal plugin list",
+                "line 4: extra_plugins must be a decodable literal plugin list",
+            ],
+            semantic_release_plugin_pinning_violations(workflow),
+        )
 
     def test_semantic_release_plugins_use_exact_versions(self):
         release_workflow = RELEASE_WORKFLOW_PATH.read_text(encoding="utf-8")

--- a/scripts/test_workflow_pinning_policy.py
+++ b/scripts/test_workflow_pinning_policy.py
@@ -43,6 +43,9 @@ DOUBLE_QUOTED_ESCAPES = {
     "P": "\u2029",
 }
 HEX_ESCAPE_LENGTHS = {"x": 2, "u": 4, "U": 8}
+EXPLICIT_MAPPING_KEY_ERROR = (
+    "explicit mapping key must be a decodable literal scalar"
+)
 
 
 @dataclass(frozen=True)
@@ -53,6 +56,7 @@ class _MappingScalar:
     key: str
     value: str | None
     comment: str | None
+    error: str | None = None
 
 
 def _quoted_scalar_at(text: str, start: int) -> tuple[str, int] | None:
@@ -113,7 +117,7 @@ def _split_yaml_comment(line: str) -> tuple[str, str | None]:
 
 def _mapping_scalar_at(
     text: str, boundary: int
-) -> tuple[str, str | None, str | None] | None:
+) -> tuple[str, str | None, str | None, str | None] | None:
     """Parse one mapping scalar beginning at a known mapping boundary."""
     index = boundary
     while index < len(text) and text[index].isspace():
@@ -131,38 +135,68 @@ def _mapping_scalar_at(
     if index >= len(text):
         return None
 
-    if text[index] in "'\"":
-        scalar = _quoted_scalar_at(text, index)
-        if scalar is None:
-            return None
-        key, index = scalar
-    else:
-        key_start = index
-        while index < len(text) and not text[index].isspace() and text[index] != ":":
+    explicit_key = text[index] == "?" and (
+        index + 1 == len(text) or text[index + 1].isspace()
+    )
+    if explicit_key:
+        index += 1
+        while index < len(text) and text[index].isspace():
             index += 1
-        key = text[key_start:index]
+        if index >= len(text) or text[index] in "*&![{|>":
+            return "", None, None, EXPLICIT_MAPPING_KEY_ERROR
+
+    parsed_key = _mapping_key_at(text, index)
+    if parsed_key is None:
+        if explicit_key:
+            return "", None, None, EXPLICIT_MAPPING_KEY_ERROR
+        return None
+    key, index = parsed_key
 
     while index < len(text) and text[index].isspace():
         index += 1
     if not key or index >= len(text) or text[index] != ":":
+        if explicit_key:
+            return "", None, None, EXPLICIT_MAPPING_KEY_ERROR
         return None
 
-    index += 1
+    value, block_style = _mapping_value_at(text, index + 1)
+    return key, value, block_style, None
+
+
+def _mapping_key_at(text: str, start: int) -> tuple[str, int] | None:
+    """Parse one plain or quoted scalar used as a mapping key."""
+    if start >= len(text):
+        return None
+    if text[start] in "'\"":
+        return _quoted_scalar_at(text, start)
+
+    index = start
+    while index < len(text) and not text[index].isspace() and text[index] != ":":
+        index += 1
+    key = text[start:index]
+    if not key:
+        return None
+    return key, index
+
+
+def _mapping_value_at(text: str, start: int) -> tuple[str | None, str | None]:
+    """Parse one mapping value after its YAML value indicator."""
+    index = start
     while index < len(text) and text[index].isspace():
         index += 1
     if index >= len(text):
-        return key, None, None
+        return None, None
 
     if text[index] in "'\"":
         scalar = _quoted_scalar_at(text, index)
         if scalar is None:
-            return key, None, None
+            return None, None
         value, value_end = scalar
         while value_end < len(text) and text[value_end] not in ",}]":
             if not text[value_end].isspace():
-                return key, None, None
+                return None, None
             value_end += 1
-        return key, value, None
+        return value, None
 
     value_end = index
     while value_end < len(text) and text[value_end] not in ",}]":
@@ -170,18 +204,76 @@ def _mapping_scalar_at(
     value = text[index:value_end].strip()
     block_header = BLOCK_SCALAR_HEADER_PATTERN.fullmatch(value)
     if block_header is not None:
-        return key, None, block_header.group("style")
+        return None, block_header.group("style")
     if value.startswith(
         ("*", "&", "!", "${{", "[", "{", "|", ">")
     ) or value in {"~", "null", "Null", "NULL"}:
-        return key, None, None
+        return None, None
 
-    return key, value or None, None
+    return value or None, None
+
+
+def _explicit_mapping_key_at(text: str) -> tuple[str | None, int] | None:
+    """Return an explicit key, or an opaque-key marker, and its column."""
+    index = 0
+    while index < len(text) and text[index].isspace():
+        index += 1
+
+    if (
+        index < len(text)
+        and text[index] == "-"
+        and (index + 1 == len(text) or text[index + 1].isspace())
+    ):
+        index += 1
+        while index < len(text) and text[index].isspace():
+            index += 1
+
+    indicator_column = index
+    if (
+        index >= len(text)
+        or text[index] != "?"
+        or (index + 1 < len(text) and not text[index + 1].isspace())
+    ):
+        return None
+
+    index += 1
+    while index < len(text) and text[index].isspace():
+        index += 1
+    if index >= len(text) or text[index] in "*&![{|>":
+        return None, indicator_column
+    parsed_key = _mapping_key_at(text, index)
+    if parsed_key is None:
+        return None, indicator_column
+    key, index = parsed_key
+    while index < len(text) and text[index].isspace():
+        index += 1
+    if not key or index != len(text):
+        return None, indicator_column
+
+    return key, indicator_column
+
+
+def _explicit_mapping_value_at(
+    text: str, indicator_column: int
+) -> tuple[str | None, str | None] | None:
+    """Parse a split explicit mapping value at its key's YAML column."""
+    if (
+        len(text) <= indicator_column
+        or text[:indicator_column].strip()
+        or text[indicator_column] != ":"
+        or (
+            indicator_column + 1 < len(text)
+            and not text[indicator_column + 1].isspace()
+        )
+    ):
+        return None
+
+    return _mapping_value_at(text, indicator_column + 1)
 
 
 def _mapping_scalars_on_line(
     text: str,
-) -> Iterator[tuple[str, str | None, str | None]]:
+) -> Iterator[tuple[str, str | None, str | None, str | None]]:
     """Yield mapping scalars at block or flow mapping-entry boundaries."""
     scalar = _mapping_scalar_at(text, 0)
     if scalar is not None:
@@ -252,26 +344,68 @@ def _mapping_scalars(contents: str) -> Iterator[_MappingScalar]:
     """Yield decoded mapping scalars without rescanning block-scalar bodies."""
     lines = contents.splitlines()
     index = 0
+    pending_explicit_key: tuple[str, int, int] | None = None
 
     while index < len(lines):
         mapping, comment = _split_yaml_comment(lines[index])
+
+        if pending_explicit_key is not None:
+            if not mapping.strip():
+                index += 1
+                continue
+            key, indicator_column, key_line_number = pending_explicit_key
+            explicit_value = _explicit_mapping_value_at(mapping, indicator_column)
+            pending_explicit_key = None
+            if explicit_value is not None:
+                value, style = explicit_value
+                line_number = index + 1
+                if style is not None:
+                    body, next_index = _block_scalar_body(lines, index)
+                    value = _decode_block_scalar(style, body)
+                    index = next_index
+                else:
+                    index += 1
+                yield _MappingScalar(line_number, key, value, comment)
+                continue
+            yield _MappingScalar(key_line_number, key, None, None)
+
+        explicit_key = _explicit_mapping_key_at(mapping)
+        if explicit_key is not None:
+            key, indicator_column = explicit_key
+            if key is None:
+                yield _MappingScalar(
+                    index + 1,
+                    "",
+                    None,
+                    None,
+                    EXPLICIT_MAPPING_KEY_ERROR,
+                )
+            else:
+                pending_explicit_key = (key, indicator_column, index + 1)
+            index += 1
+            continue
+
         scalars = list(_mapping_scalars_on_line(mapping))
         block_scalar = next(
             (scalar for scalar in scalars if scalar[2] is not None), None
         )
 
         if block_scalar is None:
-            for key, value, _ in scalars:
-                yield _MappingScalar(index + 1, key, value, comment)
+            for key, value, _, error in scalars:
+                yield _MappingScalar(index + 1, key, value, comment, error)
             index += 1
             continue
 
         body, next_index = _block_scalar_body(lines, index)
-        for key, value, style in scalars:
+        for key, value, style, error in scalars:
             if style is not None:
                 value = _decode_block_scalar(style, body)
-            yield _MappingScalar(index + 1, key, value, comment)
+            yield _MappingScalar(index + 1, key, value, comment, error)
         index = next_index
+
+    if pending_explicit_key is not None:
+        key, _, key_line_number = pending_explicit_key
+        yield _MappingScalar(key_line_number, key, None, None)
 
 
 def remote_action_pinning_violations(contents: str) -> list[str]:
@@ -279,6 +413,9 @@ def remote_action_pinning_violations(contents: str) -> list[str]:
     violations = []
 
     for scalar in _mapping_scalars(contents):
+        if scalar.error is not None:
+            violations.append(f"line {scalar.line_number}: {scalar.error}")
+            continue
         if scalar.key != "uses":
             continue
         if scalar.value is None or not scalar.value.strip():
@@ -329,6 +466,9 @@ def semantic_release_plugin_pinning_violations(contents: str) -> list[str]:
     violations = []
 
     for scalar in _mapping_scalars(contents):
+        if scalar.error is not None:
+            violations.append(f"line {scalar.line_number}: {scalar.error}")
+            continue
         if scalar.key != "extra_plugins":
             continue
         if scalar.value is None or not scalar.value.strip():
@@ -407,6 +547,75 @@ class TestWorkflowPinningPolicy(unittest.TestCase):
             ],
             remote_action_pinning_violations(workflow),
         )
+
+    def test_remote_action_policy_rejects_split_explicit_key_references(self):
+        workflow = """
+        - ? uses
+          : actions/checkout@v7
+        """
+
+        self.assertEqual(
+            [
+                "line 3: actions/checkout@v7 must use a full 40-character "
+                "commit SHA",
+                "line 3: actions/checkout@v7 must include its tag or channel "
+                "in a same-line comment",
+            ],
+            remote_action_pinning_violations(workflow),
+        )
+
+    def test_remote_action_policy_handles_explicit_key_scalar_forms(self):
+        documented_sha = """
+        - ? uses
+          : actions/checkout@0123456789012345678901234567890123456789 # v7.0.1
+        - ? uses
+          : ./.github/actions/local
+        - ? uses
+          : docker://alpine:3.23
+        """
+        quoted_split_key = """
+        - ? "uses"
+          : actions/checkout@v7
+        """
+        flow_explicit_entry = '- { ? "uses": "owner/action@v7" }'
+        folded_value = """
+        - ? uses
+          : >- # v7.0.1
+            actions/checkout@v7
+        """
+
+        cases = [
+            (documented_sha, []),
+            (
+                quoted_split_key,
+                [
+                    "line 3: actions/checkout@v7 must use a full 40-character "
+                    "commit SHA",
+                    "line 3: actions/checkout@v7 must include its tag or channel "
+                    "in a same-line comment",
+                ],
+            ),
+            (
+                flow_explicit_entry,
+                [
+                    "line 1: owner/action@v7 must use a full 40-character commit "
+                    "SHA",
+                    "line 1: owner/action@v7 must include its tag or channel in a "
+                    "same-line comment",
+                ],
+            ),
+            (
+                folded_value,
+                [
+                    "line 3: actions/checkout@v7 must use a full 40-character "
+                    "commit SHA"
+                ],
+            ),
+        ]
+
+        for workflow, expected in cases:
+            with self.subTest(workflow=workflow):
+                self.assertEqual(expected, remote_action_pinning_violations(workflow))
 
     def test_remote_action_policy_allows_documented_shas_and_local_actions(self):
         workflow = """
@@ -504,6 +713,125 @@ class TestWorkflowPinningPolicy(unittest.TestCase):
             remote_action_pinning_violations(workflow),
         )
 
+    def test_policies_reject_opaque_explicit_mapping_keys(self):
+        workflows = [
+            """
+            ? *target-key
+            : owner/action@v7
+            """,
+            """
+            ? [uses]
+            : owner/action@v7
+            """,
+            """
+            ? "uses
+            : owner/action@v7
+            """,
+            """
+            values: { ? *target-key: owner/action@v7 }
+            """,
+            """
+            values: { ? [uses]: owner/action@v7 }
+            """,
+            """
+            values: { ? "uses: owner/action@v7 }
+            """,
+        ]
+        expected = [
+            "line 2: explicit mapping key must be a decodable literal scalar"
+        ]
+
+        for workflow in workflows:
+            with self.subTest(workflow=workflow, policy="actions"):
+                self.assertEqual(expected, remote_action_pinning_violations(workflow))
+            with self.subTest(workflow=workflow, policy="plugins"):
+                self.assertEqual(
+                    expected, semantic_release_plugin_pinning_violations(workflow)
+                )
+
+    def test_policies_reject_unbound_explicit_target_keys(self):
+        action_workflows = [
+            """
+            ? uses
+            """,
+            """
+            ? uses
+            name: unbound key
+            """,
+        ]
+        plugin_workflows = [
+            """
+            ? extra_plugins
+            """,
+            """
+            ? extra_plugins
+            name: unbound key
+            """,
+        ]
+
+        for workflow in action_workflows:
+            with self.subTest(workflow=workflow, policy="actions"):
+                self.assertEqual(
+                    ["line 2: uses must be a decodable literal action reference"],
+                    remote_action_pinning_violations(workflow),
+                )
+        for workflow in plugin_workflows:
+            with self.subTest(workflow=workflow, policy="plugins"):
+                self.assertEqual(
+                    [
+                        "line 2: extra_plugins must be a decodable literal plugin "
+                        "list"
+                    ],
+                    semantic_release_plugin_pinning_violations(workflow),
+                )
+
+    def test_policies_reject_undecodable_explicit_target_values(self):
+        action_workflows = [
+            """
+            ? uses
+            : *floating-action
+            """,
+            """
+            ? uses
+            : "owner/action@v7
+            """,
+        ]
+        plugin_workflows = [
+            """
+            ? extra_plugins
+            : *floating-plugins
+            """,
+            """
+            ? extra_plugins
+            : "@semantic-release/changelog@6
+            """,
+        ]
+
+        for workflow in action_workflows:
+            with self.subTest(workflow=workflow, policy="actions"):
+                self.assertEqual(
+                    ["line 3: uses must be a decodable literal action reference"],
+                    remote_action_pinning_violations(workflow),
+                )
+        for workflow in plugin_workflows:
+            with self.subTest(workflow=workflow, policy="plugins"):
+                self.assertEqual(
+                    [
+                        "line 3: extra_plugins must be a decodable literal plugin "
+                        "list"
+                    ],
+                    semantic_release_plugin_pinning_violations(workflow),
+                )
+
+    def test_explicit_keys_bind_across_comments_at_the_same_yaml_column(self):
+        workflow = """
+        - ? uses
+          # The explicit value indicator belongs to the key above.
+          : actions/checkout@0123456789012345678901234567890123456789 # v7.0.1
+        """
+
+        self.assertEqual([], remote_action_pinning_violations(workflow))
+
     def test_all_remote_workflow_actions_use_documented_full_shas(self):
         violations = []
         workflow_paths = sorted(WORKFLOW_DIRECTORY.glob("*.y*ml"))
@@ -559,6 +887,30 @@ class TestWorkflowPinningPolicy(unittest.TestCase):
                 "@semantic-release/changelog@6 must use an exact version",
                 "@semantic-release/git@10 must use an exact version",
             ],
+            semantic_release_plugin_pinning_violations(workflow),
+        )
+
+    def test_semantic_release_plugin_policy_handles_explicit_keys(self):
+        workflow = """
+        mutable:
+          ? extra_plugins
+          : '@semantic-release/changelog@6'
+        exact:
+          ? "extra_plugins"
+          : >-
+            @semantic-release/changelog@6.0.3
+            @semantic-release/git@10.0.1
+        unrelated:
+          ? name
+          : '@semantic-release/exec@7'
+        commands:
+          - run: |
+              ? extra_plugins
+              : '@semantic-release/exec@7'
+        """
+
+        self.assertEqual(
+            ["@semantic-release/changelog@6 must use an exact version"],
             semantic_release_plugin_pinning_violations(workflow),
         )
 

--- a/scripts/test_workflow_pinning_policy.py
+++ b/scripts/test_workflow_pinning_policy.py
@@ -1,0 +1,154 @@
+"""Regression checks for immutable GitHub Actions workflow dependencies."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_DIRECTORY = REPOSITORY_ROOT / ".github" / "workflows"
+RELEASE_WORKFLOW_PATH = WORKFLOW_DIRECTORY / "release.yml"
+DEPENDABOT_PATH = REPOSITORY_ROOT / ".github" / "dependabot.yml"
+
+USES_PATTERN = re.compile(
+    r"^\s*(?:-\s*)?uses:\s*(?P<quote>['\"]?)"
+    r"(?P<spec>[^\s#'\"]+)(?P=quote)"
+    r"(?:\s+#\s*(?P<label>.+?))?\s*$"
+)
+FULL_COMMIT_SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
+VERSION_LABEL_PATTERN = re.compile(r"(?:v?\d+(?:\.\d+){0,2}|stable)(?:\s|$)")
+SEMANTIC_RELEASE_PLUGIN_PATTERN = re.compile(
+    r"^\s+(?P<package>@semantic-release/[a-z0-9-]+)@(?P<version>\S+)\s*$",
+    re.MULTILINE,
+)
+EXACT_SEMVER_PATTERN = re.compile(
+    r"\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?"
+)
+
+
+def remote_action_pinning_violations(contents: str) -> list[str]:
+    """Return policy failures for remote action references in a workflow."""
+    violations = []
+
+    for line_number, line in enumerate(contents.splitlines(), start=1):
+        match = USES_PATTERN.match(line)
+        if match is None:
+            continue
+
+        spec = match.group("spec")
+        if spec.startswith(("./", "docker://")) or "@" not in spec:
+            continue
+
+        repository, reference = spec.rsplit("@", 1)
+        if "/" not in repository:
+            continue
+
+        if FULL_COMMIT_SHA_PATTERN.fullmatch(reference) is None:
+            violations.append(
+                f"line {line_number}: {spec} must use a full 40-character commit SHA"
+            )
+
+        label = match.group("label")
+        if label is None or VERSION_LABEL_PATTERN.match(label) is None:
+            violations.append(
+                f"line {line_number}: {spec} must include its tag or channel "
+                "in a same-line comment"
+            )
+
+    return violations
+
+
+def semantic_release_plugin_pinning_violations(contents: str) -> list[str]:
+    """Return semantic-release plugin specs that do not use exact SemVer."""
+    return [
+        f"{match.group('package')}@{match.group('version')} must use an exact version"
+        for match in SEMANTIC_RELEASE_PLUGIN_PATTERN.finditer(contents)
+        if EXACT_SEMVER_PATTERN.fullmatch(match.group("version")) is None
+    ]
+
+
+def dependabot_update_block(contents: str, ecosystem: str) -> str:
+    """Extract one package ecosystem's update block without a YAML dependency."""
+    lines = contents.splitlines()
+    marker = f'- package-ecosystem: "{ecosystem}"'
+
+    for start, line in enumerate(lines):
+        if line.strip() != marker:
+            continue
+
+        indentation = len(line) - len(line.lstrip())
+        end = len(lines)
+        for index in range(start + 1, len(lines)):
+            candidate = lines[index]
+            if not candidate.strip():
+                continue
+            candidate_indentation = len(candidate) - len(candidate.lstrip())
+            if (
+                candidate_indentation == indentation
+                and candidate.lstrip().startswith("- package-ecosystem:")
+            ):
+                end = index
+                break
+        return "\n".join(lines[start:end])
+
+    raise ValueError(f"Dependabot ecosystem not found: {ecosystem}")
+
+
+class TestWorkflowPinningPolicy(unittest.TestCase):
+    def test_remote_action_policy_rejects_mutable_or_opaque_references(self):
+        workflow = """
+        - uses: actions/checkout@v7
+        - uses: actions/setup-node@abc123 # v7.0.0
+        - uses: owner/action@0123456789012345678901234567890123456789
+        """
+
+        violations = remote_action_pinning_violations(workflow)
+
+        self.assertEqual(4, len(violations))
+
+    def test_remote_action_policy_allows_documented_shas_and_local_actions(self):
+        workflow = """
+        - uses: actions/checkout@0123456789012345678901234567890123456789 # v7.0.1
+        - uses: dtolnay/rust-toolchain@abcdefabcdefabcdefabcdefabcdefabcdefabcd # stable
+        - uses: ./.github/actions/local
+        - uses: docker://alpine:3.23
+        """
+
+        self.assertEqual([], remote_action_pinning_violations(workflow))
+
+    def test_all_remote_workflow_actions_use_documented_full_shas(self):
+        violations = []
+        workflow_paths = sorted(WORKFLOW_DIRECTORY.glob("*.y*ml"))
+
+        for workflow_path in workflow_paths:
+            relative_path = workflow_path.relative_to(REPOSITORY_ROOT)
+            for violation in remote_action_pinning_violations(
+                workflow_path.read_text(encoding="utf-8")
+            ):
+                violations.append(f"{relative_path}: {violation}")
+
+        self.assertEqual([], violations, "\n".join(violations))
+
+    def test_semantic_release_plugins_use_exact_versions(self):
+        release_workflow = RELEASE_WORKFLOW_PATH.read_text(encoding="utf-8")
+        violations = semantic_release_plugin_pinning_violations(release_workflow)
+
+        self.assertEqual([], violations, "\n".join(violations))
+
+    def test_dependabot_keeps_sha_pinned_actions_current(self):
+        dependabot_config = DEPENDABOT_PATH.read_text(encoding="utf-8")
+        try:
+            actions_updates = dependabot_update_block(
+                dependabot_config, "github-actions"
+            )
+        except ValueError as error:
+            self.fail(str(error))
+
+        configured_lines = {line.strip() for line in actions_updates.splitlines()}
+        for required_line in ('directory: "/"', 'interval: "weekly"'):
+            with self.subTest(line=required_line):
+                self.assertIn(required_line, configured_lines)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_workflow_pinning_policy.py
+++ b/scripts/test_workflow_pinning_policy.py
@@ -1,5 +1,6 @@
 """Regression checks for immutable GitHub Actions workflow dependencies."""
 
+from collections.abc import Iterator
 from pathlib import Path
 import re
 import unittest
@@ -10,11 +11,6 @@ WORKFLOW_DIRECTORY = REPOSITORY_ROOT / ".github" / "workflows"
 RELEASE_WORKFLOW_PATH = WORKFLOW_DIRECTORY / "release.yml"
 DEPENDABOT_PATH = REPOSITORY_ROOT / ".github" / "dependabot.yml"
 
-USES_PATTERN = re.compile(
-    r"^\s*(?:-\s*)?uses:\s*(?P<quote>['\"]?)"
-    r"(?P<spec>[^\s#'\"]+)(?P=quote)"
-    r"(?:\s+#\s*(?P<label>.+?))?\s*$"
-)
 FULL_COMMIT_SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
 VERSION_LABEL_PATTERN = re.compile(r"(?:v?\d+(?:\.\d+){0,2}|stable)(?:\s|$)")
 SEMANTIC_RELEASE_PLUGIN_PATTERN = re.compile(
@@ -26,16 +22,129 @@ EXACT_SEMVER_PATTERN = re.compile(
 )
 
 
+def _quoted_scalar_at(text: str, start: int) -> tuple[str, int] | None:
+    """Return one minimally decoded quoted scalar and its exclusive end."""
+    quote = text[start]
+    value = []
+    index = start + 1
+
+    while index < len(text):
+        character = text[index]
+        if character == quote:
+            if quote == "'" and index + 1 < len(text) and text[index + 1] == quote:
+                value.append(quote)
+                index += 2
+                continue
+            return "".join(value), index + 1
+        if quote == '"' and character == "\\" and index + 1 < len(text):
+            value.append(text[index + 1])
+            index += 2
+            continue
+        value.append(character)
+        index += 1
+
+    return None
+
+
+def _split_yaml_comment(line: str) -> tuple[str, str | None]:
+    """Split at the first YAML comment marker outside quoted scalars."""
+    index = 0
+    while index < len(line):
+        character = line[index]
+        if character in "'\"":
+            scalar = _quoted_scalar_at(line, index)
+            if scalar is None:
+                return line, None
+            _, index = scalar
+            continue
+        if character == "#":
+            return line[:index], line[index + 1 :].strip() or None
+        index += 1
+
+    return line, None
+
+
+def _uses_value_at(text: str, boundary: int) -> str | None:
+    """Parse a uses mapping entry beginning at a known mapping boundary."""
+    index = boundary
+    while index < len(text) and text[index].isspace():
+        index += 1
+
+    if index < len(text) and text[index] == "-":
+        index += 1
+        while index < len(text) and text[index].isspace():
+            index += 1
+
+    if index >= len(text):
+        return None
+
+    if text[index] in "'\"":
+        scalar = _quoted_scalar_at(text, index)
+        if scalar is None:
+            return None
+        key, index = scalar
+    else:
+        key_start = index
+        while index < len(text) and not text[index].isspace() and text[index] != ":":
+            index += 1
+        key = text[key_start:index]
+
+    while index < len(text) and text[index].isspace():
+        index += 1
+    if key != "uses" or index >= len(text) or text[index] != ":":
+        return None
+
+    index += 1
+    while index < len(text) and text[index].isspace():
+        index += 1
+    if index >= len(text):
+        return None
+
+    if text[index] in "'\"":
+        scalar = _quoted_scalar_at(text, index)
+        return None if scalar is None else scalar[0]
+
+    value_start = index
+    while index < len(text) and not text[index].isspace() and text[index] not in ",}]":
+        index += 1
+    return text[value_start:index] or None
+
+
+def _uses_values(line: str) -> Iterator[str]:
+    """Yield uses values at block or flow mapping-entry boundaries."""
+    value = _uses_value_at(line, 0)
+    if value is not None:
+        yield value
+
+    index = 0
+    while index < len(line):
+        character = line[index]
+        if character in "'\"":
+            scalar = _quoted_scalar_at(line, index)
+            if scalar is None:
+                return
+            _, index = scalar
+            continue
+        if character in "{,":
+            value = _uses_value_at(line, index + 1)
+            if value is not None:
+                yield value
+        index += 1
+
+
+def action_references(contents: str) -> Iterator[tuple[int, str, str | None]]:
+    """Yield line-numbered action specs and their same-line comments."""
+    for line_number, line in enumerate(contents.splitlines(), start=1):
+        mapping, comment = _split_yaml_comment(line)
+        for spec in _uses_values(mapping):
+            yield line_number, spec, comment
+
+
 def remote_action_pinning_violations(contents: str) -> list[str]:
     """Return policy failures for remote action references in a workflow."""
     violations = []
 
-    for line_number, line in enumerate(contents.splitlines(), start=1):
-        match = USES_PATTERN.match(line)
-        if match is None:
-            continue
-
-        spec = match.group("spec")
+    for line_number, spec, label in action_references(contents):
         if spec.startswith(("./", "docker://")) or "@" not in spec:
             continue
 
@@ -48,7 +157,6 @@ def remote_action_pinning_violations(contents: str) -> list[str]:
                 f"line {line_number}: {spec} must use a full 40-character commit SHA"
             )
 
-        label = match.group("label")
         if label is None or VERSION_LABEL_PATTERN.match(label) is None:
             violations.append(
                 f"line {line_number}: {spec} must include its tag or channel "
@@ -106,6 +214,26 @@ class TestWorkflowPinningPolicy(unittest.TestCase):
 
         self.assertEqual(4, len(violations))
 
+    def test_remote_action_policy_rejects_flow_style_references(self):
+        workflow = """
+        - { uses: actions/checkout@v7 }
+        - { name: Checkout, uses: actions/setup-node@abc123 } # v7.0.0
+        - { name: Toolchain, "uses": "dtolnay/rust-toolchain@stable" } # stable
+        """
+
+        self.assertEqual(
+            [
+                "line 2: actions/checkout@v7 must use a full 40-character commit SHA",
+                "line 2: actions/checkout@v7 must include its tag or channel "
+                "in a same-line comment",
+                "line 3: actions/setup-node@abc123 must use a full 40-character "
+                "commit SHA",
+                "line 4: dtolnay/rust-toolchain@stable must use a full 40-character "
+                "commit SHA",
+            ],
+            remote_action_pinning_violations(workflow),
+        )
+
     def test_remote_action_policy_allows_documented_shas_and_local_actions(self):
         workflow = """
         - uses: actions/checkout@0123456789012345678901234567890123456789 # v7.0.1
@@ -115,6 +243,43 @@ class TestWorkflowPinningPolicy(unittest.TestCase):
         """
 
         self.assertEqual([], remote_action_pinning_violations(workflow))
+
+    def test_remote_action_policy_handles_flow_quotes_comments_and_exclusions(self):
+        workflow = """
+        - { uses: actions/checkout@0123456789012345678901234567890123456789 } # v7.0.1
+        - { name: "Toolchain #1", "uses": "dtolnay/rust-toolchain@abcdefabcdefabcdefabcdefabcdefabcdefabcd" } # stable
+        - { 'uses': './.github/actions/local' }
+        - { name: Container, uses: 'docker://alpine:3.23' }
+        - { run: "echo '{ uses: owner/action@v7 } # not a YAML comment'" }
+        """
+
+        self.assertEqual([], remote_action_pinning_violations(workflow))
+
+    def test_remote_action_policy_handles_multiline_and_nested_flow_mappings(self):
+        workflow = """jobs:
+          build:
+            steps:
+              - {
+                  uses: actions/checkout@v7,
+                }
+              - {
+                  uses: actions/setup-node@0123456789012345678901234567890123456789, # v7.0.0
+                }
+            compact: [{ uses: owner/action@abc123 }]
+        """
+
+        self.assertEqual(
+            [
+                "line 5: actions/checkout@v7 must use a full 40-character commit SHA",
+                "line 5: actions/checkout@v7 must include its tag or channel "
+                "in a same-line comment",
+                "line 10: owner/action@abc123 must use a full 40-character commit "
+                "SHA",
+                "line 10: owner/action@abc123 must include its tag or channel "
+                "in a same-line comment",
+            ],
+            remote_action_pinning_violations(workflow),
+        )
 
     def test_all_remote_workflow_actions_use_documented_full_shas(self):
         violations = []


### PR DESCRIPTION
## Summary

- pin every remote GitHub Actions dependency to a full immutable commit SHA while retaining release/channel comments for Dependabot and reviewers
- pin semantic-release extra plugins to exact patch versions
- enforce both policies across block, flow, quoted, and escaped YAML scalar styles
- fail closed on targeted action/plugin values that the dependency-free scanner cannot safely decode
- retain weekly GitHub Actions Dependabot maintenance for immutable pins

## Validation

- `python3 -m unittest discover -s scripts -p 'test_workflow_pinning_policy.py'`
- `python3 -m unittest discover -s scripts -p 'test_*_policy.py'`
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`
- `./ci_check.sh`

Closes #694

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**