### PR TITLE
docs(search): clarify candidate-pool cache intent

### DIFF
--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -808,6 +808,7 @@ where
     }
 
     fn reset(&mut self) {
+        // Preserve the candidate pool so its generated instructions remain reusable across resets.
         self.statistics = SearchStatistics::new(Algorithm::Enumerative);
     }
 }

--- a/src/search/enumerative/search.rs
+++ b/src/search/enumerative/search.rs
@@ -387,6 +387,7 @@ where
     /// generated up front.
     pub fn with_config(config: &SearchConfig) -> Self {
         let mut search = Self::new();
+        // Populate the cache eagerly; the returned slice is intentionally discarded.
         let _ = search.candidate_pool_for_config(config);
         search
     }


### PR DESCRIPTION
Clarify that `with_config` deliberately discards the returned slice after eagerly populating the enumerative candidate-pool cache.

Document that `reset` intentionally preserves the generated candidate pool for reuse while clearing per-run statistics. This is a comment-only change; the existing focused regression tests continue to enforce both behaviors.

Closes #461

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**