### PR TITLE
refactor(aarch64): clarify move-wide alias bindings

### DIFF
--- a/src/capstone_bridge.rs
+++ b/src/capstone_bridge.rs
@@ -84,11 +84,11 @@ fn normalize_mov_wide_alias(op_str: &str) -> Result<Option<String>, String> {
     }
 
     let value = imm as u64;
-    if let Some((imm, shift)) = move_wide_movz_encoding(value) {
-        return Ok(Some(format_move_wide("movz", rd, imm, shift)));
+    if let Some((enc_imm, enc_shift)) = move_wide_movz_encoding(value) {
+        return Ok(Some(format_move_wide("movz", rd, enc_imm, enc_shift)));
     }
-    if let Some((imm, shift)) = move_wide_movn_encoding(value) {
-        return Ok(Some(format_move_wide("movn", rd, imm, shift)));
+    if let Some((enc_imm, enc_shift)) = move_wide_movn_encoding(value) {
+        return Ok(Some(format_move_wide("movn", rd, enc_imm, enc_shift)));
     }
 
     Ok(None)


### PR DESCRIPTION
## Summary

- rename the encoded MOVZ and MOVN immediate/shift tuple bindings to `enc_imm` and `enc_shift`
- keep parsed source immediates visibly distinct from encoded move-wide fields without changing normalization behavior

## Testing

- `cargo test --lib capstone_bridge::tests::convert_capstone_op_normalizes_mov_wide_aliases` (before and after)
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `just build-tests && cargo test --all`
- `./ci_check.sh`

The Vow-template command `scripts/full_test.sh` is not present in this s11 repository; the project-defined comprehensive `./ci_check.sh` gate passed instead.

Closes #441

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**