### PR TITLE
test(llm): cover near-zero SMT timeout classification

### DIFF
--- a/src/search/llm/outcome.rs
+++ b/src/search/llm/outcome.rs
@@ -239,9 +239,16 @@ mod tests {
     #[test]
     fn near_zero_smt_timeout_classifies_as_equiv_unknown() {
         // Each target group expands addition into its carry identity:
-        // a + b = (a ^ b) + 2 * (a & b). Eight independent outputs keep the
-        // proof non-trivial enough for a 1 ms Z3 budget while still passing
-        // the concrete fast path.
+        // a + b = (a ^ b) + 2 * (a & b). Eight independent outputs put the
+        // full proof around 250 ms of Z3 time, far beyond a 1 ms budget.
+        //
+        // The concrete fast path cannot refute the pair either, but not
+        // because the rewrite is subtle: with `fast_only` off, `run_fast_path`
+        // randomizes only the live-out registers (x0-x7, all *outputs* here),
+        // so the operands x10-x25 stay zero on every trial. That makes the
+        // fast path vacuous, which is why the generous-budget assertion at
+        // the end of this test — not the fast path — is what pins the
+        // fixture's equivalence.
         let groups = [
             (Register::X0, Register::X10, Register::X11),
             (Register::X1, Register::X12, Register::X13),
@@ -284,12 +291,9 @@ mod tests {
         }
 
         let live_out = LiveOut::from_registers(groups.map(|(output, _, _)| output).to_vec());
-        let (outcome, metrics) = classify(
-            &target,
-            &candidate_lines.join("\n"),
-            &live_out,
-            Duration::from_millis(1),
-        );
+        let raw = candidate_lines.join("\n");
+
+        let (outcome, metrics) = classify(&target, &raw, &live_out, Duration::from_millis(1));
 
         assert_eq!(outcome, IterationOutcome::EquivUnknown);
         let metrics = metrics.expect("equiv-unknown path must have verification metrics");
@@ -297,6 +301,22 @@ mod tests {
             metrics.smt_called,
             "near-zero timeout must reach SMT before returning equiv-unknown"
         );
+        assert!(
+            metrics.smt_formula_bytes.is_none(),
+            "formula size is serialized only on the unsat branch"
+        );
+
+        // The budget must be the *only* reason for equiv-unknown. Without
+        // this second classification the test stays green even when it has
+        // stopped testing anything: a fixture that drifted into a
+        // non-equivalent pair (e.g. `sub` in place of `add`) also returns
+        // EquivUnknown with `smt_called` set at 1 ms, because the fast path
+        // above never varies the operands.
+        let (generous, _) = classify(&target, &raw, &live_out, Duration::from_secs(30));
+        match generous {
+            IterationOutcome::Success(seq) => assert_eq!(seq.len(), groups.len()),
+            other => panic!("fixture must be equivalent under a generous budget, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/search/llm/outcome.rs
+++ b/src/search/llm/outcome.rs
@@ -40,6 +40,26 @@ pub fn classify(
     live_out: &LiveOut,
     smt_timeout: Duration,
 ) -> (IterationOutcome, Option<EquivalenceMetrics>) {
+    classify_with_verifier(
+        target,
+        raw_asm,
+        live_out,
+        smt_timeout,
+        check_equivalence_with_config_metrics,
+    )
+}
+
+fn classify_with_verifier(
+    target: &[Instruction],
+    raw_asm: &str,
+    live_out: &LiveOut,
+    smt_timeout: Duration,
+    verifier: impl FnOnce(
+        &[Instruction],
+        &[Instruction],
+        &EquivalenceConfig,
+    ) -> (EquivalenceResult, EquivalenceMetrics),
+) -> (IterationOutcome, Option<EquivalenceMetrics>) {
     let candidate = match parse_assembly_string(raw_asm, "<llm-output>".to_string()) {
         Ok(v) => v,
         Err(_) => {
@@ -68,7 +88,7 @@ pub fn classify(
     // upstream flag-liveness early-exit could silently accept flag-divergent
     // rewrites.
     let cfg = verification_config(live_out, smt_timeout);
-    let (result, metrics) = check_equivalence_with_config_metrics(target, &candidate, &cfg);
+    let (result, metrics) = verifier(target, &candidate, &cfg);
     let outcome = match result {
         EquivalenceResult::Equivalent => IterationOutcome::Success(candidate),
         EquivalenceResult::NotEquivalent | EquivalenceResult::NotEquivalentFast(_) => {
@@ -116,7 +136,7 @@ fn extract_unsupported_mnemonics(raw: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ir::{Operand, Register, RegisterWidth};
+    use crate::ir::{Operand, Register};
 
     fn live_out_x0() -> LiveOut {
         LiveOut::from_registers(vec![Register::X0])
@@ -238,62 +258,44 @@ mod tests {
 
     #[test]
     fn near_zero_smt_timeout_classifies_as_equiv_unknown() {
-        // Each target group expands addition into its carry identity:
-        // a + b = (a ^ b) + 2 * (a & b). Eight independent outputs put the
-        // full proof around 250 ms of Z3 time, far beyond a 1 ms budget.
-        //
-        // The concrete fast path cannot refute the pair either, but not
-        // because the rewrite is subtle: with `fast_only` off, `run_fast_path`
-        // randomizes only the live-out registers (x0-x7, all *outputs* here),
-        // so the operands x10-x25 stay zero on every trial. That makes the
-        // fast path vacuous, which is why the generous-budget assertion at
-        // the end of this test — not the fast path — is what pins the
-        // fixture's equivalence.
-        let groups = [
-            (Register::X0, Register::X10, Register::X11),
-            (Register::X1, Register::X12, Register::X13),
-            (Register::X2, Register::X14, Register::X15),
-            (Register::X3, Register::X16, Register::X17),
-            (Register::X4, Register::X18, Register::X19),
-            (Register::X5, Register::X20, Register::X21),
-            (Register::X6, Register::X22, Register::X23),
-            (Register::X7, Register::X24, Register::X25),
+        let target = vec![
+            Instruction::MovReg {
+                rd: Register::X0,
+                rn: Register::X1,
+            },
+            Instruction::Add {
+                rd: Register::X0,
+                rn: Register::X0,
+                rm: Operand::Immediate(1),
+            },
         ];
-        let mut target = Vec::new();
-        let mut candidate_lines = Vec::new();
+        let candidate = Instruction::Add {
+            rd: Register::X0,
+            rn: Register::X1,
+            rm: Operand::Immediate(1),
+        };
+        let timeout = Duration::from_millis(1);
 
-        for (output, a, b) in groups {
-            target.extend([
-                Instruction::Eor {
-                    rd: Register::X26,
-                    rn: a,
-                    rm: Operand::Register(b),
-                    width: RegisterWidth::X64,
-                },
-                Instruction::And {
-                    rd: Register::X27,
-                    rn: a,
-                    rm: Operand::Register(b),
-                    width: RegisterWidth::X64,
-                },
-                Instruction::Lsl {
-                    rd: Register::X27,
-                    rn: Register::X27,
-                    shift: Operand::Immediate(1),
-                },
-                Instruction::Add {
-                    rd: output,
-                    rn: Register::X26,
-                    rm: Operand::Register(Register::X27),
-                },
-            ]);
-            candidate_lines.push(format!("add {output}, {a}, {b}"));
-        }
+        let (outcome, metrics) = classify_with_verifier(
+            &target,
+            "add x0, x1, #1",
+            &live_out_x0(),
+            timeout,
+            |verified_target, verified_candidate, cfg| {
+                assert_eq!(verified_target, target);
+                assert_eq!(verified_candidate, [candidate]);
+                assert_eq!(cfg.smt_timeout, Some(timeout));
 
-        let live_out = LiveOut::from_registers(groups.map(|(output, _, _)| output).to_vec());
-        let raw = candidate_lines.join("\n");
-
-        let (outcome, metrics) = classify(&target, &raw, &live_out, Duration::from_millis(1));
+                (
+                    EquivalenceResult::Unknown("solver timeout".to_string()),
+                    EquivalenceMetrics {
+                        smt_called: true,
+                        smt_elapsed: Duration::from_millis(1),
+                        ..EquivalenceMetrics::default()
+                    },
+                )
+            },
+        );
 
         assert_eq!(outcome, IterationOutcome::EquivUnknown);
         let metrics = metrics.expect("equiv-unknown path must have verification metrics");
@@ -305,18 +307,7 @@ mod tests {
             metrics.smt_formula_bytes.is_none(),
             "formula size is serialized only on the unsat branch"
         );
-
-        // The budget must be the *only* reason for equiv-unknown. Without
-        // this second classification the test stays green even when it has
-        // stopped testing anything: a fixture that drifted into a
-        // non-equivalent pair (e.g. `sub` in place of `add`) also returns
-        // EquivUnknown with `smt_called` set at 1 ms, because the fast path
-        // above never varies the operands.
-        let (generous, _) = classify(&target, &raw, &live_out, Duration::from_secs(30));
-        match generous {
-            IterationOutcome::Success(seq) => assert_eq!(seq.len(), groups.len()),
-            other => panic!("fixture must be equivalent under a generous budget, got {other:?}"),
-        }
+        assert_eq!(metrics.smt_elapsed, Duration::from_millis(1));
     }
 
     #[test]

--- a/src/search/llm/outcome.rs
+++ b/src/search/llm/outcome.rs
@@ -116,7 +116,7 @@ fn extract_unsupported_mnemonics(raw: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ir::{Operand, Register};
+    use crate::ir::{Operand, Register, RegisterWidth};
 
     fn live_out_x0() -> LiveOut {
         LiveOut::from_registers(vec![Register::X0])
@@ -233,6 +233,69 @@ mod tests {
         assert!(
             metrics.smt_formula_bytes.map(|n| n > 0).unwrap_or(false),
             "smt_formula_bytes should be populated and non-zero"
+        );
+    }
+
+    #[test]
+    fn near_zero_smt_timeout_classifies_as_equiv_unknown() {
+        // Each target group expands addition into its carry identity:
+        // a + b = (a ^ b) + 2 * (a & b). Eight independent outputs keep the
+        // proof non-trivial enough for a 1 ms Z3 budget while still passing
+        // the concrete fast path.
+        let groups = [
+            (Register::X0, Register::X10, Register::X11),
+            (Register::X1, Register::X12, Register::X13),
+            (Register::X2, Register::X14, Register::X15),
+            (Register::X3, Register::X16, Register::X17),
+            (Register::X4, Register::X18, Register::X19),
+            (Register::X5, Register::X20, Register::X21),
+            (Register::X6, Register::X22, Register::X23),
+            (Register::X7, Register::X24, Register::X25),
+        ];
+        let mut target = Vec::new();
+        let mut candidate_lines = Vec::new();
+
+        for (output, a, b) in groups {
+            target.extend([
+                Instruction::Eor {
+                    rd: Register::X26,
+                    rn: a,
+                    rm: Operand::Register(b),
+                    width: RegisterWidth::X64,
+                },
+                Instruction::And {
+                    rd: Register::X27,
+                    rn: a,
+                    rm: Operand::Register(b),
+                    width: RegisterWidth::X64,
+                },
+                Instruction::Lsl {
+                    rd: Register::X27,
+                    rn: Register::X27,
+                    shift: Operand::Immediate(1),
+                },
+                Instruction::Add {
+                    rd: output,
+                    rn: Register::X26,
+                    rm: Operand::Register(Register::X27),
+                },
+            ]);
+            candidate_lines.push(format!("add {output}, {a}, {b}"));
+        }
+
+        let live_out = LiveOut::from_registers(groups.map(|(output, _, _)| output).to_vec());
+        let (outcome, metrics) = classify(
+            &target,
+            &candidate_lines.join("\n"),
+            &live_out,
+            Duration::from_millis(1),
+        );
+
+        assert_eq!(outcome, IterationOutcome::EquivUnknown);
+        let metrics = metrics.expect("equiv-unknown path must have verification metrics");
+        assert!(
+            metrics.smt_called,
+            "near-zero timeout must reach SMT before returning equiv-unknown"
         );
     }
 


### PR DESCRIPTION
## Summary

- exercise the LLM classifier with a valid shorter candidate and a 1 ms SMT budget
- route production `classify()` through a private injectable verifier core without changing its API or real-verifier behavior
- deterministically assert that the verifier sees the near-zero timeout and that `Unknown` maps to `EquivUnknown` with verification metrics
- remove the wall-clock-dependent carry-identity fixture and generous-budget fallback solve

## Testing

- red phase: targeted test failed to compile because `classify_with_verifier` did not exist
- green phase: targeted regression, all 7 classifier tests, and all 45 LLM tests passed
- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`
- `./ci_check.sh`

The implementation-stage template also named `scripts/full_test.sh`, but that Vow-specific script does not exist in this s11 repository; `./ci_check.sh` is the repository-documented full gate and passed.

Closes #465

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**
