### PR TITLE
docs(aarch64): explain defensive MOVZ zero guard

### DIFF
--- a/src/capstone_bridge.rs
+++ b/src/capstone_bridge.rs
@@ -37,6 +37,7 @@ fn move_wide_movz_encoding(value: u64) -> Option<(u16, u8)> {
         let mask = 0xffff_u64 << shift;
         if value & !mask == 0 {
             let imm = ((value >> shift) & 0xffff) as u16;
+            // The current caller excludes zero; keep `None` for zero if this helper is reused.
             if imm != 0 {
                 return Some((imm, shift));
             }


### PR DESCRIPTION
## Summary

- explain why the current move-wide alias caller cannot reach the MOVZ zero guard
- retain the defensive check so direct helper reuse continues to return `None` for zero
- leave executable behavior unchanged

## Testing

- `cargo test --lib capstone_bridge::tests` (before and after)
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`
- `./ci_check.sh`

Closes #438

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**